### PR TITLE
Fixing levels in definitions

### DIFF
--- a/UniversalAlgebra/GaloisConnections/Basic.lagda
+++ b/UniversalAlgebra/GaloisConnections/Basic.lagda
@@ -31,9 +31,9 @@ open import Relation.Unary          using    ( _⊆_ ;  _∈_ ; Pred   )
 
 
 
-module _ {α β ρ : Level}
-         (A : Poset (lsuc (α ⊔ ρ)) (α ⊔ ρ) (α ⊔ ρ))
-         (B : Poset (lsuc (β ⊔ ρ)) (β ⊔ ρ) (β ⊔ ρ))
+module _ {α β ρ₁ ρ₂ ρ₃ ρ₄ : Level}
+         (A : Poset α ρ₁ ρ₂)
+         (B : Poset β ρ₃ ρ₄)
          where
 
  open Poset
@@ -42,14 +42,14 @@ module _ {α β ρ : Level}
   _≤A_ = _≤_ A
   _≤B_ = _≤_ B
 
- record Galois : Type (lsuc (α ⊔ β ⊔ ρ))  where
+ record Galois : Type (lsuc (α ⊔ β ⊔ ρ₂ ⊔ ρ₄))  where
   field
    F : Carrier A → Carrier B
    G : Carrier B → Carrier A
    GF≥id : ∀ a →  a ≤A G (F a)
    FG≥id : ∀ b →  b ≤B F (G b)
 
- record Residuation : Type (lsuc (α ⊔ β ⊔ ρ))  where
+ record Residuation : Type (lsuc (α ⊔ β ⊔ ρ₂ ⊔ ρ₄))  where
   field
    f     : Carrier A → Carrier B
    fhom  : f Preserves _≤A_ ⟶ _≤B_
@@ -58,38 +58,35 @@ module _ {α β ρ : Level}
    fg≤id : ∀ b → f (g b) ≤B b
 
 
-module _ {α β ρ : Level}{𝒜 : Type α}{ℬ : Type β} where
+module _ {α β : Level}{𝒜 : Type α}{ℬ : Type β} where
 
  -- For A ⊆ 𝒜, define A ⃗ R = {b : b ∈ ℬ,  ∀ a ∈ A → R a b }
- _⃗_ : Pred 𝒜 (α ⊔ β ⊔ ρ) → REL 𝒜 ℬ ρ → Pred ℬ (α ⊔ β ⊔ ρ)
+ _⃗_ : ∀ {ρ₁ ρ₂} → Pred 𝒜 ρ₁ → REL 𝒜 ℬ ρ₂ → Pred ℬ (α ⊔ ρ₁ ⊔ ρ₂)
  A ⃗ R = λ b → A ⊆ (λ a → R a b)
 
  -- For B ⊆ ℬ, define R ⃖ B = {a : a ∈ 𝒜,  ∀ b ∈ B → R a b }
- _⃖_ : REL 𝒜 ℬ ρ → Pred ℬ (α ⊔ β ⊔ ρ) → Pred 𝒜 (α ⊔ β ⊔ ρ)
+ _⃖_ : ∀ {ρ₁ ρ₂} → REL 𝒜 ℬ ρ₁ → Pred ℬ ρ₂ → Pred 𝒜 (β ⊔ ρ₁ ⊔ ρ₂)
  R ⃖ B = λ a → B ⊆ R a
 
- ←→≥id : {A : Pred 𝒜 (α ⊔ β ⊔ ρ)} {R : REL 𝒜 ℬ ρ} → A ⊆ R ⃖ (A ⃗ R)
+ ←→≥id : ∀ {ρ₁ ρ₂} {A : Pred 𝒜 ρ₁} {R : REL 𝒜 ℬ ρ₂} → A ⊆ R ⃖ (A ⃗ R)
  ←→≥id p b = b p
 
- →←≥id : {B : Pred ℬ (α ⊔ β ⊔ ρ)} {R : REL 𝒜 ℬ ρ}  → B ⊆ (R ⃖ B) ⃗ R
+ →←≥id : ∀ {ρ₁ ρ₂} {B : Pred ℬ ρ₁} {R : REL 𝒜 ℬ ρ₂}  → B ⊆ (R ⃖ B) ⃗ R
  →←≥id p a = a p
 
- →←→⊆→ : {A : Pred 𝒜 (α ⊔ β ⊔ ρ)}{R : REL 𝒜 ℬ ρ} → (R ⃖ (A ⃗ R)) ⃗ R ⊆ A ⃗ R
+ →←→⊆→ : ∀ {ρ₁ ρ₂} {A : Pred 𝒜 ρ₁}{R : REL 𝒜 ℬ ρ₂} → (R ⃖ (A ⃗ R)) ⃗ R ⊆ A ⃗ R
  →←→⊆→ p a = p (λ z → z a)
 
- ←→←⊆← : {B : Pred ℬ (α ⊔ β ⊔ ρ)}{R : REL 𝒜 ℬ ρ}  → R ⃖ ((R ⃖ B) ⃗ R) ⊆ R ⃖ B
+ ←→←⊆← : ∀ {ρ₁ ρ₂} {B : Pred ℬ ρ₁}{R : REL 𝒜 ℬ ρ₂}  → R ⃖ ((R ⃖ B) ⃗ R) ⊆ R ⃖ B
  ←→←⊆← p b = p (λ z → z b)
 
  -- Definition of "closed" with respect to the closure operator λ A → R ⃖ (A ⃗ R)
- ←→Closed : {A : Pred 𝒜 (α ⊔ β ⊔ ρ)}{R : REL 𝒜 ℬ ρ} → Type _
+ ←→Closed : ∀ {ρ₁ ρ₂} {A : Pred 𝒜 ρ₁} {R : REL 𝒜 ℬ ρ₂} → Type _
  ←→Closed {A = A}{R} = R ⃖ (A ⃗ R) ⊆ A
 
  -- Definition of "closed" with respect to the closure operator λ B → (R ⃖ B) ⃗ R
- →←Closed : {B : Pred ℬ (α ⊔ β ⊔ ρ)}{R : REL 𝒜 ℬ ρ} → Type _
+ →←Closed : ∀ {ρ₁ ρ₂} {B : Pred ℬ ρ₁}{R : REL 𝒜 ℬ ρ₂} → Type _
  →←Closed {B = B}{R} = (R ⃖ B) ⃗ R ⊆ B
-
-
-
 
 \end{code}
 
@@ -135,4 +132,3 @@ module one-level {ℓ : Level}{𝒜 ℬ : Type ℓ} where
 
  ←→←⊆← : {B : Pred ℬ ℓ}{R : REL 𝒜 ℬ ℓ}  → R ⃖ ((R ⃖ B) ⃗ R) ⊆ R ⃖ B
  ←→←⊆← p b = p (λ z → z b)
-

--- a/UniversalAlgebra/GaloisConnections/Properties.lagda
+++ b/UniversalAlgebra/GaloisConnections/Properties.lagda
@@ -31,7 +31,7 @@ open Poset
 
 -- Definition of the poset of subsets of a set with the usual set inclusion relation.
 -- (I couldn't find this in the standard library, though I suspect it's somewhere.)
-module _ {α ρ : Level}{𝒜 : Type α} where
+module _ {α ρ : Level} {𝒜 : Type α} where
 
  _≐_ : Pred 𝒜 ρ → Pred 𝒜 ρ → Type (α ⊔ ρ)
  P ≐ Q = (P ⊆ Q) × (Q ⊆ P)
@@ -44,10 +44,10 @@ module _ {α ρ : Level}{𝒜 : Type α} where
  tran ≐-iseqv (u₁ , u₂) (v₁ , v₂) = v₁ ∘ u₁ , u₂ ∘ v₂
 
 
-module _ {α ρ : Level}{𝒜 : Type α} where
+module _ {α : Level} (ρ : Level) (𝒜 : Type α) where
 
- PosetOfSubsets : Poset (lsuc (α ⊔ ρ)) (α ⊔ ρ) (α ⊔ ρ)
- Carrier PosetOfSubsets = Pred 𝒜 (α ⊔ ρ)
+ PosetOfSubsets : Poset (α ⊔ lsuc ρ) (α ⊔ ρ) (α ⊔ ρ)
+ Carrier PosetOfSubsets = Pred 𝒜 ρ
  _≈_ PosetOfSubsets = _≐_
  _≤_ PosetOfSubsets = _⊆_
  isPartialOrder PosetOfSubsets =
@@ -58,20 +58,26 @@ module _ {α ρ : Level}{𝒜 : Type α} where
          ; antisym = _,_
          }
 
+\end{code}
 
-module _ {ℓ ρ : Level}{𝒜 ℬ : Type ℓ} where
+A Binary relation from one poset to another induces a Galois connection, but only in a very special
+situation, namely when all the involved sets are of the same size.  This is akin to the situation
+with Adjunctions in Category Theory (unsurprisingly). In other words, there is likely a
+unit/counit definition that is more level polymorphic.
+\begin{code}
+module _ {ℓ : Level}{𝒜 : Type ℓ} {ℬ : Type ℓ} where
 
- 𝒫𝒜 𝒫ℬ : Poset (lsuc (ℓ ⊔ ρ)) (ℓ ⊔ ρ) (ℓ ⊔ ρ)
- 𝒫𝒜 = PosetOfSubsets{ℓ}{ρ}{𝒜 = 𝒜}
- 𝒫ℬ = PosetOfSubsets{ℓ}{ρ}{𝒜 = ℬ}
+ 𝒫𝒜 : Poset (lsuc ℓ) ℓ ℓ
+ 𝒫ℬ : Poset (lsuc ℓ) ℓ ℓ
+ 𝒫𝒜 = PosetOfSubsets ℓ 𝒜
+ 𝒫ℬ = PosetOfSubsets ℓ ℬ
 
  -- Every binary relation from one poset to another induces a Galois connection.
- Rel→Gal : (R : REL 𝒜 ℬ ρ) → Galois{ℓ}{ℓ}{ρ} 𝒫𝒜 𝒫ℬ
+ Rel→Gal : (R : REL 𝒜 ℬ ℓ) → Galois 𝒫𝒜 𝒫ℬ
  Rel→Gal R = record { F = _⃗ R
                     ; G = R ⃖_
                     ; GF≥id = λ _ → ←→≥id
                     ; FG≥id = λ _ → →←≥id }
-
 \end{code}
 
 
@@ -103,5 +109,3 @@ module _ {ℓ ρ : Level}{𝒜 ℬ : Type ℓ} where
 --                     ; G = R ⃖_
 --                     ; GF≥id = λ _ → ←→≥id
 --                     ; FG≥id = λ _ → →←≥id }
-
-


### PR DESCRIPTION
Make the levels in the definitions as general as possible. Don't let  the level restrictions of Rel→Gal backward-infect the definitions.