### PR TITLE
[Statement of Work] category theory refactor of agda-algebras

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # agda-algebras
 
-This is a copy of the Agda Universal Algebra Library which depends the [Standard Library](https://github.com/agda/agda-stdlib) of the [Agda](https://wiki.portal.chalmers.se/agda/pmwiki.php) proof assistant language.
+This is an update of the Agda Universal Algebra Library which depends on the [Standard Library](https://github.com/agda/agda-stdlib) of the [Agda](https://wiki.portal.chalmers.se/agda/pmwiki.php) proof assistant language.
+
 It is currently under active reconstruction, and should be regarded as α software.
+
+For more details on the latest developments, see the `README_NEWS.md` file in this repository.
 
 The **previous version** of the library (which was called `UALib` and relied more heavily on the [Type Topology](https://github.com/martinescardo/TypeTopology) library of [Martín Escardó][]) is no longer maintained, but is still available at the following urls.
 

--- a/README_NEWS.md
+++ b/README_NEWS.md
@@ -1,0 +1,51 @@
+## 20 Dec 2025: A category-theory refactor of `agda-algebras`
+
+Instead of rewriting everything at once, we will add a *parallel* layer that:
+
+1.  **Recasts signatures as functors / containers**
+
+    +  Our "operation signature" (symbols + arities) is essentially a **polynomial functor** (aka a container) in Set:
+
+       + shapes = operation symbols
+       + positions = arity (dependent positions for many-sorted algebras)
+       + extension = `⟦Σ⟧ X = Σ (op : Ops) (Pos op → X)` (or its dependent/many-sorted version)
+
+    +  Then an algebra is just an **Eilenberg–Moore algebra** for that endofunctor: `α : ⟦Σ⟧ A → A`.
+
+2.  **Adds algebraic theories / equations as a second layer**
+
+    +  Once we've got terms as the **free monad** on the signature functor, equations
+       are a congruence relation on terms.
+    +  Models/varieties become "algebras satisfying equations" (or algebras for a quotient monad, depending on how quotienty we want to get).
+
+3.  **Keeps our existing UA-facing API intact**
+
+    +  Our current development has lots of "downstream" lemmas and proofs.
+    +  The cats layer can provide *views* (equivalences) so we can say: "this is the same notion, but in functor language."
+
+That path gives us something immediately valuable; we can write docs like:
+
+> "A single-sorted signature is a container (polynomial functor). An algebra is an algebra for that functor. Terms are the free monad. Equations present a theory."
+
+...and keep the old code working while we slowly migrate the pieces we want.
+
+### What we'll learn and what wiil likely be most fun
+
++  **Polynomial functors / containers**: the sweet spot of "cats flavor" with concrete computations in Agda.
++  **Free monads / substitution**: terms-as-syntax falls out cleanly.
++  **Algebraic theories**: finitary monads, Lawvere theories, presentations.
++  **Initiality / induction principles** become categorical statements we prove once and reuse.
+
+### A minimal "first milestone" that would pay off fast
+
+A very contained first deliverable could be:
+
++  A module `UA.Signature.Polynomial` that defines:
+
+   +  `Signature : Type` (container-ish)
+   +  interpretation `⟦_⟧ : Signature → (Type → Type)`
+   +  `Alg : Signature → Type` defined as `Σ A , (⟦Σ⟧ A → A)`
+   +  equivalence to your existing notion of an algebra over a signature (where applicable)
+
+This alone would let us sprinkle in cats language in docs and give cat people a familiar entry point.
+


### PR DESCRIPTION
# Description

The idea/plan is outlined in the new `README_NEWS.md` file.

## Copilot-generated Description

This pull request updates the documentation to announce a major upcoming refactor of the Agda Universal Algebra Library, focusing on incorporating category-theoretic concepts such as polynomial functors and free monads. The changes clarify the project's direction and provide details on the planned approach, while keeping the existing API stable for downstream users.

Documentation updates and project direction:

* Updated `README.md` to clarify that the repository is an updated version of the Agda Universal Algebra Library, and added a pointer to the new `README_NEWS.md` file for ongoing developments.
* Added `README_NEWS.md` with a detailed announcement of the category-theory-based refactor, outlining the plan to recast operation signatures as polynomial functors, introduce algebraic theories as equations, and maintain compatibility with the current API.

Planned technical improvements:

* Described the intent to introduce a parallel layer using categorical abstractions (functors/containers, free monads, and quotient monads) for signatures, terms, and equations, with a proposed first milestone of a new module `UA.Signature.Polynomial`.
* Emphasized benefits such as cleaner induction principles, reusable categorical proofs, and improved documentation for both universal algebra and category theory audiences.
