### PR TITLE
[M2-7c] Port Legacy.Base.Complexity.* to Setoid.Complexity.* (#307)

### DIFF
--- a/src/Exercises/Complexity/FiniteCSP.lagda.md
+++ b/src/Exercises/Complexity/FiniteCSP.lagda.md
@@ -48,7 +48,7 @@ Some exercises below refer to the following relations on 𝟚 := \{0, 1\} (where
 
 **Exercise 1**. Prove that the definitions of CSP(𝔸) (satisfiability of a list of constraints, homomorphism   problem, truth of primitive positive formulas) are equivalent.
 
-**Exercise 2**. Find a polymomial-time algorithm for CSP(A), where
+**Exercise 2**. Find a polynomial-time algorithm for CSP(A), where
 
 2.1. 𝑨 = ({0, 1}, Rᵃ) = (𝟚 , \{(0,0), (1, 1)\})
 2.2. 𝑨 = ({0, 1}, Rᵃ, C₀ᵃ, C₁ᵃ) = (𝟚 , \{ (0,0) , (1, 1) \} , \{ 0 \} , \{ 1 \})

--- a/src/Exercises/Complexity/FiniteCSP.lagda.md
+++ b/src/Exercises/Complexity/FiniteCSP.lagda.md
@@ -15,8 +15,6 @@ University in Prague. They were formalized in dependent type theory by the
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Exercises.Complexity.FiniteCSP  where
@@ -36,7 +34,6 @@ open signature
 open structure
 ```
 
-
 Some exercises below refer to the following relations on 𝟚 := \{0, 1\} (where i, j ∈ 𝟚):
 
 \begin{align*}
@@ -49,9 +46,7 @@ Some exercises below refer to the following relations on 𝟚 := \{0, 1\} (where
  Gᵃ₂   & := \{ (0,0,1), (0,1,0), (1,0,0), (1,1,1) \}
 \end{align*}
 
-
 **Exercise 1**. Prove that the definitions of CSP(𝔸) (satisfiability of a list of constraints, homomorphism   problem, truth of primitive positive formulas) are equivalent.
-
 
 **Exercise 2**. Find a polymomial-time algorithm for CSP(A), where
 
@@ -65,8 +60,6 @@ Some exercises below refer to the following relations on 𝟚 := \{0, 1\} (where
 2.8. 𝑨 = ({0, 1}, Rᵃ, Nᵃ, C₀ᵃ, C₁ᵃ, 𝑆₀₀, S₀₁ᵃ, S₁₀ᵃ, S₁₁ᵃ) = (𝟚 , \{ (0,0) , (1, 1) \} , \{ (0, 1) , (1, 0) \} , \{ 0 \} , \{ 1 \} , 𝟚³ - \{ (0, 0) \} , 𝟚³ - \{ (0, 1) \} , 𝟚³ - \{ (1, 0) \} , 𝟚³ - \{ (1, 1) \})
 2.9. 𝑨 = ({0, 1}, all unary and binary relations)
 
-
-
 **Solution 2.1**. If 𝑨 = ({0, 1}, Rᵃ) = (𝟚 , \{(0,0), (1, 1)\}), then an instance of (the HOM
 formulation of) CSP(𝑨) is a relational structure 𝑩 = (B, Rᵇ⟩, where Rᵇ ⊆ B² and we must decide
 whether there exists a homomorphism f : 𝑩 → 𝑨, that is, a map f : B → A (= 𝟚) such that
@@ -77,7 +70,6 @@ constantly-1 map) is such a homomorphism.  Let's prove this formally.
 
 
 ```agda
-
 module solution-2-1 where
 
  -- The (purely) relational structure with
@@ -96,18 +88,14 @@ module solution-2-1 where
             ; rel = λ _ x → ((x 𝟚.𝟎) , (x 𝟚.𝟏)) ∈ Rᵃ
             }
 
-
  -- Claim: Given an arbitrary 𝑩 in the signatures Sig∅ Sig001, we can construct a homomorphism from 𝑩 to 𝑨.
  claim : (𝑩 : structure {ℓ₀}{ℓ₀}{ℓ₀}{ℓ₀} S∅ S001 {ℓ₀}{ℓ₀}) → hom 𝑩 𝑨
  claim 𝑩 = (λ x → 𝟚.𝟎) , (λ _ _ _ → r1) , λ ()
 ```
 
-
 In general, whenever the template structure 𝑨 has a one-element subuniverse, say, \{ a \},
 then the constant map that always gives a is a homomorphism from any structure in the given
 signature to 𝑨. ∎
-
-
 
 **Solution 2.2**. If 𝑨 = (\{ 0, 1 \}, Rᵃ, C₀ᵃ, C₁ᵃ) = (𝟚 , \{ (0, 0) , (1, 1) \} , \{ 0 \} , \{ 1 \}),
 then an instance of HOM CSP(𝑨) is a relational structure 𝑩 = (B, Rᵇ, C₀ᵇ, C₁ᵇ), where
@@ -127,10 +115,7 @@ to check each pair (x, y) ∈ Rᵇ and make sure that the following two implicat
  1.  x ∈ C₀ᵇ  only if  y ∉ C₁ᵇ, and
  2.  x ∈ C₁ᵇ  only if  y ∉ C₀ᵇ.
 
-
 ```agda
-
-
 module solution-2-2 where
 
  -- The (purely) relational structure with
@@ -148,7 +133,6 @@ module solution-2-2 where
  data C₁ᵃ : Pred 𝟚 ℓ₀ where
   c₁ : 𝟚.𝟏 ∈ C₁ᵃ
 
-
  𝑨 : structure S∅    -- (no operations)
                S021  -- (two unary relations and one binary relation)
 
@@ -162,7 +146,6 @@ module solution-2-2 where
             rels 𝟛.𝟏 x = x 𝟎 ∈ C₀ᵃ
             rels 𝟛.𝟐 x = x 𝟎 ∈ C₁ᵃ
 
-
  -- Claim: Given an arbitrary 𝑩 in the signatures S∅ S021, we can construct a homomorphism from 𝑩 to 𝑨.
  -- claim :  (𝑩 : structure S∅ S021 {ℓ₀}{ℓ₀})
  --  →       (∀ (x : 𝟚 → carrier 𝑩)
@@ -174,8 +157,6 @@ module solution-2-2 where
  --  →       hom 𝑩 𝑨
  -- claim 𝑩 x = {!!}
 ```
-
-
 
 (The remainder are "todo.")
 
@@ -193,7 +174,6 @@ module solution-2-2 where
 
 **Solution 2.9**. 𝑨 = ({0, 1}, all unary and binary relations)
 
-
 **Exercise 3**. Find a polynomial-time algorithm for CSP({0, 1}, Hᵃ, C₀ᵃ, C₁ᵃ).
 
 **Exercise 4**. Find a polynomial-time algorithm for CSP({0, 1}, C₀ᵃ, C₁ᵃ, G₁ᵃ, G₂ᵃ).
@@ -203,5 +183,3 @@ module solution-2-2 where
 --------------------------------
 
 {% include UALib.Links.md %}
-
-

--- a/src/Legacy/Base/Complexity.lagda.md
+++ b/src/Legacy/Base/Complexity.lagda.md
@@ -9,10 +9,9 @@ author: "agda-algebras development team"
 
 This is the [Base.Complexity][] module of the [Agda Universal Algebra Library][].
 
+> **Deprecated**.  Canonical home is now [`Setoid.Complexity`](Setoid.Complexity.html), ported under #307 (M2-7c).  The legacy modules in this subtree remain in `Legacy.Base.Complexity.*` for one minor cycle to support downstream migration; they will be removed in v3.1.  See [`src/Legacy/Base/DEPRECATED.md`](../DEPRECATED.md) for the migration guidance.
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Legacy.Base.Complexity where
@@ -20,7 +19,6 @@ module Legacy.Base.Complexity where
 open import Legacy.Base.Complexity.Basic  public
 open import Legacy.Base.Complexity.CSP    public
 ```
-
 
 --------------------------------
 

--- a/src/Legacy/Base/Complexity/Basic.lagda.md
+++ b/src/Legacy/Base/Complexity/Basic.lagda.md
@@ -7,15 +7,13 @@ author: "agda-algebras development team"
 
 ### <a id="complexity-theory">Complexity Theory</a>
 
+> **Deprecated**.  Canonical home is now [`Setoid.Complexity.Basic`](Setoid.Complexity.Basic.html), ported under #307 (M2-7c).  This module has no Agda exports of its own, so no `WARNING_ON_USAGE` pragmas are attached; the deprecation lives at the documentation level.  See [`src/Legacy/Base/DEPRECATED.md`](../../DEPRECATED.md) for migration guidance.  Removal is planned for v3.1.
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Legacy.Base.Complexity.Basic where
 ```
-
 
 #### <a id="words">Words</a>
 

--- a/src/Legacy/Base/Complexity/CSP.lagda.md
+++ b/src/Legacy/Base/Complexity/CSP.lagda.md
@@ -7,6 +7,8 @@ author: "the agda-algebras development team"
 
 ### <a id="constraint-satisfaction-problems">Constraint Satisfaction Problems</a>
 
+> **Deprecated**.  Canonical home is now [`Setoid.Complexity.CSP`](Setoid.Complexity.CSP.html), ported under #307 (M2-7c).  Importers will see `WARNING_ON_USAGE` warnings on `Constraint` and `CSPInstance`; migrate by replacing `Legacy.Base.Complexity.CSP` with `Setoid.Complexity.CSP` (signature parameter is unchanged).  See [`src/Legacy/Base/DEPRECATED.md`](../../DEPRECATED.md).  Removal is planned for v3.1.
+
 This is the [Base.Complexity.CSP][] module of the [Agda Universal Algebra Library][].
 
 #### <a id="the-relational-formulation-of-csp">The relational formulation of CSP</a>
@@ -39,8 +41,6 @@ CSP(𝒜) of 𝑅 structures having homomorphisms into 𝒜.
 
 That is, our algorithm must take as input an 𝑅-structure (a relational structure in the
 signature of 𝒜) and decide whether or not it belongs to the set CSP(𝒜).
-
-
 
 #### <a id="connection-to-algebraic-csp">Connection to algebraic CSP</a>
 
@@ -90,8 +90,6 @@ algebra, 𝑨(R) := (A , ∣: ⃖ R).
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using ( 𝓞 ; 𝓥 ; Signature )
@@ -140,8 +138,6 @@ where,
 
 
 ```agda
-
-
 module  _              -- levels for...
         {ι : Level}    -- ...arity (or argument index) types
         {ν : Level}    -- ...variable symbol types
@@ -158,8 +154,6 @@ module  _              -- levels for...
   satisfies f = rel (f ∘ scope)      -- *satisfies* the constraint 𝐶 = (σ , 𝑅) provided
                                     -- 𝑓 ∘ σ ∈ 𝑅, where σ is the scope of the constraint.
 ```
-
-
 
 #### <a id="csp-templates-and-instances">CSP templates and instances</a>
 
@@ -178,10 +172,7 @@ An instance of a constraint satisfaction problem is a triple 𝑃 = (𝑉, 𝐷,
 * 𝐷 denotes a "domain",
 * 𝐶 denotes an indexed collection of constraints.
 
-
 ```agda
-
-
  open Algebra
  open Setoid
  record CSPInstance (var : Type ν)(𝒜 : var → Algebra α ℓ) : Type (ν ⊔ α ⊔ lsuc ι) where
@@ -193,6 +184,10 @@ An instance of a constraint satisfaction problem is a triple 𝑃 = (𝑉, 𝐷,
   isSolution f = ∀ i → (Constraint.satisfies (cs i)) f  -- if it satisfies all the constraints.
 ```
 
+```agda
+{-# WARNING_ON_USAGE Constraint   "Use Setoid.Complexity.CSP.Constraint instead. Deprecated under #307; removal planned one minor cycle later." #-}
+{-# WARNING_ON_USAGE CSPInstance  "Use Setoid.Complexity.CSP.CSPInstance instead. Deprecated under #307; removal planned one minor cycle later." #-}
+```
 
 --------------------------------
 

--- a/src/Legacy/Base/DEPRECATED.md
+++ b/src/Legacy/Base/DEPRECATED.md
@@ -44,6 +44,9 @@ For users of these modules, the migration is mechanical when the concrete settin
 | `Legacy.Base.Algebras.Products`               | `Setoid.Algebras.Products`               |
 | `Legacy.Base.Categories`                      | `Examples.PolynomialFunctors`            |
 | `Legacy.Base.Categories.Functors`             | `Examples.PolynomialFunctors.Functors`   |
+| `Legacy.Base.Complexity`                      | `Setoid.Complexity`                      |
+| `Legacy.Base.Complexity.Basic`                | `Setoid.Complexity.Basic`                |
+| `Legacy.Base.Complexity.CSP`                  | `Setoid.Complexity.CSP`                  |
 | `Legacy.Base.Functions`                       | `Setoid.Functions`                       |
 | `Legacy.Base.Functions.Injective`             | `Setoid.Functions.Injective`             |
 | `Legacy.Base.Functions.Inverses`              | `Setoid.Functions.Inverses`              |
@@ -132,9 +135,6 @@ to `open import Overture using ( … )`.
 
 | Legacy module                              | Planned destination                              | Target milestone | Tracking issue |
 |--------------------------------------------|--------------------------------------------------|------------------|----------------|
-| `Legacy.Base.Complexity`                   | `Setoid.Complexity`                              | M9               | #307           |
-| `Legacy.Base.Complexity.Basic`             | `Setoid.Complexity.Basic`                        | M9               | #307           |
-| `Legacy.Base.Complexity.CSP`               | `Setoid.Complexity.CSP`                          | M9               | #307           |
 | `Legacy.Base.Functions.Transformers`       | stdlib redirect or `Setoid.Functions.Transformers` (decision part of #310) | TBD | #310 |
 | `Legacy.Base.Relations.Continuous`         | `Setoid.Relations.Continuous`                    | M9               | #308           |
 | `Legacy.Base.Relations.Properties`         | `Setoid.Relations.Properties`                    | M2 follow-up     | #309           |

--- a/src/Setoid/Complexity.lagda.md
+++ b/src/Setoid/Complexity.lagda.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title : "Setoid.Complexity module (Agda Universal Algebra Library)"
+date : "2026-05-09"
+author: "agda-algebras development team"
+---
+
+## <a id="types-for-computational-complexity">Types for Computational Complexity</a>
+
+This is the [Setoid.Complexity][] module of the [Agda Universal Algebra Library][].
+
+This subtree collects the setoid-canonical formulation of computational complexity infrastructure used by the library: word and algorithm definitions ([`Setoid.Complexity.Basic`](Setoid.Complexity.Basic.html)) and the relational formulation of CSP, including the Galois connection to polymorphism clones ([`Setoid.Complexity.CSP`](Setoid.Complexity.CSP.html)).
+
+This module is the canonical home for the content previously developed in `Legacy.Base.Complexity.*`, ported under #307 (M2-7c).  See [`src/Legacy/Base/DEPRECATED.md`](../Legacy/Base/DEPRECATED.md) for the inventory and migration guidance.  Substantial extensions — polymorphism clones as a first-class type, the Jeavons Galois connection, Post's lattice, Bulatov–Zhuk — are tracked under #274 (M7-1) and build on this module.
+
+```agda
+
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+
+module Setoid.Complexity {𝑆 : Signature 𝓞 𝓥} where
+
+open import Setoid.Complexity.Basic               public
+open import Setoid.Complexity.CSP    {𝑆 = 𝑆}      public
+```
+
+--------------------------------
+
+<span style="float:left;">[← Setoid.Varieties](Setoid.Varieties.html)</span>
+<span style="float:right;">[Setoid.Complexity.Basic →](Setoid.Complexity.Basic.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Complexity/Basic.lagda.md
+++ b/src/Setoid/Complexity/Basic.lagda.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title : "Setoid.Complexity.Basic module (The Agda Universal Algebra Library)"
+date : "2026-05-09"
+author: "agda-algebras development team"
+---
+
+### <a id="complexity-theory">Complexity Theory</a>
+
+This is the [Setoid.Complexity.Basic][] module of the [Agda Universal Algebra Library][].
+
+This module is the canonical home for the content previously developed in `Legacy.Base.Complexity.Basic`, ported under #307 (M2-7c).  Its present scope is the prose definitions of words, algorithms, and polynomial-time computability that frame the CSP development in [`Setoid.Complexity.CSP`](Setoid.Complexity.CSP.html); concrete Agda content is intentionally deferred to #274 (M7-1, "Extend Complexity module beyond Basic and CSP"), which is the substantive sequel to this canonical-path migration.
+
+```agda
+
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Setoid.Complexity.Basic where
+```
+
+#### <a id="words">Words</a>
+
+Let 𝑇ₙ be a totally ordered set of size 𝑛.  Let 𝐴 be a set (the alphabet).
+We can model the set 𝑊ₙ, of *words* (strings of letters from 𝐴) of length 𝑛
+by the type 𝑇ₙ → 𝐴 of functions from 𝑇ₙ to 𝐴.
+
+The set of all (finite length) words is then
+
+\[ W = ⋃[n ∈ ℕ] Wₙ \]
+
+The *length* of a word 𝑥 is given by the function `size x`, which will be defined below.
+
+An *algorithm* is a computer program with infinite memory (i.e., a Turing machine).
+
+A function 𝑓 : 𝑊 → 𝑊 is *computable in polynomial time* if there exist an
+algorithm and numbers 𝑐, 𝑑 ∈ ℕ such that for each word 𝑥 ∈ 𝑊 the algorithm
+stops in at most (size 𝑥) 𝑐 + 𝑑 steps and computes 𝑓 𝑥.
+
+At first we will simplify by assuming 𝑇ₙ is `Fin n`.
+
+--------------------------------
+
+<span style="float:left;">[↑ Setoid.Complexity](Setoid.Complexity.html)</span>
+<span style="float:right;">[Setoid.Complexity.CSP →](Setoid.Complexity.CSP.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Complexity/CSP.lagda.md
+++ b/src/Setoid/Complexity/CSP.lagda.md
@@ -56,7 +56,7 @@ Let 𝑨(R) denote the algebraic structure with domain A and operations ∣: ⃖
 The reason this Galois connection is useful is due to the following fact (observed by Peter Jeavons in the late 1990's):
 
 *Theorem*. Let 𝒜 = (A, R) be a finite relational structure.
-           If R' ⊆ (∣: ⃖ R) ⃗ ∣: is finite, then CSP((A, Γ'))
+           If R' ⊆ (∣: ⃖ R) ⃗ ∣: is finite, then CSP((A, R'))
            is reducible in poly-time to CSP(𝒜)
 
 In particular, the tractability of CSP(𝒜) depends only on its associated polymorphism algebra, 𝑨(R) := (A , ∣: ⃖ R).
@@ -148,7 +148,7 @@ An instance of a constraint satisfaction problem is a triple 𝑃 = (𝑉, 𝐷,
  record CSPInstance (var : Type ν)(𝒜 : var → Algebra α ρ)
                     : Type (ν ⊔ α ⊔ lsuc ι ⊔ lsuc ρʳ) where
   field
-   ar : Type ι       -- ar indexes the contraints in the instance
+   ar : Type ι       -- ar indexes the constraints in the instance
    cs : (i : ar) → Constraint var (λ v → Domain (𝒜 v))
 
   isSolution : ((v : var) → Carrier (Domain (𝒜 v))) → Type (ι ⊔ ρʳ)  -- An assignment *solves* the instance

--- a/src/Setoid/Complexity/CSP.lagda.md
+++ b/src/Setoid/Complexity/CSP.lagda.md
@@ -1,0 +1,157 @@
+---
+layout: default
+title : "Setoid.Complexity.CSP module (The Agda Universal Algebra Library)"
+date : "2026-05-09"
+author: "the agda-algebras development team"
+---
+
+### <a id="constraint-satisfaction-problems">Constraint Satisfaction Problems</a>
+
+This is the [Setoid.Complexity.CSP][] module of the [Agda Universal Algebra Library][].
+
+This module is the canonical home for the content previously developed in `Legacy.Base.Complexity.CSP`, ported under #307 (M2-7c).  The relational formulation of CSP and the Galois connection to polymorphism clones (Jeavons) are stated below; substantive theorems — most importantly the Jeavons Galois connection itself for a fixed finite domain, and a statement of the Bulatov–Zhuk algebraic dichotomy — are scheduled under #274 (M7-1).  The infinite-template / ω-categorical extension is covered separately under #281 (M9-2), which depends on this canonical-path version.
+
+#### <a id="the-relational-formulation-of-csp">The relational formulation of CSP</a>
+
+Let 𝒜 = (𝐴 , 𝑅ᵃ) be a *relational structure* (or 𝑅-structure), that is, a pair consisting of a set 𝐴 along with a collection 𝑅ᵃ ⊆ ⋃ₙ 𝒫(𝐴ⁿ) of relations on 𝐴.
+
+We associate with 𝒜 a *constraint satisfaction problem* denoted by CSP(𝒜), which is the decision problem that is solved by finding an algorithm or program that does the following:
+
+Take as input
++ an *instance*, which is an 𝑅-structure ℬ = (𝐵 , 𝑅ᵇ) (in the same signature as 𝒜)
+
+Output
++ "yes" or "no" according as there is, or is not, a *solution*, which is a 𝑅-structure homomorphism h : ℬ → 𝒜.
+
+If there is such an algorithm that takes at most a power of 𝑛 operations to process an input structure ℬ of size 𝑛 (i.e., 𝑛 bits of memory are required to encode ℬ), then we say that CSP(𝒜) is *tractable*.  Otherwise, CSP(𝒜) is *intractable*.
+
+Equivalently, if we define
+
+  CSP(𝒜) := \{ ℬ ∣ ℬ an 𝑅-structure and ∃ hom ℬ → 𝒜 \}
+
+then the CSP problem described above is simply the membership problem for the subset CSP(𝒜) of 𝑅 structures having homomorphisms into 𝒜.  That is, our algorithm must take as input an 𝑅-structure (a relational structure in the signature of 𝒜) and decide whether or not it belongs to the set CSP(𝒜).
+
+#### <a id="connection-to-algebraic-csp">Connection to algebraic CSP</a>
+
+Let A be a set, let Op(A) denote the set of all operations, Rel(A) the set of all relations, on A.
+
+Given R ⊆ Rel(A), define the set of operations on A that preserve all relations in R as follows:
+
+∣: ⃖ R  =  \{ f ∈ Op(𝐴) ∣ ∀ r ∈ R, f ∣: r \}.
+
+Recall, f ∣: r is our notation for `f Preserves r ⟶ r`, which means that r is a subuniverse of a power of the algebra (A , {f}).  Equivalently, `f Preserves r ⟶ r` means the following: if f is 𝑚-ary and r is 𝑛-ary, then for every size-𝑚 collection 𝑎𝑠 of 𝑛-tuples from r (that is, ∣ 𝑎𝑠 ∣ = 𝑚 and ∀ a ∈ 𝑎𝑠, r a) we have r (f ∘ (zip 𝑎𝑠)).
+
+If 𝒜 = (A , R) is a relational structure, then the set ∣: ⃖R of operations on A that preserve all relations in R is called the set of *polymorphisms* of 𝒜.
+
+Conversely, starting with a collection F ⊆ Op(A) of operations on A, define the set of all relations preserved by the functions in F as follows:
+
+F ⃗ ∣:  =  \{ r ∈ Rel(A) ∣ ∀ f ∈ F, f ∣: r \}.
+
+It is easy to see that for all F ⊆ Op(A) and all R ⊆ Rel(A), we have
+
+  F ⊆  ∣: ⃖ (F ⃗ ∣:)    and    R ⊆ (∣: ⃖ R) ⃗ ∣:.
+
+Let 𝑨(R) denote the algebraic structure with domain A and operations ∣: ⃖ R.  Then every r ∈ R is a subalgebra of a power of 𝑨(R).  Clearly (∣: ⃖ R) ⃗ ∣: is the set 𝖲 (𝖯fin 𝑨(R)) of subalgebras of finite powers of 𝑨(R).
+
+The reason this Galois connection is useful is due to the following fact (observed by Peter Jeavons in the late 1990's):
+
+*Theorem*. Let 𝒜 = (A, R) be a finite relational structure.
+           If R' ⊆ (∣: ⃖ R) ⃗ ∣: is finite, then CSP((A, Γ'))
+           is reducible in poly-time to CSP(𝒜)
+
+In particular, the tractability of CSP(𝒜) depends only on its associated polymorphism algebra, 𝑨(R) := (A , ∣: ⃖ R).
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+
+module Setoid.Complexity.CSP {𝑆 : Signature 𝓞 𝓥} where
+
+-- Imports from Agda and the Agda Standard Library ------------------------------
+open import Agda.Primitive   using ( _⊔_ ; lsuc ; Level ) renaming ( Set to Type )
+open import Function.Base    using ( _∘_ )
+open import Relation.Binary  using ( Setoid )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+-- NOTE: `Legacy.Base.Relations.Continuous` is imported here because
+-- `Setoid.Relations.Continuous` does not yet exist; the port of `Continuous` is
+-- tracked under #308 (M2-7d, scheduled with M9).  Per the Category-B contract
+-- in `src/Legacy/Base/DEPRECATED.md`, importing from `Legacy.Base.*` is the
+-- supported, non-deprecated path until that port lands.  When #308 lands this
+-- import will be redirected to the canonical path and the note removed.
+open import Legacy.Base.Relations.Continuous  using ( REL ; REL-syntax )
+open import Setoid.Algebras.Basic  {𝑆 = 𝑆}    using ( Algebra )
+```
+
+#### <a id="constraints">Constraints</a>
+
+A constraint c consists of
+
+1. a scope function,  s : I → var, and
+2. a constraint relation, i.e., a predicate over the function type I → D
+
+        I ···> var
+         .     .
+          .   .
+           ⌟ ⌞
+            D
+
+The *scope* of a constraint is an indexed subset of the set of variable symbols.  We could define a type for this, e.g.,
+
+    Scope : Type ν → Type ι → _
+    Scope V I = I → V
+
+but we omit this definition because it's so simple; to reiterate, a scope of "arity" I on "variables" V is simply a map from I to V, where,
+
+* I denotes the "number" of variables involved in the scope
+* V denotes a collection (type) of "variable symbols"
+
+```agda
+module  _              -- levels for...
+        {ι : Level}    -- ...arity (or argument index) types
+        {ν : Level}    -- ...variable symbol types
+        {α ρ : Level}  -- ...domain carrier and equivalence levels
+ where
+ open Setoid
+
+ record Constraint (var : Type ν) (dom : var → Setoid α ρ) : Type (ν ⊔ α ⊔ lsuc ι) where
+  field
+   arity  : Type ι               -- The "number" of variables involved in the constraint.
+   scope  : arity → var          -- Which variables are involved in the constraint.
+   rel    : REL[ i ∈ arity ] (Carrier (dom (scope i)))   -- The constraint relation.
+
+  satisfies : (∀ v → Carrier (dom v)) → Type _   -- An assignment 𝑓 : var → dom of values to variables
+  satisfies f = rel (f ∘ scope)                  -- *satisfies* the constraint 𝐶 = (σ , 𝑅) provided
+                                                 -- 𝑓 ∘ σ ∈ 𝑅, where σ is the scope of the constraint.
+```
+
+#### <a id="csp-templates-and-instances">CSP templates and instances</a>
+
+A CSP "template" restricts the relations that may occur in instances of the problem.  A convenient way to specify a template is to give an indexed family 𝒜 : var → Algebra α ρ of algebras (one for each variable symbol in var) and require that relations be subalgebras of the product ⨅ var 𝒜.
+
+To construct a CSP instance, then, we just have to give a family 𝒜 of algebras, specify the number (ar) of constraints, and for each i : ar, define a constraint as a relation over (some of) the members of 𝒜.
+
+An instance of a constraint satisfaction problem is a triple 𝑃 = (𝑉, 𝐷, 𝐶) where
+* 𝑉 denotes a set of "variables"
+* 𝐷 denotes a "domain",
+* 𝐶 denotes an indexed collection of constraints.
+
+```agda
+ open Algebra
+
+ record CSPInstance (var : Type ν)(𝒜 : var → Algebra α ρ) : Type (ν ⊔ α ⊔ lsuc ι) where
+  field
+   ar : Type ι       -- ar indexes the contraints in the instance
+   cs : (i : ar) → Constraint var (λ v → Domain (𝒜 v))
+
+  isSolution : (∀ v → Carrier (Domain (𝒜 v))) → Type _   -- An assignment *solves* the instance
+  isSolution f = ∀ i → (Constraint.satisfies (cs i)) f   -- if it satisfies all the constraints.
+```
+
+--------------------------------
+
+<span style="float:left;">[← Setoid.Complexity.Basic](Setoid.Complexity.Basic.html)</span>
+<span style="float:right;">[Top ↑](index.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Complexity/CSP.lagda.md
+++ b/src/Setoid/Complexity/CSP.lagda.md
@@ -112,19 +112,24 @@ module  _              -- levels for...
         {ι : Level}    -- ...arity (or argument index) types
         {ν : Level}    -- ...variable symbol types
         {α ρ : Level}  -- ...domain carrier and equivalence levels
+        {ρʳ : Level}   -- ...constraint relation level
  where
  open Setoid
 
- record Constraint (var : Type ν) (dom : var → Setoid α ρ) : Type (ν ⊔ α ⊔ lsuc ι) where
+ record Constraint (var : Type ν) (dom : var → Setoid α ρ)
+                   : Type (ν ⊔ α ⊔ lsuc ι ⊔ lsuc ρʳ) where
   field
    arity  : Type ι               -- The "number" of variables involved in the constraint.
    scope  : arity → var          -- Which variables are involved in the constraint.
-   rel    : REL[ i ∈ arity ] (Carrier (dom (scope i)))   -- The constraint relation.
+   rel    : REL[ i ∈ arity ] (Carrier (dom (scope i))) -- The constraint relation.
 
-  satisfies : (∀ v → Carrier (dom v)) → Type _   -- An assignment 𝑓 : var → dom of values to variables
-  satisfies f = rel (f ∘ scope)                  -- *satisfies* the constraint 𝐶 = (σ , 𝑅) provided
-                                                 -- 𝑓 ∘ σ ∈ 𝑅, where σ is the scope of the constraint.
+  satisfies : ((v : var) → Carrier (dom v)) → Type ρʳ  -- An assignment, 𝑓 : var → dom, of values to variables
+  satisfies f = rel (f ∘ scope)                        -- *satisfies* the constraint 𝐶 = (σ , 𝑅) provided
+                                                       -- 𝑓 ∘ σ ∈ 𝑅, where σ is the scope of the constraint.
 ```
+
+**Note on `ρʳ`**.  The constraint-relation level `ρʳ` is fixed at the module level rather than parameterizing each `Constraint` independently.  This matches the universal-algebraic CSP literature, where every constraint of an instance typically lives at the same relation level (in practice `lzero`).  Lifting `ρʳ` to a per-record parameter is a mechanical refactor that may become warranted when later content (e.g., the M7-1 polymorphism-clone development under #274 or the M9-2 infinitary CSP work under #281) needs to mix relation levels across constraints in a single instance.
+
 
 #### <a id="csp-templates-and-instances">CSP templates and instances</a>
 
@@ -140,13 +145,14 @@ An instance of a constraint satisfaction problem is a triple 𝑃 = (𝑉, 𝐷,
 ```agda
  open Algebra
 
- record CSPInstance (var : Type ν)(𝒜 : var → Algebra α ρ) : Type (ν ⊔ α ⊔ lsuc ι) where
+ record CSPInstance (var : Type ν)(𝒜 : var → Algebra α ρ)
+                    : Type (ν ⊔ α ⊔ lsuc ι ⊔ lsuc ρʳ) where
   field
    ar : Type ι       -- ar indexes the contraints in the instance
    cs : (i : ar) → Constraint var (λ v → Domain (𝒜 v))
 
-  isSolution : (∀ v → Carrier (Domain (𝒜 v))) → Type _   -- An assignment *solves* the instance
-  isSolution f = ∀ i → (Constraint.satisfies (cs i)) f   -- if it satisfies all the constraints.
+  isSolution : ((v : var) → Carrier (Domain (𝒜 v))) → Type (ι ⊔ ρʳ)  -- An assignment *solves* the instance
+  isSolution f = ∀ i → (Constraint.satisfies (cs i)) f               -- if it satisfies all the constraints.
 ```
 
 --------------------------------


### PR DESCRIPTION

## Summary

Ports the three-module `Legacy.Base.Complexity.*` subtree to canonical paths under `Setoid.Complexity/`, mirroring the legacy shape:

+  `Legacy.Base.Complexity`        →  `Setoid.Complexity`        (aggregator, now parameterized by `{𝑆 : Signature 𝓞 𝓥}`)
+  `Legacy.Base.Complexity.Basic`  →  `Setoid.Complexity.Basic`
+  `Legacy.Base.Complexity.CSP`    →  `Setoid.Complexity.CSP`


## Related issues

Closes #307.

Child of #302 (parent — port orphan Base modules).

---

## Destination decision

`Setoid.Complexity/` (per #307's recommendation), not a top-level `Complexity/` tree.  Rationale: minimum churn for v3.0; mirrors `Setoid.Algebras/` / `Setoid.Varieties/` / `Setoid.Terms/`; the `CSP.lagda.md` body already reasons over `Setoid α ρ`.  The "complexity is a domain, not a flavor" framing is real and worth revisiting at the v4.0 Cubical canonicalization moment, but not at v3.0.

## Cosmetic improvements over the legacy

+  **Aggregator parameterization**.  `module Setoid.Complexity {𝑆 : Signature 𝓞 𝓥} where` — matches `Setoid.Algebras` / `Setoid.Varieties` / `Setoid.Terms`.  The legacy aggregator's unparameterized re-export of a parameterized `CSP` typechecks via implicit hoisting but is non-standard; tightening it here costs one signature parameter at the use site and removes a quiet idiosyncrasy.
+  **Level-name alignment**.  `Constraint` and `CSPInstance` use `{α ρ : Level}` for "domain carrier and equivalence levels", matching the `Algebra α ρ` convention in `Setoid.Algebras.Basic` (the legacy used `{α ℓ : Level}`).  No semantic change.

## One transitional Legacy import remains

`Setoid.Complexity.CSP` imports `Legacy.Base.Relations.Continuous` for `REL` / `REL-syntax`, because `Setoid.Relations.Continuous` does not yet exist — its port is tracked under #308 (M2-7d, M9).  Per the Category-B contract in `src/Legacy/Base/DEPRECATED.md`:

> Importing from `Legacy.Base.*` is the supported, non-deprecated way to use this content until the corresponding canonical module exists.

This is exactly the sequencing that #307 → #308 → #274 was designed to support.  An inline TODO in `Setoid.Complexity.CSP` marks the redirection target so the cleanup is mechanical when #308 lands.  After this PR `grep -rn 'open import Legacy.Base' src/Setoid` returns exactly one match (this Continuous import); it will return zero again after #308.

## Deprecation surface in `Legacy.Base.Complexity.*`

`WARNING_ON_USAGE` pragmas are attached to `Constraint` and `CSPInstance` in `Legacy.Base.Complexity.CSP` — the only top-level Agda exports in the subtree.  The aggregator and `Basic` have no own exports; their deprecation lives at the module-header documentation level, consistent with the per-export pragma convention established under #303 (M2-6) and #305 (M2-7a).  All three legacy files gain a deprecation banner at the top of their prose.

Removal of the legacy modules is planned for v3.1, one minor cycle after this release, per the standard deprecation cadence.

## Acceptance criteria

+  [x] Three canonical-path modules exist and are wired through `src/Setoid/Complexity.lagda.md` (and reachable through `Everything.lagda.md` once the auto-generated aggregator picks them up).
+  [x] `Legacy.Base.Complexity.CSP` carries `WARNING_ON_USAGE` pragmas on `Constraint` and `CSPInstance`; the aggregator and `Basic` carry header-level deprecation banners (no own exports to pragma).
+  [x] `DEPRECATED.md` reflects the move: three rows out of Category B, three rows into Category A in alphabetical position; no `#TBD` cells remain for the Complexity rows.
+  [ ] `make check` and the `EverythingLegacy` gate both pass.

## Downstream

+  #274 (M7-1, extend Complexity) is the substantive sequel and depends on this canonical-path version.
+  #281 (M9-2, infinitary CSP) builds on `Setoid.Complexity.CSP` directly.
+  #304 (M2-8, migrate `src/Examples` and `src/Exercises`) gains the dependency it was waiting on for `src/Exercises/Complexity/FiniteCSP.lagda.md` — but only partially: `FiniteCSP.lagda.md` also imports `Legacy.Base.Relations.Continuous`, so it remains blocked on #308.

## References

+  Parent — #302
+  M7-1 (extend Complexity) — #274
+  M9-2 (infinitary CSP) — #281
+  Continuous port (companion blocker for full Setoid-purity) — #308
+  Exercises migration — #304
+  ADR-001 — `docs/adr/001-setoid-as-canonical.md`
+  DEPRECATED.md — `src/Legacy/Base/DEPRECATED.md`

---

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [x] Refactoring / cleanup ~~(no user-facing change)~~
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [ ] `make check` passes locally under `nix develop`.
- [ ] New public definitions have prose comment blocks.
- [ ] Commits are coherent and have explanatory messages.
- [ ] If this PR touches the `src/` tree, the change is targeted at `Base/`, `Setoid/`, or the shared `Overture/` foundation.
- [ ] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.

## Notes for reviewers

<!-- Anything specific you'd like the reviewer to focus on?  Known limitations?  Open questions? -->


