### PR TITLE
Galois connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ More extensive instructions, that still apply, can be found on [the original pro
 
 The [agda-algebras][] library is developed and maintained by the *ualib/agda-algebras development team*.
 
-### The UALib/Agda-Algebras Development Team
+### The agda-algebras development team
 
 [Jacques Carette][]  
 [William DeMeo][]  

--- a/UniversalAlgebra/Algebras/Congruences.lagda
+++ b/UniversalAlgebra/Algebras/Congruences.lagda
@@ -2,7 +2,7 @@
 layout: default
 title : Algebras.Congruences module (The Agda Universal Algebra Library)
 date : 2021-01-13
-author: William DeMeo
+author: [the agda-algebras development team][]
 ---
 
 ### <a id="congruence-relations">Congruence Relations</a>
@@ -157,53 +157,12 @@ open IsCongruence
 
 
 
+--------------------------------
+
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team
 
 
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
--- OLD STUFF
-
--- 𝟎-IsEquivalence : {A : Type α} →  IsEquivalence {A = A} 0[ A ]
--- 𝟎-IsEquivalence = record { refl = refl ; sym = sym; trans = trans }
-
-\end{code}
-
-Next we formally record another obvious fact---that `𝟎-rel` is compatible with all operations of all algebras.
-
-𝟎-compatible-op : funext 𝓥 α → {𝑨 : Algebra α 𝑆} (𝑓 : ∣ 𝑆 ∣) → (𝑓 ̂ 𝑨) |: 0[ ∣ 𝑨 ∣ ]
-𝟎-compatible-op fe {𝑨} 𝑓 {i}{j} ptws0  = cong (𝑓 ̂ 𝑨) (fe ptws0)
-
-𝟎-compatible : funext 𝓥 α → {𝑨 : Algebra α 𝑆} → compatible 𝑨 0[ ∣ 𝑨 ∣ ]
-𝟎-compatible fe {𝑨} = λ 𝑓 x → 𝟎-compatible-op fe {𝑨} 𝑓 x
-
-\end{code}
-
-Finally, we have the ingredients need to construct the zero congruence of any algebra we like.
-
-
-Δ : (𝑨 : Algebra α 𝑆){fe : funext 𝓥 α} → IsCongruence 𝑨 0[ ∣ 𝑨 ∣ ]
-Δ 𝑨 {fe} = mkcon 0[ A ]-IsEquivalence (𝟎-compatible fe)
-
-𝟘 : (𝑨 : Algebra α 𝑆){fe : funext 𝓥 α} → Con{α} 𝑨
-𝟘 𝑨 {fe} = IsCongruence→Con 0[ ∣ 𝑨 ∣ ] (Δ 𝑨 {fe})
 

--- a/UniversalAlgebra/Algebras/Setoid.lagda
+++ b/UniversalAlgebra/Algebras/Setoid.lagda
@@ -13,7 +13,7 @@ This is the [Algebras.Basic][] module of the [Agda Universal Algebra Library][].
 
 {-# OPTIONS --without-K --exact-split --safe #-}
 
-open import Algebras.Basic
+open import Algebras.Basic using (𝓞 ; 𝓥 ; Signature )
 
 module Algebras.Setoid {𝑆 : Signature 𝓞 𝓥} where
 
@@ -34,6 +34,7 @@ open import Relation.Binary        using    ( Setoid  ;  IsEquivalence )
 
 -- -- -- Imports from the Agda Universal Algebra Library
 open import Overture.Preliminaries using ( ∥_∥ ; ∣_∣ )
+open import Relations.Discrete using ( _|:_)
 
 \end{code}
 
@@ -49,10 +50,10 @@ First we define an operator that translates an ordinary signature into a signatu
 
 open Setoid using    (_≈_ ; Carrier )
             renaming ( refl  to reflS
-                      ; sym   to symS
-                      ; trans to transS
-                      ; isEquivalence to isEqv )
-open Func renaming ( f to apply )
+                     ; sym   to symS
+                     ; trans to transS
+                     ; isEquivalence to isEqv )
+open Func renaming   ( f to apply )
 
 ⟦_⟧s : {α ρ : Level} → Signature 𝓞 𝓥 → Setoid α ρ → Setoid _ _
 
@@ -90,6 +91,17 @@ record SetoidAlgebra α ρ : Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)) where
      --       1. a function  f : (⟦ 𝑆 ⟧s Den) .Carrier  → Den . Carrier
      --       2. a proof cong : f Preserves _≈₁_ ⟶ _≈₂_ (that f preserves the setoid equalities)
 
+\end{code}
+
+Easier notation for application of an (interpreted) operation symbol.
+
+\begin{code}
+
+_̂_ : {α ρ : Level} (f : ∣ 𝑆 ∣)(𝑨 : Algebroid α ρ) → (∥ 𝑆 ∥ f  →  Carrier ∣ 𝑨 ∣) → Carrier ∣ 𝑨 ∣
+
+f ̂ 𝑨 = λ a → apply ∥ 𝑨 ∥ (f , a)
+
+\end{code}
 
 \end{code}
 

--- a/UniversalAlgebra/Algebras/Setoid.lagda
+++ b/UniversalAlgebra/Algebras/Setoid.lagda
@@ -2,7 +2,7 @@
 layout: default
 title : Algebras.Basic module (Agda Universal Algebra Library)
 date : 2021-04-23
-author: [the ualib/agda-algebras development team][]
+author: [the agda-algebras development team][]
 ---
 
 ### <a id="algebras">Basic Definitions</a>
@@ -33,7 +33,7 @@ open import Relation.Binary        using    ( Setoid  ;  IsEquivalence )
                                    renaming ( Rel     to BinRel        )
 
 -- -- -- Imports from the Agda Universal Algebra Library
-open import Overture.Preliminaries using ( ∥_∥ )
+open import Overture.Preliminaries using ( ∥_∥ ; ∣_∣ )
 
 \end{code}
 
@@ -47,43 +47,83 @@ First we define an operator that translates an ordinary signature into a signatu
 
 \begin{code}
 
+open Setoid using    (_≈_ ; Carrier )
+            renaming ( refl  to reflS
+                      ; sym   to symS
+                      ; trans to transS
+                      ; isEquivalence to isEqv )
+open Func renaming ( f to apply )
+
 ⟦_⟧s : {α ρ : Level} → Signature 𝓞 𝓥 → Setoid α ρ → Setoid _ _
 
-open Setoid using    ( _≈_      ;   isEquivalence )
-            renaming ( Carrier  to  ∣_∣           )
-
-⟦ 𝑆 ⟧s ξ .∣_∣ = Σ[ f ∈ (fst 𝑆) ] ((∥ 𝑆 ∥ f) → ∣ ξ ∣)
-⟦ 𝑆 ⟧s ξ ._≈_ (f , args) (f' , args') = Σ[ eq ∈ f ≡ f' ] EqArgs eq args args'
+Carrier (⟦ 𝑆 ⟧s ξ) = Σ[ f ∈ ∣ 𝑆 ∣ ] ((∥ 𝑆 ∥ f) → ξ .Carrier)
+_≈_ (⟦ 𝑆 ⟧s ξ) (f , u) (g , v) = Σ[ eqv ∈ f ≡ g ] EqArgs eqv u v
  where
- EqArgs : (eq : f ≡ f') → (∥ 𝑆 ∥ f → ∣ ξ ∣) → (∥ 𝑆 ∥ f' → ∣ ξ ∣) → Type _
- EqArgs refl args args' = (i : ∥ 𝑆 ∥ f) → ξ ._≈_ (args i) (args' i)
+ EqArgs : f ≡ g → (∥ 𝑆 ∥ f → Carrier ξ) → (∥ 𝑆 ∥ g → Carrier ξ) → Type _
+ EqArgs refl u v = ∀ i → (_≈_ ξ) (u i) (v i)
 
-IsEquivalence.refl  (⟦ 𝑆 ⟧s ξ .isEquivalence)                       = refl , λ _ → Setoid.refl  ξ
-IsEquivalence.sym   (⟦ 𝑆 ⟧s ξ .isEquivalence) (refl , g)            = refl , λ i → Setoid.sym   ξ (g i)
-IsEquivalence.trans (⟦ 𝑆 ⟧s ξ .isEquivalence) (refl , g) (refl , h) = refl , λ i → Setoid.trans ξ (g i) (h i)
+IsEquivalence.refl  (isEqv (⟦ 𝑆 ⟧s ξ))                     = refl , λ _ → reflS  ξ
+IsEquivalence.sym   (isEqv (⟦ 𝑆 ⟧s ξ))(refl , g)           = refl , λ i → symS   ξ (g i)
+IsEquivalence.trans (isEqv (⟦ 𝑆 ⟧s ξ))(refl , g)(refl , h) = refl , λ i → transS ξ (g i) (h i)
 
 \end{code}
 
 
-##### Setoid Algebra
+##### Setoid Algebras
 
 A setoid algebra is just like an algebra but we require that all basic operations of the algebra respect the underlying setoid equality.
 The `Func` record packs a function (apply) with a proof (cong) that the function respects equality.
 
 \begin{code}
 
-Algebroid : (α ρ : Level)(𝑆 : Signature 𝓞 𝓥) → Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ))
-Algebroid α ρ 𝑆 = Σ[ A ∈ Setoid α ρ ]      -- the domain (a setoid)
-                   Func (⟦ 𝑆 ⟧s A) A       -- the basic operations, along with proofs that each respects setoid equality
+Algebroid : (α ρ : Level) → Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ))
+Algebroid α ρ = Σ[ A ∈ Setoid α ρ ]      -- the domain (a setoid)
+                 Func (⟦ 𝑆 ⟧s A) A       -- the basic operations,
+                                           -- along with congruence proofs that
+                                           -- each operation espects setoid equality
 
 record SetoidAlgebra α ρ : Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)) where
   field
-    Den  :  Setoid α ρ
-    den  :  Func (⟦ 𝑆 ⟧s Den) Den
+    Domain : Setoid α ρ
+    Interp : Func (⟦ 𝑆 ⟧s Domain) Domain
      --      ^^^^^^^^^^^^^^^^^^^^^^^ is a record type with two fields:
      --       1. a function  f : (⟦ 𝑆 ⟧s Den) .Carrier  → Den . Carrier
      --       2. a proof cong : f Preserves _≈₁_ ⟶ _≈₂_ (that f preserves the setoid equalities)
 
+
+\end{code}
+
+#### Products of Algebroids
+
+\begin{code}
+
+open Func           using    ( cong                     )
+                    renaming ( f             to  apply  )
+open Setoid         using    ( Carrier       ;   _≈_    )
+                    renaming ( isEquivalence to  isEqv  )
+open IsEquivalence  renaming ( refl          to  reflE
+                             ; sym           to  symE
+                             ; trans         to  transE )
+
+module _ {α ρ ι : Level} where
+
+ ⨅ : {I : Type ι }(𝒜 : I → Algebroid α ρ) → Algebroid (α ⊔ ι) (ρ ⊔ ι)
+
+ ⨅ {I} 𝒜 = domain , interp-ops
+  where
+  domain : Setoid _ _
+  domain = record { Carrier = ∀ i → Carrier ∣ 𝒜 i ∣
+                  ; _≈_ = λ u v  → ∀ i → (_≈_ ∣ 𝒜 i ∣) (u i) (v i)
+                  ; isEquivalence =
+                     record { refl  =     λ i → reflE  (isEqv ∣ 𝒜 i ∣)
+                            ; sym   =   λ x i → symE   (isEqv ∣ 𝒜 i ∣)(x i)
+                            ; trans = λ u v i → transE (isEqv ∣ 𝒜 i ∣)(u i)(v i)
+                            }
+                  }
+
+  interp-ops : Func (⟦ 𝑆 ⟧s domain) domain
+  apply interp-ops ( f   , as ) i = apply ∥ 𝒜 i ∥ ( f   , (flip as i ))
+  cong  interp-ops (refl , f=g) i = cong  ∥ 𝒜 i ∥ (refl , (flip f=g i))
 
 \end{code}
 
@@ -94,31 +134,28 @@ record SetoidAlgebra α ρ : Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)) where
 module _ {α ρ ι : Level} where
 
  open SetoidAlgebra
- open Func           using    ( cong                     )
-                     renaming ( f             to  apply  )
- open Setoid         using    ( Carrier       ;   _≈_    )
-                     renaming ( isEquivalence to  isEqv  )
- open IsEquivalence  renaming ( refl          to  reflE
-                              ; sym           to  symE
-                              ; trans         to  transE )
 
- ⨅ : {I : Type ι }(𝒜 : I → SetoidAlgebra α ρ) → SetoidAlgebra (α ⊔ ι) (ρ ⊔ ι)
+ ⨅' : {I : Type ι }(𝒜 : I → SetoidAlgebra α ρ) → SetoidAlgebra (α ⊔ ι) (ρ ⊔ ι)
 
- Den (⨅ {I} 𝒜) =
+ Domain (⨅' {I} 𝒜) =
 
-  record { Carrier = ∀ i → Carrier (Den (𝒜 i))
+  record { Carrier = ∀ i → Carrier (Domain (𝒜 i))
 
-         ; _≈_ = λ a b → ∀ i → Den (𝒜 i) ._≈_ (a i) (b i)
+         ; _≈_ = λ a b → ∀ i → Domain (𝒜 i) ._≈_ (a i) (b i)
 
          ; isEquivalence =
-            record { refl  =     λ i → reflE  (isEqv (Den (𝒜 i)))
-                   ; sym   =   λ x i → symE   (isEqv (Den (𝒜 i)))(x i)
-                   ; trans = λ x y i → transE (isEqv (Den (𝒜 i)))(x i)(y i)
+            record { refl  =     λ i → reflE  (isEqv (Domain (𝒜 i)))
+                   ; sym   =   λ x i → symE   (isEqv (Domain (𝒜 i)))(x i)
+                   ; trans = λ x y i → transE (isEqv (Domain (𝒜 i)))(x i)(y i)
                    }
          }
 
- (den (⨅ {I} 𝒜)) .apply (f    , a    ) i = apply (den (𝒜 i)) (f    , flip a i    )
- (den (⨅ {I} 𝒜)) .cong  (refl , u'≈v') i = cong  (den (𝒜 i)) (refl , flip u'≈v' i)
+ (Interp (⨅' {I} 𝒜)) .apply (f    , a   ) i = apply (Interp (𝒜 i)) (f    , flip a i   )
+ (Interp (⨅' {I} 𝒜)) .cong  (refl , f=g ) i = cong  (Interp (𝒜 i)) (refl , flip f=g i )
 
 \end{code}
 
+
+--------------------------------
+
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team

--- a/UniversalAlgebra/Algebras/SetoidCongruences.lagda
+++ b/UniversalAlgebra/Algebras/SetoidCongruences.lagda
@@ -1,0 +1,120 @@
+---
+layout: default
+title : Algebras.SetoidCongruences module (The Agda Universal Algebra Library)
+date : 2021-01-13
+author: [the agda-algebras development team][]
+---
+
+### <a id="congruence-relations">Congruence Relations</a>
+This section presents the [Algebras.Congruences][] module of the [Agda Universal Algebra Library][].
+
+\begin{code}
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
+open import Algebras.Basic using (𝓞 ; 𝓥 ; Signature)
+
+module Algebras.SetoidCongruences {𝑆 : Signature 𝓞 𝓥} where
+
+-- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
+open import Function.Bundles       using    ( Func                    )
+open import Agda.Builtin.Equality  using    ( _≡_    ;  refl          )
+open import Agda.Primitive         using    ( _⊔_    ;  Level         )
+                                   renaming ( Set    to Type          )
+open import Data.Product           using    ( _,_    ;  Σ-syntax      )
+open import Relation.Binary        using    ( Setoid ;  IsEquivalence )
+                                   renaming ( Rel    to BinRel        )
+
+-- -- Imports from agda-algebras --------------------------------------------------------------
+open import Overture.Preliminaries    using ( ∣_∣  ; ∥_∥  )
+open import Relations.Discrete        using ( 0[_] ; _|:_ )
+open import Algebras.Products {𝑆 = 𝑆} using ( ov )
+open import Algebras.Setoid   {𝑆 = 𝑆} using ( Algebroid ; _̂_ ; ⟦_⟧s)
+
+private variable α ρ ℓ : Level
+
+\end{code}
+
+#### Compatibility of binary relations
+
+We now define the function `compatible` so that, if `𝑨` denotes an algebra and `R` a binary relation, then `compatible 𝑨 R` will represent the assertion that `R` is *compatible* with all basic operations of `𝑨`. The formal definition is immediate since all the work is done by the relation `|:`, which we defined above (see [Relations.Discrete][]).
+
+\begin{code}
+open Setoid
+
+_∣≈_ : (𝑨 : Algebroid α ρ) → BinRel (Carrier ∣ 𝑨 ∣) ℓ → Type _
+𝑨 ∣≈ R = ∀ 𝑓 → (𝑓 ̂ 𝑨) |: R
+
+\end{code}
+
+
+A *congruence relation* of an algebra `𝑨` is defined to be an equivalence relation that is compatible with the basic operations of `𝑨`.  This concept can be represented in a number of alternative but equivalent ways.
+Formally, we define a record type (`IsCongruence`) to represent the property of being a congruence, and we define a Sigma type (`Con`) to represent the type of congruences of a given algebra.
+
+\begin{code}
+
+record IsCongruence (𝑨 : Algebroid α ρ)(θ : BinRel (Carrier ∣ 𝑨 ∣) ℓ) : Type (ov ℓ ⊔ α)  where
+ constructor mkcon
+ field       is-equivalence : IsEquivalence θ
+             is-compatible  : 𝑨 ∣≈ θ
+
+Con : {α ρ : Level}(𝑨 : Algebroid α ρ) → {ℓ : Level} → Type _
+Con 𝑨 {ℓ} = Σ[ θ ∈ ( BinRel (Carrier ∣ 𝑨 ∣) ℓ ) ] IsCongruence 𝑨 θ
+
+\end{code}
+
+Each of these types captures what it means to be a congruence and they are equivalent in the sense that each implies the other. One implication is the "uncurry" operation and the other is the second projection.
+
+\begin{code}
+
+IsCongruence→Con : {𝑨 : Algebroid α ρ}(θ : BinRel (Carrier ∣ 𝑨 ∣) ℓ) → IsCongruence 𝑨 θ → Con 𝑨
+IsCongruence→Con θ p = θ , p
+
+Con→IsCongruence : {ℓ : Level}{𝑨 : Algebroid α ρ}((θ , _) : Con 𝑨 {ℓ}) → IsCongruence 𝑨 θ
+Con→IsCongruence θ = ∥ θ ∥
+
+\end{code}
+
+#### <a id="quotient-algebras">Quotient algebras</a>
+In many areas of abstract mathematics the *quotient* of an algebra `𝑨` with respect to a congruence relation `θ` of `𝑨` plays an important role. This quotient is typically denoted by `𝑨 / θ` and Agda allows us to define and express quotients using this standard notation.<sup>[1](Algebras.Congruences.html#fn1)</sup>
+
+\begin{code}
+
+open IsCongruence
+
+module _ {α ρ ℓ : Level} where
+
+ _╱_ : (𝑨 : Algebroid α ρ) → Con 𝑨 {ℓ} → Algebroid _ _
+
+ 𝑨 ╱ θ = domain            -- the domain of the quotient algebra
+       , interp            -- the basic operations of the quotient algebra
+  where
+  open Func using ( cong ) renaming ( f to apply  )
+
+  -- the domain of the quotient algebra
+  domain : Setoid α ℓ
+  domain = record { Carrier = Carrier ∣ 𝑨 ∣
+              ; _≈_ = λ x y → ∣ θ ∣ x y
+              ; isEquivalence = is-equivalence ∥ θ ∥
+              }
+
+  -- the basic operations of the quotient algebra
+  interp : Func (⟦ 𝑆 ⟧s domain) domain
+  apply interp (f , a) = (f ̂ 𝑨) a
+  cong interp {f , u} {.f , v} (refl , a) = Goal
+   where
+   Goal : ∣ θ ∣ ((f ̂ 𝑨) u) ((f ̂ 𝑨) v)
+   Goal = is-compatible ∥ θ ∥ f a
+
+
+\end{code}
+
+--------------------------------------
+
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team
+
+
+
+
+
+

--- a/UniversalAlgebra/Relations/Discrete.lagda
+++ b/UniversalAlgebra/Relations/Discrete.lagda
@@ -86,6 +86,13 @@ The homogeneous binary relation type is imported from the standard library and r
   BinRel A ℓ' = REL A A ℓ'
   ```
 
+\begin{code}
+
+Level-of-Rel : {A : Type α}{ℓ : Level} → BinRel A ℓ → Level
+Level-of-Rel {A = A}{ℓ} _ = ℓ
+
+\end{code}
+
 
 #### <a id="kernels">Kernels</a>
 

--- a/UniversalAlgebra/Relations/GaloisConnection.lagda
+++ b/UniversalAlgebra/Relations/GaloisConnection.lagda
@@ -1,0 +1,51 @@
+---
+layout: default
+title : Relations.GaloisConnection module (The Agda Universal Algebra Library)
+date : 2021-07-01
+author: [the agda-algebras development team][]
+---
+
+## Galois Connection
+
+If 𝑨 = (A, ≤) and 𝑩 = (B, ≤) are two partially ordered sets (posets), then a
+*Galois connection* between 𝑨 and 𝑩 is a pair (F , G) of functions such that
+
+1. F : A → B
+2. G : B → A
+3. ∀ (a : A)(b : B)  →  F(a) ≤   b   →    a  ≤ G(b)
+r. ∀ (a : A)(b : B)  →    a  ≤ G(b)  →  F(a) ≤   b
+
+In other terms, F is a left adjoint of G and G is a right adjoint of F.
+
+\begin{code}
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
+open import Relation.Binary.Bundles using (Poset)
+open import Agda.Primitive          using    ( _⊔_ ; Level)
+                                    renaming ( Set to Type )
+
+module Relations.GaloisConnection
+ {α α₁ α₂ : Level}(A : Poset α α₁ α₂)
+ {β β₁ β₂ : Level}(B : Poset β β₁ β₂)
+ where
+
+open Poset
+
+private
+ _≤A_ = _≤_ A
+ _≤B_ = _≤_ B
+
+record Galois : Type  (α ⊔ α₂ ⊔ β ⊔ β₂) where
+ field
+  F : Carrier A → Carrier B
+  G : Carrier B → Carrier A
+  F⊣G : ∀ a b → (F a) ≤B b → a ≤A (G b)
+  F⊢G : ∀ a b → a ≤A (G b) → (F a) ≤B b
+
+\end{code}
+
+--------------------------------------
+
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-ualib-agda-algebras-development-team
+

--- a/UniversalAlgebra/Relations/GaloisConnections.lagda
+++ b/UniversalAlgebra/Relations/GaloisConnections.lagda
@@ -1,0 +1,48 @@
+---
+layout: default
+title : Relations.GaloisConnections module (The Agda Universal Algebra Library)
+date : 2021-07-01
+author: [the ualib/agda-algebras development team][]
+---
+
+## Galois Connections
+
+If 𝑨 = (A, ≤) and 𝑩 = (B, ≤) are two partially ordered sets (posets), then a
+*Galois connection* between 𝑨 and 𝑩 is a pair (F , G) of functions such that
+
+1. F : A → B
+2. G : B → A
+3. ∀ (a : A) (b : B)  →   (F(a) ≤ b  ↔  a ≤ G(b))
+
+That is, F is a left adjoint of G and G is a right adjoint of F.
+
+\begin{code}
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
+open import Relation.Binary.Bundles using (Poset)
+open import Relation.Binary.Core
+open import Agda.Primitive          using    ( _⊔_ ;  lsuc ; Level)
+                                    renaming ( Set to Type )
+
+module Relations.GaloisConnection
+ {α α₁ α₂ : Level}(𝑨 : Poset α α₁ α₂)
+ {β β₁ β₂ : Level}(𝑩 : Poset β β₁ β₂)
+ where
+
+open Poset
+
+private
+ A = Carrier 𝑨
+ B = Carrier 𝑩
+ _≤A_ = _≤_ 𝑨
+ _≤B_ = _≤_ 𝑩
+
+record GaloisConnex : Type  (α ⊔ α₂ ⊔ β ⊔ β₂) where
+ field
+  F : A → B
+  G : B → A
+  F⊣G : ∀ a b → (F a) ≤B b → a ≤A (G b)
+  F⊢G : ∀ a b → a ≤A (G b) → (F a) ≤B b
+
+\end{code}

--- a/UniversalAlgebra/Terms/Setoid.lagda
+++ b/UniversalAlgebra/Terms/Setoid.lagda
@@ -2,12 +2,12 @@
 layout: default
 title : Terms.Setoid module (The Agda Universal Algebra Library)
 date : 2021-06-28
-author: [the ualib/agda-algebras development team][]
+author: [the agda-algebras development team][]
 ---
 
 ### Interpretation of Terms in Setoid Algebras
 
-This approach to terms and their interpretation is inspired by
+The approach to terms and their interpretation in this module was inspired by
 Andreas Abel's proof of Birkhoff's completeness theorem.
 (See http://www.cse.chalmers.se/~abela/agda/MultiSortedAlgebra.pdf.)
 
@@ -20,20 +20,18 @@ open import Algebras.Basic
 module Terms.Setoid {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library -------------------------------------------
-open import Agda.Primitive         using    ( Level   ;  _⊔_  ;  lsuc  )
-                                   renaming ( Set     to Type          )
-open import Agda.Builtin.Equality  using    ( _≡_     ;  refl          )
-open import Data.Product           using    ( _,_     ;  Σ  ; Σ-syntax )
-open import Function.Bundles       using    ( Func                     )
-open import Relation.Binary        using    ( Setoid  ;  IsEquivalence )
-open import Data.Empty.Polymorphic using    ( ⊥       ;  ⊥-elim        )
-open import Data.Sum.Base          using    ( _⊎_                      )
-                                   renaming ( inj₁    to inl
-                                            ; inj₂    to inr           )
-open Func                          renaming ( f       to apply         )
-open Setoid                        using    ( Carrier ;  isEquivalence ; _≈_ )
+open import Agda.Primitive         using    ( Level  ;  _⊔_  ;  lsuc  )
+                                   renaming ( Set    to Type          )
+open import Agda.Builtin.Equality  using    ( _≡_    ;  refl          )
+open import Data.Product           using    ( _,_                     )
+open import Function.Bundles       using    ( Func                    )
+open import Relation.Binary        using    ( Setoid ;  IsEquivalence )
+open import Data.Empty.Polymorphic using    ( ⊥      ;  ⊥-elim        )
+open import Data.Sum.Base          using    ( _⊎_                     )
+                                   renaming ( inj₁   to inl
+                                            ; inj₂   to inr           )
 
--- imports from agda-algebras --------------------------------------------------------------
+-- -- imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries           using ( ∣_∣ ; ∥_∥ )
 open import Algebras.Setoid          {𝑆 = 𝑆} using ( SetoidAlgebra )
 open import Terms.Basic              {𝑆 = 𝑆} using ( Term )
@@ -74,36 +72,40 @@ module Environment (M : SetoidAlgebra α ℓ) where
 
  open SetoidAlgebra M
 
- open IsEquivalence renaming ( refl  to  reflE
-                             ; sym   to  symE
-                             ; trans to  transE )
-
  open Setoid        renaming ( refl  to  reflS
                              ; sym   to  symS
                              ; trans to  transS)
 
  -- Equality in M's interpretation of its sort.
- _≃_ : Den .Carrier → Den .Carrier → Type ℓ
- _≃_ = Den ._≈_
+ _≃_ : Domain .Carrier → Domain .Carrier → Type ℓ
+ _≃_ = Domain ._≈_
 
 
  -- An environment for Γ maps each variable `x : Γ` to an element of M.
  -- Equality of environments is defined pointwise.
  Env : Type χ → Setoid _ _
- Env Γ .Carrier                     = (x : Γ) → Den .Carrier
- Env Γ ._≈_ ρ ρ'                    = (x : Γ) → ρ x ≃ ρ' x
- Env Γ .isEquivalence .reflE      x = reflS  Den
- Env Γ .isEquivalence .symE     h x = symS   Den (h x)
- Env Γ .isEquivalence .transE g h x = transS Den (g x) (h x)
+ Env Γ = record { Carrier = (x : Γ) → Carrier Domain
+
+                ; _≈_ = λ ρ ρ' → (x : Γ) → ρ x ≃ ρ' x
+
+                ; isEquivalence =
+                   record { refl = λ _ → reflS Domain
+                          ; sym = λ h x → symS Domain (h x)
+                          ; trans = λ g h x → transS Domain (g x) (h x)
+                          }
+                }
+
 
 
  -- Interpretation of terms is iteration on the W-type.
  -- The standard library offers `iter' (on sets), but we need this to be a Func (on setoids).
- ⦅_⦆ : (t : Term Γ) → Func (Env Γ) Den
+ open Func renaming ( f to apply )
+
+ ⦅_⦆ : (t : Term Γ) → Func (Env Γ) Domain
  apply ⦅ ℊ x ⦆         ρ      =  ρ x
  cong  ⦅ ℊ x ⦆         ρ₁=ρ₂  =  ρ₁=ρ₂ x
- apply ⦅ node f args ⦆  ρ      =  apply den (f , λ i → apply ⦅ args i ⦆ ρ)
- cong  ⦅ node f args ⦆  ρ₁=ρ₂  =  cong den (refl , λ i → cong ⦅ args i ⦆ ρ₁=ρ₂)
+ apply ⦅ node f args ⦆  ρ      =  apply Interp (f , λ i → apply ⦅ args i ⦆ ρ)
+ cong  ⦅ node f args ⦆  ρ₁=ρ₂  =  cong Interp (refl , λ i → cong ⦅ args i ⦆ ρ₁=ρ₂)
 
 
  -- An equality between two terms holds in a model
@@ -111,11 +113,14 @@ module Environment (M : SetoidAlgebra α ℓ) where
  Equal : ∀ {Γ : Type χ} (p q : Term Γ) → Type _
  Equal p q = ∀ (ρ : Env _ .Carrier) →  apply ⦅ p ⦆ ρ ≃ apply ⦅ q ⦆ ρ
 
+
  -- Equal is an equivalence relation.
  isEquiv : IsEquivalence (Equal {Γ = Γ})
- reflE  isEquiv     ρ = reflS  Den
- symE   isEquiv   i ρ = symS   Den (i ρ)
- transE isEquiv i j ρ = transS Den (i ρ) (j ρ)
+
+ isEquiv = record { refl  =         λ ρ → reflS  Domain
+                  ; sym   =     λ x=y ρ → symS   Domain (x=y ρ)
+                  ; trans = λ i=j j=k ρ → transS Domain (i=j ρ) (j=k ρ)
+                  }
 
  -- Evaluation of a substitution gives an environment.
  ⦅_⦆s : Sub Γ Δ → Env Γ .Carrier → Env Δ .Carrier
@@ -125,7 +130,11 @@ module Environment (M : SetoidAlgebra α ℓ) where
  substitution : (t : Term Δ) (σ : Sub Γ Δ) (ρ : Env Γ .Carrier)
   →             apply ⦅ t [ σ ] ⦆ ρ  ≃  apply ⦅ t ⦆ (⦅ σ ⦆s ρ)
 
- substitution (ℊ x) σ ρ = reflS Den
- substitution (node f ts) σ ρ = den .cong (refl , λ i → substitution (ts i) σ ρ)
+ substitution (ℊ x) σ ρ = reflS Domain
+ substitution (node f ts) σ ρ = Interp .cong (refl , λ i → substitution (ts i) σ ρ)
 
 \end{code}
+
+--------------------------------
+
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team

--- a/UniversalAlgebra/Varieties/EquationalLogic.lagda
+++ b/UniversalAlgebra/Varieties/EquationalLogic.lagda
@@ -87,7 +87,7 @@ module _ {ι : Level}{I : Type ι} where
  Mod : (I → Eq{χ}) → Pred(SetoidAlgebra α ρ) (χ ⊔ ι ⊔ α ⊔ ρ)
  Mod E = λ 𝑨 → 𝑨 ⊧ E
 
-_⊫_ : Pred (SetoidAlgebra α ρ) ρ → Eq{χ} → Type _
+_⊫_ : Pred (SetoidAlgebra α ρ) ℓ → Eq{χ} → Type _
 𝒦 ⊫ eq = ∀ 𝑨 → 𝒦 𝑨 → 𝑨 ⊨ eq                        -- (type \||= to get ⊫)
 
 

--- a/UniversalAlgebra/Varieties/EquationalLogic.lagda
+++ b/UniversalAlgebra/Varieties/EquationalLogic.lagda
@@ -143,13 +143,13 @@ module Soundness {χ α ρ ι : Level}{I : Type ι} (E : I → Eq{χ})
  open SetoidAlgebra M
 
  -- In any model M that satisfies the equations E, derived equality is actual equality.
- open SetoidReasoning Den
+ open SetoidReasoning Domain
 
  open Environment M
  sound : ∀ {p q} → E ⊢ Γ ▹ p ≈ q → M ⊨ (p ≐ q)
 
  sound (hyp i)                      =  V i
- sound (app {f = f} es) ρ           =  den .cong (≡-refl , λ i → sound (es i) ρ)
+ sound (app {f = f} es) ρ           =  Interp .cong (≡-refl , λ i → sound (es i) ρ)
  sound (sub {p = p} {q} Epq σ) ρ    =  begin
                                        ⦅ p [ σ ] ⦆ .apply ρ          ≈⟨ substitution p σ ρ ⟩
                                        ⦅ p       ⦆ .apply (⦅ σ ⦆s ρ) ≈⟨ sound Epq (⦅ σ ⦆s ρ)  ⟩
@@ -204,8 +204,8 @@ module TermModel {χ ι : Level}{Γ : Type χ}{I : Type ι} (E : I → Eq) where
 
  -- The term model per context Γ.
  M : Type χ → SetoidAlgebra _ _
- Den (M Γ) = TermSetoid Γ
- den (M Γ) = TermInterp
+ Domain (M Γ) = TermSetoid Γ
+ Interp (M Γ) = TermInterp
 
  open Environment (M Γ)
 
@@ -273,7 +273,7 @@ module Completeness {χ ι : Level}{I : Type ι} (E : I → Eq{χ}) {Γ} where
 
 --------------------------------------
 
-[the ualib/agda-algebras development team]: https://github.com/ualib/agda-algebras#the-ualib-agda-algebras-development-team
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team
 
 
 

--- a/UniversalAlgebra/Varieties/FreeAlgebras.lagda
+++ b/UniversalAlgebra/Varieties/FreeAlgebras.lagda
@@ -2,7 +2,7 @@
 layout: default
 title : Varieties.FreeAlgebras module (Agda Universal Algebra Library)
 date : 2021-03-01
-author: William DeMeo
+author: [the agda-algebras development team][]
 ---
 
 ## <a id="free-algebras-and-birkhoffs-theorem">Free Algebras and Birkhoff's Theorem</a>
@@ -461,3 +461,8 @@ From these it follows that every equational class is a variety. Thus, our formal
 <span style="float:right;">[Varieties ↑](Varieties.html)</span>
 
 {% include UALib.Links.md %}
+
+
+--------------------------------
+
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team

--- a/UniversalAlgebra/Varieties/Invariants.lagda
+++ b/UniversalAlgebra/Varieties/Invariants.lagda
@@ -1,0 +1,34 @@
+---
+layout: default
+title : Varieties.Invariants module (Agda Universal Algebra Library)
+date : 2021-06-29
+author: [the ualib/agda-algebras development team][]
+---
+
+### Algebraic invariants
+
+These are properties that are preserved under isomorphism.
+
+\begin{code}
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
+
+open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature ; Algebra )
+
+module Varieties.Invariants (𝑆 : Signature 𝓞 𝓥) where
+
+
+-- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
+open import Agda.Primitive          using    ( Level )
+                                    renaming ( Set to Type )
+open import Relation.Unary          using    ( Pred )
+
+-- -- Imports from the Agda Universal Algebra Library -------------------------------------------
+open import Homomorphisms.Isomorphisms {𝑆 = 𝑆} using ( _≅_ )
+
+private variable α ℓ : Level
+AlgebraicInvariant : Pred (Algebra α 𝑆) ℓ → Type _
+AlgebraicInvariant P = ∀ 𝑨 𝑩 → P 𝑨 → 𝑨 ≅ 𝑩 → P 𝑩
+
+\end{code}

--- a/UniversalAlgebra/Varieties/Setoid.lagda
+++ b/UniversalAlgebra/Varieties/Setoid.lagda
@@ -1,0 +1,78 @@
+---
+layout: default
+title : Varieties.Setoid module (Agda Universal Algebra Library)
+date : 2021-06-29
+author: [the agda-algebras development team][]
+---
+
+### Free Algebras and Birkhoff's Theorem (Setoid version)
+
+\begin{code}
+
+{-# OPTIONS --without-K --exact-split --safe #-}
+
+
+open import Level using (Level)
+open import Algebras.Basic
+
+module Varieties.Setoid {α 𝓞 𝓥 : Level} (𝑆 : Signature 𝓞 𝓥) where
+
+
+-- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
+open import Agda.Primitive          renaming ( Set to Type )
+                                    using    ( _⊔_ )
+open import Data.Product            using    ( _,_ ; Σ-syntax ; Σ ; _×_ )
+                                    renaming ( proj₁ to fst
+                                             ; proj₂ to snd )
+open import Relation.Unary          using    ( Pred ; _∈_ ) -- ; _⊆_ ; ｛_｝ ; _∪_ )
+
+-- Imports from the Agda Universal Algebra Library -------------------------------------------
+open import Overture.Preliminaries       using ( ∣_∣ ) -- ; ∥_∥ ; _∙_ ; _⁻¹ )
+open import Algebras.Products          {𝑆 = 𝑆} using ( ov ) 
+open import Algebras.Setoid      {𝑆 = 𝑆} using ( SetoidAlgebra ; ⟦_⟧s ; ⨅')
+open import Homomorphisms.Basic        {𝑆 = 𝑆} using ( hom ; epi ) -- ⨅-hom-co ; ker[_⇒_]_↾_ ; 
+open import Varieties.EquationalLogic     {𝑆 = 𝑆} using ( Eq ; _⊫_ ; module TermModel)
+
+private variable
+ χ ρ ℓ : Level
+
+module _ {Γ : Type χ}{𝒦 : Pred (SetoidAlgebra α ρ) ℓ} where
+
+ -- I indexes the collection of equations modeled by 𝒦
+ ℐ : Type (ℓ ⊔ ov(α ⊔ χ ⊔ ρ))
+ ℐ = Σ[ eq ∈ Eq{χ} ] 𝒦 ⊫ eq
+
+ ℰ : ℐ → Eq
+ ℰ (eq , p) = eq
+
+\end{code}
+
+#### The free algebra
+
+We now define the algebra `𝔽`, which plays the role of the relatively free algebra, along with the natural epimorphism `epi𝔽 : epi (𝑻 X) 𝔽` from `𝑻 X` to `𝔽`.
+
+\begin{code}
+
+ -- The relatively free algebra (relative to Th 𝒦) is called `M`
+ -- and is derived from `TermSetoid Γ` and `TermInterp Γ` and
+ -- imported from the EquationalLogic module.
+ open TermModel {ι = (ℓ ⊔ ov(α ⊔ χ ⊔ ρ))}{Γ = Γ}{I = ℐ} ℰ
+
+ 𝔽 : SetoidAlgebra _ _
+ 𝔽 = M Γ
+
+ -- epi𝔽 : epi TermSetoid(𝑻 X) 𝔽
+ -- epi𝔽 = ?
+
+ -- hom𝔽 : hom (𝑻 X) 𝔽
+ -- hom𝔽 = epi-to-hom 𝔽 epi𝔽
+
+ -- hom𝔽-is-epic : IsSurjective ∣ hom𝔽 ∣
+ -- hom𝔽-is-epic = snd ∥ epi𝔽 ∥
+
+\end{code}
+
+
+----------------------------
+
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team

--- a/UniversalAlgebra/agda-algebras-everything.lagda
+++ b/UniversalAlgebra/agda-algebras-everything.lagda
@@ -2,7 +2,7 @@
 layout: default
 title : Overture.Inverses module
 date : 2021-06-09
-author: [the ualib/agda-algebras development team][]
+author: [the agda-algebras development team][]
 ---
 
 All definitions/theorems in agda-algebras as of 22 June 2021.
@@ -203,6 +203,6 @@ open import Structures.Homs                 using    ( preserves ; is-hom-rel ; 
 
 
 
---------------------------------------
+--------------------------------
 
-[the ualib/agda-algebras development team]: https://github.com/ualib/agda-algebras#the-ualib-agda-algebras-development-team
+[the agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team

--- a/UniversalAlgebra/agda-algebras-everything.lagda
+++ b/UniversalAlgebra/agda-algebras-everything.lagda
@@ -61,13 +61,18 @@ open import Algebras.Basic                  using    ( Signature ; signature ; m
                                                      ; compatible-Rel-lilAlg ; compatible-ΠΡ-lilAlg )
 
 
-open import Algebras.Setoid                 using    ( ⟦_⟧s ; Algebroid ; SetoidAlgebra )
+open import Algebras.Setoid                 using    ( ⟦_⟧s ; Algebroid ; SetoidAlgebra ; _̂_ ; ⨅ ; ⨅' )
 
 open import Algebras.Products               using    ( ⨅ ; ⨅' ; ov ; ℑ ; 𝔄 ; class-product )
 
 open import Algebras.Congruences            using    ( IsCongruence ; Con ; IsCongruence→Con
                                                      ; Con→IsCongruence ; 0[_]Compatible ; 0Con[_]
                                                      ; _╱_ ; 𝟘[_╱_] ; 𝟎[_╱_] ; /-≡ )
+
+
+open import Algebras.SetoidCongruences      using    ( _∣≈_ ; IsCongruence ; Con ; IsCongruence→Con
+                                                     ; Con→IsCongruence ; _╱_ )
+
 
 open import Homomorphisms.Basic             using    ( compatible-op-map ; is-homomorphism ; hom ; ∘-hom
                                                      ; ∘-is-hom ; 𝒾𝒹 ; 𝓁𝒾𝒻𝓉 ; 𝓁ℴ𝓌ℯ𝓇 ; is-monomorphism


### PR DESCRIPTION
Adding a general Galois connection type.

...a type we can use to express the simple (perhaps useless) fact that (Mod , Th) is a Galois pair for the ⊧ relation on the posets: "sets of equations" and "classes of models" (with subset inclusion partial ordering).