### PR TITLE
rename dependent relation type to REL (instead of ΠΡ)

### DIFF
--- a/src/Base/Algebras/Basic.lagda
+++ b/src/Base/Algebras/Basic.lagda
@@ -26,7 +26,7 @@ open import Relation.Unary  using ( _∈_ ; Pred )
 -- Imports from the Agda Universal Algebra Library -------------------------------------
 open import Base.Overture.Preliminaries using ( ∣_∣ ; ∥_∥ )
 open import Base.Relations.Discrete     using ( Op ; _|:_ ; _|:pred_ )
-open import Base.Relations.Continuous   using ( Rel ; compatible-Rel ; ΠΡ ; compatible-ΠΡ )
+open import Base.Relations.Continuous   using ( Rel ; compatible-Rel ; REL ; compatible-REL )
 
 private variable α β ρ : Level
 
@@ -217,7 +217,7 @@ Recall, the `|:` type was defined in [Base.Relations.Discrete][] module.
 
 #### <a id="compatibility-of-continuous-relations">Compatibility of continuous relations</a>
 
-In the [Base.Relations.Continuous][] module, we defined a function called `cont-compatible-op` to represent the assertion that a given continuous relation is compatible with a given operation. With that, it is easy to define a function, which we call `cont-compatible`, representing compatibility of a continuous relation with all operations of an algebra.  Similarly, we define the analogous `dep-compatible` function for the (even more general) type of *dependent relations*.
+In the [Base.Relations.Continuous][] module, we defined a function called `compatible-Rel` to represent the assertion that a given continuous relation is compatible with a given operation. With that, it is easy to define a function, which we call `compatible-Rel-alg`, representing compatibility of a continuous relation with all operations of an algebra.  Similarly, we define the analogous `compatible-REL-alg` function for the (even more general) type of *dependent relations*.
 
 \begin{code}
 
@@ -226,8 +226,8 @@ module _ {I : Type 𝓥} {𝑆 : Signature 𝓞 𝓥} where
  compatible-Rel-alg : (𝑨 : Algebra α 𝑆) → Rel ∣ 𝑨 ∣ I{ρ} → Type(𝓞 ⊔ α ⊔ 𝓥 ⊔ ρ)
  compatible-Rel-alg 𝑨 R = ∀ (𝑓 : ∣ 𝑆 ∣ ) →  compatible-Rel (𝑓 ̂ 𝑨) R
 
- compatible-ΠΡ-alg : (𝒜 : I → Algebra α 𝑆) → ΠΡ I (λ i → ∣ 𝒜  i ∣) {ρ} → Type(𝓞 ⊔ α ⊔ 𝓥 ⊔ ρ)
- compatible-ΠΡ-alg 𝒜 R = ∀ ( 𝑓 : ∣ 𝑆 ∣ ) →  compatible-ΠΡ (λ i → 𝑓 ̂ (𝒜 i)) R
+ compatible-REL-alg : (𝒜 : I → Algebra α 𝑆) → REL I (λ i → ∣ 𝒜  i ∣) {ρ} → Type(𝓞 ⊔ α ⊔ 𝓥 ⊔ ρ)
+ compatible-REL-alg 𝒜 R = ∀ ( 𝑓 : ∣ 𝑆 ∣ ) →  compatible-REL (λ i → 𝑓 ̂ (𝒜 i)) R
 
 \end{code}
 

--- a/src/Base/Complexity/CSP.lagda
+++ b/src/Base/Complexity/CSP.lagda
@@ -102,7 +102,7 @@ open import Function.Base    using ( _∘_ )
 open import Relation.Binary  using ( Setoid )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Base.Relations.Continuous       using ( ΠΡ ; ΠΡ-syntax )
+open import Base.Relations.Continuous       using ( REL ; REL-syntax )
 open import Setoid.Algebras.Basic  {𝑆 = 𝑆}  using ( Algebra )
 
 \end{code}
@@ -148,7 +148,7 @@ module _                -- levels for...
   field
    arity  : Type ι               -- The "number" of variables involved in the constraint.
    scope  : arity → var          -- Which variables are involved in the constraint.
-   rel    : ΠΡ[ i ∈ arity ] (Carrier (dom (scope i)))   -- The constraint relation.
+   rel    : REL[ i ∈ arity ] (Carrier (dom (scope i)))   -- The constraint relation.
 
   satisfies : (∀ v → Carrier (dom v)) → Type  -- An assignment 𝑓 : var → dom of values to variables
   satisfies f = rel (f ∘ scope)      -- *satisfies* the constraint 𝐶 = (σ , 𝑅) provided

--- a/src/Base/Equality/Truncation.lagda
+++ b/src/Base/Equality/Truncation.lagda
@@ -34,7 +34,7 @@ open import Relation.Binary.PropositionalEquality
 open import Base.Overture.Preliminaries using ( ∣_∣ ; ∥_∥ ; _⁻¹ ; _≈_ ; transport)
 open import Base.Overture.Injective     using ( IsInjective )
 open import Base.Relations.Quotients    using ( IsBlock )
-open import Base.Relations.Continuous   using ( Rel ; ΠΡ )
+open import Base.Relations.Continuous   using ( Rel ; REL )
 
 private variable α β ρ 𝓥 : Level
 
@@ -226,14 +226,14 @@ module _ {I : Type 𝓥} where
  RelPropExt : Type α → (ρ : Level) → Type (𝓥 ⊔ α ⊔ lsuc ρ)
  RelPropExt A ρ = {P Q : RelProp A ρ } → ∣ P ∣ ⊆ ∣ Q ∣ → ∣ Q ∣ ⊆ ∣ P ∣ → P ≡ Q
 
- IsΠΡProp : {ρ : Level} (𝒜 : I → Type α) → ΠΡ I 𝒜 {ρ}  → Type (𝓥 ⊔ α ⊔ ρ)
- IsΠΡProp 𝒜 P = ∀ (a : ((i : I) → 𝒜 i)) → is-prop (P a)
+ IsRELProp : {ρ : Level} (𝒜 : I → Type α) → REL I 𝒜 {ρ}  → Type (𝓥 ⊔ α ⊔ ρ)
+ IsRELProp 𝒜 P = ∀ (a : ((i : I) → 𝒜 i)) → is-prop (P a)
 
- ΠΡProp : (I → Type α) → (ρ : Level) → Type (𝓥 ⊔ α ⊔ lsuc ρ)
- ΠΡProp 𝒜 ρ = Σ[ P ∈ ΠΡ I 𝒜 {ρ} ] IsΠΡProp 𝒜 P
+ RELProp : (I → Type α) → (ρ : Level) → Type (𝓥 ⊔ α ⊔ lsuc ρ)
+ RELProp 𝒜 ρ = Σ[ P ∈ REL I 𝒜 {ρ} ] IsRELProp 𝒜 P
 
- ΠΡPropExt : (I → Type α) → (ρ : Level) → Type (𝓥 ⊔ α ⊔ lsuc ρ)
- ΠΡPropExt 𝒜 ρ = {P Q : ΠΡProp 𝒜 ρ} → ∣ P ∣ ⊆ ∣ Q ∣ → ∣ Q ∣ ⊆ ∣ P ∣ → P ≡ Q
+ RELPropExt : (I → Type α) → (ρ : Level) → Type (𝓥 ⊔ α ⊔ lsuc ρ)
+ RELPropExt 𝒜 ρ = {P Q : RELProp 𝒜 ρ} → ∣ P ∣ ⊆ ∣ Q ∣ → ∣ Q ∣ ⊆ ∣ P ∣ → P ≡ Q
 
 \end{code}
 

--- a/src/Base/Relations/Continuous.lagda
+++ b/src/Base/Relations/Continuous.lagda
@@ -30,23 +30,26 @@ private variable α ρ : Level
 
 In set theory, an n-ary relation on a set `A` is simply a subset of the n-fold product `A × A × ⋯ × A`.  As such, we could model these as predicates over the type `A × A × ⋯ × A`, or as relations of type `A → A → ⋯ → A → Type β` (for some universe β).  To implement such a relation in type theory, we would need to know the arity in advance, and then somehow form an n-fold arrow →.  It's easier and more general to instead define an arity type `I : Type 𝓥`, and define the type representing `I`-ary relations on `A` as the function type `(I → A) → Type β`.  Then, if we are specifically interested in an n-ary relation for some natural number `n`, we could take `I` to be a finite set (e.g., of type `Fin n`).
 
-Below we will define `ContRel` to be the type `(I → A) → Type β` and we will call `ContRel` the type of *continuous relations*.  This generalizes the discrete relations we defined in [Base.Relations.Discrete] (unary, binary, etc.) since continuous relations can be of arbitrary arity.  They are not completely general, however, since they are defined over a single type. Said another way, they are *single-sorted* relations. We will remove this limitation when we define the type of *dependent continuous relations* at the end of this module.
+Below we define `Rel` to be the type `(I → A) → Type β` and we call this the type of *continuous relations*.  This generalizes "discrete" relations (i.e., relations of finite arity---unary, binary, etc), defined in the standard library since inhabitants of the continuous relation type can have arbitrary arity.
 
-Just as `Rel A β` was the single-sorted special case of the multisorted `REL A B β` type, so too will `ContRel I A β` be the single-sorted version of a completely general type of relations. The latter will represent relations that not only have arbitrary arities, but also are defined over arbitrary families of types.
+The relations of type `Rel` not completely general, however, since they are defined over a single type. Said another way, they are *single-sorted* relations. We will remove this limitation when we define the type of *dependent continuous relations* later in the module. Just as `Rel A β` is the single-sorted special case of the multisorted `REL A B β` in the standard library, so too is our continuous version, `Rel I A β`, the single-sorted special case of a completely general type of relations. The latter represents relations that not only have arbitrary arities, but also are defined over arbitrary families of types.
 
-To be more concrete, given an arbitrary family `A : I → Type α` of types, we may have a relation from `A i` to `A j` to `A k` to …, where the collection represented by the "indexing" type `I` might not even be enumerable.
+Concretely, given an arbitrary family `A : I → Type α` of types, we may have a relation from `A i` to `A j` to `A k` to …, where the collection represented by the "indexing" type `I` might not even be enumerable.
 
-We refer to such relations as *dependent continuous relations* (or *dependent relations* for short) because the definition of a type that represents them requires depedent types.  The `DepRel` type that we define [below](Base.Relations.Continuous.html#dependent-relations) manifests this completely general notion of relation.
+We refer to such relations as *dependent continuous relations* (or *dependent relations* for short) because the definition of a type that represents them requires depedent types.  The `REL` type that we define [below](Base.Relations.Continuous.html#dependent-relations) manifests this completely general notion of relation.
+
+**Warning**! The type of binary relations in the standard library's `Relation.Binary` module is also called `Rel`.  Therefore, to use both the discrete binary relation from the standard library, and our continuous relation type, we recommend renaming the former when importing with a line like this
+
+`open import Relation.Binary  renaming ( REL to BinREL ; Rel to BinRel )`
 
 
 
 #### <a id="continuous-and-dependent-relations">Continuous and dependent relations</a>
 
-Here we define the types `Rel` and `ΠΡ` ("Pi Rho"). The first of these represents predicates of arbitrary arity over a single type `A`; we call these *continuous relations*.
-To define `ΠΡ`, the type of *dependent relations*, we exploit the full power of dependent types and provide a completely general relation type.
+Here we define the types `Rel` and `REL`. The first of these represents predicates of arbitrary arity over a single type `A`. As noted above, we call these *continuous relations*.
+The definition of `REL` goes even further and exploits the full power of dependent types resulting in a completely general relation type, which we call the type of *dependent relations*.
 
-Here, the tuples of a relation of type `DepRel I 𝒜 β` will inhabit the dependent function type `𝒜 : I → Type α` (where the codomain may depend on the input coordinate `i : I` of the domain). Heuristically, we can think of an inhabitant of type `DepRel I 𝒜 β` as a relation from `𝒜 i` to `𝒜 j` to `𝒜 k` to …. (This is only a rough heuristic since `I` could denote an uncountable collection.
-
+Here, the tuples of a relation of type `REL I 𝒜 β` inhabit the dependent function type `𝒜 : I → Type α` (where the codomain may depend on the input coordinate `i : I` of the domain). Heuristically, we can think of an inhabitant of type `REL I 𝒜 β` as a relation from `𝒜 i` to `𝒜 j` to `𝒜 k` to …. (This is only a rough heuristic since `I` could denote an uncountable collection.)  See the discussion below for a more detailed explanation.
 
 \begin{code}
 
@@ -66,14 +69,14 @@ module _ {𝓥 : Level} where
  infix 6 Rel-syntax
 
  -- The type of arbitrarily multisorted relations of arbitrary arity
- ΠΡ : (I : ar) → (I → Type α) → {ρ : Level} → Type (𝓥 ⊔ α ⊔ lsuc ρ)
- ΠΡ I 𝒜 {ρ} = ((i : I) → 𝒜 i) → Type ρ
+ REL : (I : ar) → (I → Type α) → {ρ : Level} → Type (𝓥 ⊔ α ⊔ lsuc ρ)
+ REL I 𝒜 {ρ} = ((i : I) → 𝒜 i) → Type ρ
 
- ΠΡ-syntax : (I : ar) → (I → Type α) → {ρ : Level} → Type (𝓥 ⊔ α ⊔ lsuc ρ)
- ΠΡ-syntax I 𝒜 {ρ} = ΠΡ I 𝒜 {ρ}
+ REL-syntax : (I : ar) → (I → Type α) → {ρ : Level} → Type (𝓥 ⊔ α ⊔ lsuc ρ)
+ REL-syntax I 𝒜 {ρ} = REL I 𝒜 {ρ}
 
- syntax ΠΡ-syntax I (λ i → 𝒜) = ΠΡ[ i ∈ I ] 𝒜
- infix 6 ΠΡ-syntax
+ syntax REL-syntax I (λ i → 𝒜) = REL[ i ∈ I ] 𝒜
+ infix 6 REL-syntax
 
 \end{code}
 
@@ -100,33 +103,42 @@ sections of `t` also belongs to `R`.
 \end{code}
 
 
-#### <a id="compatibility-of-operations-with-pirho-types">Compatibility of operations with ΠΡ types</a>
+#### <a id="compatibility-of-operations-with-dependent-relations">Compatibility of operations with dependent relations</a>
 
 \begin{code}
 
- eval-ΠΡ : {I J : ar}{𝒜 : I → Type α}
-  →         ΠΡ I 𝒜 {ρ}            -- the relation type: subsets of Π[ i ∈ I ] 𝒜 i
+ eval-REL :  {I J : ar}{𝒜 : I → Type α}
+  →          REL I 𝒜 {ρ}          -- the relation type: subsets of Π[ i ∈ I ] 𝒜 i
                                   -- (where Π[ i ∈ I ] 𝒜 i is a type of dependent functions or "tuples")
-  →         ((i : I) → J → 𝒜 i)  -- an I-tuple of (𝒥 i)-tuples
-  →         Type (𝓥 ⊔ ρ)
- eval-ΠΡ{I = I}{J}{𝒜} R t = ∀ j → R λ i → (t i) j
+  →          ((i : I) → J → 𝒜 i)  -- an I-tuple of (𝒥 i)-tuples
+  →          Type (𝓥 ⊔ ρ)
+ eval-REL{I = I}{J}{𝒜} R t = ∀ j → R λ i → (t i) j
 
- compatible-ΠΡ : {I J : ar}{𝒜 : I → Type α}
-  →               (∀ i → Op (𝒜 i) J)  -- for each i : I, an operation of type  𝒪(𝒜 i){J} = (J → 𝒜 i) → 𝒜 i
-  →               ΠΡ I 𝒜 {ρ}             -- a subset of Π[ i ∈ I ] 𝒜 i
-                                         -- (where Π[ i ∈ I ] 𝒜 i is a type of dependent functions or "tuples")
-  →               Type _
- compatible-ΠΡ {I = I}{J}{𝒜} 𝑓 R  = Π[ t ∈ ((i : I) → J → 𝒜 i) ] eval-ΠΡ R t
+ compatible-REL :  {I J : ar}{𝒜 : I → Type α}
+  →                (∀ i → Op (𝒜 i) J)  -- for each i : I, an operation of type  Op(𝒜 i){J} = (J → 𝒜 i) → 𝒜 i
+  →                REL I 𝒜 {ρ}         -- a subset of Π[ i ∈ I ] 𝒜 i
+                                       -- (where Π[ i ∈ I ] 𝒜 i is a type of dependent functions or "tuples")
+  →                Type (𝓥 ⊔ α ⊔ ρ)
+ compatible-REL {I = I}{J}{𝒜} 𝑓 R  = Π[ t ∈ ((i : I) → J → 𝒜 i) ] eval-REL R t
 
 \end{code}
 
-#### <a id="detailed-explanation">Detailed explanation</a>
+The definition `eval-REL` denotes an *evaluation* function which lifts an `I`-ary relation to an `(I → J)`-ary relation.
+The lifted relation will relate an `I`-tuple of `J`-tuples when the `I`-slices (or rows) of the `J`-tuples belong
+to the original relation. The second definition, compatible-REL,  denotes compatibility of an operation with a continuous relation.
 
-The first of these is an *evaluation* function which "lifts" an `I`-ary relation to an `(I → J)`-ary relation. The lifted relation will relate an `I`-tuple of `J`-tuples when the "`I`-slices" (or "rows") of the `J`-tuples belong to the original relation. The second definition denotes compatibility of an operation with a continuous relation.
 
-Readers who find the syntax of the last two definitions nauseating might be helped by an explication of the semantics of these deifnitions. First, internalize the fact that `𝒶 : I → J → A` denotes an `I`-tuple of `J`-tuples of inhabitants of `A`. Next, recall that a continuous relation `R` denotes a certain collection of `I`-tuples (if `x : I → A`, then `R x` asserts that `x` "belongs to" or "satisfies" `R`).  For such `R`, the type `eval-cont-rel R` represents a certain collection of `I`-tuples of `J`-tuples, namely, the tuples `𝒶 : I → J → A` for which `eval-cont-rel R 𝒶` holds.
+#### <a id="detailed-explanation-of-the-dependent-relation-type">Detailed explanation of the dependent relation type</a>
 
-For simplicity, pretend for a moment that `J` is a finite set, say, `{1, 2, ..., J}`, so that we can write down a couple of the `J`-tuples as columns. For example, here are the i-th and k-th columns (for some `i k : I`).
+The last two definitions above may be hard to comprehend at first, so perhaps a more detailed explanation of the semantics of these deifnitions would help.
+
+First, one should internalize the fact that `𝒶 : I → J → A` denotes an `I`-tuple of `J`-tuples of inhabitants of `A`.
+
+Next, recall that a continuous relation `R` denotes a certain collection of `I`-tuples (if `x : I → A`, then `R x` asserts that `x` belongs to `R`).
+For such `R`, the type `eval-REL R` represents a certain collection of `I`-tuples of `J`-tuples, namely, the tuples `𝒶 : I → J → A` for which `eval-REL R 𝒶` holds.
+
+For simplicity, pretend for a moment that `J` is a finite set, say, `{1, 2, ..., J}`, so that we can write down a couple of the `J`-tuples as columns.
+For example, here are the i-th and k-th columns (for some `i k : I`).
 
 ```
 𝒶 i 1      𝒶 k 1
@@ -135,7 +147,12 @@ For simplicity, pretend for a moment that `J` is a finite set, say, `{1, 2, ...,
 𝒶 i J      𝒶 k J
 ```
 
-Now `eval-cont-rel R 𝒶` is defined by `∀ j → R (λ i → 𝒶 i j)` which asserts that each row of the `I` columns shown above belongs to the original relation `R`. Finally, `cont-compatible-op` takes a `J`-ary operation `𝑓 : Op J A` and an `I`-tuple `𝒶 : I → J → A` of `J`-tuples, and determines whether the `I`-tuple `λ i → 𝑓 (𝑎 i)` belongs to `R`.
+Now `eval-REL R 𝒶` is defined by `∀ j → R (λ i → 𝒶 i j)` which asserts that each row of the `I` columns shown above belongs to the original relation `R`.
+Finally, `compatible-REL` takes
+
+*  an `I`-tuple (`λ i → (𝑓 i)`) of `J`-ary operations, where for each i the type of `𝑓 i` is `(J → 𝒜 i) → 𝒜 i`, and
+*  an `I`-tuple (`𝒶 : I → J → A`) of `J`-tuples
+and determines whether the `I`-tuple `λ i → (𝑓 i) (𝑎 i)` belongs to `R`.
 
 --------------------------------------
 

--- a/src/Base/Relations/Discrete.lagda
+++ b/src/Base/Relations/Discrete.lagda
@@ -16,17 +16,15 @@ This is the [Base.Relations.Discrete][] module of the [Agda Universal Algebra Li
 module Base.Relations.Discrete where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------------------------
-open import Agda.Primitive       using ( _⊔_ ; lsuc ) renaming ( Set to Type )
-open import Data.Product         using ( _,_ ; _×_ )
-open import Function.Base        using ( _∘_ )
-open import Level                using ( Level ; Lift )
-open import Relation.Binary      using ( IsEquivalence )
-open import Relation.Binary.Core using ( _⇒_ ; _=[_]⇒_ ) renaming ( REL to BinREL ; Rel to BinRel )
-open import Relation.Binary.Definitions
-                                 using ( Reflexive ; Transitive )
-open import Relation.Unary       using ( _∈_; Pred )
-open import Relation.Binary.PropositionalEquality
-                                 using ( _≡_ )
+open import Agda.Primitive               using ( _⊔_ ; lsuc ) renaming ( Set to Type )
+open import Data.Product                 using ( _,_ ; _×_ )
+open import Function.Base                using ( _∘_ )
+open import Level                        using ( Level ; Lift )
+open import Relation.Binary              using ( IsEquivalence ; _⇒_ ; _=[_]⇒_ )
+                                      renaming ( REL to BinREL ; Rel to BinRel )
+open import Relation.Binary.Definitions  using ( Reflexive ; Transitive )
+open import Relation.Unary               using ( _∈_; Pred )
+open import Relation.Binary.PropositionalEquality using ( _≡_ )
 
 -- Imports from agda-algebras -------------------------------------------------------------------
 open import Base.Overture.Preliminaries using (_≈_ ; Π-syntax)

--- a/src/agda-algebras-everything.lagda
+++ b/src/agda-algebras-everything.lagda
@@ -51,8 +51,8 @@ open import
                             using (  _|:_ ; compatibility-agreement ; arity[_]               )
                             using ( compatibility-agreement'                                 )
 open import
- Base.Relations.Continuous  using ( ar ; Rel ; Rel-syntax ; ΠΡ ; ΠΡ-syntax ; eval-Rel        )
-                            using ( compatible-Rel ; eval-ΠΡ ; compatible-ΠΡ                 )
+ Base.Relations.Continuous  using ( ar ; Rel ; Rel-syntax ; REL ; REL-syntax ; eval-Rel      )
+                            using ( compatible-Rel ; eval-REL ; compatible-REL               )
 open import
  Base.Relations.Quotients   using ( Equivalence ; ker-IsEquivalence ; kerlift-IsEquivalence  )
                             using ( [_] ; [_/_] ; Block ; IsBlock ; Quotient ; _/_ ; ⟪_⟫     )
@@ -69,8 +69,8 @@ open import
                                using ( fiber ; singleton-is-prop ; is-equiv ; hfunext        )
                                using ( is-set ; to-Σ-≡ ; is-embedding ; singleton-type       )
                                using ( invertible ; blk-uip ; equiv-is-embedding             )
-                               using ( monic-is-embedding|Set ; IsRelProp ; ΠΡPropExt        )
-                               using ( RelProp ; RelPropExt ; IsΠΡProp ; ΠΡProp              )
+                               using ( monic-is-embedding|Set ; IsRelProp ; RELPropExt       )
+                               using ( RelProp ; RelPropExt ; IsRELProp ; RELProp            )
 open import
  Base.Equality.Extensionality  using ( DFunExt ; _≐_ ; pred-ext ; block-ext ; block-ext|uip  )
 
@@ -90,9 +90,9 @@ open import
  Base.Algebras.Basic        using ( Signature ; compatible ; Algebra ; Level-of-Alg          )
                             using ( Level-of-Carrier ; algebra ; algebra→Algebra             )
                             using ( Algebra→algebra ; _̂_ ; Lift-alg-op ; Lift-algebra        )
-                            using ( Lift-Alg ; compatible-Rel-alg ; compatible-ΠΡ-alg        )
+                            using ( Lift-Alg ; compatible-Rel-alg ; compatible-REL-alg       )
 open import
- Base.Algebras.Products     using ( ⨅ ; ⨅' ; ov ; ℑ ; 𝔄 ; class-product                      )
+ Base.Algebras.Products     using ( ⨅ ; ⨅' ; ov ; ℑ ; 𝔄 ; class-product                     )
 open import
  Base.Algebras.Congruences  using ( IsCongruence ; Con ; IsCongruence→Con                    )
                             using ( Con→IsCongruence ; 0[_]Compatible ; 0Con[_]              )

--- a/src/agda-algebras.lagda
+++ b/src/agda-algebras.lagda
@@ -64,12 +64,19 @@ module agda-algebras where
 open import Preface
 open import Base     -- standard version of the library
 open import Setoid   -- setoid-based version of the library
+open import Demos    -- demonstrations (e.g., proof of the HSP Theorem in a single module)
 open import Cubical  -- forthcoming version of the library based on Cubical Agda
 
 \end{code}
 
 
-If you're looking for our latest (setoid-based) formalization of Brkhoff's Theorem, see the [Birkhoff HSP Theorem Section](https://ualib.org/Setoid.Varieties.HSP.html#proof-of-the-hsp-theorem) of the documentation, or the source code of the [Setoid.Varieties.HSP][] module, which is in the file [Setoid/Varieties/HSP.lagda][] in the [agda-algebras][] GitHub repository.
+### The formalization of Brkhoff's Theorem
+
+The [Demos/HSP][] module presents a fairly self-contained formal proof of Birkhoff's HSP Theorem in a single module.
+
+An earlier version of the proof is described in the [Birkhoff HSP Theorem Section](https://ualib.org/Setoid.Varieties.HSP.html#proof-of-the-hsp-theorem) of the documentation; specifically, see [Setoid.Varieties.HSP][].
+
+The source code containing the complete formal proof of Birkhoff's Theorem is available in the [agda-algebras][] GitHub repository; see [Demos/HSP.lagda][] or [Setoid/Varieties/HSP.lagda][].
 
 
 ------------------------------


### PR DESCRIPTION
This also fixes some problems with the documentation, which referred to older names of certain functions or types.

These edits are not related to the paper revisions but had to be done today to facilitate an anticipated discussion about relation types.