### PR TITLE
[M1-8] ADR-004 and audit script for .lagda.md migration

### DIFF
--- a/docs/adr/0004-lagda-md-canonical.md
+++ b/docs/adr/0004-lagda-md-canonical.md
@@ -1,0 +1,53 @@
+# ADR-004: Markdown-literate Agda (`.lagda.md`) as the canonical literate format
+
+## Status
+
+Accepted — 2026-04-24.
+
+## Context
+
+Through the 2.x line, `agda-algebras` maintained literate sources in two places and two formats: minimal `src/X/Y/Z.agda` skeletons carrying only the `OPTIONS` pragma and the `module ... where` header, paired with LaTeX-literate `docs/lagda/X/Y/Z.lagda` files containing the actual prose and code inside `\begin{code}` / `\end{code}` blocks.  The type checker reads the skeletons; the `make html` target reads the LaTeX-literate files through `admin/generate-tex` and `admin/generate-html` and renders them into the Jekyll site at [ualib.org](https://ualib.org).
+
+This split is a maintenance hazard: prose and proof live in two files that must be held in sync by hand, and every new module multiplies the number of such pairs.  It also directly undermines the library-as-corpus pillar: a training-corpus extractor that pairs theorem statements with their prose explanations must recover the pairing from path correspondence, with no checking that the pairing is complete or current.  (If `docs/lagda/X/Y/Z.lagda` drifts from `src/X/Y/Z.agda`, the extractor produces mismatched records and nothing in the build pipeline catches it.)
+
+Three resolutions must be made before implementation begins:
+
+1.  What happens to `docs/lagda/` after migration?
+2.  Are there files that should remain in LaTeX-literate form?
+3.  How does the Jekyll rendering pipeline change?
+
+## Decision
+
+**Markdown-literate Agda (`.lagda.md`) is the canonical literate format for `agda-algebras`.**  Each module is a single `src/X/Y/Z.lagda.md` file that is both type-checked by `make check` and rendered by `make html`.
+
+The three open questions resolve as follows.
+
++  **`docs/lagda/` is deleted.**  Every file moves to the matching `src/X/Y/Z.lagda.md` path.  External bookmarks pointing at specific `docs/lagda/X.lagda` paths will break; this is accepted as a one-time cost, announced in the 3.0 CHANGELOG.  The ualib.org rendered site is unaffected because it serves HTML under `X.Y.Z.html` paths, not `docs/lagda` paths.
++  **No files remain in LaTeX-literate form under `src/` or `docs/lagda/`.**  Paper companions that are co-built with a LaTeX paper PDF live under `docs/papers/`, separately from the library proper; that location is out of scope for this ADR and retains its LaTeX-literate shape as long as the companion paper expects it.  The principle is that `src/` and the rendered ualib.org site have one canonical format; `docs/papers/` is a different kind of artifact and has its own conventions.
++  **The Jekyll pipeline consumes `agda --html` Markdown output directly.**  `agda --html --html-highlight=code` on a `.lagda.md` file produces Markdown with fenced code blocks that Jekyll renders natively.  `admin/generate-tex` is removed.  `admin/generate-html` is either removed or reduced to a thin wrapper that invokes `agda --html` with the library's options; the post-processing of `.tex` files goes away.
+
+## Consequences
+
++  **One source of truth per module.**  Prose and proof sit in the same file; drift between them is impossible.  The `src/*.agda` skeletons disappear entirely, as does the dual-tree structure of `src/` vs `docs/lagda/`.
++  **Training-corpus extraction becomes straightforward.**  A walker over `src/**/*.lagda.md` can emit `(prose, code-block)` records without having to reconcile two paths; the proximity of prose paragraph to code block is preserved structurally.  This is the prerequisite for M8-1 (publish the (theorem, proof) corpus), and it moves that milestone substantially closer to trivial.
++  **The documentation site's URL structure is unchanged.**  `agda --html` produces `X.Y.Z.html` for both `.lagda` and `.lagda.md` inputs; external HTML links continue to resolve.
++  **External bookmarks into the repository tree that point at `docs/lagda/X/Y/Z.lagda` break.**  The cost is bounded — the file is a 3.0-era reorganization rather than a URL-scheme change — and is announced in CHANGELOG with a redirect table for the modules most likely to be linked from external sources (Preface, Demos.HSP, Setoid.Algebras.Basic).
++  **New contributors author in Markdown, not LaTeX.**  Lower onboarding friction; GitHub renders `.lagda.md` natively in the web UI; editor tooling (VSCode, Emacs) previews the Markdown cleanly.  This is a non-trivial ergonomics improvement paid for by the migration.
++  **Agda tooling for `.lagda.md` is production-quality.**  Agda 2.6+ has treated `.lagda.md` as a first-class literate format; `1Lab` is the large-scale existence proof.  No language-level risk.
++  **The `admin/generate-tex` pipeline goes away.**  That removes roughly the nontrivial portion of the current `admin/` scripting.  The fallback implication is that if we ever need to produce a LaTeX rendering of the library (for a paper, say) we would author a new small pipeline from `.lagda.md` to LaTeX; this is a modest cost that a future paper project would absorb.
++  **Paper companions under `docs/papers/` keep their current shape.**  The decision is explicit: `docs/papers/` is a separate tree whose artifacts are co-built with external LaTeX documents, and retrofitting those to Markdown-literate is out of scope.  If a future paper project prefers to author in `.lagda.md`, that decision can be made per-paper without disturbing this ADR.
+
+## Alternatives considered
+
++  **Keep the dual-file `.agda` skeleton + `.lagda` content structure indefinitely.**  Rejected because it is the status quo whose costs motivated this ADR: drift-prone, corpus-hostile, and a maintenance tax on every new module.
++  **Consolidate to single-file LaTeX-literate (`.lagda`) with prose inline, keeping LaTeX as the canonical format.**  Rejected because (i) the LaTeX syntax is higher-friction for new contributors than Markdown, (ii) GitHub's native rendering of `.lagda` is poor whereas `.lagda.md` renders cleanly in the web UI, (iii) the modern Agda ecosystem (1Lab most visibly) has standardized on Markdown-literate for exactly the same reasons, (iv) the corpus-extractor argument applies identically to both formats, but the Markdown form is meaningfully easier for downstream consumers who aren't Agda-aware.
++  **Move to `.agda` with extensive comment blocks; drop literate programming entirely.**  Rejected because literate programming with rendered HTML is a central feature of the library's presentation — ualib.org is the interface most readers encounter — and the HTML rendering is materially better with fenced code blocks than with commented Agda.
+
+## References
+
++  Issue M1-8 — [Consolidate literate and bare-Agda sources into .lagda.md](https://github.com/ualib/agda-algebras/issues/280).
++  [1Lab](https://github.com/plt-amy/1lab) — large-scale Agda library authored entirely in `.lagda.md`.
++  [Agda literate-programming documentation](https://agda.readthedocs.io/en/latest/tools/literate-programming.html).
++  ADR-001 — Setoid as canonical (establishes the one-canonical-form-per-concept principle this ADR extends).
+
+

--- a/docs/adr/004-lagda-md-canonical.md
+++ b/docs/adr/004-lagda-md-canonical.md
@@ -43,6 +43,15 @@ The three open questions resolve as follows.
 +  **Consolidate to single-file LaTeX-literate (`.lagda`) with prose inline, keeping LaTeX as the canonical format.**  Rejected because (i) the LaTeX syntax is higher-friction for new contributors than Markdown, (ii) GitHub's native rendering of `.lagda` is poor whereas `.lagda.md` renders cleanly in the web UI, (iii) the modern Agda ecosystem (1Lab most visibly) has standardized on Markdown-literate for exactly the same reasons, (iv) the corpus-extractor argument applies identically to both formats, but the Markdown form is meaningfully easier for downstream consumers who aren't Agda-aware.
 +  **Move to `.agda` with extensive comment blocks; drop literate programming entirely.**  Rejected because literate programming with rendered HTML is a central feature of the library's presentation — ualib.org is the interface most readers encounter — and the HTML rendering is materially better with fenced code blocks than with commented Agda.
 
+## Addendum
+
+Migration is a one-time mechanical operation applied uniformly to every `.lagda` file under `docs/lagda/`.  The destination path mirrors the existing `.agda` skeleton's path, with the extension changed to `.lagda.md` and the skeleton deleted.  This rule applies regardless of which subtree (`Base/`, `Setoid/`, etc.) the file lives in.
+
+The question of which migrated modules receive ongoing maintenance is governed by ADR-001 (canonical-tree policy) and is independent of the migration.  In particular,
+
++  the fact that a file is located in `Base/` does not by itself imply abandonment;
++  modules in `Base/` whose content has no `Setoid/` analogue may support active research (e.g., `Base/Relations/Continuous.agda`) and, as such, constitute "first-class" content that happens to live in `Base/`; the migration puts such modules on the same footing as canonical-tree content.
+
 ## References
 
 +  Issue M1-8 — [Consolidate literate and bare-Agda sources into .lagda.md](https://github.com/ualib/agda-algebras/issues/280).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ ADRs are **append-only**.  Once accepted, the body text is not edited except to 
 +  [ADR-001 — Setoid as canonical development tree for 3.0](001-setoid-as-canonical.md)
 +  [ADR-002 — Classical structures layer: Σ-typed core with record-typed bundle views](002-classical-layer-design.md)
 +  [ADR-003 — Cubical Agda as the canonical long-term target](003-cubical-canonical-target.md)
++  [ADR-004 — Markdown-literate Agda as the canonical literate format](004-lagda-md-canonical.md)
 
 ## When to write an ADR
 

--- a/scripts/audit_lagda_migration.sh
+++ b/scripts/audit_lagda_migration.sh
@@ -29,7 +29,7 @@ banner "2. skeleton .agda files in src/"
 # whether what remains begins with 'module' and contains no '='.
 SKELETON_COUNT=0
 SUBSTANTIVE_COUNT=0
-rm -f /tmp/skeleton.txt /tmp/substantive.txt
+rm -f /tmp/skeleton.txt /tmp/substantive.txt /tmp/substantive-paired.txt
 for f in $(find src -name '*.agda' -not -path '*/Legacy/*'); do
   body=$(sed -E -e 's|--.*$||' -e '/^\{-/,/-\}/d' "$f" \
           | awk 'NF' | sed -E 's/^\s+//;s/\s+$//')
@@ -46,10 +46,12 @@ done
 print -- "  skeleton .agda files:    $SKELETON_COUNT  (list: /tmp/skeleton.txt)"
 print -- "  substantive .agda files: $SUBSTANTIVE_COUNT  (list: /tmp/substantive.txt)"
 
-banner "3. skeleton-to-.lagda pairing"
+banner "3. .agda-to-.lagda pairing (all files, not just skeletons)"
 PAIRED=0
 UNPAIRED=0
+SUBSTANTIVE_PAIRED=0
 rm -f /tmp/unpaired-skeletons.txt
+rm -f /tmp/substantive-paired.txt
 for f in $(cat /tmp/skeleton.txt 2>/dev/null); do
   # src/X/Y/Z.agda  →  docs/lagda/X/Y/Z.lagda
   rel=${f#src/}
@@ -63,6 +65,27 @@ for f in $(cat /tmp/skeleton.txt 2>/dev/null); do
 done
 print -- "  paired skeleton → .lagda: $PAIRED"
 print -- "  unpaired skeletons:       $UNPAIRED  (list: /tmp/unpaired-skeletons.txt)"
+
+# DRIFT HAZARD: substantive .agda files that ALSO have a .lagda partner.
+# These are the files where prose and code may have desynchronized.
+for f in $(cat /tmp/substantive.txt 2>/dev/null); do
+  rel=${f#src/}
+  lagda="docs/lagda/${rel%.agda}.lagda"
+  if [[ -f "$lagda" ]]; then
+    SUBSTANTIVE_PAIRED=$((SUBSTANTIVE_PAIRED + 1))
+    agda_size=$(wc -l < "$f")
+    lagda_size=$(wc -l < "$lagda")
+    agda_mtime=$(stat -c %Y "$f")
+    lagda_mtime=$(stat -c %Y "$lagda")
+    delta=$((agda_mtime - lagda_mtime))
+    print -- "$f  ($agda_size lines)  vs  $lagda  ($lagda_size lines)  Δmtime=${delta}s" \
+      >> /tmp/substantive-paired.txt
+  fi
+done
+print -- "  substantive .agda WITH a .lagda partner (drift hazard): $SUBSTANTIVE_PAIRED"
+if [[ $SUBSTANTIVE_PAIRED -gt 0 ]]; then
+  print -- "  (list: /tmp/substantive-paired.txt)"
+fi
 
 banner "4. external references to .lagda paths"
 print -- "  grepping for '\\.lagda' outside docs/lagda/ ..."
@@ -82,6 +105,8 @@ print -- "  external .lagda references: $REF_COUNT  (list: /tmp/lagda-references
 
 banner "Agda 2.8.0 .lagda.md smoke test"
 # Verify the minimal .lagda.md round-trips under the project's flags.
+# Use --no-libraries so the project's include path doesn't try to
+# resolve the temp module against stdlib or src/.
 TMP=$(mktemp -d)
 cat > "$TMP/Smoke.lagda.md" <<'EOF'
 # Smoke test
@@ -92,8 +117,8 @@ module Smoke where
 data ⊤ : Set where tt : ⊤
 ```
 EOF
-if (cd "$TMP" && agda --html --html-dir="$TMP/out" Smoke.lagda.md \
-                      >/dev/null 2>&1); then
+if (cd "$TMP" && agda --no-libraries --html --html-dir="$TMP/out" \
+                      Smoke.lagda.md >/dev/null 2>&1); then
   print -- "  .lagda.md smoke test: OK"
 else
   print -- "  .lagda.md smoke test: FAILED — investigate before migrating"
@@ -106,5 +131,6 @@ print -- "  skeleton .agda files in src/:           $SKELETON_COUNT"
 print -- "  substantive .agda files in src/:        $SUBSTANTIVE_COUNT"
 print -- "  skeleton → .lagda pairs:                $PAIRED"
 print -- "  skeletons lacking a paired .lagda:      $UNPAIRED"
+print -- "  substantive .agda WITH .lagda partner:  $SUBSTANTIVE_PAIRED  (drift hazard)"
 print -- "  external .lagda references:             $REF_COUNT"
 print -- ""

--- a/scripts/audit_lagda_migration.sh
+++ b/scripts/audit_lagda_migration.sh
@@ -23,19 +23,26 @@ find docs/lagda -name '*.lagda' 2>/dev/null | sort > /tmp/lagda-files.txt
 print -- "  list written to /tmp/lagda-files.txt"
 
 banner "2. skeleton .agda files in src/"
-# Heuristic for "skeleton": the file's non-comment, non-blank body consists
-# of just a single module declaration and nothing else.  We strip line
-# comments, block comments (approximately), and blank lines, then check
-# whether what remains begins with 'module' and contains no '='.
+# Heuristic for "skeleton": after stripping comments and blank lines, only
+# allow either:
+#   1. a single "module ... where" line, or
+#   2. one OPTIONS pragma followed by a single "module ... where" line.
+# Anything else counts as substantive content.
 SKELETON_COUNT=0
 SUBSTANTIVE_COUNT=0
 rm -f /tmp/skeleton.txt /tmp/substantive.txt /tmp/substantive-paired.txt
 for f in $(find src -name '*.agda' -not -path '*/Legacy/*'); do
   body=$(sed -E -e 's|--.*$||' -e '/^\{-/,/-\}/d' "$f" \
           | awk 'NF' | sed -E 's/^\s+//;s/\s+$//')
-  # A skeleton's body starts with OPTIONS pragma or "module ... where" and
-  # contains no "=" signs (which would indicate a definition).
-  if [[ -z "$body" ]] || ( ! grep -q '=' <<< "$body" ); then
+  first_line=$(printf '%s\n' "$body" | sed -n '1p')
+  second_line=$(printf '%s\n' "$body" | sed -n '2p')
+  line_count=$(printf '%s\n' "$body" | awk 'NF { count++ } END { print count + 0 }')
+
+  if { [[ "$line_count" -eq 1 ]] \
+       && grep -Eq '^module[[:space:]]+.+[[:space:]]+where$' <<< "$first_line"; } \
+     || { [[ "$line_count" -eq 2 ]] \
+          && grep -Eq '^\{-# OPTIONS .+#-\}$' <<< "$first_line" \
+          && grep -Eq '^module[[:space:]]+.+[[:space:]]+where$' <<< "$second_line"; }; then
     SKELETON_COUNT=$((SKELETON_COUNT + 1))
     print -- "$f" >> /tmp/skeleton.txt
   else

--- a/scripts/audit_lagda_migration.sh
+++ b/scripts/audit_lagda_migration.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env zsh
+# scripts/audit_lagda_migration.sh
+#
+# Answers the audit questions from issue #280 (M1-8):
+#   1. How many .lagda files exist?
+#   2. How many .agda files in src/ are skeletons (pragma + module + whitespace)?
+#   3. How many .agda files have substantive content?
+#   4. Which .lagda paths are referenced elsewhere in the repo?
+#
+# Run from the repo root.  Zero dependencies beyond zsh + standard coreutils.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+banner() { printf '\n━━━ %s ━━━\n' "$1"; }
+
+banner "1. .lagda files under docs/lagda/"
+LAGDA_COUNT=$(find docs/lagda -name '*.lagda' 2>/dev/null | wc -l | tr -d ' ')
+print -- "  total .lagda files: $LAGDA_COUNT"
+find docs/lagda -name '*.lagda' 2>/dev/null | sort > /tmp/lagda-files.txt
+print -- "  list written to /tmp/lagda-files.txt"
+
+banner "2. skeleton .agda files in src/"
+# Heuristic for "skeleton": the file's non-comment, non-blank body consists
+# of just a single module declaration and nothing else.  We strip line
+# comments, block comments (approximately), and blank lines, then check
+# whether what remains begins with 'module' and contains no '='.
+SKELETON_COUNT=0
+SUBSTANTIVE_COUNT=0
+rm -f /tmp/skeleton.txt /tmp/substantive.txt
+for f in $(find src -name '*.agda' -not -path '*/Legacy/*'); do
+  body=$(sed -E -e 's|--.*$||' -e '/^\{-/,/-\}/d' "$f" \
+          | awk 'NF' | sed -E 's/^\s+//;s/\s+$//')
+  # A skeleton's body starts with OPTIONS pragma or "module ... where" and
+  # contains no "=" signs (which would indicate a definition).
+  if [[ -z "$body" ]] || ( ! grep -q '=' <<< "$body" ); then
+    SKELETON_COUNT=$((SKELETON_COUNT + 1))
+    print -- "$f" >> /tmp/skeleton.txt
+  else
+    SUBSTANTIVE_COUNT=$((SUBSTANTIVE_COUNT + 1))
+    print -- "$f" >> /tmp/substantive.txt
+  fi
+done
+print -- "  skeleton .agda files:    $SKELETON_COUNT  (list: /tmp/skeleton.txt)"
+print -- "  substantive .agda files: $SUBSTANTIVE_COUNT  (list: /tmp/substantive.txt)"
+
+banner "3. skeleton-to-.lagda pairing"
+PAIRED=0
+UNPAIRED=0
+rm -f /tmp/unpaired-skeletons.txt
+for f in $(cat /tmp/skeleton.txt 2>/dev/null); do
+  # src/X/Y/Z.agda  →  docs/lagda/X/Y/Z.lagda
+  rel=${f#src/}
+  lagda="docs/lagda/${rel%.agda}.lagda"
+  if [[ -f "$lagda" ]]; then
+    PAIRED=$((PAIRED + 1))
+  else
+    UNPAIRED=$((UNPAIRED + 1))
+    print -- "$f  (no $lagda)" >> /tmp/unpaired-skeletons.txt
+  fi
+done
+print -- "  paired skeleton → .lagda: $PAIRED"
+print -- "  unpaired skeletons:       $UNPAIRED  (list: /tmp/unpaired-skeletons.txt)"
+
+banner "4. external references to .lagda paths"
+print -- "  grepping for '\\.lagda' outside docs/lagda/ ..."
+# Exclude the obvious places we expect matches (the files themselves,
+# generated HTML archives, etc.) and focus on references that will need
+# rewriting post-migration.
+grep -rn '\.lagda\b' \
+     --include='*.md' --include='*.yml' --include='*.yaml' \
+     --include='Makefile' --include='*.mk' --include='*.sh' \
+     --include='*.py' --include='*.bib' --include='README*' \
+     --include='*.nix' \
+     . 2>/dev/null \
+  | grep -v '^docs/lagda/' \
+  > /tmp/lagda-references.txt || true
+REF_COUNT=$(wc -l < /tmp/lagda-references.txt | tr -d ' ')
+print -- "  external .lagda references: $REF_COUNT  (list: /tmp/lagda-references.txt)"
+
+banner "Agda 2.8.0 .lagda.md smoke test"
+# Verify the minimal .lagda.md round-trips under the project's flags.
+TMP=$(mktemp -d)
+cat > "$TMP/Smoke.lagda.md" <<'EOF'
+# Smoke test
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+module Smoke where
+data ⊤ : Set where tt : ⊤
+```
+EOF
+if (cd "$TMP" && agda --html --html-dir="$TMP/out" Smoke.lagda.md \
+                      >/dev/null 2>&1); then
+  print -- "  .lagda.md smoke test: OK"
+else
+  print -- "  .lagda.md smoke test: FAILED — investigate before migrating"
+fi
+rm -rf "$TMP"
+
+banner "Summary"
+print -- "  .lagda files in docs/lagda/:            $LAGDA_COUNT"
+print -- "  skeleton .agda files in src/:           $SKELETON_COUNT"
+print -- "  substantive .agda files in src/:        $SUBSTANTIVE_COUNT"
+print -- "  skeleton → .lagda pairs:                $PAIRED"
+print -- "  skeletons lacking a paired .lagda:      $UNPAIRED"
+print -- "  external .lagda references:             $REF_COUNT"
+print -- ""

--- a/scripts/audit_lagda_migration.sh
+++ b/scripts/audit_lagda_migration.sh
@@ -1,5 +1,6 @@
-#!/usr/bin/env zsh
-# scripts/audit_lagda_migration.sh
+#!/usr/bin/env bash
+#
+# File: scripts/audit_lagda_migration.sh
 #
 # Answers the audit questions from issue #280 (M1-8):
 #   1. How many .lagda files exist?
@@ -7,59 +8,83 @@
 #   3. How many .agda files have substantive content?
 #   4. Which .lagda paths are referenced elsewhere in the repo?
 #
-# Run from the repo root.  Zero dependencies beyond zsh + standard coreutils.
+# Run from the repo root.  External dependencies: bash 4+, git, agda
+# (for the smoke test only), and the standard POSIX text utilities sed,
+# awk, grep, find, wc, tr, stat, mktemp.  Tested under Ubuntu 24.04;
+# a portability shim is used for stat(1) so the script also works on
+# macOS / BSD.
+
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# All output files live under a per-run temporary directory.  The path
+# is printed at the end of the run so the user knows where to find
+# /skeleton.txt, /substantive.txt, etc.
+OUT_DIR="$(mktemp -d -t agda-algebras-audit-XXXXXX)"
+
+# Portable file-mtime in seconds since the epoch.  GNU stat uses
+# `-c %Y`, BSD/macOS stat uses `-f %m`.  Rather than detect which
+# variant is in scope, shell out to Python — it's available on every
+# platform agda-algebras supports and produces consistent output.
+file_mtime() { python3 -c 'import os, sys; print(int(os.path.getmtime(sys.argv[1])))' "$1"; }
+
 banner() { printf '\n━━━ %s ━━━\n' "$1"; }
 
 banner "1. .lagda files under docs/lagda/"
 LAGDA_COUNT=$(find docs/lagda -name '*.lagda' 2>/dev/null | wc -l | tr -d ' ')
-print -- "  total .lagda files: $LAGDA_COUNT"
-find docs/lagda -name '*.lagda' 2>/dev/null | sort > /tmp/lagda-files.txt
-print -- "  list written to /tmp/lagda-files.txt"
+printf '%s\n' "  total .lagda files: $LAGDA_COUNT"
+find docs/lagda -name '*.lagda' 2>/dev/null | sort > "$OUT_DIR/lagda-files.txt"
+printf '%s\n' "  list written to $OUT_DIR/lagda-files.txt"
 
 banner "2. skeleton .agda files in src/"
-# Heuristic for "skeleton": after stripping comments and blank lines, only
-# allow either:
-#   1. a single "module ... where" line, or
-#   2. one OPTIONS pragma followed by a single "module ... where" line.
-# Anything else counts as substantive content.
+# Heuristic for "skeleton": after stripping
+#   - whole-line OPTIONS pragmas    {-# OPTIONS ... #-}
+#   - line comments                  -- ...
+#   - block comments                 {- ... -}
+#   - blank lines
+# the file's body should be exactly one line: the `module X where`
+# declaration.  Any further surviving line (an import, a definition,
+# anything) marks the file as substantive.
+#
+# Stripping OPTIONS pragmas explicitly is necessary because they begin
+# with `{-`, which would otherwise be interpreted as the start of a
+# block-comment range by sed.
 SKELETON_COUNT=0
 SUBSTANTIVE_COUNT=0
-rm -f /tmp/skeleton.txt /tmp/substantive.txt /tmp/substantive-paired.txt
+rm -f "$OUT_DIR/skeleton.txt" "$OUT_DIR/substantive.txt" "$OUT_DIR/substantive-paired.txt"
 for f in $(find src -name '*.agda' -not -path '*/Legacy/*'); do
-  body=$(sed -E -e 's|--.*$||' -e '/^\{-/,/-\}/d' "$f" \
-          | awk 'NF' | sed -E 's/^\s+//;s/\s+$//')
+  body=$(sed -E \
+              -e 's|^[[:space:]]*\{-#[[:space:]]*OPTIONS[^}]*#-\}[[:space:]]*$||' \
+              -e 's|--.*$||' \
+              -e '/^[[:space:]]*\{-([^#]|$)/,/-\}/d' "$f" \
+          | awk 'NF' | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
   first_line=$(printf '%s\n' "$body" | sed -n '1p')
-  second_line=$(printf '%s\n' "$body" | sed -n '2p')
   line_count=$(printf '%s\n' "$body" | awk 'NF { count++ } END { print count + 0 }')
-
-  if { [[ "$line_count" -eq 1 ]] \
-       && grep -Eq '^module[[:space:]]+.+[[:space:]]+where$' <<< "$first_line"; } \
-     || { [[ "$line_count" -eq 2 ]] \
-          && grep -Eq '^\{-# OPTIONS .+#-\}$' <<< "$first_line" \
-          && grep -Eq '^module[[:space:]]+.+[[:space:]]+where$' <<< "$second_line"; }; then
+  # After comment-stripping, a "skeleton" should have exactly one
+  # surviving line: the `module X where` declaration.  The OPTIONS
+  # pragma was already deleted; any imports or definitions push the
+  # line count above 1 and mark the file as substantive.
+  if [[ "$line_count" -eq 1 ]] \
+     && grep -Eq '^module[[:space:]]+.+[[:space:]]+where$' <<< "$first_line"; then
     SKELETON_COUNT=$((SKELETON_COUNT + 1))
-    print -- "$f" >> /tmp/skeleton.txt
+    printf '%s\n' "$f" >> "$OUT_DIR/skeleton.txt"
   else
     SUBSTANTIVE_COUNT=$((SUBSTANTIVE_COUNT + 1))
-    print -- "$f" >> /tmp/substantive.txt
+    printf '%s\n' "$f" >> "$OUT_DIR/substantive.txt"
   fi
 done
-print -- "  skeleton .agda files:    $SKELETON_COUNT  (list: /tmp/skeleton.txt)"
-print -- "  substantive .agda files: $SUBSTANTIVE_COUNT  (list: /tmp/substantive.txt)"
+printf '%s\n' "  skeleton .agda files:    $SKELETON_COUNT  (list: $OUT_DIR/skeleton.txt)"
+printf '%s\n' "  substantive .agda files: $SUBSTANTIVE_COUNT  (list: $OUT_DIR/substantive.txt)"
 
 banner "3. .agda-to-.lagda pairing (all files, not just skeletons)"
 PAIRED=0
 UNPAIRED=0
 SUBSTANTIVE_PAIRED=0
-rm -f /tmp/unpaired-skeletons.txt
-rm -f /tmp/substantive-paired.txt
-for f in $(cat /tmp/skeleton.txt 2>/dev/null); do
+rm -f "$OUT_DIR/unpaired-skeletons.txt" "$OUT_DIR/substantive-paired.txt"
+for f in $(cat "$OUT_DIR/skeleton.txt" 2>/dev/null); do
   # src/X/Y/Z.agda  →  docs/lagda/X/Y/Z.lagda
   rel=${f#src/}
   lagda="docs/lagda/${rel%.agda}.lagda"
@@ -67,35 +92,35 @@ for f in $(cat /tmp/skeleton.txt 2>/dev/null); do
     PAIRED=$((PAIRED + 1))
   else
     UNPAIRED=$((UNPAIRED + 1))
-    print -- "$f  (no $lagda)" >> /tmp/unpaired-skeletons.txt
+    printf '%s\n' "$f  (no $lagda)" >> "$OUT_DIR/unpaired-skeletons.txt"
   fi
 done
-print -- "  paired skeleton → .lagda: $PAIRED"
-print -- "  unpaired skeletons:       $UNPAIRED  (list: /tmp/unpaired-skeletons.txt)"
+printf '%s\n' "  paired skeleton → .lagda: $PAIRED"
+printf '%s\n' "  unpaired skeletons:       $UNPAIRED  (list: $OUT_DIR/unpaired-skeletons.txt)"
 
 # DRIFT HAZARD: substantive .agda files that ALSO have a .lagda partner.
 # These are the files where prose and code may have desynchronized.
-for f in $(cat /tmp/substantive.txt 2>/dev/null); do
+for f in $(cat "$OUT_DIR/substantive.txt" 2>/dev/null); do
   rel=${f#src/}
   lagda="docs/lagda/${rel%.agda}.lagda"
   if [[ -f "$lagda" ]]; then
     SUBSTANTIVE_PAIRED=$((SUBSTANTIVE_PAIRED + 1))
     agda_size=$(wc -l < "$f")
     lagda_size=$(wc -l < "$lagda")
-    agda_mtime=$(stat -c %Y "$f")
-    lagda_mtime=$(stat -c %Y "$lagda")
+    agda_mtime=$(file_mtime "$f")
+    lagda_mtime=$(file_mtime "$lagda")
     delta=$((agda_mtime - lagda_mtime))
-    print -- "$f  ($agda_size lines)  vs  $lagda  ($lagda_size lines)  Δmtime=${delta}s" \
-      >> /tmp/substantive-paired.txt
+    printf '%s\n' "$f  ($agda_size lines)  vs  $lagda  ($lagda_size lines)  Δmtime=${delta}s" \
+      >> "$OUT_DIR/substantive-paired.txt"
   fi
 done
-print -- "  substantive .agda WITH a .lagda partner (drift hazard): $SUBSTANTIVE_PAIRED"
+printf '%s\n' "  substantive .agda WITH a .lagda partner (drift hazard): $SUBSTANTIVE_PAIRED"
 if [[ $SUBSTANTIVE_PAIRED -gt 0 ]]; then
-  print -- "  (list: /tmp/substantive-paired.txt)"
+  printf '%s\n' "  (list: $OUT_DIR/substantive-paired.txt)"
 fi
 
 banner "4. external references to .lagda paths"
-print -- "  grepping for '\\.lagda' outside docs/lagda/ ..."
+printf '%s\n' "  grepping for '\\.lagda' outside docs/lagda/ ..."
 # Exclude the obvious places we expect matches (the files themselves,
 # generated HTML archives, etc.) and focus on references that will need
 # rewriting post-migration.
@@ -106,9 +131,9 @@ grep -rn '\.lagda\b' \
      --include='*.nix' \
      . 2>/dev/null \
   | grep -v '^docs/lagda/' \
-  > /tmp/lagda-references.txt || true
-REF_COUNT=$(wc -l < /tmp/lagda-references.txt | tr -d ' ')
-print -- "  external .lagda references: $REF_COUNT  (list: /tmp/lagda-references.txt)"
+  > "$OUT_DIR/lagda-references.txt" || true
+REF_COUNT=$(wc -l < "$OUT_DIR/lagda-references.txt" | tr -d ' ')
+printf '%s\n' "  external .lagda references: $REF_COUNT  (list: $OUT_DIR/lagda-references.txt)"
 
 banner "Agda 2.8.0 .lagda.md smoke test"
 # Verify the minimal .lagda.md round-trips under the project's flags.
@@ -126,18 +151,18 @@ data ⊤ : Set where tt : ⊤
 EOF
 if (cd "$TMP" && agda --no-libraries --html --html-dir="$TMP/out" \
                       Smoke.lagda.md >/dev/null 2>&1); then
-  print -- "  .lagda.md smoke test: OK"
+  printf '%s\n' "  .lagda.md smoke test: OK"
 else
-  print -- "  .lagda.md smoke test: FAILED — investigate before migrating"
+  printf '%s\n' "  .lagda.md smoke test: FAILED — investigate before migrating"
 fi
 rm -rf "$TMP"
 
 banner "Summary"
-print -- "  .lagda files in docs/lagda/:            $LAGDA_COUNT"
-print -- "  skeleton .agda files in src/:           $SKELETON_COUNT"
-print -- "  substantive .agda files in src/:        $SUBSTANTIVE_COUNT"
-print -- "  skeleton → .lagda pairs:                $PAIRED"
-print -- "  skeletons lacking a paired .lagda:      $UNPAIRED"
-print -- "  substantive .agda WITH .lagda partner:  $SUBSTANTIVE_PAIRED  (drift hazard)"
-print -- "  external .lagda references:             $REF_COUNT"
-print -- ""
+printf '%s\n' "  .lagda files in docs/lagda/:            $LAGDA_COUNT"
+printf '%s\n' "  skeleton .agda files in src/:           $SKELETON_COUNT"
+printf '%s\n' "  substantive .agda files in src/:        $SUBSTANTIVE_COUNT"
+printf '%s\n' "  skeleton → .lagda pairs:                $PAIRED"
+printf '%s\n' "  skeletons lacking a paired .lagda:      $UNPAIRED"
+printf '%s\n' "  substantive .agda WITH .lagda partner:  $SUBSTANTIVE_PAIRED  (drift hazard)"
+printf '%s\n' "  external .lagda references:             $REF_COUNT"
+printf '\n%s\n' "Output files: $OUT_DIR"


### PR DESCRIPTION

## Summary

First of three PRs addressing #280.  Scope is deliberately limited to the pre-work: writing down the decision, and producing the audit numbers that the subsequent PRs will key on.



## Related issues

Part of #280.

<!-- Or "Part of #" if this is one of several PRs addressing an issue. -->



---

## Description

### What's in this PR

+  **ADR-004** resolves the three open design questions the issue flags.  Summary: `docs/lagda/` is deleted, no files remain in LaTeX-literate form under `src/`, and the Jekyll pipeline consumes `agda --html` Markdown output directly.  Paper companions under `docs/papers/` are explicitly out of scope and keep their current shape.
+  **`scripts/audit_lagda_migration.sh`** quantifies the current state and smoke-tests Agda 2.8.0's `.lagda.md` support under the project's flags.

### Audit output

```
━━━ 1. .lagda files under docs/lagda/ ━━━
  total .lagda files: 127
  list written to /tmp/lagda-files.txt

━━━ 2. skeleton .agda files in src/ ━━━
  skeleton .agda files:    123  (list: /tmp/skeleton.txt)
  substantive .agda files: 4  (list: /tmp/substantive.txt)

━━━ 3. .agda-to-.lagda pairing (all files, not just skeletons) ━━━
  paired skeleton → .lagda: 123
  unpaired skeletons:       0  (list: /tmp/unpaired-skeletons.txt)
  substantive .agda WITH a .lagda partner (drift hazard): 4
  (list: /tmp/substantive-paired.txt)

━━━ 4. external references to .lagda paths ━━━
  grepping for '.lagda' outside docs/lagda/ ...
  external .lagda references: 180  (list: /tmp/lagda-references.txt)

━━━ Agda 2.8.0 .lagda.md smoke test ━━━
  .lagda.md smoke test: OK

━━━ Summary ━━━
  .lagda files in docs/lagda/:            127
  skeleton .agda files in src/:           123
  substantive .agda files in src/:        4
  skeleton → .lagda pairs:                123
  skeletons lacking a paired .lagda:      0
  substantive .agda WITH .lagda partner:  4  (drift hazard)
  external .lagda references:             180
```

### What this PR does not do

No source-tree migration.  No build-system changes.  No deletion of `docs/lagda/`.  Those land in PRs 2 and 3 of the #280 series, each independently reviewable.

### Refs

+  Issue #280 — M1-8.
+  ADR-001, ADR-002, ADR-003 (#255) — the ADR infrastructure this PR extends.

---

## Type of change

- [ ] Bug fix
- [x] New definition, theorem, or feature
- [ ] Refactoring / cleanup (no user-facing change)
- [x] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [ ] `make check` passes locally under `nix develop`.
- [ ] New public definitions have prose comment blocks.
- [ ] Commits are coherent and have explanatory messages.
- [ ] If this PR touches the `src/` tree, the change is targeted at `Base/`, `Setoid/`, or the shared `Overture/` foundation.
- [ ] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.

