### PR TITLE
[M2-6] Extract Setoid-canonical foundations from Legacy.Base (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,32 +22,25 @@ The 3.0 release is a major reconstruction of agda-algebras building on the Setoi
 +  **GitHub Actions CI** (`.github/workflows/ci.yml`) that type-checks the library on every push and pull request.
 +  **Community-health files**: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, issue templates, pull-request template.
 +  **Dual license**: Apache 2.0 for source code under `src/`, CC BY 4.0 for documentation under `docs/`.
++  **Three new `Overture/` submodules** (M2-6, #303):
+
+   +  `Overture.Terms` (the W-type `Term` over a signature, with constructors `ℊ` and `node`);
+   +  `Overture.Relations` (the `Equivalence` Σ-bundle, the identity relation `0[_]` with its `IsEquivalence`/`Equivalence` bundles, raw-function kernels `kerRel` / `kernelRel` / `kerRelOfEquiv`, the bare-types image-containment `Im_⊆_`, the compatibility relations `_preserves_` and `_|:_`, and the lifting helpers `eval-rel` / `eval-pred`);
+   +  `Overture.Functions` (the bare-types image-and-inverse infrastructure `Image_∋_` / `Inv` / `InvIsInverseʳ`, surjectivity `IsSurjective` with its right-inverse `SurjInv` and the composition law `epic-factor`, and the coordinate-projection cluster `proj` / `projIsOnto`).
+
+   These house the foundational definitions that the canonical `Setoid/` tree had been importing from `Legacy.Base.*` since the M2-1 freeze; relocating them to `Overture/` makes `Setoid/` self-sufficient and lets `Classical/` (M3-1, #260) build on a clean canonical foundation without inheriting a `Legacy.Base` dependency.  See [ADR-001 §Consequences "Setoid/ is not
+   yet self-sufficient"](docs/adr/001-setoid-as-canonical.md) for the motivation and `src/Legacy/Base/DEPRECATED.md` for the per-symbol relocation table.
 
 ### Changed (BREAKING)
 
-+  **`src/Base/` frozen as `src/Legacy/Base/`** (M2-1, #256).  `Setoid/` is now
-   the canonical development tree for agda-algebras 3.0.  The pre-3.0 bare-types
-   tree has been moved to `src/Legacy/Base/`; the top-level aggregator
-   `agda-algebras.lagda.md` re-exports it as `Legacy.Base`.  This is a breaking
-   change for downstream users of `Base.*`.  The migration is mechanical for
-   most imports; see `src/Legacy/Base/DEPRECATED.md` for the categorization
-   (deprecated-with-replacement vs. pending-port vs. no-replacement-planned)
-   and `docs/adr/001-setoid-as-canonical.md` for the rationale.
++  **`src/Base/` frozen as `src/Legacy/Base/`** (M2-1, #256).  `Setoid/` is now the canonical development tree for agda-algebras 3.0.  The pre-3.0 bare-types tree has been moved to `src/Legacy/Base/`; the top-level aggregator `agda-algebras.lagda.md` re-exports it as `Legacy.Base`.  This is a breaking change for downstream users of `Base.*`.  The migration is mechanical for most imports; see `src/Legacy/Base/DEPRECATED.md` for the categorization (deprecated-with-replacement vs. pending-port vs. no-replacement-planned) and `docs/adr/001-setoid-as-canonical.md` for the rationale.
 
    Migration recipe (most imports):
 
        sed -i -E 's/import(\s+)Base\./import\1Legacy.Base./g' YOUR_FILE.lagda.md
 
-   For modules that have a `Setoid/` analog (Category A in DEPRECATED.md),
-   prefer migrating to the `Setoid.*` import and passing
-   `Relation.Binary.PropositionalEquality.setoid A` where a setoid is now
-   expected.  For modules without one (Category B), the `Legacy.Base.*`
-   import is the supported interim path until the per-orphan port lands.
-+  **`src/agda-algebras.lagda.md` substantially revised** (#256).  Updated
-   to reflect the v3.0 source-tree organization (canonical `Setoid/`,
-   planned `Classical/` and `Cubical/`, frozen `Legacy.Base/`).  Removed
-   stale per-file license boilerplate that contradicted the project-level
-   licensing.
+   For modules that have a `Setoid/` analog (Category A in DEPRECATED.md), prefer migrating to the `Setoid.*` import and passing `Relation.Binary.PropositionalEquality.setoid A` where a setoid is now expected.  For modules without one (Category B), the `Legacy.Base.*` import is the supported interim path until the per-orphan port lands.
++  **`src/agda-algebras.lagda.md` substantially revised** (#256).  Updated to reflect the v3.0 source-tree organization (canonical `Setoid/`, planned `Classical/` and `Cubical/`, frozen `Legacy.Base/`).  Removed stale per-file license boilerplate that contradicted the project-level licensing.
 +  **Agda target**: 2.6.2 → 2.8.0.
 +  **Standard library target**: 1.7 → 2.3.
 +  **Pragma**: `--without-K` → `--cubical-compatible` across the tree.  See `src/Overture/Basic.lagda.md` for the reasoning.
@@ -58,11 +51,22 @@ The 3.0 release is a major reconstruction of agda-algebras building on the Setoi
 ### Deprecated
 
 +  **`docs/INSTALL_AGDA.md`** superseded by `INSTALL.md`.  Retained with a deprecation banner; will be removed in a future release.
++  **Legacy.Base.Terms.{Term, ℊ, node}** (M2-6, #303).  Use `Overture.Terms.{Term, ℊ, node}` instead.  The two `Term` types are definitionally identical; migration is a pure import rewrite.
++  **Legacy.Base.Relations.Quotients.{Equivalence, [_], 0[_]Equivalence, 0[_]IsEquivalence}** (M2-6, #303).  Use `Overture.Relations` instead.
++  **Legacy.Base.Relations.Discrete.{0[_], kerRel, kerRelOfEquiv, kernelRel, Im_⊆_, _preserves_, _|:_, eval-rel, eval-pred}** (M2-6, #303).  Use `Overture.Relations` instead.
++  **Legacy.Base.Functions.Inverses.{Image_∋_, eq, Inv, InvIsInverseʳ}** (M2-6, #303).  Use `Overture.Functions` instead.
++  **Legacy.Base.Functions.Surjective.{IsSurjective, IsSurjective→Surjective, Surjective→IsSurjective, SurjInv, SurjInvIsInverseʳ, epic-factor, epic-factor-intensional, proj, projIsOnto}** (M2-6, #303).  Use `Overture.Functions` instead.
+
+Each deprecated definition carries a `{-# WARNING_ON_USAGE #-}` pragma at its definition site pointing at the canonical home.  The legacy modules themselves continue to type-check and to export the deprecated names; the removal of these names is scheduled for the next minor release after the release that lands #303 (per the deprecation policy in `docs/STYLE_GUIDE.md`).
+
+Migration recipe (most call sites): replace `open import Legacy.Base.X using (…)` with `open import Overture using (…)` (since the `Overture` aggregator re-exports `Overture.Relations` and `Overture.Functions`); for `Term` / `ℊ` / `node`, use `open import Overture.Terms {𝑆 = 𝑆} using (…)` directly since the parameterized module is not re-exported through the umbrella.
 
 ### Removed
 
 +  **`docs/lagda/` tree** (127 LaTeX-literate `.lagda` files).  Content migrated to `src/X/Y/Z.lagda.md`; see "Literate-Agda format" above.
 +  **`src/X/Y/Z.agda` skeleton companions** (127 files) that were mechanically derived from the LaTeX-literate sources by `admin/illiterator/`.  The illiterator program itself is slated for deletion in the rendering-pipeline-modernization follow-up.
+
+---
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ The 3.0 release is a major reconstruction of agda-algebras building on the Setoi
    +  `Overture.Relations` (the `Equivalence` Σ-bundle, the identity relation `0[_]` with its `IsEquivalence`/`Equivalence` bundles, raw-function kernels `kerRel` / `kernelRel` / `kerRelOfEquiv`, the bare-types image-containment `Im_⊆_`, the compatibility relations `_preserves_` and `_|:_`, and the lifting helpers `eval-rel` / `eval-pred`);
    +  `Overture.Functions` (the bare-types image-and-inverse infrastructure `Image_∋_` / `Inv` / `InvIsInverseʳ`, surjectivity `IsSurjective` with its right-inverse `SurjInv` and the composition law `epic-factor`, and the coordinate-projection cluster `proj` / `projIsOnto`).
 
-   These house the foundational definitions that the canonical `Setoid/` tree had been importing from `Legacy.Base.*` since the M2-1 freeze; relocating them to `Overture/` makes `Setoid/` self-sufficient and lets `Classical/` (M3-1, #260) build on a clean canonical foundation without inheriting a `Legacy.Base` dependency.  See [ADR-001 §Consequences "Setoid/ is not
-   yet self-sufficient"](docs/adr/001-setoid-as-canonical.md) for the motivation and `src/Legacy/Base/DEPRECATED.md` for the per-symbol relocation table.
+   These house the foundational definitions that the canonical `Setoid/` tree had been importing from `Legacy.Base.*` since the M2-1 freeze; relocating them to `Overture/` makes `Setoid/` self-sufficient and lets `Classical/` (M3-1, #260) build on a clean canonical foundation without inheriting a `Legacy.Base` dependency.  See [ADR-001 §Consequences "Setoid/ is not yet self-sufficient"](docs/adr/001-setoid-as-canonical.md) for the motivation and `src/Legacy/Base/DEPRECATED.md` for the per-symbol relocation table.
 
 ### Changed (BREAKING)
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -542,6 +542,16 @@ See [Module structure and organization](#module-structure-and-organization) abov
 
 Every module under `src/` is a literate-Agda file (`.lagda.md`); see [File format](#file-format) above.  The in-source-comment rules above apply to the Agda content inside fenced ```` ```agda ```` blocks; the surrounding Markdown prose can be more expansive and is the primary vehicle for tutorial-style documentation.  Tutorial-style chapters that historically lived under `docs/lagda/` are now ordinary modules under `src/` (typically under `Demos/` or `Overture/`).
 
+### Prose belongs in Markdown
+
+`.lagda.md` files give us first-class natural-language sections; use them.  Reserve in-code comments for syntax-adjacent annotations: argument-level type clarifications, termination justifications, naming choices a reader needs while reading that line.  Module-level framing, definition-level exposition, and motivating discussion all belong in the surrounding Markdown prose, not in `-- |` blocks inside code fences.  The corpus serves both human readers and downstream ML training; prose-as-Markdown serves both better than prose-as-line-comments.
+
+### Don't hard-wrap prose
+
+Markdown paragraphs are written without artificial line breaks: one paragraph is one line in the source.  Editors and viewers (GitHub diff view, Jekyll-rendered HTML, modern terminals) soft-wrap to viewport width.  Hard-wrapping at a fixed column turns one-word edits into multi-line diffs as the wrap has to be redone, and competes badly with the long inline code spans common in this library (e.g., `Π[ t ∈ ((i : I) → J → 𝒜 i) ] eval-REL R t`).
+
+The convention applies to paragraph prose only.  Bullet items and numbered list items get one line each (the line break is structural, not cosmetic).  YAML front matter and link-reference blocks follow their own per-entry-per-line conventions.
+
 ---
 
 ## Deprecation policy

--- a/src/Legacy/Base/DEPRECATED.md
+++ b/src/Legacy/Base/DEPRECATED.md
@@ -29,6 +29,18 @@ The bare-types style in these modules typically depends on postulates of
 function extensionality and propositional extensionality that `Setoid/` retires
 by construction.
 
+Some Category-A relocations target `Overture/` rather than `Setoid/`.  This is
+correct when the relocated definition does not presuppose a setoid structure —
+for instance, `Term` is the W-type for the polynomial functor of a signature,
+`Equivalence A {ρ}` is a Σ-bundle of a `BinRel` with an `IsEquivalence` proof,
+and bare-types `IsSurjective` is parametric in a raw function `A → B`.  Such
+definitions belong in the shared foundations, not in the setoid layer; they
+are needed identically by the canonical `Setoid/` tree, by the planned
+`Classical/` tree (M3), and by the long-term `Cubical/` target (M5).  The
+per-symbol table below records the relocations to `Overture/` from the audit
+at #303 (M2-6).  The per-module table that follows it records the broader
+module-level deprecations to `Setoid/` for everything else.
+
 Note on aggregator rows: `Legacy.Base.Relations`, `Legacy.Base.Functions`, and
 `Legacy.Base.Varieties` are aggregator modules whose contents straddle Categories
 A and B.  The "canonical replacement" column points at the corresponding canonical
@@ -80,6 +92,10 @@ parallel abstract foundation.
 | `Legacy.Base.Varieties.Preservation`          | `Setoid.Varieties.Preservation`          |
 | `Legacy.Base.Varieties.Properties`            | `Setoid.Varieties.Properties`            |
 
+
+
+
+
 ### Category B — Pending port; no `Setoid/` analog yet
 
 These modules contain mathematical content with **no canonical replacement at
@@ -93,6 +109,43 @@ PR that lands the port, and the legacy file gains a `{-# WARNING_ON_USAGE #-}`
 pragma pointing to the new home.  The legacy module is removed in the
 *following* minor release, never in the same release that introduces the
 replacement; this gives downstream users one full minor cycle to migrate.
+
+
+#### Foundational definitions relocated to `Overture/` (per #303, M2-6)
+
+The following individual symbols are relocated to `Overture/` because they do
+not presuppose a setoid structure and are needed across `Setoid/`, `Classical/`,
+and `Cubical/`.  They were authored in the bare-types tree as a historical
+accident — `Base/` was the only tree at the time — and #303 corrects the
+structural placement.  At each definition site in the legacy tree there is now
+a `{-# WARNING_ON_USAGE #-}` pragma pointing at the canonical home.
+
+| Symbol                                              | Legacy location                          | Canonical home              |
+|-----------------------------------------------------|------------------------------------------|-----------------------------|
+| `Term`, `ℊ`, `node`                                 | `Legacy.Base.Terms.Basic`                | `Overture.Terms`            |
+| `Equivalence`                                       | `Legacy.Base.Relations.Quotients`        | `Overture.Relations`        |
+| `[_]`                                               | `Legacy.Base.Relations.Quotients`        | `Overture.Relations`        |
+| `0[_]`                                              | `Legacy.Base.Relations.Discrete`         | `Overture.Relations`        |
+| `0[_]IsEquivalence`, `0[_]Equivalence`              | `Legacy.Base.Relations.Quotients`        | `Overture.Relations`        |
+| `kerRel`, `kerRelOfEquiv`, `kernelRel`              | `Legacy.Base.Relations.Discrete`         | `Overture.Relations`        |
+| `Im_⊆_`                                             | `Legacy.Base.Relations.Discrete`         | `Overture.Relations`        |
+| `_preserves_`, `_|:_`                               | `Legacy.Base.Relations.Discrete`         | `Overture.Relations`        |
+| `eval-rel`, `eval-pred`                             | `Legacy.Base.Relations.Discrete`         | `Overture.Relations`        |
+| `Image_∋_`, `eq`                                    | `Legacy.Base.Functions.Inverses`         | `Overture.Functions`        |
+| `Inv`, `InvIsInverseʳ`                              | `Legacy.Base.Functions.Inverses`         | `Overture.Functions`        |
+| `IsSurjective`                                      | `Legacy.Base.Functions.Surjective`       | `Overture.Functions`        |
+| `IsSurjective→Surjective`, `Surjective→IsSurjective`| `Legacy.Base.Functions.Surjective`       | `Overture.Functions`        |
+| `SurjInv`, `SurjInvIsInverseʳ`                      | `Legacy.Base.Functions.Surjective`       | `Overture.Functions`        |
+| `epic-factor`, `epic-factor-intensional`            | `Legacy.Base.Functions.Surjective`       | `Overture.Functions`        |
+| `proj`, `projIsOnto`                                | `Legacy.Base.Functions.Surjective`       | `Overture.Functions`        |
+
+Migration: replace the legacy module path with `Overture.Terms` (with `{𝑆 = 𝑆}`
+instantiation), `Overture.Relations`, or `Overture.Functions` as appropriate.
+The Overture aggregator re-exports `Overture.Relations` and `Overture.Functions`
+(but not the parameterized `Overture.Terms`), so most call sites can simplify
+to `open import Overture using ( … )`.
+
+#### Module-level Setoid analogues
 
 | Legacy module                              | Planned destination                              | Target milestone | Tracking issue |
 |--------------------------------------------|--------------------------------------------------|------------------|----------------|
@@ -187,6 +240,27 @@ Three reasons:
     `Legacy.Base/` would actively remove formalized mathematics from the
     library.  The freeze-but-retain policy is what lets M2-1 ship without
     blocking on milestones M3, M9, and beyond.
+
+
+## Internal helpers
+
+The internal helpers `update`, `update-id`, and `proj-is-onto` (used by
+`projIsOnto`) were relocated alongside it but do not carry deprecation pragmas:
+no consumer imports them directly, and pragmatizing every internal helper would
+inflate the deprecation-warning volume without serving a real migration audience.
+If a downstream consumer turns out to need them at the legacy path, the omission
+is recoverable in a follow-up.
+
+## Deprecation-warning volume after #303
+
+The `WARNING_ON_USAGE` pragmas added in #303 fire on every import site, including
+internal `Legacy.Base.*` cross-imports.  This is intentional: the warnings are
+aimed at downstream consumers of `Legacy.Base`, and they fire correctly on
+internal Legacy uses too because those internal uses are themselves slated for
+removal in the next minor cycle.  The warnings under `EverythingLegacy.lagda.md`
+during `make check` are expected and do not indicate a regression.  Suppressing
+the warnings inside `Legacy.Base/*` would defeat their purpose.
+
 
 ## Further reading
 

--- a/src/Legacy/Base/DEPRECATED.md
+++ b/src/Legacy/Base/DEPRECATED.md
@@ -29,17 +29,7 @@ The bare-types style in these modules typically depends on postulates of
 function extensionality and propositional extensionality that `Setoid/` retires
 by construction.
 
-Some Category-A relocations target `Overture/` rather than `Setoid/`.  This is
-correct when the relocated definition does not presuppose a setoid structure —
-for instance, `Term` is the W-type for the polynomial functor of a signature,
-`Equivalence A {ρ}` is a Σ-bundle of a `BinRel` with an `IsEquivalence` proof,
-and bare-types `IsSurjective` is parametric in a raw function `A → B`.  Such
-definitions belong in the shared foundations, not in the setoid layer; they
-are needed identically by the canonical `Setoid/` tree, by the planned
-`Classical/` tree (M3), and by the long-term `Cubical/` target (M5).  The
-per-symbol table below records the relocations to `Overture/` from the audit
-at #303 (M2-6).  The per-module table that follows it records the broader
-module-level deprecations to `Setoid/` for everything else.
+Some Category-A relocations target `Overture/` rather than `Setoid/`.  This is correct when the relocated definition does not presuppose a setoid structure — for instance, `Term` is the W-type for the polynomial functor of a signature, `Equivalence A {ρ}` is a Σ-bundle of a `BinRel` with an `IsEquivalence` proof, and bare-types `IsSurjective` is parametric in a raw function `A → B`.  Such definitions belong in the shared foundations, not in the setoid layer; they are needed identically by the canonical `Setoid/` tree, by the planned `Classical/` tree (M3), and by the long-term `Cubical/` target (M5).  The per-symbol table below records the relocations to `Overture/` from the audit at #303 (M2-6).  The per-module table that follows it records the broader module-level deprecations to `Setoid/` for everything else.
 
 Note on aggregator rows: `Legacy.Base.Relations`, `Legacy.Base.Functions`, and
 `Legacy.Base.Varieties` are aggregator modules whose contents straddle Categories

--- a/src/Legacy/Base/Functions/Inverses.lagda.md
+++ b/src/Legacy/Base/Functions/Inverses.lagda.md
@@ -43,6 +43,9 @@ module _ {A : Type a}{B : Type b} where
  data Image_∋_ (f : A → B) : B → Type (a ⊔ b) where
   eq : {b : B} → (a : A) → b ≡ f a → Image f ∋ b
 
+ {-# WARNING_ON_USAGE Image_∋_ "Use Overture.Functions.Image_∋_ instead. Deprecated under #303; removal planned one minor cycle after #303 lands." #-}
+ {-# WARNING_ON_USAGE eq "Use Overture.Functions.eq instead. Deprecated under #303." #-}
+
  open Image_∋_
 
  Range : (A → B) → Pred B (a ⊔ b)
@@ -74,11 +77,10 @@ function, which we call `Inv`, and which takes an arbitrary `b : B` and a
 
 
 ```agda
-
-
  Inv : (f : A → B){b : B} → Image f ∋ b  →  A
  Inv f (eq a _) = a
 
+ {-# WARNING_ON_USAGE Inv "Use Overture.Functions.Inv instead. Deprecated under #303." #-}
 
  [_]⁻¹ : (f : A → B) → range f →  A
  [ f ]⁻¹ (_ , (a , _)) = a
@@ -94,6 +96,8 @@ follows.
 
  InvIsInverseʳ : {f : A → B}{b : B}(q : Image f ∋ b) → f(Inv f q) ≡ b
  InvIsInverseʳ (eq _ p) = sym p
+
+ {-# WARNING_ON_USAGE InvIsInverseʳ "Use Overture.Functions.InvIsInverseʳ instead. Deprecated under #303." #-}
 
  ⁻¹IsInverseʳ : {f : A → B}{bap : range f} → f ([ f ]⁻¹ bap) ≡ ∣ bap ∣
  ⁻¹IsInverseʳ {bap = (_ , (_ , p))} = p

--- a/src/Legacy/Base/Functions/Surjective.lagda.md
+++ b/src/Legacy/Base/Functions/Surjective.lagda.md
@@ -11,8 +11,6 @@ This is the [Base.Functions.Surjective][] module of the [agda-algebras][] librar
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 module Legacy.Base.Functions.Surjective where
 
@@ -45,12 +43,12 @@ and codomain of `f` agree.  The following types manifest this notion.
 
 
 ```agda
-
-
 module _ {A : Type a}{B : Type b} where
 
  IsSurjective : (A → B) →  Type _
  IsSurjective f = ∀ y → Image f ∋ y
+
+ {-# WARNING_ON_USAGE IsSurjective "Use Overture.Functions.IsSurjective instead. Deprecated under #303." #-}
 
  onto : Type _
  onto = Σ (A → B) IsSurjective
@@ -65,10 +63,14 @@ module _ {A : Type a}{B : Type b} where
   Goal : Σ[ x ∈ A ] ({z : A} → z ≡ x → f z ≡ y)
   Goal = fst (imgfy→A $ fE y) , λ z≡fst → trans (cong f z≡fst) $ snd (imgfy→A $ fE y)
 
+ {-# WARNING_ON_USAGE IsSurjective→Surjective "Use Overture.Functions.IsSurjective→Surjective instead. Deprecated under #303." #-}
+
  Surjective→IsSurjective :  (f : A → B) → Surjective{A = A} _≡_ _≡_ f
   →                         IsSurjective f
 
  Surjective→IsSurjective f fE y = eq (fst $ fE y) (sym $ snd (fE y) refl)
+
+ {-# WARNING_ON_USAGE Surjective→IsSurjective "Use Overture.Functions.Surjective→IsSurjective instead. Deprecated under #303." #-}
 ```
 
 With the next definition, we can represent a *right-inverse* of a surjective
@@ -76,10 +78,10 @@ function.
 
 
 ```agda
-
-
  SurjInv : (f : A → B) → IsSurjective f → B → A
  SurjInv f fE = Inv f ∘ fE
+
+ {-# WARNING_ON_USAGE SurjInv "Use Overture.Functions.SurjInv instead. Deprecated under #303." #-}
 ```
 
 
@@ -88,14 +90,14 @@ of `IsSurjective f`.  Next we prove that this does indeed give the right-inverse
 
 
 ```agda
-
-
 module _ {A : Type a}{B : Type b} where
 
  SurjInvIsInverseʳ :  (f : A → B)(fE : IsSurjective f)
   →                   ∀ b → f ((SurjInv f fE) b) ≡ b
 
  SurjInvIsInverseʳ f fE b = InvIsInverseʳ (fE b)
+
+ {-# WARNING_ON_USAGE SurjInvIsInverseʳ "Use Overture.Functions.SurjInvIsInverseʳ instead. Deprecated under #303." #-}
 
  -- composition law for epics
  epic-factor :  {C : Type c}(f : A → B)(g : A → C)(h : C → B)
@@ -115,6 +117,8 @@ module _ {A : Type a}{B : Type b} where
    Goal : Image h ∋ y
    Goal = eq (g (finv y)) η
 
+ {-# WARNING_ON_USAGE epic-factor "Use Overture.Functions.epic-factor instead. Deprecated under #303." #-}
+
  epic-factor-intensional :  {C : Type c}(f : A → B)(g : A → C)(h : C → B)
   →                         f ≡ h ∘ g → IsSurjective f → IsSurjective h
 
@@ -131,6 +135,8 @@ module _ {A : Type a}{B : Type b} where
 
    Goal : Image h ∋ y
    Goal = eq (g (finv y)) (sym η)
+
+ {-# WARNING_ON_USAGE epic-factor-intensional "Use Overture.Functions.epic-factor-intensional instead. Deprecated under #303." #-}
 ```
 
 
@@ -138,8 +144,6 @@ Later we will need the fact that the projection of an arbitrary product onto one
 
 
 ```agda
-
-
 module _  {I : Set ι}(_≟_ : Decidable{A = I} _≡_)
           {B : I → Set b}
           (bs₀ : ∀ i → (B i))
@@ -168,6 +172,9 @@ module _  {I : Set ι}(_≟_ : Decidable{A = I} _≡_)
 
  projIsOnto : ∀{j} → IsSurjective (proj j)
  projIsOnto {j} = Surjective→IsSurjective (proj j) proj-is-onto
+
+ {-# WARNING_ON_USAGE proj "Use Overture.Functions.proj instead. Deprecated under #303." #-}
+ {-# WARNING_ON_USAGE projIsOnto "Use Overture.Functions.projIsOnto instead. Deprecated under #303." #-}
 ```
 
 

--- a/src/Legacy/Base/Relations/Discrete.lagda.md
+++ b/src/Legacy/Base/Relations/Discrete.lagda.md
@@ -70,10 +70,10 @@ is contained in a particular "subset" (predicate) of the codomain.
 
 
 ```agda
-
-
  Im_⊆_ : {B : Type b} → (A → B) → Pred B ρ → Type (a ⊔ ρ)
  Im f ⊆ S = ∀ x → f x ∈ S
+
+ {-# WARNING_ON_USAGE Im_⊆_ "Use Overture.Relations.Im_⊆_ instead. Deprecated under #303." #-}
 ```
 
 
@@ -168,9 +168,15 @@ module _ {A : Type a}{B : Type b} where
  kernel : (A → B) → Pred (A × A) b
  kernel g (x , y) = g x ≡ g y
 
+{-# WARNING_ON_USAGE kerRel "Use Overture.Relations.kerRel instead. Deprecated under #303; removal planned one minor cycle after #303 lands." #-}
+{-# WARNING_ON_USAGE kerRelOfEquiv "Use Overture.Relations.kerRelOfEquiv instead. Deprecated under #303; removal planned one minor cycle after #303 lands." #-}
+{-# WARNING_ON_USAGE kernelRel "Use Overture.Relations.kernelRel instead. Deprecated under #303; removal planned one minor cycle after #303 lands." #-}
+
 -- The *identity relation* (equivalently, the kernel of a 1-to-1 function)
 0[_] : (A : Type a) → {ρ : Level} → BinRel A (a ⊔ ρ)
 0[ A ] {ρ} = λ x y → Lift ρ (x ≡ y)
+
+{-# WARNING_ON_USAGE 0[_] "Use Overture.Relations.0[_] instead. Deprecated under #303; removal planned one minor cycle after #303 lands." #-}
 
 module _ {A : Type (a ⊔ ρ)} where
 
@@ -222,6 +228,11 @@ f preserves R  = ∀ u v → (eval-rel R) u v → R (f u) (f v)
 --shorthand notation for preserves
 _|:_ : {A : Type a}{I : Type 𝓥} → Op A I → BinRel A ρ → Type (a ⊔ 𝓥 ⊔ ρ)
 f |: R  = (eval-rel R) =[ f ]⇒ R
+
+{-# WARNING_ON_USAGE eval-rel "Use Overture.Relations.eval-rel instead. Deprecated under #303." #-}
+{-# WARNING_ON_USAGE eval-pred "Use Overture.Relations.eval-pred instead. Deprecated under #303." #-}
+{-# WARNING_ON_USAGE _preserves_ "Use Overture.Relations._preserves_ instead. Deprecated under #303." #-}
+{-# WARNING_ON_USAGE _|:_ "Use Overture.Relations._|:_ instead. Deprecated under #303." #-}
 
 -- predicate version of the compatibility relation
 _preserves-pred_ : {A : Type a}{I : Type 𝓥} → Op A I → Pred ( A × A ) ρ → Type (a ⊔ 𝓥 ⊔ ρ)

--- a/src/Legacy/Base/Relations/Quotients.lagda.md
+++ b/src/Legacy/Base/Relations/Quotients.lagda.md
@@ -46,10 +46,10 @@ is a proof that `r` satisfies `IsEquivalence`.
 
 
 ```agda
-
-
 Equivalence : Type a → {ρ : Level} → Type (a ⊔ suc ρ)
 Equivalence A {ρ} = Σ[ r ∈ BinRel A ρ ] IsEquivalence r
+
+{-# WARNING_ON_USAGE Equivalence "Use Overture.Relations.Equivalence instead. Deprecated under #303." #-}
 ```
 
 
@@ -125,6 +125,8 @@ i.e., blocks of a partition (recall partitions correspond to equivalence relatio
 
 [_] : {A : Type a} → A → {ρ : Level} → BinRel A ρ → Pred A ρ
 [ u ]{ρ} R = R u      -- (the R-block containing u : A)
+
+{-# WARNING_ON_USAGE [_] "Use Overture.Relations.[_] instead. Deprecated under #303." #-}
 
 -- Alternative notation
 [_/_] : {A : Type a} → A → {ρ : Level} → Equivalence A {ρ} → Pred A ρ
@@ -244,6 +246,8 @@ This is obviously an equivalence relation, as we now confirm.
 0[_]Equivalence : (A : Type a) {ρ : Level} → Equivalence A {a ⊔ ρ}
 0[ A ]Equivalence {ρ} = 0[ A ] {ρ} , 0[ A ]IsEquivalence
 
+{-# WARNING_ON_USAGE 0[_]IsEquivalence "Use Overture.Relations.0[_]IsEquivalence instead. Deprecated under #303." #-}
+{-# WARNING_ON_USAGE 0[_]Equivalence "Use Overture.Relations.0[_]Equivalence instead. Deprecated under #303." #-}
 
 ⟪_∼_⟫-elim : {A : Type a} → (u v : A) → {ρ : Level}{R : Equivalence A{ρ} }
  →           ⟪ u ⟫{∣ R ∣} ≡ ⟪ v ⟫ → ∣ R ∣ u v

--- a/src/Legacy/Base/Terms/Basic.lagda.md
+++ b/src/Legacy/Base/Terms/Basic.lagda.md
@@ -66,6 +66,16 @@ data Term (X : Type χ ) : Type (ov χ)  where
  node : (f : ∣ 𝑆 ∣)(t : ∥ 𝑆 ∥ f → Term X) → Term X
 
 open Term
+
+{-# WARNING_ON_USAGE Term
+"Use Overture.Terms.Term instead.  Legacy.Base.Terms.Term is deprecated and will be removed one minor version after #303 lands."
+#-}
+{-# WARNING_ON_USAGE ℊ
+"Use Overture.Terms.ℊ instead.  Legacy.Base.Terms.ℊ is deprecated and will be removed one minor version after #303 lands."
+#-}
+{-# WARNING_ON_USAGE node
+"Use Overture.Terms.node instead.  Legacy.Base.Terms.node is deprecated and will be removed one minor version after #303 lands."
+#-}
 ```
 
 

--- a/src/Overture.lagda.md
+++ b/src/Overture.lagda.md
@@ -21,6 +21,7 @@ open import Overture.Preface     public
 open import Overture.Basic       public
 open import Overture.Signatures  public
 open import Overture.Operations  public
+open import Overture.Relations   public
 ```
 
 

--- a/src/Overture.lagda.md
+++ b/src/Overture.lagda.md
@@ -22,6 +22,7 @@ open import Overture.Basic       public
 open import Overture.Signatures  public
 open import Overture.Operations  public
 open import Overture.Relations   public
+open import Overture.Functions   public
 ```
 
 

--- a/src/Overture/Functions.lagda.md
+++ b/src/Overture/Functions.lagda.md
@@ -1,0 +1,187 @@
+---
+layout: default
+title : "Overture.Functions module (The Agda Universal Algebra Library)"
+date : "2026-05-07"
+author: "the agda-algebras development team"
+---
+
+### <a id="functions">Foundational function infrastructure</a>
+
+This is the [Overture.Functions][] module of the [Agda Universal Algebra Library][].
+
+This module collects the foundational definitions concerning raw functions `A → B` between bare types that are needed by the canonical `Setoid/` tree.  All the definitions here take their arguments at the level of bare types and raw functions; none presupposes a setoid structure.  The setoid-respecting analogues — image and surjectivity for setoid functions `𝐴 ⟶ 𝐵` — live in `Setoid.Functions.*` and are independent.  The two coexist because they have genuinely different type signatures and serve genuinely different call sites.
+
+The contents fall into three clusters.
+
++  **Image and inverse**.  An inductive type `Image f ∋ b` representing the image of a raw function as the existence of a preimage, together with the `Inv` operation that extracts a preimage from an inhabitant of that type.  The inductive presentation lets us *compute* a range-restricted inverse, which is what surjectivity needs.
++  **Surjectivity**.  A predicate `IsSurjective f`, the right-inverse `SurjInv`, the right-inverse-correctness lemma `SurjInvIsInverseʳ`, and the composition law `epic-factor` (used in the homomorphism factorization theorem in `Setoid.Homomorphisms.Factor`).
++  **Coordinate projection**.  Given an indexed family `B : I → Type b` over a type `I` with decidable equality, the projection `proj j : (∀ i → B i) → B j` and its surjectivity proof `projIsOnto`.  Used in `Setoid.Algebras.Products` to witness that the carrier-level projection from a product algebra onto a single factor is a surjection — a bare-types claim about raw functions, even though it sits inside the Setoid tree.  (A setoid-respecting upgrade is tracked as a follow-up to #303.)
+
+This module is a Category-A relocation under #303 (M2-6).  See [`src/Legacy/Base/DEPRECATED.md`](../Legacy/Base/DEPRECATED.md) for the full inventory and migration guidance.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Overture.Functions where
+
+-- Imports from Agda primitives and the standard library.
+open import Agda.Primitive    using ()           renaming ( Set to Type )
+open import Data.Empty        using ( ⊥-elim )
+open import Data.Product      using ( Σ ; Σ-syntax ; _,_ )
+                              renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function          using ( _∘_ ; _$_ ; Surjective )
+open import Level             using ( Level ; _⊔_ )
+open import Relation.Binary   using ( Decidable )
+open import Relation.Nullary  using ( Dec ; yes ; no )
+
+open import Axiom.UniquenessOfIdentityProofs  using ( module Decidable⇒UIP )
+open import Relation.Binary.PropositionalEquality
+                              using ( _≡_ ; refl ; sym ; trans ; cong ; cong-app )
+
+-- Imports from agda-algebras.
+open import Overture.Basic  using ( _≈_ ; _∙_ ; transport )
+
+private variable a b c ι : Level
+```
+
+#### <a id="image">The image of a raw function</a>
+
+The *image* of a raw function `f : A → B` at a point `b : B` is the proposition that some `a : A` satisfies `f a ≡ b`.  We represent it as an inductive type with one constructor, `eq`, which packages the witness `a` together with the equality proof.  This inductive presentation matters: an inhabitant of `Image f ∋ b` carries an actual point of `A`, so we can extract that point computationally (the function `Inv` below).  The corresponding Σ-type formulation `Σ[ a ∈ A ] f a ≡ b` would be logically equivalent but syntactically less convenient at the call sites; the legacy module has used the inductive form throughout, and the canonical Setoid tree consumes it that way.
+
+```agda
+module _ {A : Type a}{B : Type b} where
+
+ data Image_∋_ (f : A → B) : B → Type (a ⊔ b) where
+  eq : {b : B} → ∀ a → b ≡ f a → Image f ∋ b
+```
+
+Given an inhabitant of `Image f ∋ b`, we recover the underlying preimage by pattern matching on `eq`.  This is the `Inv` function, a *range-restricted* inverse: it is defined exactly on those `b : B` that are demonstrably in the image of `f`.
+
+```agda
+ Inv : (f : A → B){b : B} → Image f ∋ b → A
+ Inv _ (eq a _) = a
+
+ InvIsInverseʳ : {f : A → B}{b : B}(q : Image f ∋ b) → f (Inv f q) ≡ b
+ InvIsInverseʳ (eq _ p) = sym p
+```
+
+#### <a id="surjectivity">Surjectivity of raw functions</a>
+
+A raw function `f : A → B` is *surjective* when every `b : B` is in the image of `f`.  The library distinguishes this from stdlib's `Function.Surjective`, which is a more general "respects two arbitrary equivalences" notion; the bare-types `IsSurjective` is the specialization to propositional equality on both sides.  Conversion in either direction is straightforward, as the two helper lemmas below show.
+
+```agda
+module _ {A : Type a}{B : Type b} where
+
+ IsSurjective : (A → B) → Type (a ⊔ b)
+ IsSurjective f = ∀ y → Image f ∋ y
+
+ IsSurjective→Surjective :  (f : A → B) → IsSurjective f
+  →                         Surjective _≡_ _≡_ f
+ IsSurjective→Surjective f fE y = goal
+  where
+  imgfy→A : Image f ∋ y → Σ[ x ∈ A ] f x ≡ y
+  imgfy→A (eq x p) = x , sym p
+  goal : Σ[ x ∈ A ] ({z : A} → z ≡ x → f z ≡ y)
+  goal = fst (imgfy→A $ fE y)
+       , λ z≡fst → trans (cong f z≡fst) $ snd (imgfy→A $ fE y)
+
+ Surjective→IsSurjective :  (f : A → B) → Surjective {A = A} _≡_ _≡_ f
+  →                         IsSurjective f
+ Surjective→IsSurjective f fE y = eq (fst $ fE y) (sym $ snd (fE y) refl)
+```
+
+A right-inverse of a surjective `f` is obtained by composing `Inv` with the surjectivity proof.  The right-inverse property is then immediate from `InvIsInverseʳ` above.
+
+```agda
+ SurjInv : (f : A → B) → IsSurjective f → B → A
+ SurjInv f fE = Inv f ∘ fE
+
+ SurjInvIsInverseʳ :  (f : A → B)(fE : IsSurjective f)
+  →                   ∀ b → f ((SurjInv f fE) b) ≡ b
+ SurjInvIsInverseʳ f fE b = InvIsInverseʳ (fE b)
+```
+
+The composition law for surjective functions: if `f` factors through `g` via `h`, and `f` is surjective, then so is `h`.  This is consumed in `Setoid.Homomorphisms.Factor` to lift surjectivity through the homomorphism factorization diagram.
+
+```agda
+
+module _ {A : Type a}{B : Type b}{C : Type c} where
+
+ epic-factor :  (f : A → B)(g : A → C)(h : C → B)
+  →             f ≈ h ∘ g → IsSurjective f → IsSurjective h
+ epic-factor f g h compId fe y = goal
+  where
+   finv : B → A
+   finv = SurjInv f fe
+
+   ζ : y ≡ f (finv y)
+   ζ = sym (SurjInvIsInverseʳ f fe y)
+
+   η : y ≡ (h ∘ g) (finv y)
+   η = ζ ∙ compId (finv y)
+
+   goal : Image h ∋ y
+   goal = eq (g (finv y)) η
+
+ epic-factor-intensional :  (f : A → B)(g : A → C)(h : C → B)
+  →                         f ≡ h ∘ g → IsSurjective f → IsSurjective h
+ epic-factor-intensional f g h compId fe y = goal
+  where
+   finv : B → A
+   finv = SurjInv f fe
+
+   ζ : f (finv y) ≡ y
+   ζ = SurjInvIsInverseʳ f fe y
+
+   η : (h ∘ g) (finv y) ≡ y
+   η = (cong-app (sym compId) (finv y)) ∙ ζ
+
+   goal : Image h ∋ y
+   goal = eq (g (finv y)) (sym η)
+```
+
+#### <a id="projection">Coordinate projection out of a dependent product</a>
+
+Given an indexed family `B : I → Type b` and a "default" point `bs₀ : ∀ i → B i` of the dependent product, we define the coordinate projection `proj j` and prove it surjective.  The default point and the decidable equality on `I` are both essential: without a fallback value at indices `i ≠ j` we cannot construct a preimage of an arbitrary `b : B j`, and without decidable equality we cannot decide which coordinate to fill in with `b`.
+
+The auxiliary `update` modifies the default point at the single coordinate `j` to take a given value `b`, leaving the other coordinates alone.  The auxiliary `update-id` says that `update bs₀ (j , b)` evaluated at `j` gives back `b`, regardless of which proof of `j ≡ j` the decision procedure happens to produce.  The latter is where uniqueness-of-identity-proofs (UIP) for the index type `I` enters: `update-id` cannot be proved without it, because the "yes" case has to handle a propositionally-but-not-definitionally trivial equality proof.  The `Decidable⇒UIP` module from stdlib gives us UIP for any type with decidable equality, which is the assumption already made on `I`.
+
+```agda
+
+module _  {I : Type ι}(_≟_ : Decidable {A = I} _≡_)
+          {B : I → Type b}
+          (bs₀ : ∀ i → B i)
+ where
+ open Decidable⇒UIP _≟_ using ( ≡-irrelevant )
+
+ proj : (j : I) → (∀ i → B i) → B j
+ proj j xs = xs j
+
+ update : (∀ i → B i) → ((j , _) : Σ I B) → (∀ i → Dec (i ≡ j) → B i)
+ update _   (_ , b)  i (yes x)  = transport B (sym x) b
+ update bs  _        i (no  _)  = bs i
+
+ update-id : ∀{j b} → (c : Dec (j ≡ j)) → update bs₀ (j , b) j c ≡ b
+ update-id {j} {b}  (yes p) = cong (λ x → transport B x b)
+                                   (≡-irrelevant (sym p) refl)
+ update-id          (no ¬p) = ⊥-elim (¬p refl)
+
+ proj-is-onto : ∀{j} → Surjective {A = ∀ i → B i} _≡_ _≡_ (proj j)
+ proj-is-onto {j} b = bs , λ x → trans (cong (λ u → proj j u) x) pf
+  where
+  bs : (i : I) → B i
+  bs i = update bs₀ (j , b) i (i ≟ j)
+
+  pf : proj j bs ≡ b
+  pf = update-id (j ≟ j)
+
+ projIsOnto : ∀{j} → IsSurjective (proj j)
+ projIsOnto {j} = Surjective→IsSurjective (proj j) proj-is-onto
+```
+
+--------------------------------------
+
+<span style="float:left;">[← Overture.Relations](Overture.Relations.html)</span>
+<span style="float:right;">[Overture.Terms →](Overture.Terms.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Overture/Relations.lagda.md
+++ b/src/Overture/Relations.lagda.md
@@ -1,0 +1,170 @@
+---
+layout: default
+title : "Overture.Relations module (The Agda Universal Algebra Library)"
+date : "2026-05-07"
+author: "the agda-algebras development team"
+---
+
+## <a id="relations">Foundational relation infrastructure</a>
+
+This is the [Overture.Relations][] module of the [Agda Universal Algebra Library][].
+
+This module collects the foundational definitions concerning binary relations on a type that are needed by both the canonical `Setoid/` tree and the planned `Classical/` tree.  Every definition in this module takes its arguments at the level of bare types and `BinRel`; none presupposes a setoid structure.  The Setoid-flavoured analogues — relations between setoid functions, kernels of setoid morphisms, etc. — live in `Setoid.Relations.*` and are built on top of, rather than parallel to, what is collected here.
+
+The contents fall into four clusters:
+
++  **`Equivalence`**.  A Σ-bundle of a binary relation with a proof that it is an equivalence relation.  The setoid `_/_` quotient construction in `Setoid.Relations.Quotients` consumes this.
++  **Kernels and identity**.  `kerRel`, `kerRelOfEquiv`, `kernelRel`, and the trivial relation `0[_]`.  Used pervasively in `Setoid.Homomorphisms.{Factor,Kernels}` and `Setoid.Algebras.Congruences`.
++  **Image-containment**.  `Im_⊆_`, the predicate that the image of a tuple lies inside a given subset.  Used in `Setoid.Subalgebras.Subuniverses` for the ar-tuple of an operation, which is a *raw* function from an arity type to the algebra's carrier — not a setoid function — so the bare-types version is what's needed at the call site.
++  **Compatibility**.  `_|:_` (and its long form `_preserves_`), expressing that an `Op A I` is compatible with a `BinRel A ρ`.  Used in `Setoid.Algebras.Congruences._∣≈_` even on setoid algebras, since congruences of a setoid algebra are bare-types relations on its carrier that contain the setoid's `_≈_`.
+
+This module is a Category-A relocation under #303 (M2-6).  See [`src/Legacy/Base/DEPRECATED.md`](../Legacy/Base/DEPRECATED.md) for the full inventory and migration guidance.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Overture.Relations where
+
+-- Imports from Agda primitives and the standard library.
+open import Agda.Primitive   using ()           renaming ( Set to Type )
+open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax )
+                             renaming ( proj₁ to fst ; proj₂ to snd )
+open import Function         using ( _∘_ )
+open import Level            using ( Level ; Lift ; lift ; lower ; suc ; _⊔_ )
+open import Relation.Binary  using ( IsEquivalence ; _=[_]⇒_ )
+                             renaming ( Rel to BinRel )
+open import Relation.Unary   using ( Pred ; _∈_ )
+
+open import Relation.Binary.PropositionalEquality as ≡  using ( _≡_ )
+
+-- Imports from agda-algebras.
+open import Overture.Signatures  using ( 𝓞 ; 𝓥 )
+open import Overture.Operations  using ( Op )
+
+private variable
+ a b ρ ℓ : Level
+ 𝓦 : Level   -- arity-tuple level, conventional name elsewhere in the library
+```
+
+### <a id="equivalence-bundle">The `Equivalence` Σ-bundle</a>
+
+`Equivalence A {ρ}` packages a binary relation on `A` with a proof that the relation is an equivalence.  Compared to stdlib's `Relation.Binary.Bundles.Setoid`, which bundles a `Carrier` *and* an `_≈_` *and* an `IsEquivalence`, `Equivalence` fixes the carrier as a parameter and bundles only the relation with its proof — useful when one wants to vary the equivalence relation over a fixed carrier (the situation in quotient and congruence constructions).
+
+```agda
+Equivalence : Type a → {ρ : Level} → Type (a ⊔ suc ρ)
+Equivalence A {ρ} = Σ[ r ∈ BinRel A ρ ] IsEquivalence r
+```
+
+Given `R : Equivalence A`, we use `∣ R ∣` for the underlying relation and `∥ R ∥` for the equivalence-relation proof, following the library convention.
+
+### <a id="equivalence-blocks">Equivalence classes</a>
+
+If `R` is a binary relation on `A`, the *`R`-block containing* `u : A` is the predicate that holds at `v` precisely when `R u v`.  The notation `[ u ] R` is shorthand for that predicate.
+
+```agda
+[_] : {A : Type a} → A → {ρ : Level} → BinRel A ρ → Pred A ρ
+[ u ] R = R u
+
+infix 60 [_]
+```
+
+### <a id="identity-relation">The identity relation</a>
+
+The *identity* (or *zero*) relation on `A` is `λ x y → Lift ρ (x ≡ y)`.  The `Lift` is there so that the relation's universe level can be parametrized independently of the carrier's level — useful when the relation has to live at a level dictated by surrounding context (e.g., congruence relations on an algebra at level `α ⊔ suc ρ`).
+
+```agda
+0[_] : (A : Type a) → {ρ : Level} → BinRel A (a ⊔ ρ)
+0[ A ] {ρ} = λ x y → Lift ρ (x ≡ y)
+```
+
+The identity relation is, of course, an equivalence relation; we package its `IsEquivalence` proof and the corresponding `Equivalence` bundle for convenience.
+
+```agda
+0[_]IsEquivalence : (A : Type a){ρ : Level} → IsEquivalence (0[ A ] {ρ})
+0[ A ]IsEquivalence {ρ} = record  { refl   = lift ≡.refl
+                                  ; sym    = λ p   → lift (≡.sym (lower p))
+                                  ; trans  = λ p q → lift (≡.trans (lower p) (lower q))
+                                  }
+
+0[_]Equivalence : (A : Type a){ρ : Level} → Equivalence A {a ⊔ ρ}
+0[ A ]Equivalence {ρ} = 0[ A ] {ρ} , 0[ A ]IsEquivalence
+```
+
+### <a id="kernels">Kernels of raw functions</a>
+
+The *kernel* of `f : A → B` is the equivalence relation on `A` whose blocks are the fibres of `f`.  We give three formulations corresponding to three idiomatic uses elsewhere in the library: `kerRel` parametrizes the codomain equivalence (used when `B` has its own equivalence relation that the kernel should reflect, e.g. the carrier of a setoid algebra); `kernelRel` repackages the same content as a predicate on pairs (more convenient for some `Pred`-based constructions); and `kerRelOfEquiv` lifts an `IsEquivalence` proof on the codomain to one on the kernel.
+
+```agda
+module _ {A : Type a}{B : Type b} where
+
+ kerRel : {ρ : Level} → BinRel B ρ → (A → B) → BinRel A ρ
+ kerRel _≈_ g x y = g x ≈ g y
+
+ kernelRel : {ρ : Level} → BinRel B ρ → (A → B) → Pred (A × A) ρ
+ kernelRel _≈_ g (x , y) = g x ≈ g y
+
+ open IsEquivalence
+
+ kerRelOfEquiv :  {ρ : Level}{R : BinRel B ρ}
+  →               IsEquivalence R → (h : A → B) → IsEquivalence (kerRel R h)
+
+ kerRelOfEquiv eqR h = record  { refl   = refl   eqR
+                               ; sym    = sym    eqR
+                               ; trans  = trans  eqR
+                               }
+```
+
+### <a id="image-containment">Image-containment of a tuple</a>
+
+If `a : I → A` is a tuple of `A`-values indexed by `I`, and `B` is a subset of `A`, then `Im a ⊆ B` asserts that every component of the tuple lies in `B`.  This is the bare-types form of image-containment, in which `a` is a raw function rather than a setoid morphism.
+
+```agda
+Im_⊆_ : {A : Type a}{I : Type 𝓦}{ℓ : Level}
+ →      (I → A) → Pred A ℓ → Type (𝓦 ⊔ ℓ)
+Im a ⊆ B = ∀ i → a i ∈ B
+```
+
+A setoid analogue of `Im_⊆_`, taking a setoid function rather than a raw function, is given separately in `Setoid.Relations.Discrete`.  The two coexist because they have genuinely different type signatures and serve genuinely different call sites.
+
+### <a id="compatibility">Compatibility of operations with relations</a>
+
+If `f : Op A I` is an `I`-ary operation on `A` and `R` is a binary relation on `A`, we say that `f` and `R` are *compatible* (equivalently, that `f` *preserves* `R`) when, for all tuples `u v : I → A`, the pointwise hypothesis `∀ i → R (u i) (v i)` implies `R (f u) (f v)`.  We provide both a long-form name `_preserves_` and the customary infix shorthand `_|:_`.
+
+The lifting of a binary relation to the corresponding `I`-ary pointwise relation is itself useful and worth naming; we call it `eval-rel`.  A predicate-of-pairs counterpart `eval-pred` is provided for symmetry with `kernelRel`.
+
+```agda
+-- Lift a binary relation to the corresponding I-ary pointwise relation.
+eval-rel : {A : Type a}{I : Type 𝓦} → BinRel A ρ → BinRel (I → A) (𝓦 ⊔ ρ)
+eval-rel R u v = ∀ i → R (u i) (v i)
+
+eval-pred : {A : Type a}{I : Type 𝓦} → Pred (A × A) ρ → BinRel (I → A) (𝓦 ⊔ ρ)
+eval-pred P u v = ∀ i → (u i , v i) ∈ P
+
+module _ {A : Type a}{I : Type 𝓦} where
+
+ _preserves_ : Op A I → BinRel A ρ → Type (a ⊔ 𝓦 ⊔ ρ)
+ f preserves R = ∀ u v → (eval-rel R) u v → R (f u) (f v)
+
+ -- Infix shorthand for `preserves`.
+ _|:_ : Op A I → BinRel A ρ → Type (a ⊔ 𝓦 ⊔ ρ)
+ f |: R = (eval-rel R) =[ f ]⇒ R
+```
+
+The two formulations are logically equivalent.  The shorthand `_|:_` is what the Setoid tree uses pervasively; the long-form `_preserves_` is provided for prose-readability at consumption sites where the brevity of `|:` is more cryptic than helpful.
+
+```agda
+module _ {A : Type a}{I : Type 𝓦}{f : Op A I}{R : BinRel A ρ} where
+
+ preserves→|: : f preserves R → f |: R
+ preserves→|: c {u}{v} Ruv = c u v Ruv
+
+ |:→preserves : f |: R → f preserves R
+ |:→preserves c = λ u v Ruv → c Ruv
+```
+
+--------------------------------------
+
+<span style="float:left;">[← Overture.Operations](Overture.Operations.html)</span>
+<span style="float:right;">[Overture.Functions →](Overture.Functions.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Overture/Terms.lagda.md
+++ b/src/Overture/Terms.lagda.md
@@ -1,0 +1,74 @@
+---
+layout: default
+title : "Overture.Terms module (The Agda Universal Algebra Library)"
+date : "2026-05-06"
+author: "agda-algebras development team"
+---
+
+## <a id="terms">Terms over a signature</a>
+
+A `Term X` is a finite tree whose leaves are drawn from a type `X` of variable symbols and whose internal nodes are labelled by operation symbols of the signature `𝑆`.  Equivalently, `Term` is the W-type for the polynomial functor associated to `𝑆`, freely adjoined a copy of `X` at the leaves.
+
+This definition presupposes only the signature: no propositional equality on a carrier, no setoid equivalence, no path type.  It is therefore foundational rather than setoid-specific, which is why it lives in `Overture/` rather than under `Setoid/`, `Classical/`, or `Cubical/`.  The Setoid term algebra `𝑻 X` (which equips `Term X` with an inductive equivalence-of-terms relation `_≐_`) is built on top of this definition in `Setoid.Terms.Basic`; the Cubical analog will sit similarly at M5.
+
+This module is a Category-A relocation under #303 (M2-6).  See [`src/Legacy/Base/DEPRECATED.md`](../Legacy/Base/DEPRECATED.md) for the full inventory.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture.Signatures using ( 𝓞 ; 𝓥 ; Signature )
+
+module Overture.Terms {𝑆 : Signature 𝓞 𝓥} where
+-- Imports from Agda primitives and the standard library.
+open import Agda.Primitive  using ()           renaming ( Set to Type )
+open import Level           using ( Level ; suc ; _⊔_ )
+
+-- Imports from agda-algebras.
+open import Overture.Basic  using ( ∣_∣ ; ∥_∥ )
+
+private variable χ : Level
+```
+
+### <a id="ov">The level shorthand `ov`</a>
+
+Throughout the library we package the universe levels of operation symbols (`𝓞`), arities (`𝓥`), and a separate "carrier-or-variable" level (`χ`) into a single shorthand `ov χ = 𝓞 ⊔ 𝓥 ⊔ suc χ`.  The `suc` is unavoidable because `Term X` mixes leaves of type `X : Type χ` with operation symbols of type `Type 𝓞`, so the resulting tree type sits one universe up.
+
+This shorthand currently appears with the same definition in `Legacy.Base.Algebras.Basic` and `Setoid.Algebras.Basic`; the three definitions are definitionally equal.  Hoisting `ov` to `Overture.Signatures` and removing the duplicates is a small candidate cleanup tracked separately from #303.
+
+```agda
+ov : Level → Level
+ov χ = 𝓞 ⊔ 𝓥 ⊔ suc χ
+```
+
+### <a id="the-type-of-terms">The type of terms</a>
+
+Fix a signature `𝑆` and let `X` denote an arbitrary collection of variable symbols, assumed disjoint from the operation symbols of `𝑆` (i.e. `X ∩ ∣ 𝑆 ∣ = ∅`).
+
+By a *word* in the language of `𝑆`, we mean a nonempty finite sequence of members of `X ∪ ∣ 𝑆 ∣`; we denote concatenation of such sequences by simple juxtaposition.
+
+Let `S₀` denote the set of nullary operation symbols of `𝑆`.  We define the sets `𝑇ₙ` of *words* over `X ∪ ∣ 𝑆 ∣` by induction on `n` (cf. [Bergman (2012)][] Def. 4.19):
+
+`𝑇₀ := X ∪ S₀`  and  `𝑇ₙ₊₁ := 𝑇ₙ ∪ 𝒯ₙ`
+
+where `𝒯ₙ` is the collection of all `f t` such that `f : ∣ 𝑆 ∣` and `t : ∥ 𝑆 ∥ f → 𝑇ₙ` (recall `∥ 𝑆 ∥ f` is the arity of `f`).  The collection of *terms* in the signature `𝑆` over `X` is then `Term X := ⋃ₙ 𝑇ₙ`.  By an 𝑆-*term* we mean a term in the language of `𝑆`.
+
+The definition of `Term X` is recursive, indicating that an inductive type suffices to represent the notion in type theory.  Such a representation is given by the inductive type below, which encodes each term as a tree with an operation symbol at each `node` and a variable symbol (the `generator`) at each leaf.
+
+```agda
+data Term (X : Type χ) : Type (ov χ) where
+ ℊ    : X → Term X                                       -- (ℊ for "generator")
+ node : (f : ∣ 𝑆 ∣)(t : ∥ 𝑆 ∥ f → Term X) → Term X
+
+open Term public
+```
+
+**Notation**.  The type `X` represents an arbitrary collection of variable symbols; `ov χ` is the universe-level shorthand defined above.
+
+The bare-types term algebra `𝑻 : (X : Type χ) → Algebra (ov χ)`, which equips `Term X` with `node` as its interpretation, is *not* relocated here: it depends on the foundation-specific `Algebra` type, which differs between the bare-types tree (`Legacy.Base.Algebras.Algebra`) and the canonical Setoid tree (`Setoid.Algebras.Basic.Algebra`).  The legacy `𝑻` continues to live in `Legacy.Base.Terms.Basic`; the Setoid term algebra continues to live in `Setoid.Terms.Basic`.
+
+--------------------------------------
+
+<span style="float:left;">[← Overture.Operations](Overture.Operations.html)</span>
+<span style="float:right;">[Overture.Relations →](Overture.Relations.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Algebras/Congruences.lagda.md
+++ b/src/Setoid/Algebras/Congruences.lagda.md
@@ -30,8 +30,7 @@ open import Relation.Binary  using ( Setoid ; IsEquivalence )
 open import Relation.Binary.PropositionalEquality using ( refl )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
-open import Overture          using ( ∣_∣  ; ∥_∥  )
-open import Legacy.Base.Relations    using ( 0[_] ; _|:_ ; Equivalence )
+open import Overture          using ( ∣_∣  ; ∥_∥ ; 0[_] ; _|:_ ; Equivalence )
 open import Setoid.Relations  using ( ⟪_⟫ ; _/_ ; ⟪_∼_⟫-elim )
 open import Setoid.Algebras.Basic {𝑆 = 𝑆} using ( ov ; Algebra ; 𝕌[_] ; _̂_ )
 

--- a/src/Setoid/Algebras/Products.lagda.md
+++ b/src/Setoid/Algebras/Products.lagda.md
@@ -34,8 +34,8 @@ open IsEquivalence  using ()                 renaming ( refl to reflE ; sym to s
 
 
 -- Imports from agda-algebras -----------------------------------------------------
-open import Overture        using ( ∣_∣; ∥_∥ )
-open import Legacy.Base.Functions  using ( proj ; projIsOnto ) renaming ( IsSurjective to onto )
+open import Overture  using ( ∣_∣; ∥_∥ ; proj ; projIsOnto )
+                      renaming ( IsSurjective to onto )
 
 open import Setoid.Algebras.Basic {𝑆 = 𝑆}  using ( Algebra ; _̂_ ; ov ; 𝕌[_])
 

--- a/src/Setoid/Homomorphisms/Factor.lagda.md
+++ b/src/Setoid/Homomorphisms/Factor.lagda.md
@@ -30,10 +30,9 @@ open import Relation.Binary.PropositionalEquality  as ≡           using ()
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library ------------------------------------------------
-open import Overture         using ( ∣_∣ ; ∥_∥ )
+open import Overture         using ( ∣_∣ ; ∥_∥ ; kernelRel )
 open import Setoid.Functions using ( Image_∋_ ; IsSurjective ; SurjInv )
                              using ( SurjInvIsInverseʳ ; epic-factor )
-open import Legacy.Base.Relations   using ( kernelRel )
 
 open import Setoid.Algebras {𝑆 = 𝑆}             using ( Algebra ; 𝕌[_] ; _̂_ )
 open import Setoid.Homomorphisms.Basic {𝑆 = 𝑆}  using ( hom ; IsHom ; compatible-map ; epi ; IsEpi)

--- a/src/Setoid/Homomorphisms/Kernels.lagda.md
+++ b/src/Setoid/Homomorphisms/Kernels.lagda.md
@@ -27,10 +27,8 @@ open  import Relation.Binary   using ( Setoid )
 open  import Relation.Binary.PropositionalEquality as ≡ using ()
 
 -- Imports from the Agda Universal Algebra Library ------------------------------------------
-open  import Overture          using  ( ∣_∣ ; ∥_∥ )
-open  import Legacy.Base.Relations    using  ( kerRel ; kerRelOfEquiv )
+open  import Overture          using  ( ∣_∣ ; ∥_∥ ; kerRel ; kerRelOfEquiv )
 open  import Setoid.Functions  using  ( Image_∋_ )
-
 open  import Setoid.Algebras {𝑆 = 𝑆}
       using ( Algebra ; _̂_ ; ov ; _∣≈_ ; Con ; mkcon ; _╱_ ; IsCongruence )
 

--- a/src/Setoid/Relations/Quotients.lagda.md
+++ b/src/Setoid/Relations/Quotients.lagda.md
@@ -29,8 +29,7 @@ open import Relation.Binary.PropositionalEquality as ≡
                               using ( _≡_ )
 
 -- Imports from agda-algebras -----------------------------------------------------
-open import Overture                   using ( ∣_∣ ; ∥_∥ )
-open import Legacy.Base.Relations             using ( [_] ; Equivalence )
+open import Overture                   using ( ∣_∣ ; ∥_∥ ; [_] ; Equivalence )
 open import Setoid.Relations.Discrete  using ( fker )
 
 private variable α β ρᵃ ρᵇ ℓ : Level

--- a/src/Setoid/Subalgebras/Subuniverses.lagda.md
+++ b/src/Setoid/Subalgebras/Subuniverses.lagda.md
@@ -29,13 +29,11 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 open import Relation.Binary.PropositionalEquality using ( refl )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------------
-open import Overture        using ( ∣_∣ ; ∥_∥ )
-open import Legacy.Base.Relations  using ( Im_⊆_ )
-
-open import Overture.Terms        {𝑆 = 𝑆} using ( Term ; ℊ ; node )
-open import Setoid.Algebras       {𝑆 = 𝑆} using ( Algebra ; 𝕌[_] ; _̂_ ; ov )
-open import Setoid.Terms          {𝑆 = 𝑆} using ( module Environment )
-open import Setoid.Homomorphisms  {𝑆 = 𝑆} using ( hom ; IsHom )
+open import Overture                       using ( ∣_∣ ; ∥_∥ ; Im_⊆_ )
+open import Overture.Terms        {𝑆 = 𝑆}  using ( Term ; ℊ ; node )
+open import Setoid.Algebras       {𝑆 = 𝑆}  using ( Algebra ; 𝕌[_] ; _̂_ ; ov )
+open import Setoid.Terms          {𝑆 = 𝑆}  using ( module Environment )
+open import Setoid.Homomorphisms  {𝑆 = 𝑆}  using ( hom ; IsHom )
 
 private variable
  α β γ ρᵃ ρᵇ ρᶜ ℓ χ : Level

--- a/src/Setoid/Subalgebras/Subuniverses.lagda.md
+++ b/src/Setoid/Subalgebras/Subuniverses.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Subalgebras.Subuniverses][] module of the [Agda Universal Al
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -34,7 +32,7 @@ open import Relation.Binary.PropositionalEquality using ( refl )
 open import Overture        using ( ∣_∣ ; ∥_∥ )
 open import Legacy.Base.Relations  using ( Im_⊆_ )
 
-open import Legacy.Base.Terms            {𝑆 = 𝑆} using ( Term ; ℊ ; node )
+open import Overture.Terms        {𝑆 = 𝑆} using ( Term ; ℊ ; node )
 open import Setoid.Algebras       {𝑆 = 𝑆} using ( Algebra ; 𝕌[_] ; _̂_ ; ov )
 open import Setoid.Terms          {𝑆 = 𝑆} using ( module Environment )
 open import Setoid.Homomorphisms  {𝑆 = 𝑆} using ( hom ; IsHom )

--- a/src/Setoid/Terms/Basic.lagda.md
+++ b/src/Setoid/Terms/Basic.lagda.md
@@ -35,7 +35,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using ( _≡_ )
 -- Imports from the Agda Universal Algebra Library -------------------------------
 open import Overture using ( ∥_∥ )
 open import Setoid.Algebras  {𝑆 = 𝑆}  using ( Algebra ; ov ; _̂_)
-open import Legacy.Base.Terms       {𝑆 = 𝑆}  using ( Term )
+open import Overture.Terms  {𝑆 = 𝑆} using ( Term )
 
 open Func renaming ( to to _⟨$⟩_ )
 open Term

--- a/src/Setoid/Terms/Operations.lagda.md
+++ b/src/Setoid/Terms/Operations.lagda.md
@@ -35,7 +35,7 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from Agda Universal Algebra Library -----------------------------------
 open  import Overture                         using ( ∣_∣ ; ∥_∥ )
-open  import Legacy.Base.Terms               {𝑆 = 𝑆} using ( Term )
+open  import Overture.Terms           {𝑆 = 𝑆} using ( Term )
 open  import Setoid.Algebras          {𝑆 = 𝑆} using ( Algebra ; _̂_ ; ov ; ⨅ )
 open  import Setoid.Homomorphisms     {𝑆 = 𝑆} using ( hom ; IsHom )
 open  import Setoid.Terms.Properties  {𝑆 = 𝑆} using ( free-lift )

--- a/src/Setoid/Terms/Properties.lagda.md
+++ b/src/Setoid/Terms/Properties.lagda.md
@@ -34,7 +34,7 @@ open import Overture          using ( ∣_∣ ; ∥_∥ )
 open import Setoid.Functions  using ( Img_∋_ ; eq ; isSurj ; IsSurjective )
                               using ( isSurj→IsSurjective )
 
-open import Legacy.Base.Terms            {𝑆 = 𝑆} using ( Term )
+open import Overture.Terms        {𝑆 = 𝑆} using ( Term )
 open import Setoid.Algebras       {𝑆 = 𝑆} using ( Algebra ; 𝕌[_] ; _̂_ )
 open import Setoid.Homomorphisms  {𝑆 = 𝑆} using ( hom ; compatible-map ; IsHom )
 open import Setoid.Terms.Basic    {𝑆 = 𝑆}  using ( 𝑻 ; _≐_  ; ≐-isRefl )

--- a/src/Setoid/Varieties/EquationalLogic.lagda.md
+++ b/src/Setoid/Varieties/EquationalLogic.lagda.md
@@ -34,7 +34,7 @@ open import Relation.Unary   using ( Pred ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
 open import Setoid.Algebras  {𝑆 = 𝑆} using ( Algebra ; ov )
-open import Legacy.Base.Terms       {𝑆 = 𝑆} using ( Term )
+open import Overture.Terms   {𝑆 = 𝑆} using ( Term )
 open import Setoid.Terms     {𝑆 = 𝑆} using ( 𝑻 ; module Environment )
 
 private variable χ α ρᵃ ℓ ι : Level

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -33,7 +33,7 @@ open  import Overture          using ( ∣_∣ ; ∥_∥ )
 open  import Setoid.Relations  using ( fkerPred )
 open  import Setoid.Functions  using ( eq ; IsSurjective )
 
-open  import Legacy.Base.Terms {𝑆 = 𝑆}       using ( ℊ )
+open  import Overture.Terms  {𝑆 = 𝑆}  using ( ℊ )
 open  import Setoid.Algebras {𝑆 = 𝑆}  using ( Algebra ; ov ; Lift-Alg )
 
 open  import Setoid.Homomorphisms {𝑆 = 𝑆}

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -37,7 +37,7 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 open import Overture          using ( ∣_∣ ; ∥_∥ )
 open import Setoid.Functions  using ( IsSurjective ; SurjInv ; SurjInvIsInverseʳ )
 
-open import Legacy.Base.Terms       {𝑆 = 𝑆} using ( Term )
+open import Overture.Terms   {𝑆 = 𝑆} using ( Term )
 open import Setoid.Algebras  {𝑆 = 𝑆} using ( Algebra ; ov ; 𝕌[_] ; Lift-Alg ; ⨅ )
 
 open  import Setoid.Homomorphisms {𝑆 = 𝑆}

--- a/src/Setoid/Varieties/Properties.lagda.md
+++ b/src/Setoid/Varieties/Properties.lagda.md
@@ -39,7 +39,7 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 -- Imports from the Agda Universal Algebra Library ---------------------------------------------
 open  import Overture                       using  ( ∣_∣ ; ∥_∥ )
 open  import Setoid.Functions               using  ( InvIsInverseʳ ; SurjInv )
-open  import Legacy.Base.Terms            {𝑆 = 𝑆}  using  ( Term ; ℊ )
+open  import Overture.Terms        {𝑆 = 𝑆}  using  ( Term ; ℊ )
 open  import Setoid.Algebras       {𝑆 = 𝑆}
       using  ( Algebra ; Lift-Algˡ ; ov ; 𝕌[_] ; 𝔻[_] ; ⨅ )
 open  import Setoid.Homomorphisms  {𝑆 = 𝑆}

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -36,7 +36,7 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
 open import Overture                  using ( ∣_∣ )
-open import Legacy.Base.Terms       {𝑆 = 𝑆}  using ( Term )
+open import Overture.Terms   {𝑆 = 𝑆}  using ( Term )
 open import Setoid.Algebras  {𝑆 = 𝑆}  using ( Algebra ; ov ; ⟨_⟩ )
 open import Setoid.Terms     {𝑆 = 𝑆}  using ( module Environment ; Sub ; _[_] )
 


### PR DESCRIPTION
## Summary

Makes `src/Setoid/` self-sufficient by relocating the foundational definitions it currently imports from `Legacy.Base.*` into three new `Overture/` submodules.  After this PR, `grep -rn 'open import Legacy.Base' src/Setoid` returns no matches, and the upcoming `Classical/` scaffold (#260, M3-1) can build on a clean canonical tree.

## Related issues

Resolves #303.  Unblocks #260.

## Why now

#303's framing — at M2-1 several `Setoid/*` modules import basic definitions (`Term`, `kernelRel`, `Equivalence`, `[_]`, `0[_]`, `_|:_`, `IsSurjective`, etc.) from what is now `Legacy.Base.*`.  Type-correct but contradicts the "Setoid/ is canonical" framing of ADR-001.  M3-1 (#260) introduces `Classical/`, which exercises Setoid/'s self-sufficiency aggressively — landing this work first means `Classical/` doesn't inherit a Legacy.Base dependency.

## What moves where

The audited definitions split cleanly: every one is parameterized by raw types, raw functions, or a generic `BinRel`, so every one is foundational rather than setoid-specific.  All move to `Overture/`:

+  **`Overture.Terms`** (new) — `Term`, `ℊ`, `node`. W-type over a signature.
+  **`Overture.Relations`** (new) — `Equivalence`, `[_]`, `0[_]`, `0[_]Equivalence`, `0[_]IsEquivalence`, `kerRel`, `kerRelOfEquiv`, `kernelRel`, `Im_⊆_`, `_preserves_`, `_|:_`, `eval-rel`, `eval-pred`.
+  **`Overture.Functions`** (new) — `Image_∋_`, `eq`, `Inv`, `InvIsInverseʳ`, bare-types `IsSurjective`, `SurjInv`, `SurjInvIsInverseʳ`, `epic-factor`, `proj`, `projIsOnto`.

The Setoid-side equivalents (`Setoid.Functions.IsSurjective`, `Setoid.Relations.Discrete.Im_⊆_`, etc.) already exist for setoid functions and continue to live in `Setoid/`; this PR doesn't change them.

## Backward compatibility

The legacy modules are not deleted.  They keep their definitions and gain `{-# WARNING_ON_USAGE #-}` pragmas pointing to the new homes.  Downstream users on `Legacy.Base.*` see deprecation warnings but no breakage.  Scheduled removal: one full minor cycle after this lands, per the deprecation policy in STYLE_GUIDE.md.

## What this leaves for follow-up

+  `Setoid.Algebras.Products.ProjAlgIsOnto` still uses bare-types surjectivity.  The setoid-respecting upgrade is contained, but loses information; tracked separately as a small follow-up issue (filed at merge time).
+  `IsInjective` machinery in `Legacy.Base.Functions.Injective` is not in #303's audit and is left alone.

## Verification

+  [x] `grep -rn 'open import Legacy.Base' src/Setoid` returns no matches.
+  [x] `make check` passes (including `EverythingLegacy.lagda.md`).
+  [x] `DEPRECATED.md` Category A reflects the relocations to `Overture/`.

## Commits

1. Add `Overture.Terms` (extract Term/ℊ/node).
2. Migrate Setoid/* Term consumers to `Overture.Terms`.
3. Add `Overture.Relations` (extract Equivalence, _|:_, 0[_], kerRel, …).
4. Migrate Setoid/* Relations consumers to `Overture.Relations`.
5. Add `Overture.Functions` (extract Image, IsSurjective, Inv, proj, …).
6. Migrate Setoid/* Functions consumers to `Overture.Functions`.
7. Update `DEPRECATED.md` to record relocations.
8. Update `CHANGELOG.md` for the [Unreleased] section.

## References

+  ADR-001 — `docs/adr/001-setoid-as-canonical.md`, Consequences §"Setoid/ is not yet self-sufficient".
+  M2-1 (#256) — predecessor freeze.
+  M3-1 (#260) — depends on this for a clean canonical foundation.

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [x] Refactoring / cleanup ~~(no user-facing change)~~
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [ ] `make check` passes locally under `nix develop`.
- [ ] New public definitions have prose comment blocks.
- [ ] Commits are coherent and have explanatory messages.
- [ ] If this PR touches the `src/` tree, the change is targeted at `Base/`, `Setoid/`, or the shared `Overture/` foundation.
- [ ] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.
