### PR TITLE
[M1-2] Add GitHub Actions CI to type-check the library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           nix develop --command bash -c '
             echo "=== Toolchain ==="
             echo "Agda    : $(agda --version | head -n1)"
-            echo "stdlib  : $(cat .agda/libraries 2>/dev/null || echo "(AGDA_DIR not yet initialized)")"
+            echo "stdlib  : $(cat .agda/libraries)"
             echo "nix     : $(nix --version)"
           '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+# =============================================================================
+#  ci.yml — CI Pipeline for agda-algebras
+#  ----------------------------------------------------------------------------
+#
+#  Single lane: type-check the library.
+#
+#  The workflow reuses the project's Nix flake, so CI runs exactly the same
+#  command a developer runs locally: `nix develop --command make check`.
+#  Agda 2.8.0 and standard-library 2.3 are pinned by flake.lock.
+#
+#  Design notes.
+#
+#    + We don't use wenkokke/setup-agda: latest release (v2.5.0, October
+#      2024) maxes at Agda 2.7.0.1.
+#
+#    + Cachix provides the Nix binary cache so Agda + stdlib resolve in
+#      seconds rather than minutes on warm runs, including forks.  On
+#      CACHIX_AUTH_TOKEN absence (e.g. external-fork PRs), the action
+#      falls back to read-only public cache — still a fast install.
+#
+#    + .agdai interface files are cached separately via actions/cache,
+#      keyed on flake.lock + the hash of src/ and agda-algebras.agda-lib.
+#      Agda's own interface-file hash check guarantees that restoring
+#      stale .agdai files is correctness-safe — it will rebuild them if
+#      the source has changed, so we use a generous restore-keys fallback.
+#
+#    + The `all-green` aggregator gate exists so that branch protection
+#      can be configured against a single stable status-check name even
+#      as we add more lanes later (e.g. M1-? weekly Agda-dev job).
+#
+#    + FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 opts us into the upcoming
+#      (2026-06-02) Node 24 default ahead of the deadline.
+#
+# =============================================================================
+
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Opt into the Node 24 default ahead of GitHub's 2026-06-02 transition.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Type-check library
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Set up Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: formalverification
+          # Read-only fallback on external-fork PRs where the secret is
+          # unavailable.  See cachix/cachix-action docs.
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Validate flake
+        run: nix flake check --no-build
+
+      - name: Cache .agdai interface files
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/**/*.agdai
+          key: agdai-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('src/**/*.agda', 'agda-algebras.agda-lib') }}
+          restore-keys: |
+            agdai-${{ runner.os }}-${{ hashFiles('flake.lock') }}-
+
+      - name: Show toolchain versions
+        run: |
+          set -euxo pipefail
+          nix develop --command bash -c '
+            echo "=== Toolchain ==="
+            echo "Agda    : $(agda --version | head -n1)"
+            echo "stdlib  : $(cat .agda/libraries 2>/dev/null || echo "(AGDA_DIR not yet initialized)")"
+            echo "nix     : $(nix --version)"
+          '
+
+      - name: Type-check the library
+        run: |
+          set -euxo pipefail
+          nix develop --command make check
+
+  # ---------------------------------------------------------------------------
+  # Aggregate status: a single stable required-check name for branch
+  # protection.  Uses `if: always()` so that skipped/conditional jobs added
+  # in the future don't block the gate.
+  # ---------------------------------------------------------------------------
+  all-green:
+    name: All checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: always()
+    needs: [check]
+    steps:
+      - name: Verify all required jobs passed
+        run: |
+          set -euxo pipefail
+          results=( "${{ needs.check.result }}" )
+          for r in "${results[@]}"; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "A required job ended with result: $r"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed. ✅"

--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,21 @@ default: Everything.agda
 
 Everything.agda:
 	@echo "target: $@"
-	@find $(SRCDIR) -name '*.agda' \
-	    ! -name 'Everything.agda' \
-	    ! -path '$(SRCDIR)/Legacy/*' \
-	  | sed -e 's|^$(SRCDIR)/||' \
-	        -e 's|\.agda$$||' \
-	        -e 's|/|.|g' \
-	        -e 's|^|import |' \
-	  | LC_ALL=C sort \
-	  > $(SRCDIR)/Everything.agda
-	@echo "  wrote $(SRCDIR)/Everything.agda ($$(wc -l < $(SRCDIR)/Everything.agda) modules)"
+	@{ \
+	  echo "{-# OPTIONS --cubical-compatible --safe #-}"; \
+	  echo ""; \
+	  echo "module Everything where"; \
+	  echo ""; \
+	  find $(SRCDIR) -name '*.agda' \
+	      ! -name 'Everything.agda' \
+	      ! -path '$(SRCDIR)/Legacy/*' \
+	    | sed -e 's|^$(SRCDIR)/||' \
+	          -e 's|\.agda$$||' \
+	          -e 's|/|.|g' \
+	          -e 's|^|import |' \
+	    | LC_ALL=C sort; \
+	} > $(SRCDIR)/Everything.agda
+	@echo "  wrote $(SRCDIR)/Everything.agda ($$(grep -c '^import' $(SRCDIR)/Everything.agda) modules)"
 
 check test: Everything.agda
 	@echo "target: $@"

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,7 @@ exec "$NIX_AGDA" \\
   --no-default-libraries \\
   --library-file "$AGDA_DIR/libraries" \\
   --library standard-library \\
+  --library agda-algebras \\
   "\$@"
 EOF
         chmod +x "$AGDA_DIR/bin/agda"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml`, a GitHub Actions workflow that type-checks the library on every push to `master` and every pull request.  The workflow reuses the project's Nix flake as the single source of toolchain truth, so CI runs exactly the same command a developer runs locally: `nix develop --command make check`.

Closes #251 (issue M1-2 from the agda-algebras 2.0 project).

## Design choices (documented inline in the workflow)

+  **Flake-based CI rather than `wenkokke/setup-agda`**.  The standard community action for Agda CI hasn't been updated since October 2024 (v2.5.0), and its supported-versions table maxes out at Agda 2.7.0.1.  Our flake handles Agda 2.8.0 + stdlib 2.3 correctly today.  Revisit `wenkokke/setup-agda` if/when it catches up.

+  **Cachix (`formalverification`) for the Nix binary cache**.  With the `CACHIX_AUTH_TOKEN` secret configured, warm-cache runs resolve the entire Agda + stdlib toolchain in seconds rather than rebuilding from source.  External-fork PRs (where the secret is unavailable) fall back to read-only public-cache mode — still fast, just no push.

+  **Separate `actions/cache` for `.agdai` interface files**, keyed on `flake.lock` + the hash of `src/` and `agda-algebras.agda-lib`.  Source-only changes should see substantial incremental-rebuild savings; toolchain or dependency changes invalidate the cache correctly.

+  **`all-green` aggregator gate**.  Single stable status-check name for branch protection.  Uses `if: always()` so future conditional/skipped jobs (e.g. a weekly Agda-dev lane) don't block the gate.

+  **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`**.  Opts into the Node 24 runtime default ahead of GitHub's 2026-06-02 transition.

+  **Concurrency cancel-in-progress on all refs**, including `master`.  Simpler and the right default for a library with no deployment pipeline — we want the latest result.

## Notes for reviewers

+  The `CACHIX_AUTH_TOKEN` secret is configured and points to the `formalverification` Cachix cache.  This cache already contains Agda 2.8.0 and stdlib 2.3 paths from agda-native-air development, so the very first CI run on this branch should see a warm cache.

+  Cold-build runtime (worst case): ~10 minutes.  Warm-cache runtime (expected): ~2–3 minutes.  Warm `.agdai`-cache runtime on whitespace-only changes: under a minute.

+  Branch-protection configuration against `all-green` is a separate repo-admin task and not part of this PR.

## Follow-up issues

Three issues to file after this PR lands, none of which block closing #251:

+  **Migrate CI to a dedicated `ualib` or `agda-algebras` Cachix cache**.  `formalverification` is personally administered; a cache namespaced to this project is cleaner long-term.  One-line workflow change plus a new secret.

+  **Add a weekly cron CI lane against Agda dev** for forward-compatibility testing (per M1-1 acceptance criterion).  Allowed to fail without gating PRs.

+  **Add `macos-latest` to the CI matrix**.  Cross-platform verification, good-first-issue candidate.
