### PR TITLE
minor change

### DIFF
--- a/src/Algebras/Basic.lagda
+++ b/src/Algebras/Basic.lagda
@@ -1,11 +1,6 @@
----
-layout: default
-title : Algebras.Basic module (Agda Universal Algebra Library)
-date : 2021-04-23
-author: [agda-algebras development team][]
----
+<h2>Algebras.Basic module</h2>
 
-### Basic Definitions
+<h3>Basic Definitions</h3>
 
 This is the [Algebras.Basic][] module of the [Agda Universal Algebra Library][].
 
@@ -21,7 +16,7 @@ open import Agda.Builtin.Equality  using (_≡_ ; refl )
 open import Agda.Primitive         using ( _⊔_ ; lsuc ) renaming ( Set to  Type ; lzero to ℓ₀ )
 open import Data.Empty             using ( ⊥ )
 open import Data.Product           using ( _,_ ; _×_ ; Σ ; Σ-syntax )
-open import Level                  using ( Level ; Lift )
+open import Level                  using ( Level )
 open import Relation.Binary        using ( IsEquivalence ) renaming ( Rel to BinRel )
 open import Relation.Unary         using ( _∈_ ; Pred )
 
@@ -32,26 +27,25 @@ open import Relations.Discrete     using ( Op ; _|:_ ; _|:pred_ )
 open import Relations.Continuous   using ( Rel; ΠΡ ; compatible-Rel ; compatible-ΠΡ )
 
 private variable α β ρ : Level
-
 variable 𝓞 𝓥 : Level
 
 \end{code}
 
-#### The signatures of an algebra
+<h4>The signatures of an algebra</h4>
 
-In [model theory](https://en.wikipedia.org/wiki/Model_theory), the *signature* `𝑆 = (𝐶, 𝐹, 𝑅, ρ)` of a structure consists of three (possibly empty) sets `𝐶`, `𝐹`, and `𝑅`---called *constant symbols*, *function symbols*, and *relation symbols*, respectively---along with a function `ρ : 𝐶 + 𝐹 + 𝑅 → 𝑁` that assigns an *arity* to each symbol. Often (but not always) `𝑁 = ℕ`, the natural numbers.
+In <a href="https://en.wikipedia.org/wiki/Model_theory">model theory</a>, the <i>signature</i> `𝑆 = (𝐶, 𝐹, 𝑅, ρ)` of a structure consists of three (possibly empty) sets `𝐶`, `𝐹`, and `𝑅`---called <i>constant symbols</i>, <i>function symbols</i>, and <i>relation symbols</i>, respectively---along with a function `ρ : 𝐶 + 𝐹 + 𝑅 → 𝑁` that assigns an <i>arity</i> to each symbol. Often (but not always) `𝑁 = ℕ`, the natural numbers.
 
-As our focus here is universal algebra, we are more concerned with the restricted notion of an *algebraic signature* (or *signature* for algebraic structures), by which we mean a pair `𝑆 = (𝐹, ρ)` consisting of a collection `𝐹` of *operation symbols* and an *arity function* `ρ : 𝐹 → 𝑁` that maps each operation symbol to its arity; here, 𝑁 denotes the *arity type*. Heuristically, the arity `ρ 𝑓` of an operation symbol `𝑓 ∈ 𝐹` may be thought of as the "number of arguments" that `𝑓` takes as "input".
+As our focus here is universal algebra, we are more concerned with the restricted notion of an <i>algebraic signature</i> (or <i>signature</i> for algebraic structures), by which we mean a pair `𝑆 = (𝐹, ρ)` consisting of a collection `𝐹` of <i>operation symbols</i> and an <i>arity function</i> `ρ : 𝐹 → 𝑁` that maps each operation symbol to its arity; here, 𝑁 denotes the <i>arity type</i>. Heuristically, the arity `ρ 𝑓` of an operation symbol `𝑓 ∈ 𝐹` may be thought of as the "number of arguments" that `𝑓` takes as "input".
 
-If the arity of `𝑓` is `n`, then we call `𝑓` an `n`-*ary* operation symbol.  In case `n` is 0 (or 1 or 2 or 3, respectively) we call the function *nullary* (or *unary* or *binary* or *ternary*, respectively).
+If the arity of `𝑓` is `n`, then we call `𝑓` an `n`-<i>ary</i> operation symbol.  In case `n` is 0 (or 1 or 2 or 3, respectively) we call the function <i>nullary</i> (or <i>unary</i> or <i>binary</i> or <i>ternary</i>, respectively).
 
 If `A` is a set and `𝑓` is a (`ρ 𝑓`)-ary operation on `A`, we often indicate this by writing `𝑓 : A`<sup>ρ 𝑓</sup> `→ A`. On the other hand, the arguments of such an operation form a (`ρ 𝑓`)-tuple, say, `(a 0, a 1, …, a (ρf-1))`, which may be viewed as the graph of the function `a : ρ𝑓 → A`. When the codomain of `ρ` is `ℕ`, we may view `ρ 𝑓` as the finite set `{0, 1, …, ρ𝑓 - 1}`. Thus, by identifying the `ρ𝑓`-th power `A`<sup>ρ 𝑓</sup> with the type `ρ 𝑓 → A` of functions from `{0, 1, …, ρ𝑓 - 1}` to `A`, we identify the function type `A`<sup>ρ f</sup> `→ A` with the function (or "functional") type `(ρ𝑓 → A) → A`.
 
-**Example**. Suppose `𝑔 : (m → A) → A` is an `m`-ary operation on `A`, and `a : m → A` is an `m`-tuple on `A`. Then `𝑔 a` may be viewed as `𝑔 (a 0, a 1, …, a (m-1))`, which has type `A`. Suppose further that `𝑓 : (ρ𝑓 → B) → B` is a `ρ𝑓`-ary operation on `B`, let `a : ρ𝑓 → A` be a `ρ𝑓`-tuple on `A`, and let `h : A → B` be a function.  Then the following typing judgments obtain: `h ∘ a : ρ𝑓 → B` and we `𝑓 (h ∘ a) : B`.
+<b>Example</b>. Suppose `𝑔 : (m → A) → A` is an `m`-ary operation on `A`, and `a : m → A` is an `m`-tuple on `A`. Then `𝑔 a` may be viewed as `𝑔 (a 0, a 1, …, a (m-1))`, which has type `A`. Suppose further that `𝑓 : (ρ𝑓 → B) → B` is a `ρ𝑓`-ary operation on `B`, let `a : ρ𝑓 → A` be a `ρ𝑓`-tuple on `A`, and let `h : A → B` be a function.  Then the following typing judgments obtain: `h ∘ a : ρ𝑓 → B` and we `𝑓 (h ∘ a) : B`.
 
-#### Signature type
+<h4>Signature type</h4>
 
-In the [UniversalAlgebra][] library we represent the *signature* of an algebraic structure using the following type.
+In the <a href="https://github.com/ualib/agda-algebras">agda-algebras library</a> we represent the <i>signature</i> of an algebraic structure using the following type.
 
 \begin{code}
 
@@ -71,26 +65,29 @@ signature 𝓞 = Σ[ F ∈ Type 𝓞 ] (F → Type)
 
 \end{code}
 
-As mentioned earlier, throughout the [UniversalAlgebra][] library `𝓞` denote the universe level of *operation symbol* types, while `𝓥` denotes the universe level of *arity* types.
+As mentioned earlier, throughout the <a href="https://github.com/ualib/agda-algebras">agda-algebras library</a> `𝓞` denote the universe level of <i>operation symbol</i> types, while `𝓥` denotes the universe level of <i>arity</i> types.
 
 In the [Overture][] module we defined special syntax for the first and second projections---namely, ∣\_∣ and ∥\_∥, resp. Consequently, if `𝑆 : Signature 𝓞 𝓥` is a signature, then ∣ 𝑆 ∣ denotes the set of operation symbols, and ∥ 𝑆 ∥ denotes the arity function. If 𝑓 : ∣ 𝑆 ∣ is an operation symbol in the signature 𝑆, then ∥ 𝑆 ∥ 𝑓 is the arity of 𝑓.
 
 
 
-#### Algebras
+<h4>Algebras</h4>
 
-Our first goal is to develop a working vocabulary and formal library for classical (single-sorted, set-based) universal algebra.  In this section we define the main objects of study.  An *algebraic structure* (or *algebra*) in the signature `𝑆 = (𝐹, ρ)` is denoted by `𝑨 = (A, F`<sup>`𝑨`</sup>`)` and consists of
+Our first goal is to develop a working vocabulary and formal library for classical (single-sorted, set-based) universal algebra.  In this section we define the main objects of study.  An <i>algebraic structure</i> (or <i>algebra</i>) in the signature `𝑆 = (𝐹, ρ)` is denoted by `𝑨 = (A, F`<sup>`𝑨`</sup>`)` and consists of
 
-* `A` := a *nonempty* set (or type), called the *domain* (or *carrier* or *universe*) of the algebra;<sup>[1](Algebras.Algebras.html#fn1)</sup>
-* `F`<sup>`𝑨`</sup> := `{ f`<sup>`𝑨`</sup>` ∣ f ∈ F, f`<sup>`𝑨`</sup>` : (ρ𝑓 → A) → A }`, a collection of *operations* on `𝐴`;
-* a (potentially empty) collection of *identities* satisfied by elements and operations of `𝐴`.
+<ul>
+<li>`A` := a <i>nonempty</i> set (or type), called the <i>domain</i> (or <i>carrier</i> or <i>universe</i>) of the algebra;</li>
+<li> `F`<sup>`𝑨`</sup> := `{ f`<sup>`𝑨`</sup>` ∣ f ∈ F, f`<sup>`𝑨`</sup>` : (ρ𝑓 → A) → A }`, a collection of <i>operations</i> on `𝐴`;</li>
+<li> a (potentially empty) collection of <i>identities</i> satisfied by elements and operations of `𝐴`.</li>
+</ul>
 
-Note that to each operation symbol `𝑓 ∈ 𝐹` corresponds an operation `𝑓`<sup>`𝑨`</sup> on `𝐴` of arity `ρ𝑓`; we call such `𝑓`<sup>`𝑨`</sup> the *interpretation* of the symbol `𝑓` in the algebra `𝑨`. We call an algebra in the signature `𝑆` an `𝑆`-*algebra*.  An algebra is called *finite* if it has a finite domain, and is called *trivial* if its universe is a singleton.  Given two algebras `𝑨` and `𝑩`, we say that `𝑩` is a *reduct* of `𝑨` if both algebras have the same domain and `𝑩` can be obtained from `𝑨` by simply removing some of the operations.
+Note that to each operation symbol `𝑓 ∈ 𝐹` corresponds an operation `𝑓`<sup>`𝑨`</sup> on `𝐴` of arity `ρ𝑓`; we call such `𝑓`<sup>`𝑨`</sup> the <i>interpretation</i> of the symbol `𝑓` in the algebra `𝑨`. We call an algebra in the signature `𝑆` an `𝑆`-<i>algebra</i>.  An algebra is called <i>finite</i> if it has a finite domain, and is called <i>trivial</i> if its universe is a singleton.  Given two algebras `𝑨` and `𝑩`, we say that `𝑩` is a <i>reduct</i> of `𝑨` if both algebras have the same domain and `𝑩` can be obtained from `𝑨` by simply removing some of the operations.
 
 
-#### <a id="algebra-types">Algebra types</a>
 
-Recall, we defined the type `Signature 𝓞 𝓥` above as the dependent pair type `Σ F ꞉ Type 𝓞 , (F → Type 𝓥)`, and the type `Op` of operation symbols is the function type `Op I A = (I → A) → A` (see [Relations.Discrete][]). For a fixed signature `𝑆 : Signature 𝓞 𝓥` and universe level `α`, we define the *type of algebras in the signature* `𝑆` (or *type of* `𝑆`-*algebras*) *with domain type* `Type α` as follows.
+<h4>Algebra types</h4>
+
+Recall, we defined the type `Signature 𝓞 𝓥` above as the dependent pair type `Σ F ꞉ Type 𝓞 , (F → Type 𝓥)`, and the type `Op` of operation symbols is the function type `Op I A = (I → A) → A` (see [Relations.Discrete][]). For a fixed signature `𝑆 : Signature 𝓞 𝓥` and universe level `α`, we define the <i>type of algebras in the signature</i> `𝑆` (or <i>type of</i> `𝑆`-<i>algebras</i>) <i>with domain type</i> `Type α` as follows.
 
 \begin{code}
 
@@ -98,41 +95,31 @@ Algebra : (α : Level)(𝑆 : Signature 𝓞 𝓥) → Type (𝓞 ⊔ 𝓥 ⊔ l
 Algebra α 𝑆 = Σ[ A ∈ Type α ]                   -- the domain
               ∀ (f : ∣ 𝑆 ∣) → Op A (∥ 𝑆 ∥ f)    -- the basic operations
 
--- special case where arity types live at universe level zero
-lilAlgebra : (α : Level)(𝑆 : signature 𝓞) → Type (𝓞 ⊔ lsuc α)
-lilAlgebra α 𝑆 = Σ[ A ∈ Type α ]                   -- the domain
-                 ∀ (f : ∣ 𝑆 ∣) → Op A (∥ 𝑆 ∥ f)    -- the basic operations
-
-
-
 \end{code}
 
-It would be more precise to refer to inhabitants of this type as ∞-*algebras* because their domains can be of arbitrary type and need not be truncated at some level and, in particular, need to be a set. (See the [Relations.Truncation][] module.)
+It would be more precise to refer to inhabitants of this type as ∞-<i>algebras</i> because their domains can be of arbitrary type and need not be truncated at some level and, in particular, need to be a set. (See the [Relations.Truncation][] module.)
 
-We might take this opportunity to define the type of 0-*algebras*, that is, algebras whose domains are sets, which is probably closer to what most of us think of when doing informal universal algebra.  However, below we will only need to know that the domains of certain algebras are sets in a few places in the [UniversalAlgebra][] library, so it seems preferable to work with general (∞-)algebras throughout and then explicitly postulate [uniquness of identity proofs](Relations.Truncation.html#uniqueness-of-identity-proofs) when and only when necessary.
+We might take this opportunity to define the type of 0-<i>algebras</i>, that is, algebras whose domains are sets, which is probably closer to what most of us think of when doing informal universal algebra.  However, below we will only need to know that the domains of certain algebras are sets in a few places in the [UniversalAlgebra][] library, so it seems preferable to work with general (∞-)algebras throughout and then explicitly postulate [uniquness of identity proofs](Relations.Truncation.html#uniqueness-of-identity-proofs) when and only when necessary.
 
-##### <a id="the-universe-level-of-an-algebra">The universe level of an algebra</a>
+
+
+<h5>The universe level of an algebra</h5>
 
 Occasionally we will be given an algebra and we just need to know the universe level of its domain. The following utility function provides this.
 
 \begin{code}
 
 Level-of-Alg : {α 𝓞 𝓥 : Level}{𝑆 : Signature 𝓞 𝓥} → Algebra α 𝑆 → Level
-Level-of-Alg {α = α}{𝓞}{𝓥} _ = 𝓞 ⊔ 𝓥 ⊔ lsuc α
+Level-of-Alg {α = α}{𝓞}{𝓥} _ = 𝓞 ⊔ 𝓥 ⊔ (lsuc α)
 
-Level-of-Carrier : {α 𝓞 𝓥  : Level}{𝑆 : Signature 𝓞 𝓥} → Algebra α 𝑆 → Level
+Level-of-Carrier : {α : Level}{𝑆 : Signature 𝓞 𝓥} → Algebra α 𝑆 → Level
 Level-of-Carrier {α = α} _ = α
-
-Level-of-lilAlg : {α 𝓞 : Level}{𝑆 : signature 𝓞} → Algebra α 𝑆 → Level
-Level-of-lilAlg {α = α}{𝓞 = 𝓞} _ = (𝓞 ⊔ lsuc α)
-
-Level-of-lilCarrier : {α 𝓞 𝓥 : Level}{𝑆 : Signature 𝓞 𝓥} → Algebra α 𝑆 → Level
-Level-of-lilCarrier {α = α} _ = α
 
 \end{code}
 
 
-##### <a id="algebras-as-record-types">Algebras as record types</a>
+
+<h5>Algebras as record types</h5>
 
 Some people prefer to represent algebraic structures in type theory using records, and for those folks we offer the following (equivalent) definition.
 
@@ -149,7 +136,6 @@ record lilalgebra (α : Level) (𝑆 : signature 𝓞) : Type(lsuc(𝓞 ⊔ α))
  field
   carrier : Type α
   opsymbol : (f : ∣ 𝑆 ∣) → ((∥ 𝑆 ∥ f) → carrier) → carrier
-
 
 \end{code}
 
@@ -170,7 +156,7 @@ module _ {𝑆 : Signature 𝓞 𝓥} where
 \end{code}
 
 
-#### <a id="operation-interpretation-syntax">Operation interpretation syntax</a>
+<h4>Operation interpretation syntax</h4>
 
 We now define a convenient shorthand for the interpretation of an operation symbol. This looks more similar to the standard notation one finds in the literature as compared to the double bar notation we started with, so we will use this new notation almost exclusively in the remaining modules of the [UniversalAlgebra][] library.
 
@@ -185,9 +171,7 @@ We now define a convenient shorthand for the interpretation of an operation symb
 So, if `𝑓 : ∣ 𝑆 ∣` is an operation symbol in the signature `𝑆`, and if `𝑎 : ∥ 𝑆 ∥ 𝑓 → ∣ 𝑨 ∣` is a tuple of the appropriate arity, then `(𝑓 ̂ 𝑨) 𝑎` denotes the operation `𝑓` interpreted in `𝑨` and evaluated at `𝑎`.
 
 
-
-
-#### <a id="lifts-of-algebras">Level lifting algebra types</a>
+<h4>Level lifting algebra types</h4>
 
 Recall, in the [section on level lifting and lowering](Overture.Lifts.html#level-lifting-and-lowering), we described the difficulties one may encounter when working with a noncumulative universe hierarchy. We made a promise to provide some domain-specific level lifting and level lowering methods. Here we fulfill this promise by supplying a couple of bespoke tools designed specifically for our operation and algebra types.
 
@@ -203,13 +187,6 @@ Lift-Alg : {𝑆 : Signature 𝓞 𝓥} → Algebra α 𝑆 → (β : Level) →
 Lift-Alg {𝑆 = 𝑆} 𝑨 β = Lift β ∣ 𝑨 ∣ , (λ (𝑓 : ∣ 𝑆 ∣) → Lift-alg-op (𝑓 ̂ 𝑨) β)
 
 
-Lift-op-lilAlg : {I : Type ℓ₀}{A : Type α} → Op A I → (β : Level) → Op (Lift β A) I
-Lift-op-lilAlg {I = I} = Lift-alg-op{𝓥 = ℓ₀}{I = I}
-
-
-Lift-lilAlg : {𝑆 : signature 𝓞} → Algebra α 𝑆 → (β : Level) → Algebra (α ⊔ β) 𝑆
-Lift-lilAlg {𝑆 = 𝑆} 𝑨 β = Lift β ∣ 𝑨 ∣ , (λ (𝑓 : ∣ 𝑆 ∣) → Lift-op-lilAlg (𝑓 ̂ 𝑨) β)
-
 open algebra
 
 Lift-algebra : {𝑆 : Signature 𝓞 𝓥} → algebra α 𝑆 → (β : Level) → algebra (α ⊔ β) 𝑆
@@ -219,15 +196,16 @@ Lift-algebra {𝑆 = 𝑆} 𝑨 β = mkalg (Lift β (carrier 𝑨)) (λ (f : ∣
 
 What makes the `Lift-Alg` type so useful for resolving type level errors involving algebras is the nice properties it possesses.  Indeed, the [UniversalAlgebra][] library contains formal proofs of the following facts.
 
-+ [`Lift-Alg` is a homomorphism](Homomorphisms.Basic.html#exmples-of-homomorphisms) (see [Homomorphisms.Basic][])
-+ [`Lift-Alg` is an algebraic invariant](Homomorphisms.Isomorphisms.html#lift-is-an-algebraic-invariant") (see [Homomorphisms.Isomorphisms][])
-+ [`Lift-Alg` of a subalgebra is a subalgebra](Subalgebras.Subalgebras.html#lifts-of-subalgebras) (see [Subalgebras.Subalgebras][])
-+ [`Lift-Alg` preserves identities](Varieties.EquationalLogic.html#lift-invariance)) (see [Varieties.EquationalLogic][])
+<ul>
+<li> <a href="Homomorphisms.Basic.html#exmples-of-homomorphisms">`Lift-Alg` is a homomorphism</a></li>
+<li> <a href="Homomorphisms.Isomorphisms.html#lift-is-an-algebraic-invariant">`Lift-Alg` is an algebraic invariant</a></li>
+<li> <a href="Subalgebras.Subalgebras.html#lifts-of-subalgebras">`Lift-Alg` of a subalgebra is a subalgebra</a></li>
+<li> <a href="Varieties.EquationalLogic.html#lift-invariance">`Lift-Alg` preserves identities</a></li>
+</ul>
 
+<h4>Compatibility of binary relations</h4>
 
-#### <a id="compatibility-of-binary-relations">Compatibility of binary relations</a>
-
-We now define the function `compatible` so that, if `𝑨` denotes an algebra and `R` a binary relation, then `compatible 𝑨 R` will represent the assertion that `R` is *compatible* with all basic operations of `𝑨`. The formal definition is immediate since all the work is done by the relation `|:`, which we defined above (see [Relations.Discrete][]).
+We now define the function `compatible` so that, if `𝑨` denotes an algebra and `R` a binary relation, then `compatible 𝑨 R` will represent the assertion that `R` is <i>compatible</i> with all basic operations of `𝑨`. The formal definition is immediate since all the work is done by the relation `|:`, which we defined above (see [Relations.Discrete][]).
 
 \begin{code}
 
@@ -237,9 +215,6 @@ compatible  𝑨 R = ∀ 𝑓 → (𝑓 ̂ 𝑨) |: R
 compatible-pred : {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra α 𝑆) → Pred (∣ 𝑨 ∣ × ∣ 𝑨 ∣)ρ → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ)
 compatible-pred  𝑨 P = ∀ 𝑓 → (𝑓 ̂ 𝑨) |:pred P
 
-compatible-lilAlg : {𝑆 : signature 𝓞}(𝑨 : Algebra α 𝑆) → BinRel ∣ 𝑨 ∣ ρ → Type(𝓞 ⊔ α ⊔ ρ)
-compatible-lilAlg  𝑨 R = ∀ 𝑓 → (𝑓 ̂ 𝑨) |: R
-
 \end{code}
 
 Recall, the `|:` type was defined in [Relations.Discrete][] module.
@@ -247,9 +222,9 @@ Recall, the `|:` type was defined in [Relations.Discrete][] module.
 
 
 
-#### <a id="compatibility-of-continuous-relations">Compatibility of continuous relations<sup>[★](Algebras.Algebras.html#fn0)</sup></a>
+<h4>Compatibility of continuous relations</h4>
 
-In the [Relations.Continuous][] module, we defined a function called `cont-compatible-op` to represent the assertion that a given continuous relation is compatible with a given operation. With that, it is easy to define a function, which we call `cont-compatible`, representing compatibility of a continuous relation with all operations of an algebra.  Similarly, we define the analogous `dep-compatible` function for the (even more general) type of *dependent relations*.
+In the [Relations.Continuous][] module, we defined a function called `cont-compatible-op` to represent the assertion that a given continuous relation is compatible with a given operation. With that, it is easy to define a function, which we call `cont-compatible`, representing compatibility of a continuous relation with all operations of an algebra.  Similarly, we define the analogous `dep-compatible` function for the (even more general) type of <i>dependent relations</i>.
 
 \begin{code}
 
@@ -261,22 +236,7 @@ module _ {I : Type 𝓥} {𝑆 : Signature 𝓞 𝓥} where
  compatible-ΠΡ-alg : (𝒜 : I → Algebra α 𝑆) → ΠΡ I (λ i → ∣ 𝒜  i ∣) {ρ} → Type(𝓞 ⊔ α ⊔ 𝓥 ⊔ ρ)
  compatible-ΠΡ-alg 𝒜 R = ∀ ( 𝑓 : ∣ 𝑆 ∣ ) →  compatible-ΠΡ (λ i → 𝑓 ̂ (𝒜 i)) R
 
-module _ {I : Type ℓ₀} {𝑆 : signature 𝓞} where
-
- compatible-Rel-lilAlg : (𝑨 : Algebra α 𝑆) → Rel ∣ 𝑨 ∣ I{ρ} → Type(𝓞 ⊔ α ⊔ ρ)
- compatible-Rel-lilAlg 𝑨 R = ∀ (𝑓 : ∣ 𝑆 ∣ ) →  compatible-Rel (𝑓 ̂ 𝑨) R
-
- compatible-ΠΡ-lilAlg : (𝒜 : I → Algebra α 𝑆) → ΠΡ I (λ i → ∣ 𝒜  i ∣) {ρ} → Type(𝓞 ⊔ α ⊔ ρ)
- compatible-ΠΡ-lilAlg 𝒜 R = ∀ ( 𝑓 : ∣ 𝑆 ∣ ) →  compatible-ΠΡ (λ i → 𝑓 ̂ (𝒜 i)) R
-
 \end{code}
 
 
-
--------------------------------------
-
-
-{% include UALib.Links.md %}
-
-
-[agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team
+{% include footer.html %}

--- a/src/Algebras/Congruences.lagda
+++ b/src/Algebras/Congruences.lagda
@@ -1,13 +1,4 @@
----
-layout: default
-title : Algebras.Congruences module (The Agda Universal Algebra Library)
-date : 2021-07-03
-author: [agda-algebras development team][]
----
-
-### Congruence Relations
-
-This is the [Algebras.Congruences][] module of the [Agda Universal Algebra Library][].
+<h2>Algebras.Congruences module</h2>
 
 \begin{code}
 
@@ -33,12 +24,12 @@ open import Relations.Quotients       using ( 0[_]Equivalence ; _/_ ; ⟪_⟫ ; 
 open import Foundations.Welldefined   using ( swelldef )
 open import Algebras.Products {𝑆 = 𝑆} using ( ov )
 
-
-
 private variable α β ρ : Level
 \end{code}
 
-A *congruence relation* of an algebra `𝑨` is defined to be an equivalence relation that is compatible with the basic operations of `𝑨`.  This concept can be represented in a number of alternative but equivalent ways.
+<h3>Congruence Relations</h3>
+
+A <i>congruence relation</i> of an algebra `𝑨` is defined to be an equivalence relation that is compatible with the basic operations of `𝑨`.  This concept can be represented in a number of alternative but equivalent ways.
 Formally, we define a record type (`IsCongruence`) to represent the property of being a congruence, and we define a Sigma type (`Con`) to represent the type of congruences of a given algebra.
 
 \begin{code}
@@ -65,8 +56,8 @@ Con→IsCongruence θ = ∥ θ ∥
 
 \end{code}
 
-#### <a id="example">Example</a>
-We defined the *zero relation* `0[_]` in the [Relations.Discrete][] module.  We now build the *trivial congruence*, which has `0[_]` as its underlying relation. Observe that `0[_]` is equivalent to the identity relation `≡` and these are obviously both equivalence relations. In fact, we already proved this of `≡` in the [Overture.Equality][] module, so we simply apply the corresponding proofs.
+<h4 id="example">Example</h4>
+We defined the <i>zero relation</i> `0[_]` in the [Relations.Discrete][] module.  We now build the <i>trivial congruence</i>, which has `0[_]` as its underlying relation. Observe that `0[_]` is equivalent to the identity relation `≡` and these are obviously both equivalence relations. In fact, we already proved this of `≡` in the [Overture.Equality][] module, so we simply apply the corresponding proofs.
 
 \begin{code}
 open Level
@@ -88,8 +79,8 @@ open IsCongruence
 
 A concrete example is `⟪𝟎⟫[ 𝑨 ╱ θ ]`, presented in the next subsection.
 
-#### <a id="quotient-algebras">Quotient algebras</a>
-In many areas of abstract mathematics the *quotient* of an algebra `𝑨` with respect to a congruence relation `θ` of `𝑨` plays an important role. This quotient is typically denoted by `𝑨 / θ` and Agda allows us to define and express quotients using this standard notation.<sup>[1](Algebras.Congruences.html#fn1)</sup>
+<h4 id="quotient-algebras">Quotient algebras</h4>
+In many areas of abstract mathematics the <i>quotient</i> of an algebra `𝑨` with respect to a congruence relation `θ` of `𝑨` plays an important role. This quotient is typically denoted by `𝑨 / θ` and Agda allows us to define and express quotients using this standard notation.<sup>[1](Algebras.Congruences.html#fn1)</sup>
 
 \begin{code}
 
@@ -100,7 +91,7 @@ _╱_ : (𝑨 : Algebra α 𝑆) → Con{α}{ρ} 𝑨 → Algebra (α ⊔ lsuc �
 
 \end{code}
 
-**Example**. If we adopt the notation `𝟎[ 𝑨 ╱ θ ]` for the zero (or identity) relation on the quotient algebra `𝑨 ╱ θ`, then we define the zero relation as follows.
+<b>Example</b>. If we adopt the notation `𝟎[ 𝑨 ╱ θ ]` for the zero (or identity) relation on the quotient algebra `𝑨 ╱ θ`, then we define the zero relation as follows.
 
 \begin{code}
 
@@ -133,18 +124,4 @@ open IsCongruence
 
 \end{code}
 
-------------------------------
-
-{% include UALib.Links.md %}
-
-
-
-------------------------------
-
-[agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team
-
-
-
-
-
-
+{% include footnote.html %}

--- a/src/Algebras/Products.lagda
+++ b/src/Algebras/Products.lagda
@@ -1,19 +1,8 @@
----
-layout: default
-title : Algebras.Products module (Agda Universal Algebra Library)
-date : 2021-01-12
-author: [agda-algebras development team][]
----
-
-
-### Products of Algebras and Product Algebras
-
-This is the [Algebras.Products][] module of the [Agda Universal Algebra Library][].
+<h2>Algebras.Products module</h2>
 
 \begin{code}
 
 {-# OPTIONS --without-K --exact-split --safe #-}
-
 
 open import Algebras.Basic using ( 𝓞 ; 𝓥 ; Signature )
 
@@ -23,22 +12,22 @@ module Algebras.Products {𝑆 : Signature 𝓞 𝓥} where
 -- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
 open import Agda.Primitive  using ( lsuc ; _⊔_ ; Level ) renaming ( Set to Type )
 open import Data.Product    using ( _,_ ; Σ ; Σ-syntax )
+open import Level using ( Level )
 open import Relation.Unary  using ( Pred ; _⊆_ ; _∈_ )
-
 
 -- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries using (_⁻¹; 𝑖𝑑; ∣_∣; ∥_∥)
-open import Algebras.Basic         using ( Algebra ; _̂_ ; algebra )
+open import Algebras.Basic using ( Algebra ; _̂_ ; algebra )
 
 private variable α β ρ 𝓘 : Level
 
 \end{code}
 
-From now on, the modules of the [UniversalAlgebra][] library will assume a fixed signature `𝑆 : Signature 𝓞 𝓥`.
+<h3>Products of Algebras and Product Algebras</h3>
 
-Recall the informal definition of a *product* of `𝑆`-algebras. Given a type `I : Type 𝓘` and a family `𝒜 : I → Algebra α 𝑆`, the *product* `⨅ 𝒜` is the algebra whose domain is the Cartesian product `Π 𝑖 ꞉ I , ∣ 𝒜 𝑖 ∣` of the domains of the algebras in `𝒜`, and whose operations are defined as follows: if `𝑓` is a `J`-ary operation symbol and if `𝑎 : Π 𝑖 ꞉ I , J → 𝒜 𝑖` is an `I`-tuple of `J`-tuples such that `𝑎 𝑖` is a `J`-tuple of elements of `𝒜 𝑖` (for each `𝑖`), then `(𝑓 ̂ ⨅ 𝒜) 𝑎 := (i : I) → (𝑓 ̂ 𝒜 i)(𝑎 i)`.
+Recall the informal definition of a <i>product</i> of `𝑆`-algebras. Given a type `I : Type 𝓘` and a family `𝒜 : I → Algebra α 𝑆`, the <i>product</i> `⨅ 𝒜` is the algebra whose domain is the Cartesian product `Π 𝑖 ꞉ I , ∣ 𝒜 𝑖 ∣` of the domains of the algebras in `𝒜`, and whose operations are defined as follows: if `𝑓` is a `J`-ary operation symbol and if `𝑎 : Π 𝑖 ꞉ I , J → 𝒜 𝑖` is an `I`-tuple of `J`-tuples such that `𝑎 𝑖` is a `J`-tuple of elements of `𝒜 𝑖` (for each `𝑖`), then `(𝑓 ̂ ⨅ 𝒜) 𝑎 := (i : I) → (𝑓 ̂ 𝒜 i)(𝑎 i)`.
 
-In [UniversalAlgebra][] a *product of* `𝑆`-*algebras* is represented by the following type.
+In [UniversalAlgebra][] a <i>product of</i> `𝑆`-<i>algebras</i> is represented by the following type.
 
 \begin{code}
 
@@ -65,8 +54,7 @@ open algebra
 \end{code}
 
 
-
-**Notation**. Given a signature `𝑆 : Signature 𝓞 𝓥`, the type `Algebra α 𝑆` has type `Type(𝓞 ⊔ 𝓥 ⊔ lsuc α)`.  Such types occur so often in the [UniversalAlgebra][] library that we define the following shorthand for their universes.
+<b>Notation</b>. Given a signature `𝑆 : Signature 𝓞 𝓥`, the type `Algebra α 𝑆` has type `Type(𝓞 ⊔ 𝓥 ⊔ lsuc α)`.  Such types occur so often in the [UniversalAlgebra][] library that we define the following shorthand for their universes.
 
 \begin{code}
 
@@ -76,8 +64,7 @@ ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α
 \end{code}
 
 
-
-#### <a id="products-of-classes-of-algebras">Products of classes of algebras</a>
+<h4 id="products-of-classes-of-algebras">Products of classes of algebras</h4>
 
 An arbitrary class `𝒦` of algebras is represented as a predicate over the type `Algebra α 𝑆`, for some universe level `α` and signature `𝑆`. That is, `𝒦 : Pred (Algebra α 𝑆) β`, for some type `β`. Later we will formally state and prove that the product of all subalgebras of algebras in `𝒦` belongs to the class `SP(𝒦)` of subalgebras of products of algebras in `𝒦`. That is, `⨅ S(𝒦) ∈ SP(𝒦 )`. This turns out to be a nontrivial exercise.
 
@@ -89,9 +76,9 @@ To begin, we need to define types that represent products over arbitrary (nonind
 
 which asserts that every inhabitant of the type `Algebra α 𝑆` belongs to `𝒦`.  Evidently this is not the product algebra that we seek.
 
-What we need is a type that serves to index the class `𝒦`, and a function `𝔄` that maps an index to the inhabitant of `𝒦` at that index. But `𝒦` is a predicate (of type `(Algebra α 𝑆) → Type β`) and the type `Algebra α 𝑆` seems rather nebulous in that there is no natural indexing class with which to "enumerate" all inhabitants of `Algebra α 𝑆` belonging to `𝒦`.<sup>[1](Algebras.Product.html#fn1)</sup>
+What we need is a type that serves to index the class `𝒦`, and a function `𝔄` that maps an index to the inhabitant of `𝒦` at that index. But `𝒦` is a predicate (of type `(Algebra α 𝑆) → Type β`) and the type `Algebra α 𝑆` seems rather nebulous in that there is no natural indexing class with which to "enumerate" all inhabitants of `Algebra α 𝑆` belonging to `𝒦`.
 
-The solution is to essentially take `𝒦` itself to be the indexing type, at least heuristically that is how one can view the type `ℑ` that we now define.<sup>[2](Algebras.Product.html#fn2)</sup>
+The solution is to essentially take `𝒦` itself to be the indexing type, at least heuristically that is how one can view the type `ℑ` that we now define.
 
 \begin{code}
 
@@ -119,21 +106,8 @@ Finally, we define `class-product` which represents the product of all members o
 
 \end{code}
 
-If `p : 𝑨 ∈ 𝒦`, we view the pair `(𝑨 , p) ∈ ℑ` as an *index* over the class, so we can think of `𝔄 (𝑨 , p)` (which is simply `𝑨`) as the projection of the product `⨅ 𝔄` onto the `(𝑨 , p)`-th component.
+If `p : 𝑨 ∈ 𝒦`, we view the pair `(𝑨 , p) ∈ ℑ` as an <i>index</i> over the class, so we can think of `𝔄 (𝑨 , p)` (which is simply `𝑨`) as the projection of the product `⨅ 𝔄` onto the `(𝑨 , p)`-th component.
 
 
+{% include footer.html %}
 
------------------------
-
-<sup>1</sup><span class="footnote" id="fn1"> If you haven't seen this before, give it some thought and see if the correct type comes to you organically.</span>
-
-<sup>2</sup><span class="footnote" id="fn2"> **Unicode Hints**. Some of our types are denoted with with Gothic ("mathfrak") symbols. To produce them in [agda2-mode][], type `\Mf` followed by a letter. For example, `\MfI` ↝ `ℑ`.</span>
-
-[← Algebras.Basic](Algebras.Basic.html)
-<span style="float:right;">[Algebras.Congruences →](Algebras.Congruences.html)</span>
-
-{% include UALib.Links.md %}
-
------------------------------------------------
-
-[agda-algebras development team]: https://github.com/ualib/agda-algebras#the-agda-algebras-development-team

--- a/src/Algebras/Setoid/Basic.lagda
+++ b/src/Algebras/Setoid/Basic.lagda
@@ -35,6 +35,8 @@ open import Overture.Preliminaries using ( ∥_∥ ; ∣_∣ )
 private variable
  α ρ ι : Level
 
+ov : Level → Level
+ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α
 \end{code}
 
 #### Models (again)
@@ -54,17 +56,17 @@ open Setoid using    (_≈_ ; Carrier )
                      ; isEquivalence to isEqv )
 open Func renaming   ( f to _<$>_ )
 
-⟦_⟧s : Signature 𝓞 𝓥 → Setoid α ρ → Setoid _ _
+⟦_⟧ : Signature 𝓞 𝓥 → Setoid α ρ → Setoid _ _
 
-Carrier (⟦ 𝑆 ⟧s ξ) = Σ[ f ∈ ∣ 𝑆 ∣ ] ((∥ 𝑆 ∥ f) → ξ .Carrier)
-_≈_ (⟦ 𝑆 ⟧s ξ) (f , u) (g , v) = Σ[ eqv ∈ f ≡ g ] EqArgs eqv u v
+Carrier (⟦ 𝑆 ⟧ ξ) = Σ[ f ∈ ∣ 𝑆 ∣ ] ((∥ 𝑆 ∥ f) → ξ .Carrier)
+_≈_ (⟦ 𝑆 ⟧ ξ) (f , u) (g , v) = Σ[ eqv ∈ f ≡ g ] EqArgs eqv u v
  where
  EqArgs : f ≡ g → (∥ 𝑆 ∥ f → Carrier ξ) → (∥ 𝑆 ∥ g → Carrier ξ) → Type _
  EqArgs refl u v = ∀ i → (_≈_ ξ) (u i) (v i)
 
-IsEquivalence.refl  (isEqv (⟦ 𝑆 ⟧s ξ))                     = refl , λ _ → reflS  ξ
-IsEquivalence.sym   (isEqv (⟦ 𝑆 ⟧s ξ))(refl , g)           = refl , λ i → symS   ξ (g i)
-IsEquivalence.trans (isEqv (⟦ 𝑆 ⟧s ξ))(refl , g)(refl , h) = refl , λ i → transS ξ (g i) (h i)
+IsEquivalence.refl  (isEqv (⟦ 𝑆 ⟧ ξ))                     = refl , λ _ → reflS  ξ
+IsEquivalence.sym   (isEqv (⟦ 𝑆 ⟧ ξ))(refl , g)           = refl , λ i → symS   ξ (g i)
+IsEquivalence.trans (isEqv (⟦ 𝑆 ⟧ ξ))(refl , g)(refl , h) = refl , λ i → transS ξ (g i) (h i)
 
 \end{code}
 
@@ -78,14 +80,14 @@ The `Func` record packs a function (f, aka apply, aka _<$>_) with a proof (cong)
 
 Algebroid : (α ρ : Level) → Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ))
 Algebroid α ρ = Σ[ A ∈ Setoid α ρ ]      -- the domain (a setoid)
-                 Func (⟦ 𝑆 ⟧s A) A       -- the basic operations,
+                 Func (⟦ 𝑆 ⟧ A) A       -- the basic operations,
                                          -- along with congruence proofs that
                                          -- each operation espects setoid equality
 
 record SetoidAlgebra α ρ : Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)) where
   field
     Domain : Setoid α ρ
-    Interp : Func (⟦ 𝑆 ⟧s Domain) Domain
+    Interp : Func (⟦ 𝑆 ⟧ Domain) Domain
      --      ^^^^^^^^^^^^^^^^^^^^^^^ is a record type with two fields:
      --       1. a function  f : Carrier (⟦ 𝑆 ⟧s Domain)  → Carrier Domain
      --       2. a proof cong : f Preserves _≈₁_ ⟶ _≈₂_ (that f preserves the setoid equalities)

--- a/src/Algebras/Setoid/Congruences.lagda
+++ b/src/Algebras/Setoid/Congruences.lagda
@@ -29,8 +29,7 @@ open import Relation.Binary.PropositionalEquality
 -- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries        using ( ∣_∣  ; ∥_∥  )
 open import Relations.Discrete            using ( 0[_] ; _|:_ )
-open import Algebras.Setoid.Basic {𝑆 = 𝑆} using ( Algebroid ; _̂_ ; _∙_ ; ⟦_⟧s ; SetoidAlgebra ; 𝕌[_])
-open import Algebras.Products     {𝑆 = 𝑆} using ( ov )
+open import Algebras.Setoid.Basic {𝑆 = 𝑆} using ( ov ; SetoidAlgebra ; 𝕌[_] ; _̂_ ; Algebroid ; _∙_ )
 
 private variable α ρ ℓ : Level
 

--- a/src/Algebras/Setoid/Products.lagda
+++ b/src/Algebras/Setoid/Products.lagda
@@ -31,7 +31,7 @@ open import Relation.Unary   using ( Pred ; _⊆_ ; _∈_ )
 
 -- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries        using ( ∣_∣; ∥_∥)
-open import Algebras.Setoid.Basic {𝑆 = 𝑆} using ( Algebroid ; ⟦_⟧s ; SetoidAlgebra ; _̂_)
+open import Algebras.Setoid.Basic {𝑆 = 𝑆} using ( Algebroid ; ⟦_⟧ ; SetoidAlgebra ; _̂_ ; ov )
 
 open Func          using ( cong ) renaming ( f to _<$>_ )
 open Setoid        using ( Carrier ; _≈_ ) renaming ( isEquivalence to isEqv )
@@ -85,7 +85,7 @@ cong (Interp (⨅ {I} 𝒜)) (refl , f=g ) = λ i → cong  (Interp (𝒜 i)) (r
                            }
                  }
 
- interp : Func (⟦ 𝑆 ⟧s domain) domain
+ interp : Func (⟦ 𝑆 ⟧ domain) domain
  interp <$> (f , as ) = λ i → ∥ 𝒜 i ∥ <$> (f , (flip as i ))
  cong  interp (refl , f=g) i = cong  ∥ 𝒜 i ∥ (refl , (flip f=g i))
 
@@ -97,14 +97,14 @@ cong (Interp (⨅ {I} 𝒜)) (refl , f=g ) = λ i → cong  (Interp (𝒜 i)) (r
 
 module _ {𝒦 : Pred (Algebroid α ρ) (𝓞 ⊔ 𝓥 ⊔ lsuc α)} where
 
- ℑ : Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ))
+ ℑ : Type (ov(α ⊔ ρ))
  ℑ = Σ[ 𝑨 ∈ (Algebroid α ρ) ] 𝑨 ∈ 𝒦
 
 
  𝔄 : ℑ → Algebroid α ρ
  𝔄 i = ∣ i ∣
 
- class-product : Algebroid (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)) _
+ class-product : Algebroid (ov (α ⊔ ρ)) _
  class-product = ⨅oid 𝔄
 
 \end{code}

--- a/src/Homomorphisms/Setoid/Isomorphisms.lagda
+++ b/src/Homomorphisms/Setoid/Isomorphisms.lagda
@@ -29,14 +29,13 @@ open import Relation.Binary.PropositionalEquality
 
 
 -- Imports from agda-algebras --------------------------------------------------------------
-open import Overture.Preliminaries             using    ( ∣_∣ ; ∥_∥ ; _⁻¹ ; _∙_ ; lower∼lift ; lift∼lower )
-                                               renaming (_≈_ to _≋_ )
-open import Overture.Inverses                  using    (IsInjective)
-open import Algebras.Products          {𝑆 = 𝑆} using    ( ov )
-open import Algebras.Setoid.Products   {𝑆 = 𝑆} using    ( ⨅ )
-open import Algebras.Setoid.Basic      {𝑆 = 𝑆} using    ( SetoidAlgebra ; 𝕌[_] ; _̂_ ; Lift-SetoidAlg)
-open import Homomorphisms.Setoid.Basic {𝑆 = 𝑆} using    ( hom ; kercon ; ker[_⇒_]_↾_ ; ∘-hom ; 𝒾𝒹
-                                                        ; 𝓁𝒾𝒻𝓉 ; 𝓁ℴ𝓌ℯ𝓇 ; is-homomorphism ; ∘-is-hom )
+open import Overture.Preliminaries             using ( ∣_∣ ; ∥_∥ ; _⁻¹ ; _∙_ ; lower∼lift ; lift∼lower )
+                                               renaming ( _≈_ to _≋_ )
+open import Overture.Inverses                  using ( IsInjective )
+open import Algebras.Setoid.Products   {𝑆 = 𝑆} using ( ⨅ )
+open import Algebras.Setoid.Basic      {𝑆 = 𝑆} using ( SetoidAlgebra ; 𝕌[_] ; _̂_ ; Lift-SetoidAlg)
+open import Homomorphisms.Setoid.Basic {𝑆 = 𝑆} using ( hom ; kercon ; ker[_⇒_]_↾_ ; ∘-hom ; 𝒾𝒹
+                                                     ; 𝓁𝒾𝒻𝓉 ; 𝓁ℴ𝓌ℯ𝓇 ; is-homomorphism ; ∘-is-hom )
 
 \end{code}
 
@@ -166,7 +165,7 @@ Lift-SetoidAlg-assoc _ _ = ≅-trans (≅-trans (≅-sym Lift-≅) Lift-≅) Lif
 
 Products of isomorphic families of algebras are themselves isomorphic. The proof looks a bit technical, but it is as straightforward as it ought to be.
 
-begin{code}
+\begin{code}
 
 module _ {𝓘 : Level}{I : Type 𝓘}{fiu : funext 𝓘 α}{fiw : funext 𝓘 β} where
 
@@ -194,15 +193,12 @@ module _ {𝓘 : Level}{I : Type 𝓘}{fiu : funext 𝓘 α}{fiw : funext 𝓘 �
    ψ∼ϕ : ψ ∘ ϕ ≋ ∣ 𝒾𝒹 (⨅ 𝒜) ∣
    ψ∼ϕ a = fiu λ i → from∼to (AB i)(a i)
 
-   -- Goal : ⨅ 𝒜 ≅ ⨅ ℬ
-   -- Goal = (ϕ , ϕhom) , ((ψ , ψhom) , ϕ~ψ , ψ~ϕ)
-
 \end{code}
 
 
 A nearly identical proof goes through for isomorphisms of lifted products (though, just for fun, we use the universal quantifier syntax here to express the dependent function type in the statement of the lemma, instead of the Pi notation we used in the statement of the previous lemma; that is, `∀ i → 𝒜 i ≅ ℬ (lift i)` instead of `Π i ꞉ I , 𝒜 i ≅ ℬ (lift i)`.)
 
-begin{code}
+\begin{code}
 
 module _ {𝓘 : Level}{I : Type 𝓘}{fizw : funext (𝓘 ⊔ γ) β}{fiu : funext 𝓘 α} where
 

--- a/src/Varieties/Setoid/Closure.lagda
+++ b/src/Varieties/Setoid/Closure.lagda
@@ -33,17 +33,14 @@ open import Relation.Unary using ( Pred  ; _∈_ ; _⊆_ )
 -- imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries           using ( ∣_∣ ; ∥_∥ )
 open import Algebras.Setoid.Products {𝑆 = 𝑆} using ( ⨅ )
-open import Algebras.Setoid.Basic    {𝑆 = 𝑆} using ( SetoidAlgebra ) renaming ( Lift-SetoidAlg to Lift-Alg )
+open import Algebras.Setoid.Basic    {𝑆 = 𝑆} using ( SetoidAlgebra ; ov )
+                                             renaming ( Lift-SetoidAlg to Lift-Alg )
 open import Homomorphisms.Setoid.Isomorphisms
                                      {𝑆 = 𝑆} using ( _≅_ ; ≅-sym ; Lift-≅ ; ≅-trans ; ≅-refl )
 open import Homomorphisms.Setoid.HomomorphicImages
                                      {𝑆 = 𝑆} using ( HomImages )
 open import Subalgebras.Setoid.Subalgebras
                                      {𝑆 = 𝑆} using (_≤_ ; _IsSubalgebraOfClass_ ; Subalgebra )
-
-ov : Level → Level
-ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α
-
 
 -- The inductive type H
 

--- a/src/Varieties/Setoid/EquationalLogic.lagda
+++ b/src/Varieties/Setoid/EquationalLogic.lagda
@@ -41,7 +41,7 @@ open IsEquivalence renaming ( refl to reflE ; sym to  symmE ; trans to tranE )
 
 -- imports from agda-algebras --------------------------------------------------------------
 open import Overture.Preliminaries       using ( ∣_∣ )
-open import Algebras.Setoid.Basic{𝑆 = 𝑆} using ( SetoidAlgebra ; ⟦_⟧s )
+open import Algebras.Setoid.Basic{𝑆 = 𝑆} using ( SetoidAlgebra ) renaming ( ⟦_⟧ to ⟦_⟧s )
 open import Algebras.Products    {𝑆 = 𝑆} using ( ov )
 open import Terms.Basic          {𝑆 = 𝑆} using ( Term )
 open import Terms.Setoid.Basic   {𝑆 = 𝑆} using ( module Environment ; Ops ; Sub ; _[_] )

--- a/src/Varieties/Setoid/FreeAlgebras.lagda
+++ b/src/Varieties/Setoid/FreeAlgebras.lagda
@@ -29,7 +29,7 @@ open import Relation.Binary.PropositionalEquality
 open import Overture.Preliminaries             using ( ∣_∣ )
 open import Overture.Inverses                  using ( IsSurjective ; Image_∋_ ; Inv ; InvIsInv ; eq )
 open import Algebras.Setoid.Products   {𝑆 = 𝑆} using ( ⨅ )
-open import Algebras.Setoid.Basic      {𝑆 = 𝑆} using ( SetoidAlgebra ; ⟦_⟧s )
+open import Algebras.Setoid.Basic      {𝑆 = 𝑆} using ( SetoidAlgebra ) renaming ( ⟦_⟧ to ⟦_⟧s )
 open import Homomorphisms.Setoid.Basic {𝑆 = 𝑆} using ( hom ; epi )
 open import Terms.Setoid.Basic         {𝑆 = 𝑆} using ( TermAlgebra )
 open import Varieties.Setoid.EquationalLogic

--- a/src/agda-algebras-everything.lagda
+++ b/src/agda-algebras-everything.lagda
@@ -88,13 +88,10 @@ open import ClosureSystems.Properties       using    ( clop→law⇒ ; clop→la
 -- ALGEBRAS ------------------------------------------------------------------------------------------
 
 open import Algebras.Basic                  using    ( Signature ; signature ; compatible ; Algebra
-                                                     ; lilAlgebra ; Level-of-Alg ; Level-of-Carrier
-                                                     ; Level-of-lilAlg ; Level-of-lilCarrier ; algebra
-                                                     ; lilalgebra ; algebra→Algebra ; Algebra→algebra
-                                                     ; _̂_ ; Lift-alg-op ; Lift-Alg ; Lift-op-lilAlg
-                                                     ; Lift-lilAlg ; Lift-algebra ;  compatible-lilAlg
-                                                     ; compatible-Rel-alg ; compatible-ΠΡ-alg
-                                                     ; compatible-Rel-lilAlg ; compatible-ΠΡ-lilAlg )
+                                                     ; Level-of-Alg ; Level-of-Carrier ; algebra
+                                                     ; algebra→Algebra ; Algebra→algebra ; _̂_
+                                                     ; Lift-alg-op ; Lift-Alg ; Lift-algebra
+                                                     ; compatible-Rel-alg ; compatible-ΠΡ-alg )
 
 open import Algebras.Products               using    ( ⨅ ; ⨅' ; ov ; ℑ ; 𝔄 ; class-product )
 
@@ -102,7 +99,7 @@ open import Algebras.Congruences            using    ( IsCongruence ; Con ; IsCo
                                                      ; Con→IsCongruence ; 0[_]Compatible ; 0Con[_]
                                                      ; _╱_ ; 𝟘[_╱_] ; 𝟎[_╱_] ; /-≡ )
 
-open import Algebras.Setoid.Basic           using    ( ⟦_⟧s ; Algebroid ; SetoidAlgebra ; _̂_ ; _∙_ )
+open import Algebras.Setoid.Basic           using    ( ⟦_⟧ ; Algebroid ; SetoidAlgebra ; _̂_ ; _∙_ )
 
 open import Algebras.Setoid.Products        using    ( ⨅ ; ⨅oid ; ℑ ; 𝔄 ; class-product )
 


### PR DESCRIPTION
For the setoid-based development, we can move the definition of ov to a more sensible
place, namely, to src/Algebras/Setoid/Basic.lagda.

We cannot do the same for the non-setoid based development because of the way Algebras/Basic.lagda introduces signatures and levels for signatures, so definition of ov in that case will remain in src/Algebras/Products.lagda.

(This PR also includes some other minor mods intended to improve the rendering
of the automatically generated html pages.)