### PR TITLE
move Graphs to 0Graphs to make room for universe polymorphic version

### DIFF
--- a/UniversalAlgebra/Structures/Graphs.lagda
+++ b/UniversalAlgebra/Structures/Graphs.lagda
@@ -1,17 +1,14 @@
 ---
 layout: default
-title : Structures.Graphs
+title : Structures.Graphs module
 date : 2021-06-22
 author: [the agda-algebras development team][]
 ---
 
-N.B. This module differs from AsRecordsGraphs.lagda in that we assume some universes are lzero (i.e., ℓ₀).
-
-This module implements the graph of a structure.  (See Definition 2 of https://arxiv.org/pdf/2010.04958v2.pdf )
+N.B. This module differs from 0Graphs.lagda in that this module is universe polymorphic; i.e., we do not restrict universe levels (to, e.g., ℓ₀). This complicates some things; e.g., we must use lift and lower in some places (cf. 0Graphs.lagda).
 
 Definition [Graph of a structure]. Let 𝑨 be an (𝑅,𝐹)-structure (relations from 𝑅 and operations from 𝐹).
-The *graph* of 𝑨 is the structure Gr 𝑨 with the same domain as 𝑨 with relations from 𝑅 and together with a (k+1)-ary relation symbol G 𝑓 for each 𝑓 ∈ 𝐹 of arity k, which is interpreted in Gr 𝑨 as all tuples (t , y) ∈ Aᵏ⁺¹ such that 𝑓 t ≡ y.
-
+The *graph* of 𝑨 is the structure Gr 𝑨 with the same domain as 𝑨 with relations from 𝑅 and together with a (k+1)-ary relation symbol G 𝑓 for each 𝑓 ∈ 𝐹 of arity k, which is interpreted in Gr 𝑨 as all tuples (t , y) ∈ Aᵏ⁺¹ such that 𝑓 t ≡ y. (See also Definition 2 of https://arxiv.org/pdf/2010.04958v2.pdf)
 
 
 \begin{code}
@@ -20,27 +17,31 @@ The *graph* of 𝑨 is the structure Gr 𝑨 with the same domain as 𝑨 with r
 
 module Structures.Graphs where
 
-open import Agda.Primitive                        using    ( _⊔_    ;   Level )
+open import Agda.Primitive                        using    ( _⊔_    ;   lsuc     )
                                                   renaming ( Set    to  Type
-                                                           ; lzero  to ℓ₀     )
-open import Agda.Builtin.Equality                 using    ( _≡_    ;   refl  )
-open import Data.Sum.Base                         using    ( _⊎_              )
-                                                  renaming ( inj₁   to inl
-                                                           ; inj₂   to inr    )
-open import Data.Product                          using    ( _,_              )
-open import Function.Base                         using    ( _∘_              )
+                                                           ; lzero  to ℓ₀        )
+open import Agda.Builtin.Equality                 using    ( _≡_    ;   refl     )
+open import Data.Sum.Base                         using    (_⊎_                  )
+                                                  renaming ( inj₁   to  inl
+                                                           ; inj₂   to  inr      )
+open import Data.Product                          using    ( _,_    ;   Σ-syntax
+                                                           ;  Σ     ;   _×_      )
+open import Level                                 using    ( Level  ;  Lift
+                                                           ; lift   ;  lower     )
+open import Function.Base                         using    ( _∘_                 )
 import Relation.Binary.PropositionalEquality as PE
 
--- -- Imports from agda-algebras --------------------------------------------------------------
-open import Overture.Preliminaries     using ( 𝟙 ; ∣_∣ ; ∥_∥ )
-open import Structures.AsRecordsBasic  using ( signature ; structure ; Sig∅)
-open import Structures.AsRecordsHoms   using ( hom ; is-hom-rel ; is-hom-op)
-open import Relations.Continuous       using ( Rel )
 
+-- Imports from agda-algebras --------------------------------------------------------------
+open import Overture.Preliminaries     using ( ∣_∣ ; _≈_ ; ∥_∥ ; _∙_ ; lower∼lift ; lift∼lower ; 𝟙)
+open import Structures.AsRecordsBasic  using ( signature ; structure ; Sig∅ )
+open import Structures.AsRecordsHoms   using ( hom ; 𝒾𝒹 ; ∘-hom ; 𝓁𝒾𝒻𝓉 ; 𝓁ℴ𝓌ℯ𝓇 ; is-hom-rel; is-hom-op)
+open import Relations.Continuous       using ( Rel )
 
 open signature
 open structure
 open _⊎_
+
 
 Gr-sig : signature → signature → signature
 
@@ -52,34 +53,35 @@ Gr-sig 𝐹 𝑅 = record { symbol = symbol 𝑅 ⊎ symbol 𝐹
  ar (inr 𝑓) = (arity 𝐹) 𝑓 ⊎ 𝟙
 
 
-module _ {𝐹 𝑅 : signature} where
+module _ {𝐹 𝑅 : signature}{α ρ : Level} where
 
- Gr : structure 𝐹 {ℓ₀} 𝑅 {ℓ₀} → structure Sig∅ {ℓ₀} (Gr-sig 𝐹 𝑅) {ℓ₀}
+ Gr : structure 𝐹 {α} 𝑅 {ρ} → structure Sig∅ {α} (Gr-sig 𝐹 𝑅) {α ⊔ ρ}
  Gr 𝑨 = record { carrier = carrier 𝑨 ; op = λ () ; rel = split }
   where
-  split : (s : symbol 𝑅 ⊎ symbol 𝐹) → Rel (carrier 𝑨) (arity (Gr-sig 𝐹 𝑅) s) {ℓ₀}
-  split (inl 𝑟) arg = rel 𝑨 𝑟 arg
-  split (inr 𝑓) args = op 𝑨 𝑓 (args ∘ inl) ≡ args (inr 𝟙.𝟎)
+  split : (s : symbol 𝑅 ⊎ symbol 𝐹) → Rel (carrier 𝑨) (arity (Gr-sig 𝐹 𝑅) s) {α ⊔ ρ}
+  split (inl 𝑟) arg = Lift α (rel 𝑨 𝑟 arg)
+  split (inr 𝑓) args = Lift ρ (op 𝑨 𝑓 (args ∘ inl) ≡ args (inr 𝟙.𝟎))
 
 
 open PE.≡-Reasoning
 
 module _ {𝐹 𝑅 : signature}
-         {𝑨 𝑩 : structure 𝐹 {ℓ₀} 𝑅 {ℓ₀}} where
+         {α ρᵃ : Level}{𝑨 : structure 𝐹 {α} 𝑅 {ρᵃ}}
+         {β ρᵇ : Level}{𝑩 : structure 𝐹 {β} 𝑅 {ρᵇ}} where
 
  hom→Grhom : hom 𝑨 𝑩 → hom (Gr 𝑨) (Gr 𝑩)
  hom→Grhom (h , hhom) = h , (i , ii)
   where
   i : is-hom-rel (Gr 𝑨) (Gr 𝑩) h
-  i (inl 𝑟) a x = ∣ hhom ∣ 𝑟 a x
-  i (inr 𝑓) a x = goal
+  i (inl 𝑟) a x = lift (∣ hhom ∣ 𝑟 a (lower x))
+  i (inr 𝑓) a x = lift goal
    where
    homop : h (op 𝑨 𝑓 (a ∘ inl)) ≡ op 𝑩 𝑓 (h ∘ (a ∘ inl))
    homop = ∥ hhom ∥ 𝑓 (a ∘ inl)
 
    goal : op 𝑩 𝑓 (h ∘ (a ∘ inl)) ≡ h (a (inr 𝟙.𝟎))
    goal = op 𝑩 𝑓 (h ∘ (a ∘ inl)) ≡⟨ PE.sym homop ⟩
-          h (op 𝑨 𝑓 (a ∘ inl))   ≡⟨ PE.cong h x ⟩
+          h (op 𝑨 𝑓 (a ∘ inl))   ≡⟨ PE.cong h (lower x) ⟩
           h (a (inr 𝟙.𝟎))         ∎
 
   ii : is-hom-op (Gr 𝑨) (Gr 𝑩) h
@@ -90,52 +92,16 @@ module _ {𝐹 𝑅 : signature}
  Grhom→hom (h , hhom) = h , (i , ii)
   where
   i : is-hom-rel 𝑨 𝑩 h
-  i R a x = ∣ hhom ∣ (inl R) a x
+  i R a x = lower (∣ hhom ∣ (inl R) a (lift x))
   ii : is-hom-op 𝑨 𝑩 h
-  ii f a = goal
+  ii f a = goal -- goal
    where
    split : arity 𝐹 f ⊎ 𝟙 → carrier 𝑨
    split (inl x) = a x
    split (inr y) = op 𝑨 f a
    goal : h (op 𝑨 f a) ≡ op 𝑩 f (λ x → h (a x))
-   goal = PE.sym (∣ hhom ∣ (inr f) split refl)
+   goal = PE.sym (lower (∣ hhom ∣ (inr f) split (lift refl)))
 
-\end{code}
-
-{- Lemma III.1. Let S be a signature and A be an S-structure.
-Let Σ be a finite set of identities such that A ⊧ Σ. For every
-instance X of CSP(A), one can compute in polynomial time an
-instance Y of CSP(A) such that Y ⊧ Σ and | Hom(X , A)| = |Hom(Y , A)|. -}
-
-
-\begin{code}
-
-module _ {𝐹 𝑅 : signature} where
-
- record _⇛_⇚_ (𝑩 𝑨 𝑪 : structure 𝐹 𝑅) : Type ℓ₀ where
-  field
-   to   : hom 𝑩 𝑨 → hom 𝑪 𝑨
-   from : hom 𝑪 𝑨 → hom 𝑩 𝑨
-   to∼from : ∀ h → (to ∘ from) h ≡ h
-   from∼to : ∀ h → (from ∘ to) h ≡ h
-
-module _ {𝐹 𝑅 : signature}{χ : Level}{X : Type χ}
-         {𝑨 : structure 𝐹 {ℓ₀} 𝑅 {ℓ₀}} where
-
-
- -- LEMMAIII1 : (ℰ : Pred (Term X × Term X) (ℓ₀ ⊔ χ))
- --  →          (𝑨 ∈ Mod ℰ)
- --  →          ∀(𝑩 : structure 𝐹 𝑅)
- --  →          Σ[ 𝑪 ∈ structure 𝐹 𝑅 ] (𝑪 ∈ Mod ℰ × (𝑩 ⇛ 𝑨 ⇚ 𝑪))
- -- LEMMAIII1 ℰ 𝑨⊧ℰ 𝑩 = {!!} , {!!}
-
- -- LEMMAIII1 : {n : ℕ}(ℰ : Fin n → (Term X × Term X))
- --  →          (𝑨 ∈ fMod ℰ)
- --  →          ∀(𝑩 : structure 𝐹 𝑅)
- --  →          Σ[ 𝑪 ∈ structure 𝐹 𝑅 ] (𝑪 ∈ fMod ℰ × (𝑩 ⇛ 𝑨 ⇚ 𝑪))
- -- LEMMAIII1 ℰ 𝑨⊧ℰ 𝑩 = {!!} , {!!}
-
-\end{code}
 
 
 ------------------------------


### PR DESCRIPTION
The universe polymorphic version is more general, perhaps unnecessarily so... but it requires the use of lift/lower in a couple of places.  The 0Graphs version, which restricts some universes to lzero is simpler.

Keeping both versions for now, putting off deciding whether the added complexity is worth it.