### PR TITLE
[M1-6] Establish docs/adr/ for Architecture Decision Records

### DIFF
--- a/docs/adr/000-template.md
+++ b/docs/adr/000-template.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Proposed | Accepted | Deprecated | Superseded by ADR-NNN — YYYY-MM-DD.
+<!-- One of: Proposed | Accepted | Deprecated | Superseded by ADR-NNN.  Include the date this status last changed. -->
+Accepted — YYYY-MM-DD.
 
 ## Context
 

--- a/docs/adr/000-template.md
+++ b/docs/adr/000-template.md
@@ -1,0 +1,39 @@
+# ADR-NNN: Short noun phrase describing the decision
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded by ADR-NNN — YYYY-MM-DD.
+
+## Context
+
+State the forces in tension that made this decision necessary.  A reader who knows nothing about the project should, after reading this section, understand *why* a decision had to be made at all.  Two or three paragraphs is typical; more than a page is a warning sign that the ADR is doing too much.
+
+## Decision
+
+State what was decided, in the imperative.  One or two sentences.  The decision should be extractable as an elevator pitch.
+
+Expand with additional paragraphs only if the decision has internal structure — e.g., "A core `X` is defined as `...`; a companion `Y` is defined as `...`; the two are related by `...`."
+
+## Consequences
+
+List the effects of the decision.  Positive, negative, and neutral.  Be honest about the costs; ADRs are read by future contributors who will live with those costs.
+
++  **Positive consequence.**
++  **Negative consequence.**
++  **Neutral consequence** (a fact that follows from the decision but is neither good nor bad).
+
+## Alternatives considered
+
+Briefly list the other options that were on the table and the reason each was rejected.  The purpose is not to re-argue the decision but to reassure readers that the rejected options were genuinely considered.
+
++  **Alternative A.**  Brief description.  Rejected because …
++  **Alternative B.**  Brief description.  Rejected because …
+
+## References
+
++  Issue — link.
++  Pull request — link.
++  External discussion — link.
++  Prior art — link.
+
+

--- a/docs/adr/001-setoid-as-canonical.md
+++ b/docs/adr/001-setoid-as-canonical.md
@@ -1,0 +1,43 @@
+# ADR-001: Setoid as canonical development tree for 3.0
+
+## Status
+
+Accepted — 2026-04-24.
+
+## Context
+
+Through the 2.x line, `agda-algebras` carried two parallel developments of universal algebra: `src/Base/`, a standard dependent-types formulation that predates setoid machinery, and `src/Setoid/`, a setoid-based reconstruction built for the TYPES 2021 proof of Birkhoff's HSP theorem.  The two trees share the same vocabulary — `Algebra`, `Hom`, `Con`, `Subalgebra` — but with incompatible underlying types: `Base/` uses propositional equality on raw domain types, `Setoid/` uses setoid equivalence.
+
+Maintaining two parallel foundations through the 3.0 cycle would double the cost of every theorem added under `Classical/` or `Cubical/` and would leave new contributors without a clear answer to the question "which tree does my work land in?"  A single canonical foundation is required.
+
+The trade-off between `Base/` and `Setoid/` is substantive rather than cosmetic.  `Base/` is simpler to read and closer to how universal algebra is typically presented in type theory; it suffices for the portion of the library that terminates at Birkhoff, which is what most published work in this repository actually uses.  `Setoid/`, on the other hand, is fully constructive — it does not postulate extensionality — and it matches the idiom of stdlib's `Algebra.Bundles`, which is where any future stdlib-interoperable classical-structure development must land.  `Setoid/` also already contains the only fully constructive proof of the HSP theorem in Martin–Löf type theory.
+
+A third consideration, previously under-emphasized: definitions in `Setoid/` that are expressed purely in terms of the `Algebra.Domain` equivalence — rather than propositional equality — port mechanically to a Cubical formulation in which the equivalence is replaced by a path type.  This is the substrate on which ADR-003 (Cubical as long-term target) rests.
+
+## Decision
+
+`src/Setoid/` is the canonical development tree for the 3.0 release.  New work lands there.  `src/Base/` is frozen: it is moved to `src/Legacy/Base/`, kept type-checking, and receives no new development.  Legacy contents may be ported forward to `Setoid/` (or, eventually, `Cubical/`) as specific theorems are needed in the canonical tree.
+
+## Consequences
+
++  **The "which tree does my work go in" question has a one-word answer for the entire 3.0 cycle.**  Contributor onboarding simplifies.  The style guide, README, and CONTRIBUTING file speak from a single foundation.
++  **The Classical layer (M3) builds cleanly on top.**  `Classical/` is designed around the `Setoid.Algebras.Basic.Algebra` record; the Σ-typed classical structures and record-typed bundle views (ADR-002) would be materially more awkward over `Base/`, whose equational machinery fights stdlib's setoid-shaped bundles.
++  **The Cubical track (M5) is reachable without an additional rewrite.**  The setoid equivalence and the path equality of cubical Agda are exchangeable at the level of definitions that never mention the underlying equality directly.  The eventual 4.0 Cubical port is thus substantively mechanical rather than a second full redevelopment.
++  **Downstream users of `Base/` must migrate.**  This is a breaking change for anyone depending on the library's pre-3.0 API surface.  The move is announced in CHANGELOG, `Base/` remains available under `Legacy/Base/`, and deprecation notes inside `Legacy/Base/` point to the canonical alternatives where they exist.
++  **`Base/` must be kept type-checking for posterity.**  Frozen-but-checked means the CI pipeline must run over both trees indefinitely, at the cost of some build time.  The alternative — deleting `Base/` — was rejected because the Base-tree proofs remain the only implementations of several lemmas that have not yet been ported, and because the historical TYPES 2021 proof should remain executable at its original location as a matter of scholarly record.
++  **Some readable but pedagogically useful Base-tree presentations are demoted to Legacy.**  `Base.Varieties.FreeAlgebras.Birkhoff` is the clearest example.  The compensation is `Demos/HSP`, which is kept as a self-contained teaching artifact (M2-4).
+
+## Alternatives considered
+
++  **Keep both `Base/` and `Setoid/` as co-canonical**.  Rejected because this is what the 2.x line did, and the cost of every new theorem being built twice is precisely what motivated the reconstruction.  There is no mathematical case for carrying both indefinitely once the Classical and Cubical tracks exist.
++  **Delete `Base/` outright**.  Rejected because (i) several theorems live only in `Base/` and would be lost until re-proven, and (ii) the TYPES 2021 citations in the literature point at `Base/`-tree modules whose URLs should continue to resolve.  Freezing under `Legacy/Base/` preserves both.
++  **Adopt `Base/` as canonical, reconstruct `Setoid/` as a translation layer**.  Rejected because `Setoid/` already contains the definitive HSP proof, matches stdlib's bundle idiom, and keeps the door open to cubical Agda — three forward-looking properties that `Base/` does not have.
+
+## References
+
++  Issue M2-1 — [Freeze Base/, adopt Setoid/ as canonical](https://github.com/ualib/agda-algebras/issues/XX).
++  `docs/STYLE_GUIDE.md` — section on record vs Σ, which depends on this decision.
++  `docs/GITHUB_PROJECT.md` — milestone 2 exit criterion.
++  DeMeo and Carette (2023), *A Machine-Checked Proof of Birkhoff's Variety Theorem in Martin-Löf Type Theory*, TYPES 2021 post-proceedings.
+
+

--- a/docs/adr/001-setoid-as-canonical.md
+++ b/docs/adr/001-setoid-as-canonical.md
@@ -35,7 +35,7 @@ A third consideration, previously under-emphasized: definitions in `Setoid/` tha
 
 ## References
 
-+  Issue M2-1 — [Freeze Base/, adopt Setoid/ as canonical](https://github.com/ualib/agda-algebras/issues/XX).
++  Issue M2-1 — [Freeze Base/, adopt Setoid/ as canonical](https://github.com/ualib/agda-algebras/issues/256).
 +  `docs/STYLE_GUIDE.md` — section on record vs Σ, which depends on this decision.
 +  `docs/GITHUB_PROJECT.md` — milestone 2 exit criterion.
 +  DeMeo and Carette (2023), *A Machine-Checked Proof of Birkhoff's Variety Theorem in Martin-Löf Type Theory*, TYPES 2021 post-proceedings.

--- a/docs/adr/002-classical-layer-design.md
+++ b/docs/adr/002-classical-layer-design.md
@@ -55,7 +55,7 @@ Each classical structure ships as a quintuple: `Classical/Signatures/X.agda`, `C
 
 ## References
 
-+  Issue M3-1 — [Introduce the Classical/ tree](https://github.com/ualib/agda-algebras/issues/XX).
++  Issue M3-1 — [Introduce the Classical/ tree](https://github.com/ualib/agda-algebras/issues/260).
 +  Issue M3-2 — `Classical.Structures.Semigroup` as the pattern-setting first structure.
 +  Issue M3-3 — Stdlib bundle bridges.
 +  `docs/STYLE_GUIDE.md` — section on record vs Σ.

--- a/docs/adr/002-classical-layer-design.md
+++ b/docs/adr/002-classical-layer-design.md
@@ -1,0 +1,65 @@
+# ADR-002: Classical structures as Σ-typed cores with record-typed bundle views
+
+## Status
+
+Accepted — 2026-04-24.
+
+## Context
+
+The 3.0 reconstruction adds a `src/Classical/` tree holding specific algebraic theories — semigroups, monoids, groups, lattices, rings — built on the universal-algebra foundation established in `src/Setoid/`.  Every classical structure `X` must answer three questions about its representation:
+
+1.  What is the type-theoretic shape of `X`?  A record with named projections, or a Σ-type pairing an algebra with a proof it satisfies the `X`-theory?
+2.  How does `X` interoperate with the Agda standard library's `Algebra.Bundles`?  Stdlib provides `Algebra.Bundles.Semigroup`, `Monoid`, and so on as records; anyone interoperating with stdlib-typed code must convert.
+3.  How is `X` kept portable to the eventual cubical Agda formulation (ADR-003), where the equivalence underlying the algebra becomes a path type?
+
+These three questions interact.  A record-typed core is easier to read at use sites (named projections, instance arguments) but commits the library to a specific projection vocabulary that fights the stdlib-shaped bundle idiom when we want bidirectional conversion.  A Σ-typed core matches the mathematical reading "`X` *is* an algebra equipped with a proof it satisfies the `X`-theory" and is also the formulation most robust to changes in the underlying equivalence — crucial for the cubical port.
+
+A related question: what does "classical" mean in this subtree?  It does not mean "classical logic" — the library stays constructive throughout.  `Classical/` names the *tradition* of concrete algebraic structures (groups, rings, lattices) as distinct from the universal-algebraic treatment of algebras-over-a-signature that lives in `Setoid/`.  An alternative name considered was `Concrete/`; `Classical/` was retained because "classical algebraic structures" is standard terminology in the universal-algebra literature (Burris and Sankappanavar use it throughout).
+
+## Decision
+
+Each classical structure `X` is represented in two parallel forms:
+
++  **Core (Σ-typed)** at `Classical/Structures/X.agda`:
+
+    ```agda
+    X : (α ρ : Level) → Type _
+    X α ρ = Σ[ 𝑨 ∈ Algebra 𝑆ₓ α ρ ] 𝑨 ⊨ Eₓ
+    ```
+
+    where `𝑆ₓ` is the signature of `X` (in `Classical/Signatures/X.agda`) and `Eₓ` is the set of defining equations (in `Classical/Theories/X.agda`).
++  **Bundle view (record-typed)** at `Classical/Bundles/X.agda`, matching the stdlib shape `Algebra.Bundles.X`, with bidirectional conversion functions to and from the Σ-typed core.
+
+The core is the canonical form for library-internal definitions and theorems.  The bundle view exists solely for stdlib interoperability.
+
+Equations in the Σ-typed core are stated purely in terms of the `Algebra.Domain` equivalence (the setoid's `_≈_`), never in terms of propositional equality or any other setoid-specific feature.  This is the portability discipline that makes the eventual cubical port (ADR-003) mechanical.
+
+A helper `fromPropEq : (A : Type α) → ... → X α α` lets users construct classical structures from propositional-equality-based definitions without writing explicit setoid wrapping.
+
+Each classical structure ships as a quintuple: `Classical/Signatures/X.agda`, `Classical/Theories/X.agda`, `Classical/Structures/X.agda`, `Classical/Bundles/X.agda`, and a level-fixed veneer `Classical/Small/Structures/X.agda` specialized to the common `ℓ₀`–`ℓ₀` case.
+
+## Consequences
+
++  **Definitions read the way a universal algebraist thinks.**  "A monoid is a magma satisfying the monoid equations" is exactly what `Σ[ 𝑨 ∈ Algebra 𝑆ₘ α ρ ] 𝑨 ⊨ Eₘ` types.  This is pedagogically valuable for the library-as-training-corpus role.
++  **Stdlib interop has a fixed cost paid once per structure.**  Every `Classical/Bundles/X.agda` is a small, mechanical file: one record definition, two conversion functions, a round-trip proof.  The cost is predictable and the pattern is copy-paste.
++  **Cubical portability is a property of the code, not a retrofit.**  Since no theorem in `Classical/Structures/X.agda` may reach for setoid-specific machinery, the 4.0 port (ADR-003) is substitutional — replace the setoid equivalence with the path type, rerun the type-checker, fix any fallout — rather than a second rewrite.  Enforcing this discipline is a design cost paid up front.
++  **Use-site ergonomics are slightly worse than with a record-typed core.**  A proof that works against a Σ-typed monoid projects with `proj₁` and `proj₂` rather than named fields.  This is annoying in short proofs; we offset it with named convenience accessors (`Domain`, `Signature`, `equations`) defined next to each structure.
++  **The core `Algebra` type stays a record.**  This is not inconsistent with the Σ-for-classical-structures choice: `Algebra` has multiple meaningful named projections (`Domain`, `Interp`, …) and is inhabited many times across the library; `Semigroup` naturally decomposes as "algebra + proof," which a Σ expresses directly.  The rule for future decisions is in `docs/STYLE_GUIDE.md` — record when there are three or more meaningful named projections or when stdlib interop demands it, Σ when the structure has a "bundled-together" mathematical reading.
++  **A parallel record implementation of any classical structure is a bug.**  The `Base/Structures/Basic` vs `Base/Structures/Sigma` dual is exactly the mistake this ADR codifies against; see the STYLE_GUIDE for the explicit rule.
+
+## Alternatives considered
+
++  **Record-typed core, no Σ-typed variant**.  Rejected because (i) the stdlib bundle idiom already exists and we would effectively be re-deriving it with our vocabulary, (ii) the mathematical reading is weaker, (iii) the record-typed core is more fragile under the cubical port since record projection definitions mention the underlying equivalence more intrusively than Σ projection does.
++  **Two record variants in parallel (one library-internal, one stdlib-shaped)**.  Rejected for the same reason the `Base/Structures/Basic` + `Base/Structures/Sigma` split in the legacy tree is a maintenance hazard: two type-level representations of the same mathematical object doubles every theorem's cost.  The Σ + bundle split is not two representations of the same object; it is a canonical core with a narrow interop view.
++  **`Classical/` built directly on `Base/` instead of `Setoid/`**.  Rejected because (i) `Base/` is frozen (ADR-001), (ii) `Base/` postulates extensionality, breaking the constructivity commitment, and (iii) `Base/`'s propositional-equality setting is not cubical-portable without further rework.
+
+## References
+
++  Issue M3-1 — [Introduce the Classical/ tree](https://github.com/ualib/agda-algebras/issues/XX).
++  Issue M3-2 — `Classical.Structures.Semigroup` as the pattern-setting first structure.
++  Issue M3-3 — Stdlib bundle bridges.
++  `docs/STYLE_GUIDE.md` — section on record vs Σ.
++  Agda standard library, `Algebra.Bundles`.
++  Burris and Sankappanavar, *A Course in Universal Algebra*, chapter II.
+
+

--- a/docs/adr/003-cubical-canonical-target.md
+++ b/docs/adr/003-cubical-canonical-target.md
@@ -35,7 +35,7 @@ Not all four need hold in the same quarter; the promotion is triggered when the 
 
 ## Consequences
 
-+  **The 3.0 development is not "set theoretic" in the sense it would have to be abandoned at 4.0.**  The setoid formulation is the path of record for the current cycle; it is preserved in `Legacy/Setoid/` at 4.0 and remains type-checking.
++  **The 3.0 development is not "set theoretic" in the sense it would have to be abandoned at 4.0.**  The setoid formulation is the path of record for the current cycle; it is preserved in `src/Legacy/Setoid/` at 4.0 and remains type-checking.
 +  **A portability discipline constrains what new contributions may assume.**  Theorems in `Setoid/` and `Classical/Structures/` that would require setoid-specific machinery without a cubical analog must either find a cubical-portable alternative or be marked as non-portable in the module header.  The constraint is real but modest; most universal-algebra theorems are portable because they are stated about the algebra's equivalence, not about the specific representation of that equivalence.
 +  **M5-1 is a genuine validation, not a formality.**  A substantive failure of the Monoid port would surface in M5-1, and the response would be to relax the commitment or to redefine the discipline, not to paper over the failure.  ADR-003 is appropriately tentative on the implementation side.
 +  **The library has a forward-looking story for the next decade.**  Cubical Agda is the direction the Agda ecosystem as a whole is moving (1Lab is the most visible exemplar); committing to it publicly aligns `agda-algebras` with that trajectory and makes the case that its setoid-era proofs remain useful — as first-class training data, if nothing else — after the foundations shift.
@@ -48,7 +48,7 @@ Not all four need hold in the same quarter; the promotion is triggered when the 
 
 ## References
 
-+  Issue M5-1 — [Cubical/Algebras/Basic with SIP and Monoid port](https://github.com/ualib/agda-algebras/issues/XX).
++  Issue M5-1 — [Cubical/Algebras/Basic with SIP and Monoid port](https://github.com/ualib/agda-algebras/issues/270).
 +  ADR-001 — Setoid as canonical development tree for 3.0.
 +  ADR-002 — Classical layer design (which makes the portability discipline concrete).
 +  Vezzosi, Mörtberg, and Abel (2019), *Cubical Agda: A Dependently Typed Programming Language with Univalence and Higher Inductive Types*, JFP.

--- a/docs/adr/003-cubical-canonical-target.md
+++ b/docs/adr/003-cubical-canonical-target.md
@@ -1,0 +1,58 @@
+# ADR-003: Cubical Agda as the canonical long-term target
+
+## Status
+
+Accepted — 2026-04-24.  Implementation deferred to 4.0.
+
+## Context
+
+The setoid-based formulation adopted in ADR-001 buys the library full constructivity at a well-understood cost: every definition carries an equivalence relation, every homomorphism proves respect for that equivalence, and the library must maintain a small discipline of never reaching for propositional equality where the setoid equivalence is the right tool.  A universal algebraist working at the whiteboard would never write any of this explicitly; the setoid machinery is type-theoretic plumbing that exists because Martin–Löf type theory, as traditionally formulated, does not provide a native account of equality that respects quotients and equivalences.
+
+Cubical type theory (as implemented in `--cubical` mode of Agda and in the `cubical` and `1Lab` libraries) provides exactly that native account.  Equality is the path type; the structure identity principle (SIP) makes isomorphic structures propositionally equal; quotients are first-class.  For a universal-algebra development, the consequence is that the setoid-specific machinery that currently mediates between "equal" and "equivalent" would disappear, and proofs would read the way mathematicians write them: equations transport along isomorphisms by substitution, without the intervening apparatus.
+
+Cubical Agda is not yet the canonical target.  Two considerations hold it back.  First, the ecosystem is still young: stdlib's `Algebra.Bundles`, on which the Classical layer's interop depends, is not cubical-compatible; neither is a substantial fraction of imports shared with the rest of the Agda community.  Second, the primary audience of `agda-algebras` — universal algebraists and formal-methods engineers — is still overwhelmingly working in MLTT-with-setoids or propositional-equality settings; a cubical-only library would underserve them.
+
+The 3.0 cycle does not ship a cubical canonical tree, but it commits to a design discipline that makes the 4.0 port mechanical rather than a second redevelopment.
+
+## Decision
+
+Cubical Agda is the canonical long-term target for `agda-algebras`.  The specific commitments:
+
++  **Version 4.0 promotes `src/Cubical/` to canonical status**; `src/Setoid/` at that point assumes a role analogous to `src/Legacy/Base/` today — frozen, type-checked, not receiving new development.  The specific promotion criteria are listed under "Promotion criteria" below.
++  **The 3.0 development is authored with cubical portability in mind.**  Equations are stated in terms of `Algebra.Domain`'s equivalence, never reaching for setoid-specific machinery where a cubical analog does not exist.  This discipline is enforced by the style guide and by code review; its correctness is validated by M5-1, which ports a single classical structure (Monoid) to cubical and verifies the port is substantive mechanical.
++  **M5-1 is the proof-of-concept:**  `Cubical/Algebras/Basic.agda`, `Cubical/Algebras/SIP.agda`, and a `Cubical/Classical/Monoid.agda` obtained by substitutional derivation from its Setoid analog.  Once M5-1 lands, the design discipline is validated; if it fails, the portability discipline is revised and the failure is documented in a follow-on ADR.
+
+## Promotion criteria
+
+4.0 may promote `src/Cubical/` to canonical status once all of the following hold:
+
+1.  `Cubical/Algebras/Basic.agda` and `Cubical/Algebras/SIP.agda` are stable and exercised by at least the content of `Setoid/Algebras/`.
+2.  A non-trivial classical structure (Monoid or beyond) has been ported from `Classical/Structures/X.agda` to `Cubical/Classical/X.agda` by substantively mechanical substitution, without reformulating any equation.
+3.  Agda's cubical mode has reached a maturity level where the `--safe --cubical` combination is robust across the library's use cases.  The criterion for "robust" is that the CI pipeline runs the cubical track without reproducible bugs in the language implementation for a two-month steady-state period.
+4.  Stdlib (or a recognized cubical companion library such as `cubical` or `1Lab`) provides the interop surface area that `Classical/Bundles/` currently relies on.
+
+Not all four need hold in the same quarter; the promotion is triggered when the last one flips.  The follow-up ADR at promotion time will record which specific versions and libraries satisfied each criterion.
+
+## Consequences
+
++  **The 3.0 development is not "set theoretic" in the sense it would have to be abandoned at 4.0.**  The setoid formulation is the path of record for the current cycle; it is preserved in `Legacy/Setoid/` at 4.0 and remains type-checking.
++  **A portability discipline constrains what new contributions may assume.**  Theorems in `Setoid/` and `Classical/Structures/` that would require setoid-specific machinery without a cubical analog must either find a cubical-portable alternative or be marked as non-portable in the module header.  The constraint is real but modest; most universal-algebra theorems are portable because they are stated about the algebra's equivalence, not about the specific representation of that equivalence.
++  **M5-1 is a genuine validation, not a formality.**  A substantive failure of the Monoid port would surface in M5-1, and the response would be to relax the commitment or to redefine the discipline, not to paper over the failure.  ADR-003 is appropriately tentative on the implementation side.
++  **The library has a forward-looking story for the next decade.**  Cubical Agda is the direction the Agda ecosystem as a whole is moving (1Lab is the most visible exemplar); committing to it publicly aligns `agda-algebras` with that trajectory and makes the case that its setoid-era proofs remain useful — as first-class training data, if nothing else — after the foundations shift.
+
+## Alternatives considered
+
++  **Keep Setoid canonical indefinitely; never promote to cubical.**  Rejected because the cubical trajectory is the mathematically natural substrate for universal algebra (isomorphism *is* equality, quotients are first-class, equations transport substitutionally), and because the cost of maintaining the setoid-specific plumbing compounds as the library grows.  A library committed to the long term should choose the foundation its successors will thank it for.
++  **Start cubical immediately; skip the setoid cycle.**  Rejected because (i) the stdlib bundle interop that `Classical/` depends on is not cubical-ready, (ii) the user base is not cubical-ready, and (iii) the library has a working Setoid-based HSP proof that would be thrown away and re-developed with no compensating mathematical gain.  The setoid cycle is not a detour; it is the shipping vehicle for a decade of prior work, and the portability discipline it trains contributors in is a precondition for the cubical cycle succeeding.
++  **Commit to cubical aspirationally but without the portability discipline.**  Rejected because this is how the library ends up with two incompatible trees at 4.0 — a setoid one that works and a cubical one that doesn't, with no mechanical migration path.  The discipline is the asset; without it the commitment is empty.
+
+## References
+
++  Issue M5-1 — [Cubical/Algebras/Basic with SIP and Monoid port](https://github.com/ualib/agda-algebras/issues/XX).
++  ADR-001 — Setoid as canonical development tree for 3.0.
++  ADR-002 — Classical layer design (which makes the portability discipline concrete).
++  Vezzosi, Mörtberg, and Abel (2019), *Cubical Agda: A Dependently Typed Programming Language with Univalence and Higher Inductive Types*, JFP.
++  The `1Lab` project — [https://1lab.dev](https://1lab.dev).
++  The Agda `cubical` library — [https://github.com/agda/cubical](https://github.com/agda/cubical).
+
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,10 +24,10 @@ A template is provided in [`000-template.md`](000-template.md); copy it to start
 
 +  **Proposed**: written and opened as a draft PR.  Review happens on the PR.
 +  **Accepted**: the PR is merged.  The decision is in force as of the merge date.
-+  **Deprecated**: the decision is no longer in force but has not been explicitly replaced.  Add a deprecation note at the top of the file and update the status; do not delete the ADR.
-+  **Superseded by ADR-NNN**: a later ADR replaces this one.  Link forward to the superseding ADR and update the status; the superseding ADR links back.
++  **Deprecated**: the decision is no longer in force but has not been explicitly replaced.  Record any deprecation note in the **Status** section/header when you update the status; do not delete the ADR.
++  **Superseded by ADR-NNN**: a later ADR replaces this one.  Record the forward link to the superseding ADR in the **Status** section/header when you update the status; the superseding ADR links back.
 
-ADRs are **append-only**.  Once accepted, the body text is not edited except to fix factual errors or update the status header.  If a decision changes, write a new ADR that supersedes the old one.
+ADRs are **append-only**.  Once accepted, the body text is not edited except to fix factual errors or update the status section/header (including deprecation or supersession notes).  If a decision changes, write a new ADR that supersedes the old one.
 
 ## Index
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,50 @@
+# Architecture Decision Records
+
+This directory holds the `agda-algebras` **Architecture Decision Records** (ADRs): short, single-purpose documents that capture significant design decisions — the context that forced the decision, the decision itself, and the consequences we accept by taking it.
+
+We follow a lightweight variant of [Michael Nygard's ADR format][nygard] adapted for a formalization project.  The goal is that a contributor joining the project a year from now can read the ADR index and understand *why* the library is shaped the way it is, without having to reconstruct the reasoning from commit messages and issue threads.
+
+## Format
+
+Each ADR is a single Markdown file named `NNN-short-kebab-title.md`, where `NNN` is a zero-padded three-digit sequence number.  Numbers are assigned in the order ADRs are *merged*, not proposed; a proposed ADR that lands after a later-numbered one simply gets the next available number.
+
+Every ADR has the following sections, in order:
+
++  **Title** — a short noun phrase describing the decision.  The file title (`# ADR-NNN: ...`) should match the filename.
++  **Status** — one of `Proposed`, `Accepted`, `Deprecated`, or `Superseded by ADR-NNN`.  Include the date the status last changed.
++  **Context** — the situation that forced a decision.  State the forces in tension concretely; avoid rehearsing settled matters.
++  **Decision** — exactly what was decided, stated as an imperative ("The canonical development tree for 3.0 is `src/Setoid/`").  The decision should be extractable as a one-sentence elevator pitch.
++  **Consequences** — the effects the decision will have, positive and negative.  Be honest about the costs.  This is the section that prevents future contributors from relitigating the decision when the cost becomes visible.
++  **Alternatives considered** — the other options that were on the table and why they were not chosen.  Short.  The purpose is to reassure readers that the rejected options were seen, not to rehearse every detail.
++  **References** — links to the issues, pull requests, papers, or external discussions that informed the decision.
+
+A template is provided in [`000-template.md`](000-template.md); copy it to start a new ADR.
+
+## Lifecycle
+
++  **Proposed**: written and opened as a draft PR.  Review happens on the PR.
++  **Accepted**: the PR is merged.  The decision is in force as of the merge date.
++  **Deprecated**: the decision is no longer in force but has not been explicitly replaced.  Add a deprecation note at the top of the file and update the status; do not delete the ADR.
++  **Superseded by ADR-NNN**: a later ADR replaces this one.  Link forward to the superseding ADR and update the status; the superseding ADR links back.
+
+ADRs are **append-only**.  Once accepted, the body text is not edited except to fix factual errors or update the status header.  If a decision changes, write a new ADR that supersedes the old one.
+
+## Index
+
++  [ADR-001 — Setoid as canonical development tree for 3.0](001-setoid-as-canonical.md)
++  [ADR-002 — Classical structures layer: Σ-typed core with record-typed bundle views](002-classical-layer-design.md)
++  [ADR-003 — Cubical Agda as the canonical long-term target](003-cubical-canonical-target.md)
+
+## When to write an ADR
+
+Write an ADR when a decision
+
++  changes a structural property of the library (what's canonical, what gets deprecated, which tree work lands in),
++  commits the project to a direction that will be costly to reverse,
++  required substantive discussion among more than one person,
+
+or whenever a contributor-facing convention is being set that a future contributor might reasonably want to challenge.  A commit message is not the right home for reasoning that needs to survive the decision.
+
+Do not write an ADR for routine implementation choices, local refactors, or decisions that are reversible within a single PR.
+
+[nygard]: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions


### PR DESCRIPTION
## Summary

Adds the `docs/adr/` scaffold — a `README.md` describing the ADR format and lifecycle, a `000-template.md` starter, and three seed ADRs capturing the architectural decisions ratified during the 3.0 planning cycle.

---

## Related issues

Closes #255

---

## Description

### What's in the ADRs

+  **ADR-001 (Setoid as canonical)** makes explicit the decision to freeze `Base/` and adopt `Setoid/` as the canonical 3.0 tree.  Reproduces the rationale from issue M2-1 and adds a careful account of why keeping both trees, or deleting `Base/` outright, were rejected.
+  **ADR-002 (Classical layer design)** records the Σ-typed-core-with-record-typed-bundle-view decision, including the cubical-portability discipline that constrains how equations may be stated in `Classical/Structures/`.
+  **ADR-003 (Cubical canonical target)** commits the project to Cubical Agda as the long-term foundation and — importantly — enumerates the explicit criteria that must be satisfied before `Cubical/` is promoted to canonical status in 4.0.

### Format

I adopted a lightweight variant of [Nygard's ADR format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) with six sections: Status, Context, Decision, Consequences, Alternatives considered, References.  The "Alternatives considered" section is the main departure from Nygard's original; I find that readers a year later are best served by an explicit record of what the decision *wasn't*, so that the same alternatives aren't relitigated in future issues.

The README specifies that ADRs are append-only: once accepted, the body is not edited except to fix factual errors or update the status header.  Changes of mind produce new ADRs that supersede old ones, with forward and backward links.

### Scope

The tasks list in #255 notes that the full content of each ADR can land with its associated implementation issue.  I opted to write them out in full here because (i) the rationale is already crystallized in the milestone-issue bodies, (ii) a scaffold with empty ADRs is less useful than a scaffold with three substantive examples of the genre, and (iii) the ADRs are readable reference material that belongs in the project knowledge immediately.  The implementation issues (M2-1, M3-1, M5-1) will reference the ADRs rather than re-author them.

### Acceptance criteria from #255

+  [x] `docs/adr/` exists with README and template.
+  [x] All three seeded ADRs are drafted.

---

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [ ] Refactoring / cleanup (no user-facing change)
- [x] Documentation
- [x] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches the `src/` tree, the change is targeted at `Base/`, `Setoid/`, or the shared `Overture/` foundation.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.

## Notes for reviewers

<!-- Anything specific you'd like the reviewer to focus on?  Known limitations?  Open questions? -->


