### PR TITLE
replace (hopefully all) occurrences of Agda.Builtin _≡_ and refl

### DIFF
--- a/src/Algebras/Congruences.lagda
+++ b/src/Algebras/Congruences.lagda
@@ -17,16 +17,16 @@ open import Algebras.Basic
 
 module Algebras.Congruences {𝑆 : Signature 𝓞 𝓥} where
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Agda.Builtin.Equality  using ( _≡_ ; refl )
-open import Agda.Primitive         using ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Data.Product           using ( Σ-syntax ; _,_ )
-open import Function.Base          using ( _∘_ )
-open import Level                  using ( Level ; Lift )
-open import Relation.Binary        using ( IsEquivalence ) renaming ( Rel to BinRel )
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Agda.Primitive  using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product    using ( Σ-syntax ; _,_ )
+open import Function.Base   using ( _∘_ )
+open import Level           using ( Level )
+open import Relation.Binary using ( IsEquivalence ) renaming ( Rel to BinRel )
+open import Relation.Binary.PropositionalEquality
+                            using ( _≡_ ; refl )
 
-
--- Imports from agda-algebras --------------------------------------------------------------
+-- Imports from agda-algebras ----------------------------------------------------------
 open import Overture.Preliminaries    using ( ∣_∣  ; ∥_∥  )
 open import Relations.Discrete        using ( _|:_ ; 0[_] )
 open import Relations.Quotients       using ( 0[_]Equivalence ; _/_ ; ⟪_⟫ ; IsBlock )

--- a/src/Algebras/Setoid/Basic.lagda
+++ b/src/Algebras/Setoid/Basic.lagda
@@ -17,20 +17,19 @@ open import Algebras.Basic using (𝓞 ; 𝓥 ; Signature )
 
 module Algebras.Setoid.Basic {𝑆 : Signature 𝓞 𝓥} where
 
--- Imports from the Agda (Builtin) and the Agda Standard Library
-open import Agda.Builtin.Equality  as ≡ using    ( _≡_ ) --    ;  refl          )
-open import Agda.Primitive         using    ( _⊔_    ;  lsuc          )
-                                   renaming ( Set    to Type          )
-open import Data.Product           using    ( _,_    ;  _×_
-                                            ; Σ      ;  Σ-syntax      )
-open import Function               using    ( _∘_                     )
-open import Function.Base          using    ( flip                    )
-open import Function.Bundles       using    ( Func                    )
-open import Level                  using    ( Level  ;  Lift          )
-open import Relation.Binary        using    ( Setoid ;  IsEquivalence )
-open import Relation.Unary         using    ( Pred  ; _∈_             )
+-- Imports from the Agda and the Agda Standard Library
+open import Agda.Primitive   using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product     using ( _,_ ; _×_ ; Σ-syntax )
+open import Function         using ( _∘_ )
+open import Function.Base    using ( flip )
+open import Function.Bundles using ( Func )
+open import Level            using ( Level  ; Lift )
+open import Relation.Binary  using ( Setoid ; IsEquivalence )
+open import Relation.Binary.PropositionalEquality as PE
+                             using ( _≡_ ; refl )
+open import Relation.Unary   using ( Pred  ; _∈_ )
 
--- -- Imports from the Agda Universal Algebra Library
+-- Imports from the Agda Universal Algebra Library
 open import Overture.Preliminaries using ( ∥_∥ ; ∣_∣ )
 
 private variable
@@ -61,11 +60,11 @@ Carrier (⟦ 𝑆 ⟧s ξ) = Σ[ f ∈ ∣ 𝑆 ∣ ] ((∥ 𝑆 ∥ f) → ξ .
 _≈_ (⟦ 𝑆 ⟧s ξ) (f , u) (g , v) = Σ[ eqv ∈ f ≡ g ] EqArgs eqv u v
  where
  EqArgs : f ≡ g → (∥ 𝑆 ∥ f → Carrier ξ) → (∥ 𝑆 ∥ g → Carrier ξ) → Type _
- EqArgs ≡.refl u v = ∀ i → (_≈_ ξ) (u i) (v i)
+ EqArgs refl u v = ∀ i → (_≈_ ξ) (u i) (v i)
 
-IsEquivalence.refl  (isEqv (⟦ 𝑆 ⟧s ξ))                     = ≡.refl , λ _ → reflS  ξ
-IsEquivalence.sym   (isEqv (⟦ 𝑆 ⟧s ξ))(≡.refl , g)           = ≡.refl , λ i → symS   ξ (g i)
-IsEquivalence.trans (isEqv (⟦ 𝑆 ⟧s ξ))(≡.refl , g)(≡.refl , h) = ≡.refl , λ i → transS ξ (g i) (h i)
+IsEquivalence.refl  (isEqv (⟦ 𝑆 ⟧s ξ))                     = refl , λ _ → reflS  ξ
+IsEquivalence.sym   (isEqv (⟦ 𝑆 ⟧s ξ))(refl , g)           = refl , λ i → symS   ξ (g i)
+IsEquivalence.trans (isEqv (⟦ 𝑆 ⟧s ξ))(refl , g)(refl , h) = refl , λ i → transS ξ (g i) (h i)
 
 \end{code}
 
@@ -142,40 +141,21 @@ Lift-SetoidAlg : SetoidAlgebra α ρ → (ℓ : Level) → SetoidAlgebra (α ⊔
 
 Domain (Lift-SetoidAlg 𝑨 ℓ) = record { Carrier = Lift ℓ 𝕌[ 𝑨 ]
                                      ; _≈_ = λ x y → lower x ≈A lower y
-                                     ; isEquivalence = record { refl = refl
+                                     ; isEquivalence = record { refl = srefl
                                                               ; sym = sym
                                                               ; trans = trans
                                                               }
-                                     } where open Setoid (Domain 𝑨) renaming (_≈_ to _≈A_)
+                                     } where open Setoid (Domain 𝑨) renaming (_≈_ to _≈A_ ; refl to srefl )
 
 Interp (Lift-SetoidAlg 𝑨 ℓ) <$> (f , la) = lift ((f ̂ 𝑨) (lower ∘ la))
 
-cong (Interp (Lift-SetoidAlg 𝑨 ℓ)) (≡.refl , la=lb) = cong (Interp 𝑨) ((≡.refl , la=lb))
+cong (Interp (Lift-SetoidAlg 𝑨 ℓ)) (refl , la=lb) = cong (Interp 𝑨) ((refl , la=lb))
 
-
--- Lift-Alg : SetoidAlgebra α ρ → (α' ρ' : Level) → SetoidAlgebra (α ⊔ α') (ρ ⊔ ρ')
-
--- Lift-Alg {α}{ρ} 𝑨 α' ρ' = record { Domain = dom
---                           ; Interp = interp }
---  where
---  dom : Setoid (α ⊔ α') (ρ ⊔ ρ')
---  dom = record { Carrier = Lift α' 𝕌[ 𝑨 ]
---               ; _≈_ = λ x y → Lift ρ' (lower x ≈A lower y)
---               ; isEquivalence = record { refl = lift refl
---                                        ; sym = λ x → lift (sym (lower x))
---                                        ; trans = λ x y → lift (trans (lower x) (lower y))
---                                        }
---               } where open Setoid (Domain 𝑨) renaming (_≈_ to _≈A_)
---  interp : Func (⟦ 𝑆 ⟧s dom) dom
---  interp = {!!}
-
--- Alternatively, we could define the Lift of a SetoidAlgebra inside an anonymous module where we open
--- SetoidAlgebra 𝑨 and Setoid (Domain 𝑨) to give ourselves simpler handles on the fields.
 
 module _ (𝑨 : SetoidAlgebra α ρ) where
 
  open SetoidAlgebra 𝑨
- open Setoid (Domain 𝑨)
+ open Setoid (Domain 𝑨) renaming ( refl to srefl )
  private
   A = Carrier (Domain 𝑨)
   _≈A_ = _≈_ (Domain 𝑨)
@@ -183,17 +163,13 @@ module _ (𝑨 : SetoidAlgebra α ρ) where
  Lift-SetoidAlg' : (ℓ : Level) → SetoidAlgebra (α ⊔ ℓ) ρ
 
  Domain (Lift-SetoidAlg' ℓ) = record { Carrier = Lift ℓ A
-                                    ; _≈_ = λ x y → lower x ≈A lower y
-                                    ; isEquivalence = record { refl = refl ; sym = sym ; trans = trans }
-                                    }
+                                     ; _≈_ = λ x y → lower x ≈A lower y
+                                     ; isEquivalence = record { refl = srefl ; sym = sym ; trans = trans }
+                                     }
 
  Interp (Lift-SetoidAlg' ℓ) <$> (f , la) = lift ((f ̂ 𝑨) (lower ∘ la))
 
- cong (Interp (Lift-SetoidAlg' ℓ)) (≡.refl , la≡lb) = cong (Interp 𝑨) (≡.refl , la≡lb)
-
-
-
-
+ cong (Interp (Lift-SetoidAlg' ℓ)) (refl , la≡lb) = cong (Interp 𝑨) (PE.refl , la≡lb)
 
 \end{code}
 

--- a/src/Algebras/Setoid/Congruences.lagda
+++ b/src/Algebras/Setoid/Congruences.lagda
@@ -18,13 +18,13 @@ open import Algebras.Basic using (𝓞 ; 𝓥 ; Signature)
 module Algebras.Setoid.Congruences {𝑆 : Signature 𝓞 𝓥} where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
+-- Imports from the Agda Standard Library ---------------------
 open import Function.Bundles      using ( Func )
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
 open import Agda.Primitive        using ( _⊔_ ; Level ) renaming ( Set to Type )
 open import Data.Product          using ( _,_ ; Σ-syntax )
 open import Relation.Binary       using ( Setoid ; IsEquivalence ) renaming ( Rel to BinRel )
-
+open import Relation.Binary.PropositionalEquality
+                                  using ( refl )
 
 -- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries        using ( ∣_∣  ; ∥_∥  )
@@ -99,42 +99,7 @@ Domain (𝑨 ╱ θ) = record { Carrier = 𝕌[ 𝑨 ]
                         ; isEquivalence = is-equivalence ∥ θ ∥
                         }
 (Interp (𝑨 ╱ θ)) <$> (f , a) = (f ̂ 𝑨) a
-cong (Interp (𝑨 ╱ θ)) {f , u} {.f , v} (_≡_.refl , a) = is-compatible  ∥ θ ∥ f a
-
-
-
--- /-≡ : {𝑨 : SetoidAlgebra α ρ}(θ : Con{α}{ρ}𝑨{ℓ}) {u v : ∣ 𝑨 ∣} → ⟪ u ⟫ {∣ θ ∣} ≡ ⟪ v ⟫ → ∣ θ ∣ u v
--- /-≡ θ refl = IsEquivalence.refl (is-equivalence ∥ θ ∥)
-
-\end{code}
-
-
-
--- Algebroid Quotient (omitting for now, in favor of SetoidAlgebra representation)
--- module _ {α ρ ℓ : Level} where
-
---  _╱_ : (𝑨 : Algebroid α ρ) → Con 𝑨 {ℓ} → Algebroid _ _
-
---  𝑨 ╱ θ = domain            -- the domain of the quotient algebra
---        , interp            -- the basic operations of the quotient algebra
---   where
---   open Func using ( cong ) renaming ( f to apply  )
-
---   -- the domain of the quotient algebra
---   domain : Setoid α ℓ
---   domain = record { Carrier = Carrier ∣ 𝑨 ∣
---               ; _≈_ = λ x y → ∣ θ ∣ x y
---               ; isEquivalence = is-equivalence ∥ θ ∥
---               }
-
---   -- the basic operations of the quotient algebra
---   interp : Func (⟦ 𝑆 ⟧s domain) domain
---   apply interp (f , a) = (f ∙ 𝑨) a
---   cong interp {f , u} {.f , v} (refl , a) = Goal
---    where
---    Goal : ∣ θ ∣ ((f ∙ 𝑨) u) ((f ∙ 𝑨) v)
---    Goal = is-compatible ∥ θ ∥ f a
-
+cong (Interp (𝑨 ╱ θ)) {f , u} {.f , v} (refl , a) = is-compatible  ∥ θ ∥ f a
 
 \end{code}
 

--- a/src/Algebras/Setoid/Products.lagda
+++ b/src/Algebras/Setoid/Products.lagda
@@ -19,14 +19,17 @@ open import Algebras.Basic using (𝓞 ; 𝓥 ; Signature)
 
 module Algebras.Setoid.Products {𝑆 : Signature 𝓞 𝓥} where
 
-open import Agda.Builtin.Equality  using ( _≡_ ; refl )
-open import Agda.Primitive         using ( lsuc ; _⊔_ ; Level ) renaming ( Set to Type )
-open import Data.Product           using ( _,_ ; Σ ; Σ-syntax )
-open import Function.Base          using ( flip )
-open import Function.Bundles       using ( Func )
-open import Relation.Binary        using ( Setoid ;  IsEquivalence )
-open import Relation.Unary         using ( Pred ; _⊆_ ; _∈_ )
+-- Imports from the Agda Standard Library ---------------------
+open import Agda.Primitive   using ( lsuc ; _⊔_ ; Level ) renaming ( Set to Type )
+open import Data.Product     using ( _,_ ; Σ ; Σ-syntax )
+open import Function.Base    using ( flip )
+open import Function.Bundles using ( Func )
+open import Relation.Binary  using ( Setoid ;  IsEquivalence )
+open import Relation.Binary.PropositionalEquality
+                             using ( refl )
+open import Relation.Unary   using ( Pred ; _⊆_ ; _∈_ )
 
+-- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries        using ( ∣_∣; ∥_∥)
 open import Algebras.Setoid.Basic {𝑆 = 𝑆} using ( Algebroid ; ⟦_⟧s ; SetoidAlgebra ; _̂_)
 

--- a/src/Foundations/Extensionality.lagda
+++ b/src/Foundations/Extensionality.lagda
@@ -16,14 +16,15 @@ This is the [Foundations.Extensionality][] module of the [Agda Universal Algebra
 module Foundations.Extensionality where
 
 -- imports from Agda and the Agda Standard Library ------------------------------------
-open import Agda.Builtin.Equality  using (_≡_ ; refl )
+open import Axiom.Extensionality.Propositional
+                                   using () renaming ( Extensionality to funext )
 open import Agda.Primitive         using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type ; Setω to Typeω )
 open import Data.Product           using ( _,_ ;  _×_ )
 open import Function.Base          using ( _∘_ ; id )
 open import Relation.Binary        using ( IsEquivalence ) renaming ( Rel to BinRel )
 open import Relation.Unary         using ( Pred ; _⊆_ )
-open import Axiom.Extensionality.Propositional using () renaming ( Extensionality to funext )
-import Relation.Binary.PropositionalEquality as PE
+open import Relation.Binary.PropositionalEquality
+                                   using ( _≡_ ; refl ; module ≡-Reasoning ; cong-app )
 
 
 -- imports from agda-algebras --------------------------------------------------------------
@@ -57,7 +58,7 @@ module _ {A : Type α}{B : Type β} where
  SurjInvIsRightInv : (f : A → B)(fE : IsSurjective f) → ∀ b → f ((SurjInv f fE) b) ≡ b
  SurjInvIsRightInv f fE b = InvIsInv f (fE b)
 
- open PE.≡-Reasoning
+ open ≡-Reasoning
 
  -- composition law for epics
  epic-factor : {C : Type γ}(f : A → B)(g : A → C)(h : C → B)
@@ -89,7 +90,7 @@ module _ {A : Type α}{B : Type β} where
    ζ = SurjInvIsRightInv f fe y
 
    η : (h ∘ g) (finv y) ≡ y
-   η = (PE.cong-app (compId ⁻¹)(finv y)) ∙ ζ
+   η = (cong-app (compId ⁻¹)(finv y)) ∙ ζ
 
    Goal : Image h ∋ y
    Goal = eq (g (finv y)) (η ⁻¹)

--- a/src/Foundations/Truncation.lagda
+++ b/src/Foundations/Truncation.lagda
@@ -20,7 +20,6 @@ Readers who want to learn more about "proof-relevant mathematics" and other conc
 
 module Foundations.Truncation where
 
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
 open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level )
                                renaming ( Set to Type )
 open import Data.Product          using ( _,_ ; Σ ; Σ-syntax ; _×_ )
@@ -29,7 +28,8 @@ open import Function.Base         using ( _∘_ ; id )
 open import Relation.Binary       using ( IsEquivalence )
                                renaming ( Rel to BinRel )
 open import Relation.Unary        using ( Pred ; _⊆_ )
-import Relation.Binary.PropositionalEquality as PE
+open import Relation.Binary.PropositionalEquality
+                                   using ( _≡_ ; refl ; module ≡-Reasoning ; cong-app ; trans )
 
 -- -- Imports from the Agda Universal Algebra Library
 open import Overture.Preliminaries using ( ∣_∣ ; ∥_∥ ; _⁻¹ ; _≈_ ; transport)
@@ -59,7 +59,7 @@ is-prop A = (x y : A) → x ≡ y
 is-prop-valued : {A : Type α} → BinRel A ρ → Type(α ⊔ ρ)
 is-prop-valued  _≈_ = ∀ x y → is-prop (x ≈ y)
 
-open PE.≡-Reasoning
+open ≡-Reasoning
 singleton-is-prop : {α : Level}(X : Type α) → is-singleton X → is-prop X
 singleton-is-prop X (c , φ) x y = x ≡⟨ (φ x)⁻¹ ⟩ c ≡⟨ φ y ⟩ y ∎
 
@@ -81,7 +81,7 @@ is-equiv f = ∀ y → is-singleton (fiber f y)
 
 -- An alternative means of postulating function extensionality.
 hfunext :  ∀ α β → Type (lsuc (α ⊔ β))
-hfunext α β = {A : Type α}{B : A → Type β} (f g : (x : A) → B x) → is-equiv (PE.cong-app{f = f}{g})
+hfunext α β = {A : Type α}{B : A → Type β} (f g : (x : A) → B x) → is-equiv (cong-app{f = f}{g})
 
 \end{code}
 
@@ -174,7 +174,7 @@ monic-is-embedding|Set : (f : A → B) → is-set B → IsInjective f → is-emb
 monic-is-embedding|Set f Bset fmon b (u , fu≡b) (v , fv≡b) = γ
  where
  fuv : f u ≡ f v
- fuv = PE.trans fu≡b (fv≡b ⁻¹)
+ fuv = trans fu≡b (fv≡b ⁻¹)
 
  uv : u ≡ v
  uv = fmon fuv

--- a/src/Foundations/Welldefined.lagda
+++ b/src/Foundations/Welldefined.lagda
@@ -11,20 +11,20 @@ author: [agda-algebras development team][]
 
 module Foundations.Welldefined where
 
-open import Agda.Builtin.Equality using (_≡_; refl)
-open import Agda.Builtin.List     using (List; []; _∷_)
 open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type ; Setω to Typeω )
 open import Axiom.Extensionality.Propositional
                                   using () renaming ( Extensionality to funext )
 open import Data.Fin.Base         using ( Fin ; toℕ)
-open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _+_; _*_ ; _≤_ ; s≤s)
-open import Data.Product                using ( _,_ ; _×_ )
-open import Data.List.Base        using ( lookup ; length ; [_] ; _++_; head ; tail)
+open import Data.Nat.Base         using (ℕ; zero; suc; _+_; _*_ ; _≤_ ; s≤s)
+open import Data.Product          using ( _,_ ; _×_ )
+open import Data.List.Base        using ( List ; [] ; _∷_ ; lookup ; length ; [_] ; _++_; head ; tail)
 open import Data.List.Properties  using ( ≡-dec )
 open import Function.Base         using ( _$_ ; _∘_ ; id )
 open import Relation.Binary       using ( Rel )
-open import Relation.Binary.Definitions  using ( DecidableEquality )
-import Relation.Binary.PropositionalEquality as PE
+open import Relation.Binary.Definitions
+                                  using ( DecidableEquality )
+open import Relation.Binary.PropositionalEquality
+                                  using ( _≡_ ; refl ; module ≡-Reasoning ; cong )
 
 
 open import Overture.Preliminaries using ( _≈_ ; _⁻¹)
@@ -49,7 +49,7 @@ Of course, operations of type `Op I A` are well-defined in the sense that equal 
 \begin{code}
 
 welldef : {A : Type α}{I : Type 𝓥}(f : Op A I) → ∀ u v → u ≡ v → f u ≡ f v
-welldef f u v = PE.cong f
+welldef f u v = cong f
 
 \end{code}
 
@@ -90,7 +90,7 @@ funext' α β = ∀ {A : Type α } {B : Type β } {f g : A → B}
 
 -- `funext ι α` implies `swelldef ι α β`        (Note the universe levels!)
 funext'→swelldef' : funext' ι α → swelldef' ι α β
-funext'→swelldef' fe f ptweq = PE.cong f (fe ptweq)
+funext'→swelldef' fe f ptweq = cong f (fe ptweq)
 
 
  -- `swelldef ι α (ι ⊔ α)` implies `funext ι α`   (Note the universe levels!)
@@ -175,7 +175,7 @@ so f is essentially of type (Fin 2 → A) → B.
 module _ {A : Type α}{B : Type β} where
 
  open Fin renaming ( zero to z ; suc to s )
- open PE.≡-Reasoning
+ open ≡-Reasoning
 
  A×A-wd : (f : A × A → B)(u v : Fin 2 → A)
   →        u ≈ v → (A×A→B-to-Fin2A→B f) u ≡ (A×A→B-to-Fin2A→B f) v

--- a/src/GaloisConnections/Basic.lagda
+++ b/src/GaloisConnections/Basic.lagda
@@ -23,11 +23,11 @@ In other terms, F is a left adjoint of G and G is a right adjoint of F.
 
 module GaloisConnections.Basic where
 
-open import Agda.Primitive          using    ( _⊔_ ;  Level ; lsuc)
-                                    renaming ( Set to Type )
-open import Relation.Binary.Bundles using    ( Poset )
-open import Relation.Binary.Core    using    ( REL ; Rel ; _⇒_ ; _Preserves_⟶_ )
-open import Relation.Unary          using    ( _⊆_ ;  _∈_ ; Pred   )
+-- imports from Agda and the Agda Standard Library
+open import Agda.Primitive          using ( _⊔_ ;  Level ; lsuc) renaming ( Set to Type )
+open import Relation.Binary.Bundles using ( Poset )
+open import Relation.Binary.Core    using ( REL ; Rel ; _⇒_ ; _Preserves_⟶_ )
+open import Relation.Unary          using ( _⊆_ ;  _∈_ ; Pred   )
 
 
 

--- a/src/GaloisConnections/Properties.lagda
+++ b/src/GaloisConnections/Properties.lagda
@@ -11,15 +11,14 @@ author: [agda-algebras development team][]
 
 module GaloisConnections.Properties where
 
-open import Agda.Primitive          using    ( _⊔_ ; Level ; lsuc )
-                                    renaming ( Set to Type )
-open import Data.Product            using    ( _,_ ; _×_ )
-                                    renaming ( proj₁ to fst ; proj₂ to snd )
-open import Data.Product            using    ( swap )
-open import Function.Base           using    ( _∘_ ; id )
-open import Relation.Binary.Bundles using    ( Poset )
-open import Relation.Binary.Core    using    ( REL )
-open import Relation.Unary          using    ( Pred ; _⊆_ )
+-- imports from Agda and the Agda Standard Library
+open import Agda.Primitive          using ( _⊔_ ; Level ; lsuc ) renaming ( Set to Type )
+open import Data.Product            using ( _,_ ; _×_ ) renaming ( proj₁ to fst )
+open import Data.Product            using ( swap )
+open import Function.Base           using ( _∘_ ; id )
+open import Relation.Binary.Bundles using ( Poset )
+open import Relation.Binary.Core    using ( REL )
+open import Relation.Unary          using ( Pred ; _⊆_ )
 import Relation.Binary.Structures as BS
 
 

--- a/src/Homomorphisms/Basic.lagda
+++ b/src/Homomorphisms/Basic.lagda
@@ -13,34 +13,28 @@ This section describes the [Homomorphisms.Basic] module of the [Agda Universal A
 
 {-# OPTIONS --without-K --exact-split --safe #-}
 
-open import Level using ( Level ; Lift )
 open import Algebras.Basic
 
 module Homomorphisms.Basic {𝑆 : Signature 𝓞 𝓥} where
 
+-- Imports from Agda and the Agda Standard Library --------------------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Axiom.Extensionality.Propositional
+                           using () renaming (Extensionality to funext)
+open import Data.Product   using ( _,_ ; Σ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst )
+open import Function.Base  using ( _∘_ ; id )
+open import Level          using ( Level )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; module ≡-Reasoning ; cong ; refl )
 
-open import Axiom.Extensionality.Propositional    using    ()
-                                                  renaming (Extensionality to funext)
-
-open import Agda.Builtin.Equality                 using    ( _≡_      ;   refl  )
-open import Agda.Primitive                        using    ( _⊔_      ;   lsuc  )
-                                                  renaming ( Set      to  Type  )
-open import Data.Product                          using    ( _,_      ;   Σ
-                                                           ; Σ-syntax ;   _×_   )
-                                                  renaming ( proj₁    to  fst
-                                                           ; proj₂    to  snd   )
-open import Function.Base                         using    ( _∘_      ;   id    )
-open import Relation.Binary.PropositionalEquality using    ( trans    ;   cong
-                                                           ; cong-app
-                                                           ; module ≡-Reasoning )
-
-open import Overture.Preliminaries       using (_⁻¹; ∣_∣; ∥_∥)
-open import Overture.Inverses            using (IsInjective; IsSurjective; Image_∋_)
-open import Foundations.Welldefined      using (swelldef)
-open import Relations.Discrete           using (ker)
-open import Relations.Quotients          using (ker-IsEquivalence; _/_; ⟪_⟫; R-block)
-open import Algebras.Congruences {𝑆 = 𝑆} using (Con; IsCongruence; mkcon; _╱_; /-≡)
-open import Algebras.Products    {𝑆 = 𝑆} using (⨅)
+-- Imports from agda-algebras --------------------------------------------------------------
+open import Overture.Preliminaries       using ( _⁻¹ ; ∣_∣ ; ∥_∥)
+open import Overture.Inverses            using ( IsInjective ; IsSurjective ; Image_∋_ )
+open import Foundations.Welldefined      using ( swelldef )
+open import Relations.Discrete           using ( ker )
+open import Relations.Quotients          using ( ker-IsEquivalence ; _/_ ; ⟪_⟫ ; R-block )
+open import Algebras.Congruences {𝑆 = 𝑆} using ( Con ; IsCongruence ; mkcon ; _╱_ ; /-≡ )
+open import Algebras.Products    {𝑆 = 𝑆} using ( ⨅ )
 
 private variable α β γ ρ : Level
 

--- a/src/Homomorphisms/HomomorphicImages.lagda
+++ b/src/Homomorphisms/HomomorphicImages.lagda
@@ -13,22 +13,18 @@ This is the [Homomorphisms.HomomorphicImages][] module of the [Agda Universal Al
 
 {-# OPTIONS --without-K --exact-split --safe #-}
 
-open import Level using ( Level ; Lift )
 open import Algebras.Basic
 
 module Homomorphisms.HomomorphicImages {𝑆 : Signature 𝓞 𝓥} where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Agda.Primitive        using    ( _⊔_ ; lsuc )
-                                  renaming ( Set to Type )
-open import Agda.Builtin.Equality using    ( _≡_ ; refl )
-open import Data.Product          using    ( _,_ ; Σ-syntax ; Σ ; _×_ )
-                                  renaming ( proj₁ to fst
-                                           ; proj₂ to snd )
-open import Relation.Binary.PropositionalEquality.Core
-                                  using    ( cong ; cong-app ; module ≡-Reasoning )
-open import Relation.Unary        using    ( Pred ; _∈_ )
+-- Imports from Agda and the Agda Standard Library --------------------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product   using ( _,_ ; Σ-syntax ; Σ ; _×_ )
+open import Level          using ( Level )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; module ≡-Reasoning ; cong ; cong-app )
+open import Relation.Unary using ( Pred ; _∈_ )
 
 
 -- Imports from agda-algebras --------------------------------------------------------------

--- a/src/Homomorphisms/Isomorphisms.lagda
+++ b/src/Homomorphisms/Isomorphisms.lagda
@@ -14,20 +14,21 @@ Here we formalize the informal notion of isomorphism between algebraic structure
 
 {-# OPTIONS --without-K --exact-split --safe #-}
 
-open import Level using ( Level ; Lift )
 open import Algebras.Basic
 
 module Homomorphisms.Isomorphisms {𝑆 : Signature 𝓞 𝓥}  where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Axiom.Extensionality.Propositional using ()  renaming (Extensionality to funext )
-open import Agda.Primitive          using ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Agda.Builtin.Equality   using ( _≡_ ; refl )
-open import Data.Product            using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst )
-open import Function.Base           using ( _∘_ )
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Agda.Primitive              using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Axiom.Extensionality.Propositional
+                                        using () renaming (Extensionality to funext )
+open import Data.Product                using ( _,_ ; Σ-syntax ; _×_ )
+open import Function.Base               using ( _∘_ )
+open import Level                       using ( Level )
 open import Relation.Binary.Definitions using ( Reflexive ; Sym ; Symmetric; Trans; Transitive )
-import Relation.Binary.PropositionalEquality as PE
+open import Relation.Binary.PropositionalEquality
+                                        using ( _≡_ ; refl ; cong ; module ≡-Reasoning ; cong-app )
 
 
 -- Imports from agda-algebras --------------------------------------------------------------
@@ -91,10 +92,10 @@ private variable α β γ ι : Level
   g = ∘-hom 𝑪 𝑨 (from bc) (from ab)
 
   τ : ∣ f ∣ ∘ ∣ g ∣ ≈ ∣ 𝒾𝒹 𝑪 ∣
-  τ x = (PE.cong ∣ to bc ∣(to∼from ab (∣ from bc ∣ x)))∙(to∼from bc) x
+  τ x = (cong ∣ to bc ∣(to∼from ab (∣ from bc ∣ x)))∙(to∼from bc) x
 
   ν : ∣ g ∣ ∘ ∣ f ∣ ≈ ∣ 𝒾𝒹 𝑨 ∣
-  ν x = (PE.cong ∣ from ab ∣(from∼to bc (∣ to ab ∣ x)))∙(from∼to ab) x
+  ν x = (cong ∣ from ab ∣(from∼to bc (∣ to ab ∣ x)))∙(from∼to ab) x
 
 
 -- The "to" map of an isomorphism is injective.
@@ -103,9 +104,9 @@ private variable α β γ ι : Level
 
 ≅toInjective (mkiso (f , _) (g , _) _ g∼f){a}{b} fafb =
  a       ≡⟨ (g∼f a)⁻¹ ⟩
- g (f a) ≡⟨ PE.cong g fafb ⟩
+ g (f a) ≡⟨ cong g fafb ⟩
  g (f b) ≡⟨ g∼f b ⟩
- b       ∎ where open PE.≡-Reasoning
+ b       ∎ where open ≡-Reasoning
 
 
 -- The "from" map of an isomorphism is injective.
@@ -130,8 +131,8 @@ open Level
 Lift-≅ : {α β : Level}{𝑨 : Algebra α 𝑆} → 𝑨 ≅ (Lift-Alg 𝑨 β)
 Lift-≅{β = β}{𝑨 = 𝑨} = record { to = 𝓁𝒾𝒻𝓉 𝑨
                               ; from = 𝓁ℴ𝓌ℯ𝓇 𝑨
-                              ; to∼from = PE.cong-app lift∼lower
-                              ; from∼to = PE.cong-app (lower∼lift {β = β})
+                              ; to∼from = cong-app lift∼lower
+                              ; from∼to = cong-app (lower∼lift {β = β})
                               }
 
 Lift-Alg-iso : {α β : Level}{𝑨 : Algebra α 𝑆}{𝓧 : Level}

--- a/src/Homomorphisms/Noether.lagda
+++ b/src/Homomorphisms/Noether.lagda
@@ -13,20 +13,19 @@ This is the [Homomorphisms.Noether][] module of the [Agda Universal Algebra Libr
 
 {-# OPTIONS --without-K --exact-split --safe #-}
 
-open import Level using ( Level )
 open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
 module Homomorphisms.Noether {𝑆 : Signature 𝓞 𝓥} where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
-open import Agda.Primitive        using ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Data.Product          using ( Σ-syntax ; _,_ ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
-open import Function.Base         using ( _∘_ ; id )
-open import Relation.Binary       using ( IsEquivalence )
-open import Relation.Unary        using ( _⊆_ )
-import Relation.Binary.PropositionalEquality as PE
+-- Imports from Agda and the Agda Standard Library ---------------------------------------
+open import Agda.Primitive  using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product    using ( Σ-syntax ; _,_ ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function.Base   using ( _∘_ ; id )
+open import Relation.Binary using ( IsEquivalence )
+open import Relation.Binary.PropositionalEquality
+                            using ( _≡_ ; refl ; module ≡-Reasoning ; cong ; cong-app )
+open import Relation.Unary  using ( _⊆_ )
 
 
 -- Imports from agda-algebras --------------------------------------------------------------
@@ -65,7 +64,7 @@ Note that the classical, informal statement of the first homomorphism theorem do
 Without further ado, we present our formalization of the first homomorphism theorem.<sup>[2](Homomorphisms.Noether.html#fn2)</sup>
 
 \begin{code}
-open PE.≡-Reasoning
+open ≡-Reasoning
 
 FirstHomTheorem|Set :
 
@@ -89,7 +88,7 @@ FirstHomTheorem|Set 𝑨 𝑩 h pe fe Bset buip = (φ , φhom) , refl , φmon , 
 
   φhom : is-homomorphism (ker[ 𝑨 ⇒ 𝑩 ] h ↾ fe) 𝑩 φ
   φhom 𝑓 a = ∣ h ∣ ( (𝑓 ̂ 𝑨) (λ x → ⌞ a x ⌟) ) ≡⟨ ∥ h ∥ 𝑓 (λ x → ⌞ a x ⌟)  ⟩
-             (𝑓 ̂ 𝑩) (∣ h ∣ ∘ (λ x → ⌞ a x ⌟))  ≡⟨ PE.cong (𝑓 ̂ 𝑩) refl ⟩
+             (𝑓 ̂ 𝑩) (∣ h ∣ ∘ (λ x → ⌞ a x ⌟))  ≡⟨ cong (𝑓 ̂ 𝑩) refl ⟩
              (𝑓 ̂ 𝑩) (λ x → φ (a x))            ∎
 
   φmon : IsInjective φ
@@ -151,8 +150,8 @@ module _ {fe : swelldef 𝓥 β}(𝑨 : Algebra α 𝑆)(𝑩 : Algebra β 𝑆)
   →                 ∀ a  →  ∣ f ∣ a ≡ ∣ g ∣ a
 
  NoetherHomUnique f g hfk hgk (_ , R-block a refl) =
-  ∣ f ∣ (_ , R-block a refl) ≡⟨ PE.cong-app(hfk ⁻¹)a ⟩
-  ∣ h ∣ a                    ≡⟨ PE.cong-app(hgk)a ⟩
+  ∣ f ∣ (_ , R-block a refl) ≡⟨ cong-app(hfk ⁻¹)a ⟩
+  ∣ h ∣ a                    ≡⟨ cong-app(hgk)a ⟩
   ∣ g ∣ (_ , R-block a refl) ∎
 
 \end{code}
@@ -230,11 +229,12 @@ module _ {𝑨 : Algebra α 𝑆}{𝑪 : Algebra γ 𝑆} where
    τφν = λ x → Kντ (ξ x)
 
    φIsHomCB : ∀ 𝑓 c → φ ((𝑓 ̂ 𝑪) c) ≡ ((𝑓 ̂ 𝑩)(φ ∘ c))
-   φIsHomCB 𝑓 c = φ ((𝑓 ̂ 𝑪) c)     ≡⟨ PE.cong φ (wd (𝑓 ̂ 𝑪) c (∣ ν ∣ ∘ (νInv ∘ c)) (λ i → (η (c i))⁻¹)) ⟩
-                  φ ((𝑓 ̂ 𝑪)(∣ ν ∣ ∘(νInv ∘ c)))   ≡⟨ PE.cong φ (∥ ν ∥ 𝑓 (νInv ∘ c))⁻¹ ⟩
-                  φ (∣ ν ∣((𝑓 ̂ 𝑨)(νInv ∘ c)))     ≡⟨ (τφν ((𝑓 ̂ 𝑨)(νInv ∘ c)))⁻¹ ⟩
-                  ∣ τ ∣((𝑓 ̂ 𝑨)(νInv ∘ c))         ≡⟨ ∥ τ ∥ 𝑓 (νInv ∘ c) ⟩
-                  (𝑓 ̂ 𝑩)(λ x → ∣ τ ∣(νInv (c x))) ∎
+   φIsHomCB 𝑓 c =
+    φ ((𝑓 ̂ 𝑪) c)                    ≡⟨ cong φ (wd (𝑓 ̂ 𝑪) c (∣ ν ∣ ∘ (νInv ∘ c)) (λ i → (η (c i))⁻¹))⟩
+    φ ((𝑓 ̂ 𝑪)(∣ ν ∣ ∘(νInv ∘ c)))   ≡⟨ cong φ (∥ ν ∥ 𝑓 (νInv ∘ c))⁻¹ ⟩
+    φ (∣ ν ∣((𝑓 ̂ 𝑨)(νInv ∘ c)))     ≡⟨ (τφν ((𝑓 ̂ 𝑨)(νInv ∘ c)))⁻¹ ⟩
+    ∣ τ ∣((𝑓 ̂ 𝑨)(νInv ∘ c))         ≡⟨ ∥ τ ∥ 𝑓 (νInv ∘ c) ⟩
+    (𝑓 ̂ 𝑩)(λ x → ∣ τ ∣(νInv (c x))) ∎
 
 \end{code}
 

--- a/src/Homomorphisms/Setoid/Basic.lagda
+++ b/src/Homomorphisms/Setoid/Basic.lagda
@@ -18,18 +18,14 @@ open import Algebras.Basic using (𝓞 ; 𝓥 ; Signature )
 module Homomorphisms.Setoid.Basic {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from the Agda (Builtin) and the Agda Standard Library
-open import Agda.Builtin.Equality  using    ( _≡_      ;  refl )
-open import Agda.Primitive         using    ( _⊔_      ;  lsuc )
-                                   renaming ( Set      to Type )
-open import Data.Product           using    ( _,_      ;  Σ
-                                            ; Σ-syntax ;  _×_  )
-                                   renaming ( proj₁    to fst
-                                            ; proj₂    to snd  )
-open import Function               using    ( _∘_      ;  id   )
-open import Level                  using    ( Level    ;  Lift )
-open import Relation.Binary        using    ( IsEquivalence    )
-open import Relation.Unary         using    ( _⊆_              )
-open import Relation.Binary.PropositionalEquality using (module ≡-Reasoning ; cong )
+open import Agda.Primitive    using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product      using ( _,_ ; Σ ; Σ-syntax ; _×_ )
+open import Function          using ( _∘_ ; id )
+open import Level             using ( Level ; Lift )
+open import Relation.Binary   using ( IsEquivalence )
+open import Relation.Unary    using ( _⊆_ )
+open import Relation.Binary.PropositionalEquality
+                              using ( _≡_ ; refl ; module ≡-Reasoning ; cong )
 
 
 -- Imports from the Agda Universal Algebra Library

--- a/src/Homomorphisms/Setoid/HomomorphicImages.lagda
+++ b/src/Homomorphisms/Setoid/HomomorphicImages.lagda
@@ -20,11 +20,11 @@ module Homomorphisms.Setoid.HomomorphicImages {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
 open import Agda.Primitive        using ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
-open import Data.Product          using ( _,_ ; Σ-syntax ; Σ ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Data.Product          using ( _,_ ; Σ-syntax ; _×_ )
 open import Level                 using ( Level ; Lift )
-open import Relation.Binary.PropositionalEquality.Core using ( cong ; cong-app ; module ≡-Reasoning ; sym )
 open import Relation.Unary        using ( Pred ; _∈_ )
+open import Relation.Binary.PropositionalEquality
+                                  using ( sym ; cong-app ; _≡_ ; module ≡-Reasoning ; cong )
 
 
 -- Imports from agda-algebras --------------------------------------------------------------

--- a/src/Homomorphisms/Setoid/Isomorphisms.lagda
+++ b/src/Homomorphisms/Setoid/Isomorphisms.lagda
@@ -18,14 +18,14 @@ module Homomorphisms.Setoid.Isomorphisms {𝑆 : Signature 𝓞 𝓥}  where
 
 -- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
 open import Axiom.Extensionality.Propositional using () renaming (Extensionality to funext )
-open import Agda.Builtin.Equality       using ( _≡_ ; refl )
 open import Agda.Primitive              using ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Data.Product                using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Data.Product                using ( _,_ ; Σ-syntax ; _×_ )
 open import Function.Base               using ( _∘_ )
 open import Level                       using ( Level ; Lift )
 open import Relation.Binary             using ( Setoid ; REL)
 open import Relation.Binary.Definitions using ( Reflexive ; Sym ; Trans ; Transitive )
-import Relation.Binary.PropositionalEquality as PE
+open import Relation.Binary.PropositionalEquality
+                                        using ( _≡_ ; refl ; cong ; module ≡-Reasoning ; cong-app )
 
 
 -- Imports from agda-algebras --------------------------------------------------------------
@@ -94,10 +94,10 @@ That is, two structures are **isomorphic** provided there are homomorphisms goin
   g = ∘-hom 𝑪 𝑩 𝑨 (from bc) (from ab)
 
   τ : ∣ f ∣ ∘ ∣ g ∣ ≋ ∣ 𝒾𝒹 𝑪 ∣
-  τ x = (PE.cong ∣ to bc ∣(to∼from ab (∣ from bc ∣ x)))∙(to∼from bc) x
+  τ x = (cong ∣ to bc ∣(to∼from ab (∣ from bc ∣ x)))∙(to∼from bc) x
 
   ν : ∣ g ∣ ∘ ∣ f ∣ ≋ ∣ 𝒾𝒹 𝑨 ∣
-  ν x = (PE.cong ∣ from ab ∣(from∼to bc (∣ to ab ∣ x)))∙(from∼to ab) x
+  ν x = (cong ∣ from ab ∣(from∼to bc (∣ to ab ∣ x)))∙(from∼to ab) x
 
 
 -- The "to" map of an isomorphism is injective.
@@ -106,9 +106,9 @@ That is, two structures are **isomorphic** provided there are homomorphisms goin
 
 ≅toInjective (mkiso (f , _) (g , _) _ g∼f){a}{b} fafb =
  a       ≡⟨ (g∼f a)⁻¹ ⟩
- g (f a) ≡⟨ PE.cong g fafb ⟩
+ g (f a) ≡⟨ cong g fafb ⟩
  g (f b) ≡⟨ g∼f b ⟩
- b       ∎ where open PE.≡-Reasoning
+ b       ∎ where open ≡-Reasoning
 
 
 -- The "from" map of an isomorphism is injective.
@@ -131,8 +131,8 @@ open Level
 Lift-≅ : {ℓ : Level}{𝑨 : SetoidAlgebra α ρᵃ} → 𝑨 ≅ (Lift-SetoidAlg 𝑨 ℓ)
 Lift-≅ {ℓ = ℓ} {𝑨} = record { to = 𝓁𝒾𝒻𝓉 {𝑨 = 𝑨}
                               ; from = 𝓁ℴ𝓌ℯ𝓇  {𝑨 = 𝑨}
-                              ; to∼from = PE.cong-app lift∼lower
-                              ; from∼to = PE.cong-app (lower∼lift {β = ℓ})
+                              ; to∼from = cong-app lift∼lower
+                              ; from∼to = cong-app (lower∼lift {β = ℓ})
                               }
 
 Lift-SetoidAlg-iso : {ℓᵃ : Level}{𝑨 : SetoidAlgebra α ρᵃ}

--- a/src/Homomorphisms/Setoid/Noether.lagda
+++ b/src/Homomorphisms/Setoid/Noether.lagda
@@ -20,8 +20,7 @@ module Homomorphisms.Setoid.Noether {𝑆 : Signature 𝓞 𝓥} where
 open import Data.Product    using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
 open import Function        using ( _∘_ ; id )
 open import Level           using ( Level )
-open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl ; sym ; cong )
-open import Relation.Binary.PropositionalEquality.Core using ( module ≡-Reasoning )
+open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl ; sym ; cong ; module ≡-Reasoning )
 open import Relation.Unary  using ( _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library

--- a/src/Overture/Inverses.lagda
+++ b/src/Overture/Inverses.lagda
@@ -16,14 +16,15 @@ This is the [Overture.Inverses][] module of the [agda-algebras][] library.
 
 module Overture.Inverses where
 
--- Imports from Agda (Builtin) and the Agda Standard Library
-open import Agda.Builtin.Equality       using ( _≡_ ; refl )
+-- Imports from Agda and the Agda Standard Library
 open import Agda.Primitive              using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
 open import Data.Product                using ( _,_ ; _×_ ; Σ )
 open import Function.Base               using ( _∘_ )
 open import Function.Definitions        using ( Injective )
 open import Function.Bundles            using ( _↣_ ; mk↣ )
 open import Function.Construct.Identity using ( id-↣ )
+open import Relation.Binary.PropositionalEquality
+                                        using ( _≡_ ; refl )
 
 -- Imports from agda-algebras
 open import Overture.Preliminaries using ( _⁻¹ )

--- a/src/Overture/Preliminaries.lagda
+++ b/src/Overture/Preliminaries.lagda
@@ -39,13 +39,13 @@ The `OPTIONS` pragma is usually followed by the start of a module.  For example,
 module Overture.Preliminaries where
 
 -- Imports from the Agda (Builtin) and the Agda Standard Library
-open import Agda.Builtin.Equality       using ( _≡_ ; refl )
 open import Agda.Primitive              using ( _⊔_ ; lsuc )           renaming ( Set to  Type ; lzero to  ℓ₀ )
 open import Data.Product                using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
 open import Function.Base               using ( _∘_ ; id )
 open import Level                       using ( Level ; Lift ; lift ; lower )
 open import Relation.Binary.Structures  using ( IsEquivalence ; IsPartialOrder )
-open import Relation.Binary.PropositionalEquality as PE
+open import Relation.Binary.PropositionalEquality
+                                        using    ( _≡_ ; refl ; sym ; trans )
 
 private variable α β : Level
 
@@ -99,7 +99,7 @@ Let's define some useful syntactic sugar that will make it easier to apply symme
 \begin{code}
 
 _⁻¹ : {A : Type α} {x y : A} → x ≡ y → y ≡ x
-p ⁻¹ = PE.sym p
+p ⁻¹ = sym p
 
 infix  40 _⁻¹
 

--- a/src/Overture/Transformers.lagda
+++ b/src/Overture/Transformers.lagda
@@ -16,13 +16,13 @@ This is the [Overture.Transformers][] module of the [agda-algebras][] library.  
 
 module Overture.Transformers where
 
--- Imports from Agda (Builtin) and the Agda Standard Library
-open import Agda.Builtin.Equality       using ( _≡_ ; refl )
-open import Agda.Primitive              using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
-open import Data.Product                using ( _,_ ; _×_ )
-open import Data.Fin.Base               using ( Fin )
-open import Function.Base               using ( _∘_ ; id )
-import Relation.Binary.PropositionalEquality as PE
+-- Imports from Agda and the Agda Standard Library
+open import Agda.Primitive using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product   using ( _,_ ; _×_ )
+open import Data.Fin.Base  using ( Fin )
+open import Function.Base  using ( _∘_ ; id )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; refl ; module ≡-Reasoning )
 
 -- Imports from agda-algebras
 open import Overture.Preliminaries using ( _≈_ )
@@ -157,7 +157,7 @@ module _ {A : Type α} {B : Type β} where
  CurryFin2~UncurryFin2 : CurryFin2 ∘ UncurryFin2 ≡ id
  CurryFin2~UncurryFin2 = refl
 
- open PE.≡-Reasoning
+ open ≡-Reasoning
  -- UncurryFin2~CurryFin2 : ∀ f u → (UncurryFin2 ∘ CurryFin2) f u ≡ f u
  -- UncurryFin2~CurryFin2 f u = Goal
  --  where

--- a/src/Relations/BinPred.lagda
+++ b/src/Relations/BinPred.lagda
@@ -15,12 +15,13 @@ This is the [Relations.BinPred][] module of the [Agda Universal Algebra Library]
 
 module Relations.BinPred where
 
-open import Agda.Builtin.Equality using ( _≡_ )
 open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
 open import Data.Product          using ( _,_ ; _×_ )
 open import Data.Sum.Base         using ( _⊎_ )
 open import Relation.Binary.Core  using ( ) renaming ( REL to BinREL ; Rel to BinRel )
 open import Relation.Unary        using ( Pred ; _∈_ ; _∉_ )
+open import Relation.Binary.PropositionalEquality
+                                  using ( _≡_ )
 
 
 private variable

--- a/src/Relations/Continuous.lagda
+++ b/src/Relations/Continuous.lagda
@@ -15,8 +15,7 @@ This is the [Relations.Continuous][] module of the [Agda Universal Algebra Libra
 
 module Relations.Continuous where
 
-open import Agda.Primitive    using ( _⊔_ ; lsuc ; Level )
-                           renaming ( Set to Type )
+open import Agda.Primitive using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
 
 open import Overture.Preliminaries using ( Π ; Π-syntax )
 open import Relations.Discrete     using ( Op ; arity[_] )

--- a/src/Relations/Discrete.lagda
+++ b/src/Relations/Discrete.lagda
@@ -15,19 +15,20 @@ This is the [Relations.Discrete][] module of the [Agda Universal Algebra Library
 
 module Relations.Discrete where
 
-open import Agda.Builtin.Equality       using ( _≡_ ; refl )
-open import Agda.Primitive              using ( _⊔_ ; lsuc )
-                                     renaming ( Set to Type )
-open import Data.Product                using ( _,_ ; _×_ )
-open import Function.Base               using ( _∘_ )
-open import Level                       using ( Level ; Lift )
-open import Relation.Binary             using ( IsEquivalence )
-open import Relation.Binary.Core        using ( _⇒_ ; _=[_]⇒_  )
-                                     renaming ( REL to BinREL ; Rel to BinRel )
-open import Relation.Binary.Definitions using ( Reflexive ; Symmetric ; Transitive )
-open import Relation.Unary              using ( ∅; _∈_; Pred )
+-- Imports from Agda and the Agda Standard Library
+open import Agda.Primitive       using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product         using ( _,_ ; _×_ )
+open import Function.Base        using ( _∘_ )
+open import Level                using ( Level ; Lift )
+open import Relation.Binary      using ( IsEquivalence )
+open import Relation.Binary.Core using ( _⇒_ ; _=[_]⇒_ ) renaming ( REL to BinREL ; Rel to BinRel )
+open import Relation.Binary.Definitions
+                                 using ( Reflexive ; Symmetric ; Transitive )
+open import Relation.Unary       using ( ∅; _∈_; Pred )
+open import Relation.Binary.PropositionalEquality
+                                 using ( _≡_ ; refl )
 
-
+-- Imports from agda-algebras
 open import Overture.Preliminaries using (_≈_ ; Π-syntax)
 
 private variable α β ρ 𝓥 : Level

--- a/src/Relations/Quotients.lagda
+++ b/src/Relations/Quotients.lagda
@@ -15,16 +15,13 @@ This is the [Relations.Quotients][] module of the [Agda Universal Algebra Librar
 
 module Relations.Quotients where
 
-open import Agda.Builtin.Equality as E using ( _≡_ )
-open import Data.Product               using ( _,_ ; _×_ ; Σ-syntax )
-                                    renaming ( proj₁ to fst ; proj₂ to snd )
-open import Agda.Primitive             using ( _⊔_ ; Level ; lsuc )
-                                    renaming ( Set to Type )
-open import Level                      using ( )
-open import Relation.Binary            using ( IsEquivalence ; IsPartialEquivalence)
-                                    renaming ( Rel to BinRel )
-open import Relation.Unary             using ( Pred ; _⊆_ )
-import Relation.Binary.PropositionalEquality as PE
+open import Data.Product    using ( _,_ ; _×_ ; Σ-syntax ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Agda.Primitive  using ( _⊔_ ; Level ; lsuc ) renaming ( Set to Type )
+open import Level           using ()
+open import Relation.Binary using ( IsEquivalence ; IsPartialEquivalence) renaming ( Rel to BinRel )
+open import Relation.Unary  using ( Pred ; _⊆_ )
+open import Relation.Binary.PropositionalEquality as PE
+                            using ( _≡_ )
 
 open import Overture.Preliminaries  using  ( ∣_∣ )
 open import Relations.Discrete      using  ( ker ; 0[_] ; kerlift )

--- a/src/Residuation/Basic.lagda
+++ b/src/Residuation/Basic.lagda
@@ -13,11 +13,10 @@ author: [agda-algebras development team][]
 
 module Residuation.Basic where
 
-open import Agda.Primitive          using    ( _⊔_ ;  Level ; lsuc)
-                                    renaming ( Set to Type )
-open import Function.Base           using    ( _on_ )
-open import Relation.Binary.Bundles using    ( Poset )
-open import Relation.Binary.Core    using    ( _Preserves_⟶_ )
+open import Agda.Primitive          using ( _⊔_ ;  Level ; lsuc) renaming ( Set to Type )
+open import Function.Base           using ( _on_ )
+open import Relation.Binary.Bundles using ( Poset )
+open import Relation.Binary.Core    using ( _Preserves_⟶_ )
 
 
 module _ {α ιᵃ ρᵃ : Level} (A : Poset α ιᵃ ρᵃ)

--- a/src/Residuation/Properties.lagda
+++ b/src/Residuation/Properties.lagda
@@ -13,11 +13,10 @@ author: [agda-algebras development team][]
 
 module Residuation.Properties where
 
-open import Agda.Primitive          using    ( _⊔_ ;  Level ; lsuc)
-                                    renaming ( Set to Type )
-open import Function.Base           using    ( _on_ ; _∘_ )
-open import Relation.Binary.Bundles using    ( Poset )
-open import Relation.Binary.Core    using    ( _Preserves_⟶_ )
+open import Agda.Primitive          using ( _⊔_ ; Level ; lsuc) renaming ( Set to Type )
+open import Function.Base           using ( _on_ ; _∘_ )
+open import Relation.Binary.Bundles using ( Poset )
+open import Relation.Binary.Core    using ( _Preserves_⟶_ )
 
 open import Relations.Discrete      using    ( PointWise )
 

--- a/src/Structures/Basic.lagda
+++ b/src/Structures/Basic.lagda
@@ -14,11 +14,13 @@ inhabitants of record types.  For a similar development using Sigma types see th
 
 module Structures.Basic  where
 
-open import Agda.Primitive       using    ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Function.Base        using    ( flip ; _∘_ )
-open import Level                using    ( Level ; Lift ; lift ; lower )
-open import Relation.Binary.Core using    () renaming ( Rel to BinRel )
+-- imports from Agda and the Agda Standard Library -------------------------------------------
+open import Agda.Primitive       using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Function.Base        using ( flip ; _∘_ )
+open import Level                using ( Level ; Lift ; lift ; lower )
+open import Relation.Binary.Core using () renaming ( Rel to BinRel )
 
+-- imports from agda-algebras --------------------------------------------------------------
 open import Relations.Discrete     using ( Op ; _|:_ ; _preserves_ )
 open import Relations.Continuous   using ( Rel )
 

--- a/src/Structures/Congruences.lagda
+++ b/src/Structures/Congruences.lagda
@@ -17,20 +17,23 @@ dependent pair type.
 
 module Structures.Congruences where
 
-open import Agda.Builtin.Equality  using ( _≡_ ; refl )
-open import Agda.Primitive         using ( _⊔_ ; lsuc ) renaming ( Set  to Type )
-open import Data.Product           using ( _,_ ; _×_ ; Σ-syntax ) renaming ( proj₁ to fst )
-open import Function.Base          using ( _∘_ )
-open import Level                  using ( Level ; Lift ; lift ; lower )
+-- imports from Agda and the Agda Standard Library -------------------------------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set  to Type )
+open import Data.Product   using ( _,_ ; _×_ ; Σ-syntax ) renaming ( proj₁ to fst )
+open import Function.Base  using ( _∘_ )
+open import Level          using ( Level ; Lift ; lift ; lower )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; refl )
 
 
-open import Overture.Preliminaries   using ( ∣_∣ )
-open import Relations.Discrete       using ( _|:_ ; 0[_] )
-open import Relations.Quotients      using ( Equivalence ; Quotient ; 0[_]Equivalence
-                                           ; ⟪_⟫ ; ⌞_⌟ ; ⟪_∼_⟫-elim ; _/_ )
-open import Foundations.Welldefined  using ( swelldef )
-open import Structures.Basic         using ( signature ; structure ; sigl ; siglʳ
-                                           ; compatible )
+-- imports from agda-algebras --------------------------------------------------------------
+open import Overture.Preliminaries using ( ∣_∣ )
+open import Relations.Discrete     using ( _|:_ ; 0[_] )
+open import Relations.Quotients    using ( Equivalence ; Quotient ; 0[_]Equivalence
+                                         ; ⟪_⟫ ; ⌞_⌟ ; ⟪_∼_⟫-elim ; _/_ )
+open import Foundations.Welldefined using ( swelldef )
+open import Structures.Basic        using ( signature ; structure ; sigl ; siglʳ
+                                          ; compatible )
 
 private variable
  𝓞₀ 𝓥₀ 𝓞₁ 𝓥₁ : Level

--- a/src/Structures/EquationalLogic.lagda
+++ b/src/Structures/EquationalLogic.lagda
@@ -11,14 +11,14 @@ author: [agda-algebras development team][]
 
 module Structures.EquationalLogic where
 
+-- imports from Agda and the Agda Standard Library -------------------------------------------
 open import Agda.Primitive using ( lsuc ; _⊔_ ; Level ) renaming ( Set to Type )
 open import Data.Fin.Base  using ( Fin )
 open import Data.Nat       using ( ℕ )
 open import Data.Product   using ( _,_ ;  _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
 open import Relation.Unary using ( Pred ; _∈_ )
 
-
--- -- Imports from agda-algebras --------------------------------------
+-- Imports from agda-algebras --------------------------------------
 open import Overture.Preliminaries  using ( _≈_ )
 open import Structures.Basic        using ( signature ; structure ; _ᵒ_ )
 open import Structures.Terms.Basic

--- a/src/Structures/Graphs.lagda
+++ b/src/Structures/Graphs.lagda
@@ -17,15 +17,14 @@ The *graph* of 𝑨 is the structure Gr 𝑨 with the same domain as 𝑨 with r
 
 module Structures.Graphs where
 
-open import Agda.Primitive         using    ( _⊔_ ; lsuc ; Level )
-                                   renaming ( Set to Type ; lzero  to ℓ₀ )
-open import Agda.Builtin.Equality  using    ( _≡_ ; refl )
-open import Data.Product           using    ( _,_ ; Σ-syntax ; _×_ )
-open import Data.Sum.Base          using    ( _⊎_ )
-                                   renaming ( inj₁ to inl ; inj₂ to inr )
-open import Level                  using    ( Lift ; lift ; lower )
-open import Function.Base          using    ( _∘_  )
-import Relation.Binary.PropositionalEquality as PE
+-- imports from Agda and the Agda Standard Library -------------------------------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type ; lzero  to ℓ₀ )
+open import Data.Product   using ( _,_ ; Σ-syntax ; _×_ )
+open import Data.Sum.Base  using ( _⊎_ ) renaming ( inj₁ to inl ; inj₂ to inr )
+open import Level          using ( Level ; Lift ; lift ; lower )
+open import Function.Base  using ( _∘_  )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; refl ; module ≡-Reasoning ; cong ; sym )
 
 
 -- Imports from agda-algebras --------------------------------------------------------------
@@ -62,7 +61,7 @@ Gr {𝐹}{𝑅}{α}{ρ} 𝑨 = record { carrier = carrier 𝑨 ; op = λ () ; re
   split (inr 𝑓) args = Lift ρ (op 𝑨 𝑓 (args ∘ inl) ≡ args (inr 𝟙.𝟎))
 
 
-open PE.≡-Reasoning
+open ≡-Reasoning
 
 private variable
  ρᵃ β ρᵇ : Level
@@ -81,8 +80,8 @@ module _ {𝑨 : structure 𝐹 𝑅 {α} {ρᵃ}}
    homop = ∥ hhom ∥ 𝑓 (a ∘ inl)
 
    goal : op 𝑩 𝑓 (h ∘ (a ∘ inl)) ≡ h (a (inr 𝟙.𝟎))
-   goal = op 𝑩 𝑓 (h ∘ (a ∘ inl)) ≡⟨ PE.sym homop ⟩
-          h (op 𝑨 𝑓 (a ∘ inl))   ≡⟨ PE.cong h (lower x) ⟩
+   goal = op 𝑩 𝑓 (h ∘ (a ∘ inl)) ≡⟨ sym homop ⟩
+          h (op 𝑨 𝑓 (a ∘ inl))   ≡⟨ cong h (lower x) ⟩
           h (a (inr 𝟙.𝟎))         ∎
 
   ii : is-hom-op (Gr 𝑨) (Gr 𝑩) h
@@ -101,7 +100,7 @@ module _ {𝑨 : structure 𝐹 𝑅 {α} {ρᵃ}}
    split (inl x) = a x
    split (inr y) = op 𝑨 f a
    goal : h (op 𝑨 f a) ≡ op 𝑩 f (λ x → h (a x))
-   goal = PE.sym (lower (∣ hhom ∣ (inr f) split (lift refl)))
+   goal = sym (lower (∣ hhom ∣ (inr f) split (lift refl)))
 
 
 \end{code}

--- a/src/Structures/Graphs0.lagda
+++ b/src/Structures/Graphs0.lagda
@@ -17,19 +17,18 @@ The *graph* of 𝑨 is the structure Gr 𝑨 with the same domain as 𝑨 with r
 
 module Structures.Graphs0 where
 
-open import Agda.Primitive          using    ( _⊔_ ; Level )
-                                    renaming ( Set to Type ; lzero to ℓ₀ )
-open import Agda.Builtin.Equality   using    ( _≡_ ; refl )
-open import Data.Product            using    ( _,_ ; _×_ ; Σ-syntax )
-open import Data.Sum.Base           using    ( _⊎_ )
-                                    renaming ( inj₁ to inl ; inj₂ to inr )
-open import Data.Fin.Base                         using ( Fin )
-open import Data.Nat                              using ( ℕ )
-open import Function.Base           using    ( _∘_ )
-open import Relation.Unary          using    ( Pred ; _∈_ ) -- ∅; Pred ; _⊆_ ; ⋂ ; ｛_｝ ; _∪_ )
-import Relation.Binary.PropositionalEquality as PE
+-- imports from Agda and the Agda Standard Library -------------------------------------------
+open import Agda.Primitive using ( _⊔_ ; Level ) renaming ( Set to Type ; lzero to ℓ₀ )
+open import Data.Product   using ( _,_ ; _×_ ; Σ-syntax )
+open import Data.Sum.Base  using ( _⊎_ ) renaming ( inj₁ to inl ; inj₂ to inr )
+open import Data.Fin.Base  using ( Fin )
+open import Data.Nat       using ( ℕ )
+open import Function.Base  using ( _∘_ )
+open import Relation.Unary using ( Pred ; _∈_ )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; module ≡-Reasoning ; cong ; sym ; refl )
 
--- -- Imports from agda-algebras --------------------------------------------------------------
+-- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries using ( 𝟙 ; ∣_∣ ; ∥_∥ )
 open import Relations.Continuous   using ( Rel )
 open import Structures.Basic       using ( signature ; structure )
@@ -65,7 +64,7 @@ Gr {𝐹}{𝑅} 𝑨 = record { carrier = carrier 𝑨 ; op = λ () ; rel = spli
   split (inr 𝑓) args = op 𝑨 𝑓 (args ∘ inl) ≡ args (inr 𝟙.𝟎)
 
 
-open PE.≡-Reasoning
+open ≡-Reasoning
 
 module _ {𝑨 𝑩 : structure 𝐹 𝑅 {ℓ₀}{ℓ₀}} where
 
@@ -80,8 +79,8 @@ module _ {𝑨 𝑩 : structure 𝐹 𝑅 {ℓ₀}{ℓ₀}} where
    homop = ∥ hhom ∥ 𝑓 (a ∘ inl)
 
    goal : op 𝑩 𝑓 (h ∘ (a ∘ inl)) ≡ h (a (inr 𝟙.𝟎))
-   goal = op 𝑩 𝑓 (h ∘ (a ∘ inl)) ≡⟨ PE.sym homop ⟩
-          h (op 𝑨 𝑓 (a ∘ inl))   ≡⟨ PE.cong h x ⟩
+   goal = op 𝑩 𝑓 (h ∘ (a ∘ inl)) ≡⟨ sym homop ⟩
+          h (op 𝑨 𝑓 (a ∘ inl))   ≡⟨ cong h x ⟩
           h (a (inr 𝟙.𝟎))         ∎
 
   ii : is-hom-op (Gr 𝑨) (Gr 𝑩) h
@@ -100,7 +99,7 @@ module _ {𝑨 𝑩 : structure 𝐹 𝑅 {ℓ₀}{ℓ₀}} where
    split (inl x) = a x
    split (inr y) = op 𝑨 f a
    goal : h (op 𝑨 f a) ≡ op 𝑩 f (λ x → h (a x))
-   goal = PE.sym (∣ hhom ∣ (inr f) split refl)
+   goal = sym (∣ hhom ∣ (inr f) split refl)
 
 \end{code}
 

--- a/src/Structures/Homs.lagda
+++ b/src/Structures/Homs.lagda
@@ -12,19 +12,19 @@ author: [agda-algebras development team][]
 
 module Structures.Homs where
 
-open import Axiom.Extensionality.Propositional using ()
-                                   renaming (Extensionality to funext)
-open import Agda.Builtin.Equality  using    ( _≡_ ; refl )
-open import Agda.Primitive         using    ( _⊔_ ; lsuc )
-                                   renaming ( lzero to ℓ₀ ; Set to Type )
-open import Data.Product           using    ( _×_ ; Σ-syntax ; _,_ )
-                                   renaming ( proj₁ to fst ; proj₂ to snd )
-open import Function.Base          using    ( _∘_ ; id )
-open import Level                  using    ( Level ;  Lift ; lift ; lower )
-open import Relation.Binary        using    ( IsEquivalence )
-import Relation.Binary.PropositionalEquality as PE
+-- imports from Agda and the Agda Standard Library -------------------------------------------
+open import Agda.Primitive  using ( _⊔_ ; lsuc ) renaming ( lzero to ℓ₀ ; Set to Type )
+open import Axiom.Extensionality.Propositional
+                            using () renaming (Extensionality to funext)
+open import Data.Product    using ( _×_ ; Σ-syntax ; _,_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function.Base   using ( _∘_ ; id )
+open import Level           using ( Level ; Lift ; lift ; lower )
+open import Relation.Binary using ( IsEquivalence )
+open import Relation.Binary.PropositionalEquality
+                            using ( _≡_ ; refl ; sym ; cong ; module ≡-Reasoning ; trans )
 
 
+-- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries   using ( _∙_ ; ∣_∣ ; ∥_∥ ; _⁻¹ ; Π-syntax )
 open import Overture.Inverses        using ( IsInjective ; IsSurjective ; Image_∋_ )
 open import Relations.Discrete       using ( ker ; kerlift )
@@ -94,7 +94,7 @@ module _ {𝑨 : structure 𝐹 𝑅 {α}{ρᵃ}}
 
  ∘-is-hom-op : (f : A → B)(g : B → C)
   →            is-hom-op 𝑨 𝑩 f → is-hom-op 𝑩 𝑪 g → is-hom-op 𝑨 𝑪 (g ∘ f)
- ∘-is-hom-op f g fho gho 𝑓 a = PE.cong g (fho 𝑓 a) ∙ gho 𝑓 (f ∘ a)
+ ∘-is-hom-op f g fho gho 𝑓 a = cong g (fho 𝑓 a) ∙ gho 𝑓 (f ∘ a)
 
  ∘-is-hom : (f : A → B)(g : B → C)
   →         is-hom 𝑨 𝑩 f → is-hom 𝑩 𝑪 g → is-hom 𝑨 𝑪 (g ∘ f)
@@ -164,7 +164,7 @@ open Lift
 -- Kernels of homomorphisms
 
 
-open PE.≡-Reasoning
+open ≡-Reasoning
 module _ {𝑨 : structure 𝐹 𝑅  {α}{β ⊔ ρᵃ}}{𝑩 : structure 𝐹 𝑅 {β} {ρᵇ}}
          where
 
@@ -192,8 +192,8 @@ module _ {𝑨 : structure 𝐹 𝑅  {α}{β ⊔ ρᵃ}}{𝑩 : structure 𝐹 
   where
   goal : IsEquivalence (λ x y → Lift (α ⊔ ρᵃ) (h x ≡ h y))
   goal = record { refl = lift refl
-                ; sym = λ p → lift (PE.sym (lower p))
-                ; trans = λ p q → lift (PE.trans (lower p)(lower q)) }
+                ; sym = λ p → lift (sym (lower p))
+                ; trans = λ p q → lift (trans (lower p)(lower q)) }
 
  kerquo : hom 𝑨 𝑩 → {wd : swelldef (siglʳ 𝐹) β} → structure 𝐹 𝑅 {lsuc (α ⊔ β ⊔ ρᵃ)} {β ⊔ ρᵃ}
  kerquo h {wd} = 𝑨 ╱ (kercon h {wd})

--- a/src/Structures/Isos.lagda
+++ b/src/Structures/Isos.lagda
@@ -14,14 +14,15 @@ author: [agda-algebras development team][]
 module Structures.Isos where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Axiom.Extensionality.Propositional using () renaming (Extensionality to funext)
-open import Agda.Primitive        using ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
-open import Data.Product          using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
-open import Level                 using ( Level ; Lift )
-open import Function.Base         using ( _∘_ )
-import Relation.Binary.PropositionalEquality as PE
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Axiom.Extensionality.Propositional
+                           using () renaming (Extensionality to funext)
+open import Data.Product   using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Level          using ( Level ; Lift )
+open import Function.Base  using ( _∘_ )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; refl ; cong ; cong-app ; module ≡-Reasoning )
 
 
 -- Imports from agda-algebras --------------------------------------------------------------
@@ -89,10 +90,10 @@ module _ {𝑨 : structure 𝐹 𝑅 {α}{ρᵃ}} where
     g = ∘-hom {𝑨 = 𝑪}{𝑩}{𝑨} (from φbc) (from φab)
 
     τ : ∣ f ∣ ∘ ∣ g ∣ ≈ ∣ 𝒾𝒹 {𝑨 = 𝑪} ∣
-    τ x = ( PE.cong ∣ to φbc ∣ (to∼from φab (∣ from φbc ∣ x)) ) ∙ (to∼from φbc) x
+    τ x = ( cong ∣ to φbc ∣ (to∼from φab (∣ from φbc ∣ x)) ) ∙ (to∼from φbc) x
 
     ν : ∣ g ∣ ∘ ∣ f ∣ ≈ ∣ 𝒾𝒹 {𝑨 = 𝑨} ∣
-    ν x = ( PE.cong ∣ from φab ∣ (from∼to φbc (∣ to φab ∣ x)) ) ∙ (from∼to φab) x
+    ν x = ( cong ∣ from φab ∣ (from∼to φbc (∣ to φab ∣ x)) ) ∙ (from∼to φab) x
 
 \end{code}
 
@@ -110,22 +111,22 @@ module _ {𝑨 : structure 𝐹 𝑅{α}{ρᵃ}} where
  Lift-≅ˡ : 𝑨 ≅ (Lift-Strucˡ ℓ 𝑨)
  Lift-≅ˡ = record { to = 𝓁𝒾𝒻𝓉ˡ
                   ; from = 𝓁ℴ𝓌ℯ𝓇ˡ {𝑨 = 𝑨}
-                  ; to∼from = PE.cong-app lift∼lower
-                  ; from∼to = PE.cong-app (lower∼lift{α}{ρᵃ})
+                  ; to∼from = cong-app lift∼lower
+                  ; from∼to = cong-app (lower∼lift{α}{ρᵃ})
                   }
 
  Lift-≅ʳ : 𝑨 ≅ (Lift-Strucʳ ℓ 𝑨)
  Lift-≅ʳ  = record { to = 𝓁𝒾𝒻𝓉ʳ
                    ; from = 𝓁ℴ𝓌ℯ𝓇ʳ
-                   ; to∼from = PE.cong-app refl
-                   ; from∼to = PE.cong-app refl
+                   ; to∼from = cong-app refl
+                   ; from∼to = cong-app refl
                    }
 
  Lift-≅ : 𝑨 ≅ (Lift-Struc ℓ ρ 𝑨)
  Lift-≅  = record { to = 𝓁𝒾𝒻𝓉
                   ; from = 𝓁ℴ𝓌ℯ𝓇 {𝑨 = 𝑨}
-                  ; to∼from = PE.cong-app lift∼lower
-                  ; from∼to = PE.cong-app (lower∼lift{α}{ρᵃ})
+                  ; to∼from = cong-app lift∼lower
+                  ; from∼to = cong-app (lower∼lift{α}{ρᵃ})
                   }
 
 
@@ -183,7 +184,7 @@ Products of isomorphic families of algebras are themselves isomorphic. The proof
 module _ {I : Type ι} {𝒜 : I → structure 𝐹 𝑅{α}{ρᵃ}}{ℬ : I → structure 𝐹 𝑅{β}{ρᵇ}} where
 
  open structure
- open PE.≡-Reasoning
+ open ≡-Reasoning
  ⨅≅ : funext ι α → funext ι β → (∀ (i : I) → 𝒜 i ≅ ℬ i) → ⨅ 𝒜 ≅ ⨅ ℬ
 
  ⨅≅ fiu fiw AB = record { to = ϕ , ϕhom ; from = ψ , ψhom ; to∼from = ϕ~ψ ; from∼to = ψ~ϕ }

--- a/src/Structures/Products.lagda
+++ b/src/Structures/Products.lagda
@@ -16,12 +16,13 @@ dependent pair type.
 
 module Structures.Products where
 
+-- Imports from the Agda Standard Library ----------------------------------
 open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type )
 open import Data.Product   using ( _,_ ; Σ-syntax )
 open import Level          using ( Level )
 open import Relation.Unary using ( _∈_ ; Pred )
 
-
+-- Imports from agda-algebras ----------------------------------------------
 open import Overture.Preliminaries using ( ∣_∣ ; Π-syntax )
 open import Structures.Basic       using ( signature ; structure )
 

--- a/src/Structures/Sigma/Basic.lagda
+++ b/src/Structures/Sigma/Basic.lagda
@@ -11,14 +11,13 @@ author: [agda-algebras development team][]
 
 module Structures.Sigma.Basic where
 
-open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level )
-                               renaming ( Set to Type ; lzero to ℓ₀ )
-open import Data.Product          using ( _,_ ; _×_ ; Σ-syntax )
-                               renaming ( proj₁ to fst ; proj₂ to snd )
-open import Level                 using ( )
-open import Relation.Binary.Core  using ( _⇒_ ; _=[_]⇒_ )
-                               renaming ( REL to BinREL ; Rel to BinRel )
+-- Imports from the Agda Standard Library ------------------------------------------------
+open import Agda.Primitive       using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type ; lzero to ℓ₀ )
+open import Data.Product         using ( _,_ ; _×_ ; Σ-syntax ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Level                using ()
+open import Relation.Binary.Core using ( _⇒_ ; _=[_]⇒_ ) renaming ( REL to BinREL ; Rel to BinRel )
 
+-- Imports from agda-algebras ------------------------------------------------------------
 open import Overture.Preliminaries using ( ∣_∣ ; ∥_∥ ; ℓ₁)
 open import Relations.Discrete     using ( Op ; _|:_ ; _preserves_ )
 open import Relations.Continuous   using ( Rel )

--- a/src/Structures/Sigma/Congruences.lagda
+++ b/src/Structures/Sigma/Congruences.lagda
@@ -12,24 +12,23 @@ author: [agda-algebras development team][]
 
 module Structures.Sigma.Congruences where
 
-open import Agda.Builtin.Equality  using    ( _≡_ ; refl )
-open import Agda.Primitive         using    ( _⊔_ ; lsuc )
-                                   renaming ( Set to Type ; lzero to ℓ₀ )
-open import Data.Product           using    ( _,_ ; _×_ ; Σ-syntax )
-                                   renaming ( proj₁ to fst )
-open import Function.Base          using    ( _∘_ )
-open import Level                  using    ( Level ; Lift ; lift ; lower )
-open import Relation.Unary         using    ( Pred ; _∈_ )
-open import Relation.Binary        using    ( IsEquivalence )
-                                   renaming ( Rel to BinRel )
+-- Imports from the Agda Standard Library ------------------------------------------------
+open import Agda.Primitive  using ( _⊔_ ; lsuc ) renaming ( Set to Type ; lzero to ℓ₀ )
+open import Data.Product    using ( _,_ ; _×_ ; Σ-syntax ) renaming ( proj₁ to fst )
+open import Function.Base   using ( _∘_ )
+open import Level           using ( Level ; Lift ; lift ; lower )
+open import Relation.Unary  using ( Pred ; _∈_ )
+open import Relation.Binary using ( IsEquivalence ) renaming ( Rel to BinRel )
+open import Relation.Binary.PropositionalEquality
+                            using ( _≡_ )
 
-
-open import Overture.Preliminaries   using ( ∣_∣ )
-open import Relations.Discrete       using ( _|:_ ; 0[_] )
-open import Relations.Quotients      using ( Equivalence ; ⟪_⟫ ; ⌞_⌟ ; 0[_]Equivalence
-                                           ; _/_ ; ⟪_∼_⟫-elim ; Quotient )
-open import Foundations.Welldefined  using ( swelldef )
-open import Structures.Sigma.Basic   using ( Signature ; Structure ; _ᵒ_ ; Compatible ; _ʳ_ )
+-- Imports from agda-algebras ------------------------------------------------------------
+open import Overture.Preliminaries  using ( ∣_∣ )
+open import Relations.Discrete      using ( _|:_ ; 0[_] )
+open import Relations.Quotients     using ( Equivalence ; ⟪_⟫ ; ⌞_⌟ ; 0[_]Equivalence
+                                          ; _/_ ; ⟪_∼_⟫-elim ; Quotient )
+open import Foundations.Welldefined using ( swelldef )
+open import Structures.Sigma.Basic  using ( Signature ; Structure ; _ᵒ_ ; Compatible ; _ʳ_ )
 
 private variable 𝑅 𝐹 : Signature
 

--- a/src/Structures/Sigma/Homs.lagda
+++ b/src/Structures/Sigma/Homs.lagda
@@ -11,16 +11,15 @@ author: [agda-algebras development team][]
 
 module Structures.Sigma.Homs where
 
-open import Agda.Builtin.Equality  using    ( _≡_ ; refl )
-open import Agda.Primitive         using    ( _⊔_ ; lsuc )
-                                   renaming ( Set to Type ; lzero to ℓ₀ )
-open import Data.Product           using    ( _,_ ; _×_ ; Σ-syntax )
-                                   renaming ( proj₁ to fst ; proj₂ to snd )
-open import Level                  using    ( Level ; Lift ; lift ; lower )
-open import Function.Base          using    ( _∘_ ; id )
-open import Relation.Binary.PropositionalEquality as PE
+-- Imports from the Agda Standard Library ----------------------------------------------------------
+open import Agda.Primitive  using ( _⊔_ ; lsuc ) renaming ( Set to Type ; lzero to ℓ₀ )
+open import Data.Product    using ( _,_ ; _×_ ; Σ-syntax ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Level           using ( Level ; Lift ; lift ; lower )
+open import Function.Base   using ( _∘_ ; id )
+open import Relation.Binary.PropositionalEquality
+                            using ( _≡_ ;  cong ; refl ; module ≡-Reasoning )
 
-
+-- Imports from agda-algebras ----------------------------------------------------------------------
 open import Overture.Preliminaries   using ( ∣_∣ ; ∥_∥ ; _∙_ ; _⁻¹)
 open import Overture.Inverses        using ( IsInjective ; IsSurjective )
 open import Relations.Discrete       using ( _|:_ ; 0[_] ; ker )

--- a/src/Structures/Sigma/Isos.lagda
+++ b/src/Structures/Sigma/Isos.lagda
@@ -14,22 +14,17 @@ author: [agda-algebras development team][]
 module Structures.Sigma.Isos where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Axiom.Extensionality.Propositional using () renaming (Extensionality to funext)
-open import Agda.Primitive                        using    ( _⊔_    ;   lsuc     )
-                                                  renaming ( Set    to  Type     )
-open import Agda.Builtin.Equality                 using    ( _≡_    ;   refl     )
-open import Data.Product                          using    ( _,_    ;   Σ-syntax
-                                                           ;  Σ     ;   _×_      )
-                                                  renaming ( proj₁  to  fst
-                                                           ; proj₂  to  snd      )
-open import Level                                 using    ( Level  ;  Lift
-                                                           ; lift   ;  lower     )
-open import Function.Base                         using    ( _∘_                 )
-open import Relation.Binary.PropositionalEquality using    ( cong   ; cong-app   )
+-- Imports from the Agda Standard Library ------------------------------------------------------
+open import Axiom.Extensionality.Propositional
+                           using () renaming (Extensionality to funext)
+open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product   using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function.Base  using ( _∘_ )
+open import Level          using ( Level ; Lift ; lift ; lower )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; refl ; cong ; cong-app )
 
-
--- Imports from agda-algebras --------------------------------------------------------------
+-- Imports from agda-algebras -------------------------------------------------------------------
 open import Overture.Preliminaries    using ( ∣_∣ ; _≈_ ; ∥_∥ ; _∙_ ; lower∼lift ; lift∼lower )
 open import Structures.Sigma.Basic    using ( Signature ; Structure ; Lift-Struc )
 open import Structures.Sigma.Homs     using ( hom ; 𝒾𝒹 ; ∘-hom ; 𝓁𝒾𝒻𝓉 ; 𝓁ℴ𝓌ℯ𝓇 ; is-hom)

--- a/src/Structures/Sigma/Products.lagda
+++ b/src/Structures/Sigma/Products.lagda
@@ -13,12 +13,13 @@ author: [agda-algebras development team][]
 
 module Structures.Sigma.Products where
 
-open import Agda.Primitive using    ( _⊔_ ; lsuc )
-                           renaming ( Set to Type )
-open import Data.Product   using    ( _,_ ; _×_ ; Σ-syntax )
-open import Level          using    ( Level ; Lift )
-open import Relation.Unary using    ( _∈_ ; Pred )
+-- Imports from the Agda Standard Library ------------------------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product   using ( _,_ ; _×_ ; Σ-syntax )
+open import Level          using ( Level ; Lift )
+open import Relation.Unary using ( _∈_ ; Pred )
 
+-- Imports from agda-algebras ------------------------------------------------
 open import Overture.Preliminaries using ( ∣_∣ ; ∥_∥ ; Π ; Π-syntax )
 open import Structures.Sigma.Basic using ( Signature ; Structure ; _ʳ_ ; _ᵒ_ )
 

--- a/src/Structures/Substructures/Basic.lagda
+++ b/src/Structures/Substructures/Basic.lagda
@@ -16,12 +16,12 @@ This is the [Structures.Substructures.Basic][] module of the [Agda Universal Alg
 module Structures.Substructures.Basic where
 
 -- imports from Agda and the Agda Standard Library
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
-open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
-open import Data.Product          using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
-open import Function.Base         using ( _∘_ )
-open import Relation.Unary        using ( Pred ; _∈_ ; _⊆_ ; ⋂ )
-import Relation.Binary.PropositionalEquality as PE
+open import Agda.Primitive using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product   using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₂ to snd )
+open import Function.Base  using ( _∘_ )
+open import Relation.Unary using ( Pred ; _∈_ ; _⊆_ ; ⋂ )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; module ≡-Reasoning )
 
 -- imports from agda-algebras ------------------------------------------------------
 open import Overture.Preliminaries   using ( ∣_∣ ; ∥_∥ ; _⁻¹ )
@@ -178,7 +178,7 @@ Alternatively, we could express the preceeding fact using an inductive type repr
    where
    IH : ∀ x → ∣ g ∣ (a x) ≡ ∣ h ∣ (a x)
    IH x = hom-unique wd G g h σ (a x) (SgGa x)
-   open PE.≡-Reasoning
+   open ≡-Reasoning
    Goal : ∣ g ∣ ((f ᵒ 𝑨) a) ≡ ∣ h ∣ ((f ᵒ 𝑨) a)
    Goal = ∣ g ∣ ((f ᵒ 𝑨) a) ≡⟨ snd ∥ g ∥ f a ⟩
           (f ᵒ 𝑩)(∣ g ∣ ∘ a ) ≡⟨ wd (f ᵒ 𝑩) (∣ g ∣ ∘ a) (∣ h ∣ ∘ a) IH ⟩

--- a/src/Structures/Substructures/Substructures.lagda
+++ b/src/Structures/Substructures/Substructures.lagda
@@ -15,10 +15,10 @@ author: [agda-algebras development team][]
 module Structures.Substructures.Substructures where
 
 -- imports from Agda and the Agda Standard Library
-open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
-open import Data.Product          using ( _,_ ; Σ-syntax ; _×_ )
-open import Relation.Binary       using ( REL )
-open import Relation.Unary        using ( Pred ; _∈_ )
+open import Agda.Primitive  using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product    using ( _,_ ; Σ-syntax ; _×_ )
+open import Relation.Binary using ( REL )
+open import Relation.Unary  using ( Pred ; _∈_ )
 
 -- imports from agda-algebras ------------------------------------------------------
 open import Overture.Preliminaries using ( ∣_∣ ; ∥_∥ )

--- a/src/Subalgebras/Properties.lagda
+++ b/src/Subalgebras/Properties.lagda
@@ -16,15 +16,15 @@ open import Algebras.Basic using (𝓞 ; 𝓥 ; Signature )
 module Subalgebras.Properties {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library ------------------------------------
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
-open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
-open import Data.Product          using ( _,_ ) renaming ( proj₁ to fst ; proj₂ to snd )
-open import Function.Base         using ( _∘_ ; id ; flip )
-open import Function.Bundles      using ( Injection )
-open import Relation.Unary        using ( Pred ; _⊆_ )
-open import Relation.Binary.Definitions using ( _Respectsʳ_ ; _Respectsˡ_ )
--- open import Relation.Binary.HeterogeneousEquality using ()
-import Relation.Binary.PropositionalEquality as PE
+open import Agda.Primitive   using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product     using ( _,_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function.Base    using ( _∘_ ; id ; flip )
+open import Function.Bundles using ( Injection )
+open import Relation.Unary   using ( Pred ; _⊆_ )
+open import Relation.Binary.Definitions
+                             using ( _Respectsʳ_ ; _Respectsˡ_ )
+open import Relation.Binary.PropositionalEquality
+                             using ( refl ; module ≡-Reasoning ; cong )
 
 -- -- imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries             using ( ∣_∣ ; ∥_∥ ; _⁻¹ )
@@ -132,12 +132,12 @@ module _ {𝑨 : Algebra α 𝑆}{𝑩 : Algebra β 𝑆}{𝑪 : Algebra γ 𝑆
  ≅-RESP-≥ ab b<c = ≤-RESP-≅ b<c (≅-sym ab)
 
 
-open PE.≡-Reasoning
+open ≡-Reasoning
 iso→injective : {𝑨 : Algebra α 𝑆}{𝑩 : Algebra β 𝑆}
  →              (φ : 𝑨 ≅ 𝑩) → IsInjective ∣ to φ ∣
 iso→injective {𝑨 = 𝑨} (mkiso f g f∼g g∼f) {x} {y} fxfy =
  x                  ≡⟨ (g∼f x)⁻¹ ⟩
- (∣ g ∣ ∘ ∣ f ∣) x  ≡⟨ PE.cong ∣ g ∣ fxfy ⟩
+ (∣ g ∣ ∘ ∣ f ∣) x  ≡⟨ cong ∣ g ∣ fxfy ⟩
  (∣ g ∣ ∘ ∣ f ∣) y  ≡⟨ g∼f y ⟩
  y                  ∎
 

--- a/src/Subalgebras/Setoid/Properties.lagda
+++ b/src/Subalgebras/Setoid/Properties.lagda
@@ -16,15 +16,16 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 module Subalgebras.Setoid.Properties {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library
-open import Agda.Primitive         using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
-open import Agda.Builtin.Equality   using    ( _≡_ ; refl )
-open import Data.Product            using    ( _,_ )
-open import Function.Base           using    ( id )
-open import Function.Bundles        using    ( Injection )
-open import Relation.Binary         using    ( Setoid ; REL )
-open import Relation.Unary          using    ( Pred ; _⊆_ )
+open import Agda.Primitive   using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product     using ( _,_ )
+open import Function.Base    using ( id )
+open import Function.Bundles using ( Injection )
+open import Relation.Binary  using ( Setoid ; REL )
+open import Relation.Unary   using ( Pred ; _⊆_ )
+open import Relation.Binary.PropositionalEquality
+                             using ( refl )
 
--- -- -- -- imports from agda-algebras ------------------------------------------------------
+-- imports from agda-algebras ------------------------------------------------------
 open import Overture.Preliminaries                    using ( ∣_∣ ; ∥_∥ )
 open import Overture.Inverses                         using ( IsInjective ; id-is-injective ; ∘-injective )
 open import Algebras.Setoid.Basic             {𝑆 = 𝑆} using ( SetoidAlgebra ; Lift-SetoidAlg )

--- a/src/Subalgebras/Setoid/Subalgebras.lagda
+++ b/src/Subalgebras/Setoid/Subalgebras.lagda
@@ -14,15 +14,14 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 module Subalgebras.Setoid.Subalgebras {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library
-open import Agda.Primitive         using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
-open import Agda.Builtin.Equality   using    ( _≡_ ; refl )
-open import Data.Product            using    ( _,_ ; Σ-syntax ; _×_ )
-open import Function.Base           using    ( id )
-open import Function.Bundles        using    ( Injection )
-open import Relation.Binary         using    ( Setoid ; REL )
-open import Relation.Unary          using    ( Pred ; _∈_ ; _⊆_ )
+open import Agda.Primitive   using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ )
+open import Function.Base    using ( id )
+open import Function.Bundles using ( Injection )
+open import Relation.Binary  using ( Setoid ; REL )
+open import Relation.Unary   using ( Pred ; _∈_ ; _⊆_ )
 
--- -- -- -- imports from agda-algebras ------------------------------------------------------
+-- imports from agda-algebras ------------------------------------------------------
 open import Overture.Preliminaries                    using ( ∣_∣ ; ∥_∥ )
 open import Overture.Inverses                         using ( IsInjective ; id-is-injective ; ∘-injective )
 open import Algebras.Setoid.Basic             {𝑆 = 𝑆} using ( SetoidAlgebra ; Lift-SetoidAlg )

--- a/src/Subalgebras/Setoid/Subuniverses.lagda
+++ b/src/Subalgebras/Setoid/Subuniverses.lagda
@@ -18,17 +18,16 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 module Subalgebras.Setoid.Subuniverses {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library
-open import Agda.Primitive          renaming ( Set to Type )
-                                    using    ( _⊔_ ; lsuc ; Level )
-open import Agda.Builtin.Equality   using    ( _≡_ ; refl )
-open import Data.Product            using    ( _,_ ; Σ-syntax ; Σ ; _×_ )
-open import Function.Base           using    ( _∘_ ; id )
-open import Function.Bundles        using    ( Func ; Injection )
-open import Relation.Binary         using    ( Setoid ; REL )
-open import Relation.Unary          using    ( Pred ; _∈_ ; _⊆_ ; ⋂ )
-import Relation.Binary.PropositionalEquality as PE
+open import Agda.Primitive   using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product     using ( _,_ ; Σ-syntax ; Σ ; _×_ )
+open import Function.Base    using ( _∘_ ; id )
+open import Function.Bundles using ( Func ; Injection )
+open import Relation.Binary  using ( Setoid ; REL )
+open import Relation.Unary   using ( Pred ; _∈_ ; _⊆_ ; ⋂ )
+open import Relation.Binary.PropositionalEquality
+                             using ( _≡_ ; module ≡-Reasoning )
 
--- -- -- imports from agda-algebras ------------------------------------------------------
+-- imports from agda-algebras ------------------------------------------------------
 open import Overture.Preliminaries             using ( ∣_∣ ; ∥_∥ ; _⁻¹ )
 open import Overture.Inverses                  using ( ∘-injective ; IsInjective ; id-is-injective )
 open import Relations.Discrete                 using ( Im_⊆_ )
@@ -210,7 +209,7 @@ Alternatively, we could express the preceeding fact using an inductive type repr
    where
    IH : ∀ x → ∣ g ∣ (a x) ≡ ∣ h ∣ (a x)
    IH x = hom-unique wd G g h σ (a x) (SgGa x)
-   open PE.≡-Reasoning
+   open ≡-Reasoning
    Goal : ∣ g ∣ ((f ̂ 𝑨) a) ≡ ∣ h ∣ ((f ̂ 𝑨) a)
    Goal = ∣ g ∣ ((f ̂ 𝑨) a) ≡⟨ ∥ g ∥ f a ⟩
           (f ̂ 𝑩)(∣ g ∣ ∘ a ) ≡⟨ wd (f ̂ 𝑩) (∣ g ∣ ∘ a) (∣ h ∣ ∘ a) IH ⟩

--- a/src/Subalgebras/Subalgebras.lagda
+++ b/src/Subalgebras/Subalgebras.lagda
@@ -18,13 +18,11 @@ open import Algebras.Basic using (𝓞 ; 𝓥 ; Signature )
 module Subalgebras.Subalgebras {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library ------------------------------------
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
 open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level )       renaming ( Set to Type )
 open import Data.Product          using ( _,_ ; Σ-syntax ; Σ ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
 open import Function.Base         using ( _∘_ )
 open import Function.Bundles      using ( Injection )
 open import Relation.Unary        using ( _∈_ ; Pred ; _⊆_ )
-import Relation.Binary.PropositionalEquality as PE
 
 -- imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries             using ( _∙_ ; _⁻¹ ; ∣_∣ ; ∥_∥ ; 𝑖𝑑 )

--- a/src/Subalgebras/Subuniverses.lagda
+++ b/src/Subalgebras/Subuniverses.lagda
@@ -20,13 +20,13 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 module Subalgebras.Subuniverses {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library
-open import Relation.Binary.PropositionalEquality using ( cong ; module ≡-Reasoning )
-open import Axiom.Extensionality.Propositional renaming (Extensionality to funext)
-open import Agda.Primitive          renaming ( Set to Type )
-                                    using    ( _⊔_ ; lsuc ; Level )
-open import Agda.Builtin.Equality   using    ( _≡_ ; refl )
-open import Function.Base           using    ( _∘_ )
-open import Relation.Unary          using    ( Pred ; _∈_ ; _⊆_ ; ⋂ )
+open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Axiom.Extensionality.Propositional
+                                  using () renaming (Extensionality to funext)
+open import Function.Base         using ( _∘_ )
+open import Relation.Binary.PropositionalEquality
+                                  using ( module ≡-Reasoning ; _≡_ )
+open import Relation.Unary        using ( Pred ; _∈_ ; _⊆_ ; ⋂ )
 
 -- imports from agda-algebras ------------------------------------------------------
 open import Overture.Preliminaries      using ( ∣_∣ ; ∥_∥ ; _⁻¹ )

--- a/src/Terms/Basic.lagda
+++ b/src/Terms/Basic.lagda
@@ -17,11 +17,11 @@ open import Algebras.Basic
 
 module Terms.Basic {𝑆 : Signature 𝓞 𝓥} where
 
-open import Agda.Primitive            using    ( Level )
-                                      renaming ( Set to Type )
-open import Data.Product              using    ( _,_ )
-open import Overture.Preliminaries    using    ( ∣_∣ ; ∥_∥ )
-open import Algebras.Products    {𝑆 = 𝑆} using    ( ov )
+open import Agda.Primitive using ( Level ) renaming ( Set to Type )
+open import Data.Product   using ( _,_ )
+
+open import Overture.Preliminaries    using ( ∣_∣ ; ∥_∥ )
+open import Algebras.Products {𝑆 = 𝑆} using ( ov )
 
 private variable χ : Level
 

--- a/src/Terms/Operations.lagda
+++ b/src/Terms/Operations.lagda
@@ -21,19 +21,14 @@ module Terms.Operations {𝑆 : Signature 𝓞 𝓥} where
 
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Agda.Primitive                        using    ( _⊔_ ;  lsuc ; Level )
-                                                  renaming ( Set to Type )
-open import Agda.Builtin.Equality                 using    ( _≡_ ; refl )
-open import Axiom.Extensionality.Propositional    using    ()
-                                                  renaming (Extensionality to funext)
-open import Data.Product                          using    ( _,_ ; Σ-syntax ; Σ )
-open import Function.Base                         using    ( _∘_ )
-open import Relation.Binary.PropositionalEquality using    (sym ; cong
-                                                           ; module ≡-Reasoning )
-
-
-
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Axiom.Extensionality.Propositional
+                           using () renaming (Extensionality to funext)
+open import Data.Product   using ( _,_ ; Σ-syntax ; Σ )
+open import Function.Base  using ( _∘_ )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; refl ; module ≡-Reasoning ; sym ; cong )
 
 -- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries       using ( _∙_ ; _⁻¹ ; ∣_∣ ; ∥_∥ ; Π ; Π-syntax ; _≈_ )

--- a/src/Terms/Properties.lagda
+++ b/src/Terms/Properties.lagda
@@ -19,19 +19,18 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 module Terms.Properties {𝑆 : Signature 𝓞 𝓥} where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Axiom.Extensionality.Propositional renaming (Extensionality to funext)
-import Relation.Binary.PropositionalEquality as PE
-open import Agda.Primitive              using    ( _⊔_ ;  lsuc   )
-                                        renaming ( Set to Type   )
-open import Agda.Builtin.Equality       using    ( _≡_ ;  refl   )
-open import Data.Product                using    ( _,_ ;  Σ
-                                                 ; Σ-syntax      )
-open import Function.Base               using    ( _∘_           )
-open import Data.Empty.Polymorphic      using    ( ⊥             )
-open import Level                       using    ( Level ; Lift  )
-open import Relation.Binary             using    ( IsEquivalence ; Setoid )
-open import Relation.Binary.Definitions using (Reflexive ; Symmetric ; Transitive )
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Axiom.Extensionality.Propositional
+                                   using () renaming (Extensionality to funext)
+open import Agda.Primitive         using ( Level ; _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product           using ( _,_ ; Σ-syntax )
+open import Function.Base          using ( _∘_ )
+open import Data.Empty.Polymorphic using ( ⊥ )
+open import Relation.Binary        using ( IsEquivalence ; Setoid )
+open import Relation.Binary.Definitions
+                                   using (Reflexive ; Symmetric ; Transitive )
+open import Relation.Binary.PropositionalEquality
+                                   using ( _≡_ ; refl ; module ≡-Reasoning ; cong )
 
 
 -- Imports from agda-algebras --------------------------------------------------------------
@@ -79,7 +78,7 @@ The free lift so defined is a homomorphism by construction. Indeed, here is the 
 \begin{code}
 
 lift-hom : (𝑨 : Algebra α 𝑆) → (X → ∣ 𝑨 ∣) → hom (𝑻 X) 𝑨
-lift-hom 𝑨 h = free-lift 𝑨 h , λ f a → PE.cong (f ̂ 𝑨) refl
+lift-hom 𝑨 h = free-lift 𝑨 h , λ f a → cong (f ̂ 𝑨) refl
 
 \end{code}
 
@@ -87,7 +86,7 @@ Finally, we prove that the homomorphism is unique.  This requires `funext 𝓥 �
 
 \begin{code}
 
-open PE.≡-Reasoning
+open ≡-Reasoning
 
 free-unique : swelldef 𝓥 α → (𝑨 : Algebra α 𝑆)(g h : hom (𝑻 X) 𝑨)
  →            (∀ x → ∣ g ∣ (ℊ x) ≡ ∣ h ∣ (ℊ x))

--- a/src/Terms/Setoid/Basic.lagda
+++ b/src/Terms/Setoid/Basic.lagda
@@ -16,24 +16,22 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 module Terms.Setoid.Basic {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library -------------------------------------------
-open import Agda.Builtin.Equality       using    ( _≡_       ;  refl )
-open import Agda.Primitive              using    ( _⊔_       ;  lsuc )
-                                        renaming ( Set       to Type )
-open import Data.Empty.Polymorphic      using    ( ⊥                 )
-open import Data.Product                using    ( _,_               )
-open import Data.Sum.Base               using    ( _⊎_               )
-                                        renaming ( inj₁      to inl
-                                                 ; inj₂      to inr  )
-open import Function.Bundles            using    ( Func              )
-open import Level                       using    ( Level     ; Lift  )
-open import Relation.Binary             using    ( Setoid    ; IsEquivalence )
-open import Relation.Binary.Definitions using    ( Reflexive ; Symmetric ; Transitive )
-import Relation.Binary.PropositionalEquality as PE
+open import Agda.Primitive         using ( Level ; _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Empty.Polymorphic using ( ⊥ )
+open import Data.Product           using ( _,_ )
+open import Data.Sum.Base          using ( _⊎_ ) renaming ( inj₁ to inl ; inj₂ to inr )
+open import Function.Bundles       using ( Func )
+open import Level                  using ( Level ; Lift )
+open import Relation.Binary        using ( Setoid ; IsEquivalence )
+open import Relation.Binary.Definitions
+                                   using ( Reflexive ; Symmetric ; Transitive )
+open import Relation.Binary.PropositionalEquality
+                                   using ( _≡_ ; sym ; trans ; refl )
 
--- -- -- imports from agda-algebras --------------------------------------------------------------
-open import Overture.Preliminaries           using ( ∣_∣ ; ∥_∥ )
-open import Algebras.Setoid.Basic    {𝑆 = 𝑆} using ( SetoidAlgebra )
-open import Terms.Basic              {𝑆 = 𝑆} using ( Term )
+-- imports from agda-algebras --------------------------------------------------------------
+open import Overture.Preliminaries        using ( ∣_∣ ; ∥_∥ )
+open import Algebras.Setoid.Basic {𝑆 = 𝑆} using ( SetoidAlgebra )
+open import Terms.Basic           {𝑆 = 𝑆} using ( Term )
 open Term
 
 
@@ -68,11 +66,11 @@ module _ {X : Type χ } where
  ≐-isRefl {node f t} = genl (λ i → ≐-isRefl)
 
  ≐-isSym : Symmetric _≐_
- ≐-isSym {.(ℊ _)} {.(ℊ _)} (refl x) = refl (PE.sym x)
+ ≐-isSym {.(ℊ _)} {.(ℊ _)} (refl x) = refl (sym x)
  ≐-isSym {.(node _ _)} {.(node _ _)} (genl x) = genl (λ i → ≐-isSym (x i))
 
  ≐-isTrans : Transitive _≐_
- ≐-isTrans {.(ℊ _)} {.(ℊ _)} {.(ℊ _)} (refl x) (refl y) = refl (PE.trans x y)
+ ≐-isTrans {.(ℊ _)} {.(ℊ _)} {.(ℊ _)} (refl x) (refl y) = refl (trans x y)
  ≐-isTrans {.(node _ _)} {.(node _ _)} {.(node _ _)} (genl x) (genl y) = genl (λ i → ≐-isTrans (x i) (y i))
 
  ≐-isEquiv : IsEquivalence _≐_

--- a/src/Varieties/Closure.lagda
+++ b/src/Varieties/Closure.lagda
@@ -28,16 +28,16 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
 module Varieties.Closure {𝑆 : Signature 𝓞 𝓥} where
 
-open import Axiom.Extensionality.Propositional renaming ( Extensionality to funext )
-open import Agda.Primitive      using    ( _⊔_ ;  lsuc )
-                                renaming ( Set to Type )
-open import Data.Product        using    ( _,_ ; Σ-syntax )
-                                renaming ( proj₁ to fst
-                                         ; proj₂ to snd )
-open import Level               using    ( Level ;  Lift )
-open import Relation.Unary      using    ( Pred  ; _∈_ ; _⊆_ )
+-- Imports from Agda and the Agda Standard Library
+open import Axiom.Extensionality.Propositional
+                            using () renaming ( Extensionality to funext )
+open import Agda.Primitive  using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product    using ( _,_ ; Σ-syntax ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Level           using ( Level ;  Lift )
+open import Relation.Unary  using ( Pred  ; _∈_ ; _⊆_ )
 
 
+-- Imports from agda-algebras
 open import Overture.Preliminaries                  using ( ∣_∣ ; ∥_∥ )
 open import Algebras.Basic                          using ( Algebra ; Lift-Alg )
 open import Algebras.Products               {𝑆 = 𝑆} using ( ov ; ⨅ )

--- a/src/Varieties/EquationalLogic.lagda
+++ b/src/Varieties/EquationalLogic.lagda
@@ -26,17 +26,12 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
 module Varieties.EquationalLogic {𝑆 : Signature 𝓞 𝓥} where
 
-
 -- imports from Agda and the Agda Standard Library -------------------------------------------
-open import Agda.Primitive   using    ( _⊔_ ;  lsuc ; Level )
-                             renaming ( Set to Type )
-open import Data.Product     using    ( _×_ ; _,_ ; Σ-syntax)
-                             renaming ( proj₁ to fst ; proj₂ to snd )
-open import Relation.Unary   using    ( Pred ; _∈_ )
+open import Agda.Primitive using ( _⊔_ ;  lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product   using ( _×_ ; _,_ ; Σ-syntax) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Relation.Unary using ( Pred ; _∈_ )
 
-
-
--- -- imports from agda-algebras --------------------------------------------------------------
+-- imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries    using ( _≈_ )
 open import Algebras.Basic            using ( Algebra )
 open import Algebras.Products {𝑆 = 𝑆} using ( ov )

--- a/src/Varieties/FreeAlgebras.lagda
+++ b/src/Varieties/FreeAlgebras.lagda
@@ -21,21 +21,16 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
 module Varieties.FreeAlgebras {α 𝓞 𝓥 : Level} (𝑆 : Signature 𝓞 𝓥) where
 
-
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Axiom.Extensionality.Propositional renaming (Extensionality to funext)
-open import Agda.Builtin.Equality   using    ( _≡_ ; refl )
-open import Agda.Primitive          renaming ( Set to Type )
-                                    using    ( _⊔_ )
-open import Data.Product            using    ( _,_ ; Σ-syntax ; Σ ; _×_ )
-                                    renaming ( proj₁ to fst
-                                             ; proj₂ to snd )
-open import Function.Base           using    ( _∘_ )
-open import Relation.Binary         using    ( IsEquivalence )
-                                    renaming ( Rel to BinRel )
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Axiom.Extensionality.Propositional
+                            using () renaming (Extensionality to funext)
+open import Agda.Primitive  using ( _⊔_ ) renaming ( Set to Type )
+open import Data.Product    using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function.Base   using ( _∘_ )
+open import Relation.Binary using ( IsEquivalence ) renaming ( Rel to BinRel )
 open import Relation.Binary.PropositionalEquality
-                                    using    ( cong ; cong-app ; module ≡-Reasoning )
-open import Relation.Unary          using    ( Pred ; _∈_ ; _⊆_ ; ｛_｝ ; _∪_ )
+                            using ( _≡_ ; refl ; cong ; cong-app ; module ≡-Reasoning )
+open import Relation.Unary  using    ( Pred ; _∈_ ; _⊆_ ; ｛_｝ ; _∪_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------------------
 open import Overture.Preliminaries             using ( ∣_∣ ; ∥_∥ ; _∙_ ; _⁻¹ )

--- a/src/Varieties/Invariants.lagda
+++ b/src/Varieties/Invariants.lagda
@@ -19,12 +19,11 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature ; Algebra )
 module Varieties.Invariants (𝑆 : Signature 𝓞 𝓥) where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Agda.Primitive          using    ( Level )
-                                    renaming ( Set to Type )
-open import Relation.Unary          using    ( Pred )
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Agda.Primitive using ( Level ) renaming ( Set to Type )
+open import Relation.Unary using ( Pred )
 
--- -- Imports from the Agda Universal Algebra Library -------------------------------------------
+-- Imports from the Agda Universal Algebra Library -------------------------------------------
 open import Homomorphisms.Isomorphisms {𝑆 = 𝑆} using ( _≅_ )
 
 private variable α ℓ : Level

--- a/src/Varieties/Preservation.lagda
+++ b/src/Varieties/Preservation.lagda
@@ -17,22 +17,21 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
 module Varieties.Preservation {𝑆 : Signature 𝓞 𝓥} where
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Agda.Builtin.Equality   using ( _≡_ ; refl )
-open import Agda.Primitive          using ( _⊔_ ; lsuc ; Level )   renaming ( Set   to Type )
-open import Axiom.Extensionality.Propositional using ()            renaming (Extensionality to funext)
-open import Data.Product            using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
-open import Data.Sum.Base           using ( _⊎_ )                  renaming ( inj₁  to inl ; inj₂  to inr )
-open import Function.Base           using ( _∘_ )
-open import Relation.Unary          using ( Pred ; _⊆_ ; _∈_ ; ｛_｝ ; _∪_ )
-import Relation.Binary.PropositionalEquality as PE
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Agda.Primitive  using ( _⊔_ ; lsuc ; Level ) renaming ( Set   to Type )
+open import Axiom.Extensionality.Propositional
+                            using () renaming (Extensionality to funext)
+open import Data.Product    using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Data.Sum.Base   using ( _⊎_ ) renaming ( inj₁  to inl ; inj₂  to inr )
+open import Function.Base   using ( _∘_ )
+open import Relation.Unary  using ( Pred ; _⊆_ ; _∈_ ; ｛_｝ ; _∪_ )
+open import Relation.Binary.PropositionalEquality
+                            using ( _≡_ ; refl ; module ≡-Reasoning ; cong-app ; cong )
 
-
-
--- -- imports from agda-algebras --------------------------------------------------------------
+-- imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries             using ( ∣_∣ ; ∥_∥ ; _⁻¹ )
 open import Overture.Inverses                  using ( Inv ; IsInjective ; InvIsInv )
-open import Foundations.Truncation               using ( hfunext )
+open import Foundations.Truncation             using ( hfunext )
 open import Foundations.Welldefined            using ( SwellDef )
 open import Foundations.Extensionality         using ( DFunExt )
 open import Algebras.Basic                     using ( Algebra ; Lift-Alg )
@@ -159,7 +158,7 @@ module _ {α β : Level} {𝒦 : Pred(Algebra α 𝑆)(ov α)} where
   ν = λ 𝑓 𝒂 → fwu λ i → (snd ∣ SA≤𝒜 i ∣) 𝑓 (λ x → 𝒂 x i)
 
   σinj : IsInjective σ
-  σinj σxσy = fwu λ i → (hinj i)(PE.cong-app σxσy i)
+  σinj σxσy = fwu λ i → (hinj i)(cong-app σxσy i)
 
   ⨅SA≤⨅𝒜 : ⨅ SA ≤ ⨅ 𝒜
   ⨅SA≤⨅𝒜 = (σ , ν) , σinj
@@ -357,7 +356,7 @@ First we prove that the closure operator H is compatible with identities that ho
 
 \begin{code}
 
-open PE.≡-Reasoning
+open ≡-Reasoning
 
 private variable 𝓧 : Level
 open Term
@@ -380,7 +379,7 @@ module _ (wd : SwellDef){X : Type 𝓧} {𝒦 : Pred (Algebra α 𝑆)(ov α)} w
   goal : (𝑩 ⟦ p ⟧) b ≡ (𝑩 ⟦ q ⟧) b
   goal = (𝑩 ⟦ p ⟧) b          ≡⟨ wd 𝓧 α (𝑩 ⟦ p ⟧) b (φ ∘ preim )(λ i → (ζ i)⁻¹)⟩
       (𝑩 ⟦ p ⟧)(φ ∘ preim) ≡⟨(comm-hom-term (wd 𝓥 α) 𝑩 (φ , φh) p preim)⁻¹ ⟩
-      φ((𝑨 ⟦ p ⟧) preim)   ≡⟨ PE.cong φ (IH preim) ⟩
+      φ((𝑨 ⟦ p ⟧) preim)   ≡⟨ cong φ (IH preim) ⟩
       φ((𝑨 ⟦ q ⟧) preim)   ≡⟨ comm-hom-term (wd 𝓥 α) 𝑩 (φ , φh) q preim ⟩
       (𝑩 ⟦ q ⟧)(φ ∘ preim) ≡⟨ wd 𝓧 α (𝑩 ⟦ q ⟧)(φ ∘ preim) b ζ ⟩
       (𝑩 ⟦ q ⟧) b          ∎
@@ -505,7 +504,7 @@ module Vid (fe : DFunExt)(wd : SwellDef){𝓧 : Level} {X : Type 𝓧} {𝒦 : P
   goal : (𝑩 ⟦ p ⟧) b ≡ (𝑩 ⟦ q ⟧) b
   goal = (𝑩 ⟦ p ⟧) b          ≡⟨ wd 𝓧 α (𝑩 ⟦ p ⟧) b (φ ∘ preim )(λ i → (ζ i)⁻¹)⟩
       (𝑩 ⟦ p ⟧)(φ ∘ preim) ≡⟨(comm-hom-term (wd 𝓥 α) 𝑩 (φ , φh) p preim)⁻¹ ⟩
-      φ((𝑨 ⟦ p ⟧) preim)   ≡⟨ PE.cong φ (IH preim) ⟩
+      φ((𝑨 ⟦ p ⟧) preim)   ≡⟨ cong φ (IH preim) ⟩
       φ((𝑨 ⟦ q ⟧) preim)   ≡⟨ comm-hom-term (wd 𝓥 α) 𝑩 (φ , φh) q preim ⟩
       (𝑩 ⟦ q ⟧)(φ ∘ preim) ≡⟨ wd 𝓧 α (𝑩 ⟦ q ⟧)(φ ∘ preim) b ζ ⟩
       (𝑩 ⟦ q ⟧) b          ∎
@@ -549,7 +548,7 @@ module Vid' (fe : DFunExt)(wd : SwellDef){𝓧 : Level} {X : Type 𝓧} {𝒦 : 
   goal : (𝑩 ⟦ p ⟧) b ≡ (𝑩 ⟦ q ⟧) b
   goal = (𝑩 ⟦ p ⟧) b          ≡⟨ wd 𝓧 _ (𝑩 ⟦ p ⟧) b (φ ∘ preim )(λ i → (ζ i)⁻¹)⟩
       (𝑩 ⟦ p ⟧)(φ ∘ preim) ≡⟨(comm-hom-term (wd 𝓥 _) 𝑩 (φ , φh) p preim)⁻¹ ⟩
-      φ((𝑨 ⟦ p ⟧) preim)   ≡⟨ PE.cong φ (IH preim) ⟩
+      φ((𝑨 ⟦ p ⟧) preim)   ≡⟨ cong φ (IH preim) ⟩
       φ((𝑨 ⟦ q ⟧) preim)   ≡⟨ comm-hom-term (wd 𝓥 _) 𝑩 (φ , φh) q preim ⟩
       (𝑩 ⟦ q ⟧)(φ ∘ preim) ≡⟨ wd 𝓧 _ (𝑩 ⟦ q ⟧)(φ ∘ preim) b ζ ⟩
       (𝑩 ⟦ q ⟧) b          ∎

--- a/src/Varieties/Properties.lagda
+++ b/src/Varieties/Properties.lagda
@@ -26,15 +26,13 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 module Varieties.Properties {𝑆 : Signature 𝓞 𝓥} where
 
 -- imports from Agda and the Agda Standard Library -------------------------------------------
-open import Agda.Builtin.Equality using ( _≡_ ; refl )
-open import Agda.Primitive        using ( _⊔_ ; lsuc ; Level )   renaming ( Set to Type ; lzero to  ℓ₀ )
-open import Axiom.Extensionality.Propositional using ()          renaming ( Extensionality to funext )
-open import Data.Product          using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
-open import Function.Base         using ( _∘_ )
-open import Relation.Unary        using ( Pred ; _∈_ ; _⊆_ ; ⋂ )
-import Relation.Binary.PropositionalEquality as PE
-
-
+open import Agda.Primitive using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type ; lzero to  ℓ₀ )
+open import Axiom.Extensionality.Propositional using () renaming ( Extensionality to funext )
+open import Data.Product   using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function.Base  using ( _∘_ )
+open import Relation.Unary using ( Pred ; _∈_ ; _⊆_ ; ⋂ )
+open import Relation.Binary.PropositionalEquality
+                           using ( _≡_ ; refl ; module ≡-Reasoning ; cong )
 
 -- imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries             using ( ∣_∣ ; ∥_∥ ; _⁻¹ )
@@ -60,7 +58,7 @@ The binary relation ⊧ would be practically useless if it were not an *algebrai
 \begin{code}
 
 open Term
-open PE.≡-Reasoning
+open ≡-Reasoning
 open _≅_
 
 module _ (wd : SwellDef){α β χ : Level}{X : Type χ}{𝑨 : Algebra α 𝑆}
@@ -71,7 +69,7 @@ module _ (wd : SwellDef){α β χ : Level}{X : Type χ}{𝑨 : Algebra α 𝑆}
  ⊧-I-invar Apq (mkiso f g f∼g g∼f) x =
   (𝑩 ⟦ p ⟧) x                      ≡⟨ wd χ β (𝑩 ⟦ p ⟧) x (∣ f ∣ ∘ ∣ g ∣ ∘ x) (λ i → ( f∼g (x i))⁻¹) ⟩
   (𝑩 ⟦ p ⟧) ((∣ f ∣ ∘ ∣ g ∣) ∘ x)  ≡⟨ (comm-hom-term (wd 𝓥 β) 𝑩 f p (∣ g ∣ ∘ x))⁻¹ ⟩
-  ∣ f ∣ ((𝑨 ⟦ p ⟧) (∣ g ∣ ∘ x))    ≡⟨ PE.cong ∣ f ∣ (Apq (∣ g ∣ ∘ x))  ⟩
+  ∣ f ∣ ((𝑨 ⟦ p ⟧) (∣ g ∣ ∘ x))    ≡⟨ cong ∣ f ∣ (Apq (∣ g ∣ ∘ x))  ⟩
   ∣ f ∣ ((𝑨 ⟦ q ⟧) (∣ g ∣ ∘ x))    ≡⟨ comm-hom-term (wd 𝓥 β) 𝑩 f q (∣ g ∣ ∘ x) ⟩
   (𝑩 ⟦ q ⟧) ((∣ f ∣ ∘ ∣ g ∣) ∘  x) ≡⟨ wd χ β (𝑩 ⟦ q ⟧) (∣ f ∣ ∘ ∣ g ∣ ∘ x) x (λ i → ( f∼g (x i))) ⟩
   (𝑩 ⟦ q ⟧) x                      ∎
@@ -197,11 +195,11 @@ module _ (wd : SwellDef){α χ : Level}{X : Type χ}{𝑨 : Algebra α 𝑆} whe
 
  ⊧-H-invar : {p q : Term X}(φ : hom (𝑻 X) 𝑨) → 𝑨 ⊧ p ≈ q  →  ∣ φ ∣ p ≡ ∣ φ ∣ q
 
- ⊧-H-invar {p}{q}φ β = ∣ φ ∣ p               ≡⟨ PE.cong ∣ φ ∣(term-agreement(wd 𝓥 (ov χ)) p)⟩
+ ⊧-H-invar {p}{q}φ β = ∣ φ ∣ p               ≡⟨ cong ∣ φ ∣(term-agreement(wd 𝓥 (ov χ)) p)⟩
                        ∣ φ ∣((𝑻 X ⟦ p ⟧) ℊ)  ≡⟨ comm-hom-term (wd 𝓥 α) 𝑨 φ p ℊ ⟩
                        (𝑨 ⟦ p ⟧) (∣ φ ∣ ∘ ℊ) ≡⟨ β (∣ φ ∣ ∘ ℊ ) ⟩
                        (𝑨 ⟦ q ⟧) (∣ φ ∣ ∘ ℊ) ≡⟨ (comm-hom-term (wd 𝓥 α)  𝑨 φ q ℊ )⁻¹ ⟩
-                       ∣ φ ∣ ((𝑻 X ⟦ q ⟧) ℊ) ≡⟨(PE.cong ∣ φ ∣ (term-agreement (wd 𝓥 (ov χ)) q))⁻¹ ⟩
+                       ∣ φ ∣ ((𝑻 X ⟦ q ⟧) ℊ) ≡⟨(cong ∣ φ ∣ (term-agreement (wd 𝓥 (ov χ)) q))⁻¹ ⟩
                        ∣ φ ∣ q               ∎
 
 

--- a/src/Varieties/Setoid/Closure.lagda
+++ b/src/Varieties/Setoid/Closure.lagda
@@ -22,22 +22,24 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
 module Varieties.Setoid.Closure {𝑆 : Signature 𝓞 𝓥} where
 
-open import Axiom.Extensionality.Propositional renaming ( Extensionality to funext )
-open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+-- imports from Agda and the Agda Standard Library -------------------------------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Axiom.Extensionality.Propositional
+                           using () renaming ( Extensionality to funext )
 open import Data.Product   using ( _,_ ; Σ-syntax ) renaming ( proj₁ to fst ; proj₂ to snd )
-open import Level          using ( Level ;  Lift )
 open import Relation.Unary using ( Pred  ; _∈_ ; _⊆_ )
 
 
-open import Overture.Preliminaries             using ( ∣_∣ ; ∥_∥ )
-open import Algebras.Setoid.Products   {𝑆 = 𝑆} using ( ⨅ )
-open import Algebras.Setoid.Basic      {𝑆 = 𝑆} using ( SetoidAlgebra ) renaming ( Lift-SetoidAlg to Lift-Alg )
-open import Homomorphisms.Setoid.Basic {𝑆 = 𝑆} using ( )
-open import Homomorphisms.Setoid.Isomorphisms {𝑆 = 𝑆} using ( _≅_ ; ≅-sym ; Lift-≅ ; ≅-trans ; ≅-refl ) -- ; Lift-Alg-⨅≅
-open import Homomorphisms.Setoid.HomomorphicImages {𝑆 = 𝑆} using ( HomImages )
-                                                     -- ; Lift-Alg-iso ; Lift-Alg-associative )
-open import Subalgebras.Setoid.Subalgebras         {𝑆 = 𝑆} using (_≤_  -- -- ; ≤-iso ; ≤-refl ; ≤-TRANS-≅ ; ≤-trans
-                                                          ; _IsSubalgebraOfClass_ ; Subalgebra )
+-- imports from agda-algebras --------------------------------------------------------------
+open import Overture.Preliminaries           using ( ∣_∣ ; ∥_∥ )
+open import Algebras.Setoid.Products {𝑆 = 𝑆} using ( ⨅ )
+open import Algebras.Setoid.Basic    {𝑆 = 𝑆} using ( SetoidAlgebra ) renaming ( Lift-SetoidAlg to Lift-Alg )
+open import Homomorphisms.Setoid.Isomorphisms
+                                     {𝑆 = 𝑆} using ( _≅_ ; ≅-sym ; Lift-≅ ; ≅-trans ; ≅-refl )
+open import Homomorphisms.Setoid.HomomorphicImages
+                                     {𝑆 = 𝑆} using ( HomImages )
+open import Subalgebras.Setoid.Subalgebras
+                                     {𝑆 = 𝑆} using (_≤_ ; _IsSubalgebraOfClass_ ; Subalgebra )
 
 ov : Level → Level
 ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α

--- a/src/Varieties/Setoid/EquationalLogic.lagda
+++ b/src/Varieties/Setoid/EquationalLogic.lagda
@@ -22,27 +22,21 @@ open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
 module Varieties.Setoid.EquationalLogic {𝑆 : Signature 𝓞 𝓥} where
 
-
 -- imports from Agda and the Agda Standard Library -------------------------------------------
-open import Agda.Builtin.Equality  using    ( _≡_                       )
-                                   renaming ( refl     to ≡-refl        )
-open import Agda.Primitive         using    ( _⊔_      ;  lsuc  ; Level )
-                                   renaming ( Set      to Type          )
-open import Data.Product           using    ( _,_      ;   Σ
-                                            ; Σ-syntax ;   _×_          )
-                                   renaming ( proj₁    to  fst
-                                            ; proj₂    to  snd          )
-open import Function.Base          using    ( _∘_      ;  flip          )
-open import Function.Bundles       using    ( Func                      )
-open import Relation.Binary        using    ( Setoid   ;  IsEquivalence )
-open import Relation.Unary         using    ( Pred     ; _∈_            )
+open import Agda.Primitive   using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function.Base    using ( _∘_ ; flip )
+open import Function.Bundles using ( Func )
+open import Relation.Binary  using ( Setoid ; IsEquivalence )
+open import Relation.Unary   using ( Pred ; _∈_ )
+open import Relation.Binary.PropositionalEquality
+                             using ( _≡_ ; refl )
+
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
-open Setoid        using    ( Carrier ; _≈_ ; isEquivalence )
-open Func          renaming ( f     to  _<$>_ )
-open IsEquivalence renaming ( refl  to  reflE
-                            ; sym   to  symmE
-                            ; trans to  tranE )
+open Setoid using ( Carrier ; _≈_ ; isEquivalence )
+open Func renaming ( f to _<$>_ )
+open IsEquivalence renaming ( refl to reflE ; sym to  symmE ; trans to tranE )
 
 
 -- imports from agda-algebras --------------------------------------------------------------
@@ -162,7 +156,7 @@ module Soundness {χ α ρ ι : Level}{I : Type ι} (E : I → Eq{χ})
  sound : ∀ {p q} → E ⊢ Γ ▹ p ≈ q → M ⊨ (p ≈̇ q)
 
  sound (hyp i)                      =  V i
- sound (app {f = f} es) ρ           =  Interp .cong (≡-refl , λ i → sound (es i) ρ)
+ sound (app {f = f} es) ρ           =  Interp .cong (refl , λ i → sound (es i) ρ)
  sound (sub {p = p} {q} Epq σ) ρ    =  begin
                                        ⟦ p [ σ ] ⟧ <$> ρ          ≈⟨ substitution p σ ρ ⟩
                                        ⟦ p       ⟧ <$> ⟪ σ ⟫ ρ ≈⟨ sound Epq (⟪ σ ⟫ ρ)  ⟩
@@ -213,7 +207,7 @@ module TermModel {χ : Level}{Γ : Type χ}{ι : Level}{I : Type ι} (E : I → 
  -- This works since E ⊢ Γ ▹_≈_ is a congruence.
  TermInterp : ∀ {Γ} → Func (⟦ 𝑆 ⟧s (TermSetoid Γ)) (TermSetoid Γ)
  TermInterp <$> (f , ts) = node f ts
- cong TermInterp (≡-refl , h) = app h
+ cong TermInterp (refl , h) = app h
 
  -- The term model per context Γ.
  M : Type χ → SetoidAlgebra _ _

--- a/src/Varieties/Setoid/FreeAlgebras.lagda
+++ b/src/Varieties/Setoid/FreeAlgebras.lagda
@@ -12,21 +12,18 @@ author: [agda-algebras development team][]
 {-# OPTIONS --without-K --exact-split --safe #-}
 
 
-open import Level using (Level)
 open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
 module Varieties.Setoid.FreeAlgebras {𝑆 : Signature 𝓞 𝓥} where
 
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Agda.Builtin.Equality       using    ( _≡_       ;  refl )
-open import Agda.Primitive using ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Data.Product            using    ( _,_   ; Σ-syntax
-                                             ; Σ     ; _×_      )
-                                    renaming ( proj₁ to fst
-                                             ; proj₂ to snd     )
-open import Function.Base           using    ( id )
-open import Relation.Unary          using    ( Pred  ; _∈_      )
+-- Imports from Agda and the Agda Standard Library ---------------------
+open import Agda.Primitive using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Data.Product   using ( _,_ ; Σ-syntax ; _×_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function.Base  using ( id )
+open import Relation.Unary using ( Pred  ; _∈_ )
+open import Relation.Binary.PropositionalEquality
+                           using ( refl )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------------------
 open import Overture.Preliminaries             using ( ∣_∣ )
@@ -35,7 +32,8 @@ open import Algebras.Setoid.Products   {𝑆 = 𝑆} using ( ⨅ )
 open import Algebras.Setoid.Basic      {𝑆 = 𝑆} using ( SetoidAlgebra ; ⟦_⟧s )
 open import Homomorphisms.Setoid.Basic {𝑆 = 𝑆} using ( hom ; epi )
 open import Terms.Setoid.Basic         {𝑆 = 𝑆} using ( TermAlgebra )
-open import Varieties.Setoid.EquationalLogic {𝑆 = 𝑆} using ( Eq ; _⊫_ ; module TermModel ; Mod ; Th)
+open import Varieties.Setoid.EquationalLogic
+                                       {𝑆 = 𝑆} using ( Eq ; _⊫_ ; module TermModel ; Mod ; Th)
 
 private variable
  α χ ρ ℓ : Level


### PR DESCRIPTION
with those from the Relation.Binary.PropositionalEquality module of the Agda StdLib.

(and checked that `make` still works, so everything still type-checks)