### PR TITLE
[M2-7d] Port Legacy.Base.Relations.Continuous to Setoid.Relations.Continuous (#308)

### DIFF
--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -604,7 +604,7 @@ graph TD
 
 <!-- BEGIN GENERATED: milestone-2 -->
 
-### Issue M2-1: Freeze Base/, adopt Setoid/ as canonical (#256)
+### Issue M2-1: Freeze Base/, adopt Setoid/ as canonical (#256, closed)
 
 **Labels**: `milestone-2-consolidation`, `breaking-change`
 
@@ -633,7 +633,7 @@ This is a breaking change for downstream users of `Base/`.  Announce prominently
 
 ---
 
-### Issue M2-2: Consolidate parallel implementations within Legacy/Base/Structures (#257)
+### Issue M2-2: Consolidate parallel implementations within Legacy/Base/Structures (#257, closed)
 
 **Labels**: `milestone-2-consolidation`
 
@@ -655,7 +655,7 @@ This is a breaking change for downstream users of `Base/`.  Announce prominently
 
 ---
 
-### Issue M2-3: Remove Base.Structures.Graphs0 (unused experimental duplicate) (#258)
+### Issue M2-3: Remove Base.Structures.Graphs0 (unused experimental duplicate) (#258, closed)
 
 **Labels**: `milestone-2-consolidation`
 
@@ -704,7 +704,7 @@ The library contains three proofs of Birkhoff's HSP theorem:
 
 ---
 
-### Issue M2-5: CI gap: `Legacy.Base` tree is not type-checked by make check (#301)
+### Issue M2-5: CI gap: `Legacy.Base` tree is not type-checked by make check (#301, closed)
 
 **Labels**: `milestone-2-consolidation`, `ci`
 
@@ -735,7 +735,7 @@ The fix is a second aggregator, `EverythingLegacy.lagda.md`, that exists purely 
 
 ---
 
-### Issue M2-6: Extract Setoid-canonical foundations from Legacy.Base (#303)
+### Issue M2-6: Extract Setoid-canonical foundations from Legacy.Base (#303, closed)
 
 **Labels**: `milestone-2-consolidation`
 
@@ -845,7 +845,7 @@ The legacy module is **not deleted** in the porting PR — it is removed in the 
 
 ---
 
-### Issue M2-7a: Port Legacy.Base.Adjunction.* to canonical paths (#305)
+### Issue M2-7a: Port Legacy.Base.Adjunction.* to canonical paths (#305, closed)
 
 **Labels**: `milestone-2-consolidation`, `design-discussion`
 
@@ -889,7 +889,7 @@ The third option is probably premature; the first two are both defensible.  Reco
 
 ---
 
-### Issue M2-7b: Port Legacy.Base.Categories.* to canonical paths (#306)
+### Issue M2-7b: Port Legacy.Base.Categories.* to canonical paths (#306, closed)
 
 **Labels**: `milestone-2-consolidation`, `design-discussion`
 
@@ -927,7 +927,7 @@ This issue's first deliverable is the **destination decision**, not the port.
 
 ---
 
-### Issue M2-7c: Port Legacy.Base.Complexity.* to canonical paths (#307)
+### Issue M2-7c: Port Legacy.Base.Complexity.* to canonical paths (#307, closed)
 
 **Labels**: `milestone-2-consolidation`, `milestone-9-apps`
 

--- a/src/Legacy/Base/DEPRECATED.md
+++ b/src/Legacy/Base/DEPRECATED.md
@@ -60,9 +60,10 @@ For users of these modules, the migration is mechanical when the concrete settin
 | `Legacy.Base.Homomorphisms.Noether`           | `Setoid.Homomorphisms.Noether`           |
 | `Legacy.Base.Homomorphisms.Products`          | `Setoid.Homomorphisms.Products`          |
 | `Legacy.Base.Homomorphisms.Properties`        | `Setoid.Homomorphisms.Properties`        |
-| `Legacy.Base.Relations`                       | `Setoid.Relations` (partial — see note above; `Continuous` and `Properties` are tracked under Category B) |
+| `Legacy.Base.Relations`                       | `Setoid.Relations` (partial — see note above; `Properties` is tracked under Category B) |
 | `Legacy.Base.Relations.Discrete`              | `Setoid.Relations.Discrete`              |
 | `Legacy.Base.Relations.Quotients`             | `Setoid.Relations.Quotients`             |
+| `Legacy.Base.Relations.Continuous`            | `Setoid.Relations.Continuous`            |
 | `Legacy.Base.Subalgebras`                     | `Setoid.Subalgebras`                     |
 | `Legacy.Base.Subalgebras.Properties`          | `Setoid.Subalgebras.Properties`          |
 | `Legacy.Base.Subalgebras.Subalgebras`         | `Setoid.Subalgebras.Subalgebras`         |
@@ -136,7 +137,6 @@ to `open import Overture using ( … )`.
 | Legacy module                              | Planned destination                              | Target milestone | Tracking issue |
 |--------------------------------------------|--------------------------------------------------|------------------|----------------|
 | `Legacy.Base.Functions.Transformers`       | stdlib redirect or `Setoid.Functions.Transformers` (decision part of #310) | TBD | #310 |
-| `Legacy.Base.Relations.Continuous`         | `Setoid.Relations.Continuous`                    | M9               | #308           |
 | `Legacy.Base.Relations.Properties`         | `Setoid.Relations.Properties`                    | M2 follow-up     | #309           |
 | `Legacy.Base.Structures`                   | `Classical/` (entire subtree superseded)         | M3               | #260           |
 | `Legacy.Base.Structures.Basic`             | as above                                         | M3               | #260           |

--- a/src/Legacy/Base/Relations/Continuous.lagda.md
+++ b/src/Legacy/Base/Relations/Continuous.lagda.md
@@ -7,12 +7,11 @@ author: "[agda-algebras development team][]"
 
 ### <a id="continuous-relations">Continuous Relations</a>
 
+> **Deprecated**.  Canonical home is now [`Setoid.Relations.Continuous`](Setoid.Relations.Continuous.html), ported under #308 (M2-7d).  Importers will see `WARNING_ON_USAGE` warnings on `Rel`, `REL`, their syntactic-sugar variants, and the `eval-*`/`compatible-*` helpers; migrate by replacing `Legacy.Base.Relations.Continuous` with `Setoid.Relations.Continuous`, and pass a `Setoid` (or `Relation.Binary.PropositionalEquality.setoid A` for a bare type `A`) where a bare type was previously expected as the relation's underlying carrier.  See [`src/Legacy/Base/DEPRECATED.md`](../../DEPRECATED.md).  Removal is planned for v3.1.
+
 This is the [Base.Relations.Continuous][] module of the [Agda Universal Algebra Library][].
 
-
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Legacy.Base.Relations.Continuous where
@@ -69,10 +68,7 @@ Heuristically, we can think of an inhabitant of type `REL I 𝒜 β` as a relati
 
 (This is only a rough heuristic since `I` could denote an uncountable collection.)  See the discussion below for a more detailed explanation.
 
-
 ```agda
-
-
 module _ {𝓥 : Level} where
  ar : Type (suc 𝓥)
  ar = Type 𝓥
@@ -101,37 +97,26 @@ module _ {𝓥 : Level} where
 
 #### <a id="compatibility-with-general-relations">Compatibility with general relations</a>
 
-
 ```agda
-
-
  -- Lift a relation of tuples up to a relation on tuples of tuples.
  eval-Rel : {I : ar}{A : Type a} → Rel A I{ρ} → (J : ar) → (I → J → A) → Type (𝓥 ⊔ ρ)
  eval-Rel R J t = ∀ (j : J) → R λ i → t i j
 ```
 
-
 A relation `R` is compatible with an operation `f` if for every tuple `t` of tuples
 belonging to `R`, the tuple whose elements are the result of applying `f` to
 sections of `t` also belongs to `R`.
 
-
 ```agda
-
-
  compatible-Rel : {I J : ar}{A : Type a} → Op(A) J → Rel A I{ρ} → Type (𝓥 ⊔ a ⊔ ρ)
  compatible-Rel f R  = ∀ t → eval-Rel R arity[ f ] t → R λ i → f (t i)
  -- (inferred type of t is I → J → A)
 ```
 
 
-
 #### <a id="compatibility-of-operations-with-dependent-relations">Compatibility of operations with dependent relations</a>
 
-
 ```agda
-
-
  eval-REL :  {I J : ar}{𝒜 : I → Type a}
   →          REL I 𝒜 {ρ}          -- the relation type: subsets of Π[ i ∈ I ] 𝒜 i
                                   -- (where Π[ i ∈ I ] 𝒜 i is a type of dependent functions or "tuples")
@@ -147,7 +132,6 @@ sections of `t` also belongs to `R`.
   →                Type (𝓥 ⊔ a ⊔ ρ)
  compatible-REL {I = I}{J}{𝒜} 𝑓 R  = Π[ t ∈ ((i : I) → J → 𝒜 i) ] eval-REL R t
 ```
-
 
 The definition `eval-REL` denotes an *evaluation* function which lifts an `I`-ary relation to an `(I → J)`-ary relation.
 
@@ -171,7 +155,6 @@ For simplicity, pretend for a moment that `J` is a finite set, say, `{1, 2, ...,
 
 For example, here are the i-th and k-th columns (for some `i k : I`).
 
-
     𝒶 i 1      𝒶 k 1
     𝒶 i 2      𝒶 k 2  <-- (a row of I such columns forms an I-tuple)
       ⋮          ⋮
@@ -185,6 +168,17 @@ Finally, `compatible-REL` takes
 *  an `I`-tuple (`𝒶 : I → J → A`) of `J`-tuples
 
 and determines whether the `I`-tuple `λ i → (𝑓 i) (𝑎 i)` belongs to `R`.
+
+```agda
+{-# WARNING_ON_USAGE Rel             "Use Setoid.Relations.Continuous.Rel instead. Deprecated under #308; removal planned one minor cycle later." #-}
+{-# WARNING_ON_USAGE Rel-syntax      "Use Setoid.Relations.Continuous.Rel-syntax instead. Deprecated under #308; removal planned one minor cycle later." #-}
+{-# WARNING_ON_USAGE REL             "Use Setoid.Relations.Continuous.REL instead. Deprecated under #308; removal planned one minor cycle later." #-}
+{-# WARNING_ON_USAGE REL-syntax      "Use Setoid.Relations.Continuous.REL-syntax instead. Deprecated under #308; removal planned one minor cycle later." #-}
+{-# WARNING_ON_USAGE eval-Rel        "Use Setoid.Relations.Continuous.eval-Rel instead. Deprecated under #308; removal planned one minor cycle later." #-}
+{-# WARNING_ON_USAGE compatible-Rel  "Use Setoid.Relations.Continuous.compatible-Rel instead. Deprecated under #308; removal planned one minor cycle later." #-}
+{-# WARNING_ON_USAGE eval-REL        "Use Setoid.Relations.Continuous.eval-REL instead. Deprecated under #308; removal planned one minor cycle later." #-}
+{-# WARNING_ON_USAGE compatible-REL  "Use Setoid.Relations.Continuous.compatible-REL instead. Note: the canonical version corrects a bug in the legacy definition (see Setoid.Relations.Continuous module header). Deprecated under #308; removal planned one minor cycle later." #-}
+```
 
 --------------------------------------
 

--- a/src/Legacy/Base/Relations/Continuous.lagda.md
+++ b/src/Legacy/Base/Relations/Continuous.lagda.md
@@ -7,7 +7,7 @@ author: "[agda-algebras development team][]"
 
 ### <a id="continuous-relations">Continuous Relations</a>
 
-> **Deprecated**.  Canonical home is now [`Setoid.Relations.Continuous`](Setoid.Relations.Continuous.html), ported under #308 (M2-7d).  Importers will see `WARNING_ON_USAGE` warnings on `Rel`, `REL`, their syntactic-sugar variants, and the `eval-*`/`compatible-*` helpers; migrate by replacing `Legacy.Base.Relations.Continuous` with `Setoid.Relations.Continuous`, and pass a `Setoid` (or `Relation.Binary.PropositionalEquality.setoid A` for a bare type `A`) where a bare type was previously expected as the relation's underlying carrier.  See [`src/Legacy/Base/DEPRECATED.md`](../../DEPRECATED.md).  Removal is planned for v3.1.
+> **Deprecated**.  Canonical home is now [`Setoid.Relations.Continuous`](Setoid.Relations.Continuous.html), ported under #308 (M2-7d).  Importers will see `WARNING_ON_USAGE` warnings on `Rel`, `REL`, their syntactic-sugar variants, and the `eval-*`/`compatible-*` helpers; in most cases, migration is just replacing `Legacy.Base.Relations.Continuous` with `Setoid.Relations.Continuous`.  The replacement `Rel`/`REL` definitions still take bare carrier types as before; only the optional setoid-respect layer (for example, `Π-Respects-Rel`/`Π-Respects-REL`) requires passing an explicit `Setoid` such as `Relation.Binary.PropositionalEquality.setoid A` for a bare type `A`.  See [`src/Legacy/Base/DEPRECATED.md`](../../DEPRECATED.md).  Removal is planned for v3.1.
 
 This is the [Base.Relations.Continuous][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Legacy/Base/Relations/Discrete.lagda.md
+++ b/src/Legacy/Base/Relations/Discrete.lagda.md
@@ -9,7 +9,6 @@ author: "the agda-algebras development team"
 
 This is the [Base.Relations.Discrete][] module of the [Agda Universal Algebra Library][].
 
-
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
@@ -32,10 +31,8 @@ open import Overture using (_≈_ ; Π-syntax ; Op)
 private variable a b ρ 𝓥 : Level
 ```
 
-
 We begin with a definition that is useful for defining poitwise "equality" of functions
 with respect to a given "equality" relation (see also the definition of `_≈̇_` in the [Base.Adjunction.Residuation][] module).
-
 
 ```agda
 module _ {A : Type a} where
@@ -49,7 +46,6 @@ we have `f (Pointwise _≋_) g` provided `∀ x → f x ≋ g x`.
 
 Here is the analogous definition for dependent functions.
 
-
 ```agda
  depPointWise :  {B : A → Type b }
                  (_≋_ : {γ : Level}{C : Type γ} → BinRel C ρ)
@@ -57,16 +53,13 @@ Here is the analogous definition for dependent functions.
  depPointWise {B = B} _≋_ = λ (f g : (a : A) → B a) → ∀ x → f x ≋ g x
 ```
 
-
 Next we define a type that is useful for asserting that the image of a function
 is contained in a particular "subset" (predicate) of the codomain.
-
 
 ```agda
  Im_⊆_ : {B : Type b} → (A → B) → Pred B ρ → Type (a ⊔ ρ)
  Im f ⊆ S = ∀ x → f x ∈ S
 ```
-
 
 
 #### <a id="operation-symbols-unary-relations-binary-relations">Operation symbols, unary relations, binary relations</a>
@@ -82,12 +75,10 @@ We represent "sets" as inhabitants of such predicate types.
 
 Sometimes it is useful to obtain the underlying type (`A`) over which the predicates in `Pred A ℓ` (the "subsets" of `A`) are defined.
 
-
 ```agda
  PredType : Pred A ρ → Type a
  PredType _ = A
 ```
-
 
 The binary relation types are called `Rel` and `REL` in the standard library, but we
 will call them `BinRel` and `BinREL` and reserve the names `Rel` and `REL` for the relation
@@ -98,7 +89,6 @@ We import the "heterogeneous" binary relation type from the standard library and
 `BinREL : ∀ {ℓ} (A B : Type ℓ) (ℓ' : Level) → Type (ℓ-max ℓ (ℓ-suc ℓ'))`
 `BinREL A B ℓ' = A → B → Type ℓ'`
 
-
 A special case, the homogeneous binary relation type is also imported and renamed `BinRel`.
 
 `BinRel : ∀{ℓ} → Type ℓ → (ℓ' : Level) → Type (ℓ ⊔ lsuc ℓ')`
@@ -106,12 +96,10 @@ A special case, the homogeneous binary relation type is also imported and rename
 
 Occasionally it is useful to extract the universe level over which a binary relation is defined.
 
-
 ```agda
  Level-of-Rel : {ℓ : Level} → BinRel A ℓ → Level
  Level-of-Rel {ℓ} _ = ℓ
 ```
-
 
 
 #### <a id="kernels">Kernels</a>
@@ -120,7 +108,6 @@ The *kernel* of `f : A → B` is defined informally by `{(x , y) ∈ A × A : f 
 This can be represented in type theory and Agda in a number of ways, each of which
 may be useful in a particular context. For example, we could define the kernel
 to be an inhabitant of a (binary) relation type, or a (unary) predicate type.
-
 
 ```agda
 module _ {A : Type a}{B : Type b} where
@@ -171,7 +158,6 @@ module _ {A : Type (a ⊔ ρ)} where
 ```
 
 
-
 ### <a id="compatibility-of-operations-and-relations">Compatibility of operations and relations</a>
 
 Recall, from the [Overture.Signatures][] and [Overture.Operations][] modules which established
@@ -180,7 +166,6 @@ represent operation symbols and arities, respectively.
 
 In the present subsection, we define types that are useful for asserting and proving
 facts about *compatibility* of operations and relations
-
 
 ```agda
 -- lift a binary relation to the corresponding `I`-ary relation.
@@ -192,9 +177,7 @@ eval-pred : {A : Type a}{I : Type 𝓥} → Pred (A × A) ρ → BinRel (I → A
 eval-pred P u v = ∀ i → (u i , v i) ∈ P
 ```
 
-
 If `f : Op I` and `R : Rel A b`, then we say `f` and `R` are *compatible* just in case `∀ u v : I → A`, `Π i ꞉ I , R (u i) (v i)  →  R (f u) (f v)`.
-
 
 ```agda
 _preserves_ : {A : Type a}{I : Type 𝓥} → Op A I → BinRel A ρ → Type (a ⊔ 𝓥 ⊔ ρ)
@@ -210,7 +193,6 @@ f preserves-pred P  = ∀ u v → (eval-pred P) u v → (f u , f v) ∈ P
 
 _|:pred_ : {A : Type a}{I : Type 𝓥} → Op A I → Pred (A × A) ρ → Type (a ⊔ 𝓥 ⊔ ρ)
 f |:pred P  = (eval-pred P) =[ f ]⇒ λ x y → (x , y) ∈ P
-
 
 -- The two types just defined are logically equivalent.
 module _ {A : Type a}{I : Type 𝓥}{f : Op A I}{R : BinRel A ρ} where

--- a/src/Setoid/Complexity/CSP.lagda.md
+++ b/src/Setoid/Complexity/CSP.lagda.md
@@ -74,13 +74,7 @@ open import Function.Base    using ( _∘_ )
 open import Relation.Binary  using ( Setoid )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
--- NOTE: `Legacy.Base.Relations.Continuous` is imported here because
--- `Setoid.Relations.Continuous` does not yet exist; the port of `Continuous` is
--- tracked under #308 (M2-7d, scheduled with M9).  Per the Category-B contract
--- in `src/Legacy/Base/DEPRECATED.md`, importing from `Legacy.Base.*` is the
--- supported, non-deprecated path until that port lands.  When #308 lands this
--- import will be redirected to the canonical path and the note removed.
-open import Legacy.Base.Relations.Continuous  using ( REL ; REL-syntax )
+open import Setoid.Relations.Continuous       using ( REL ; REL-syntax )
 open import Setoid.Algebras.Basic  {𝑆 = 𝑆}    using ( Algebra )
 ```
 

--- a/src/Setoid/Relations.lagda.md
+++ b/src/Setoid/Relations.lagda.md
@@ -9,18 +9,15 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Relations][] module of the [Agda Universal Algebra Library][].
 
-
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Relations where
 
-open import Setoid.Relations.Discrete   public
-open import Setoid.Relations.Quotients  public
+open import Setoid.Relations.Discrete    public
+open import Setoid.Relations.Quotients   public
+open import Setoid.Relations.Continuous  public
 ```
-
 
 -------------------------------------
 

--- a/src/Setoid/Relations/Continuous.lagda.md
+++ b/src/Setoid/Relations/Continuous.lagda.md
@@ -1,0 +1,147 @@
+---
+layout: default
+title : "Setoid.Relations.Continuous module (The Agda Universal Algebra Library)"
+date : "2026-05-10"
+author: "the agda-algebras development team"
+---
+
+### Continuous Relations on Setoids
+
+This is the [Setoid.Relations.Continuous][] module of the [Agda Universal Algebra Library][].
+
+A *continuous relation* of arity `I` over a type `A` is a predicate on `I`-tuples drawn from `A`.  The arity `I : Type ι` is an arbitrary type — not a fixed natural number — so the API generalises uniformly over finite, countable, and uncountable arities.  This module is the canonical setoid-flavoured home for the continuous-relation API, ported from `Legacy.Base.Relations.Continuous` under [#308][].  Three deliberate design choices distinguish it from the legacy:
+
++  **Π-setoid as the canonical `I`-tuple object.**  The natural `I`-tuple type whose pointwise equivalence a relation may be required to respect is the carrier of the Π-setoid `⨅ˢ 𝒜`, defined below.  Its level signature `(α ⊔ ι, ρᵃ ⊔ ι)` matches that of [`Setoid.Algebras.Products.⨅`][] exactly; in fact the inlined `Domain` of `⨅` *is* `⨅ˢ` applied to the algebras' domain setoids, so `⨅ˢ` and `⨅` compose by definitional unfolding.  Lifting this construction to a named referent here means every downstream relational development can speak about "I-tuples up to pointwise equivalence" without re-rolling the Π-setoid inline.
+
++  **Bare carrier types in `Rel`/`REL`, with setoid-respect as an external overlay.**  The relation types `Rel A I` and `REL I 𝒜` themselves take *bare* carrier types, exactly matching the legacy carrier shape.  Setoid structure is introduced through `⨅ˢ` and through the `Π-Respects-*` predicates, which name the property "respects pointwise equivalence" as a separate assertion.  This factorisation has three concrete payoffs.  (i) The consumer-side migration of existing call sites is purely an import-path change.  (ii) It mirrors how `Setoid.Relations.Quotients` uses bare `Pred` types throughout.  (iii) Agda's level inference works out cleanly: a setoid-parameterised `Rel` would force the user to disambiguate the unconstrained equivalence-level `ρᵃ` of every implicit setoid argument at every call site, since the projection `Carrier : Setoid α ρᵃ → Type α` is not injective in `ρᵃ`.
+
++  **Cubical-friendly by construction.**  `⨅ˢ` is defined against `Setoid`'s public interface (`Carrier`, `_≈_`, `isEquivalence`); a Cubical port replaces these with path equality, and the construction goes through with the equivalence-witness layer collapsing to triviality.  The bare-types `Rel`/`REL` are independent of the equivalence story and port with no change at all.
+
+A note on `compatible-REL`. The legacy `Legacy.Base.Relations.Continuous.compatible-REL` reads `compatible-REL 𝑓 R = Π[ t ∈ … ] eval-REL R t`, which is unconditional in `t` and never references `𝑓` — a bug, since it makes the predicate independent of the operations.  The intended definition, mirroring the structure of the (correct) single-sorted `compatible-Rel`, is `∀ t → eval-REL R t → R (λ i → 𝑓 i (t i))`.  The canonical port below uses the corrected definition.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Setoid.Relations.Continuous where
+
+-- Imports from Agda primitives and the standard library.
+open import Agda.Primitive    using () renaming ( Set to Type )
+open import Level             using ( Level ; _⊔_ ; suc )
+open import Relation.Binary   using ( Setoid ; IsEquivalence )
+
+open Setoid         using ( Carrier ; _≈_ ) renaming ( isEquivalence to isEqv )
+open IsEquivalence  using () renaming ( refl to reflᴱ ; sym to symᴱ ; trans to transᴱ )
+
+-- Imports from agda-algebras.
+open import Overture          using ( Op ; arity[_] )
+
+private variable α ρᵃ ρ ι : Level
+```
+
+#### <a id="pi-setoid">The Π-setoid construction</a>
+
+Given an indexing type `I : Type ι` and a family `𝒜 : I → Setoid α ρᵃ`, the indexed-product setoid `⨅ˢ 𝒜` has carrier the dependent function type `(i : I) → Carrier (𝒜 i)` and equivalence the pointwise equivalence `λ a b → ∀ i → _≈_ (𝒜 i) (a i) (b i)`, an equivalence relation by appeal to each `isEquivalence (𝒜 i)`.  The level signature matches `Setoid.Algebras.Products.⨅` exactly; lifting the construction to a named referent means downstream consumers can reference a single canonical Π-setoid rather than rolling it inline at each use site.
+
+```agda
+⨅ˢ : {I : Type ι} → (𝒜 : I → Setoid α ρᵃ) → Setoid (α ⊔ ι) (ρᵃ ⊔ ι)
+⨅ˢ {I = I} 𝒜 = record
+  { Carrier        = (i : I) → Carrier (𝒜 i)
+  ; _≈_            = λ a b → (i : I) → _≈_ (𝒜 i) (a i) (b i)
+  ; isEquivalence  = record
+      { refl   = λ i      → reflᴱ   (isEqv (𝒜 i))
+      ; sym    = λ p i    → symᴱ    (isEqv (𝒜 i)) (p i)
+      ; trans  = λ p q i  → transᴱ  (isEqv (𝒜 i)) (p i) (q i)
+      }
+  }
+```
+
+#### Continuous and dependent relations
+
+The single-sorted continuous relation type `Rel A I` represents predicates of arity `I` over a single carrier `A`.
+
+```agda
+Rel : (A : Type α) (I : Type ι) → {ρ : Level} → Type (α ⊔ ι ⊔ suc ρ)
+Rel A I {ρ} = (I → A) → Type ρ
+
+-- single-sorted: ρ explicit, syntax binds it
+Rel-syntax : (A : Type α) (I : Type ι) (ρ : Level) → Type (α ⊔ ι ⊔ suc ρ)
+Rel-syntax A I ρ = Rel A I {ρ}
+
+syntax Rel-syntax A I ρ = Rel[ A ^ I ] ρ
+infix 6 Rel-syntax
+```
+
+The multi-sorted (or *dependent*) continuous relation type `REL I 𝒜` represents predicates over an indexed family `𝒜 : I → Type α` of carriers.  Inhabitants are predicates on dependent `I`-tuples — i.e. on `(i : I) → 𝒜 i`.  When `𝒜 i = Carrier (𝒮 i)` for an indexed family `𝒮 : I → Setoid α ρᵃ`, this is definitionally the same as a predicate on `Carrier (⨅ˢ 𝒮)`, which is the bridge to the Π-setoid story.
+
+```agda
+REL : (I : Type ι) → (I → Type α) → {ρ : Level} → Type (α ⊔ ι ⊔ suc ρ)
+REL I 𝒜 {ρ} = ((i : I) → 𝒜 i) → Type ρ
+
+-- multi-sorted: ρ implicit, syntax does NOT bind it
+REL-syntax : (I : Type ι) → (I → Type α) → {ρ : Level} → Type (α ⊔ ι ⊔ suc ρ)
+REL-syntax I 𝒜 {ρ} = REL I 𝒜 {ρ}
+
+syntax REL-syntax I (λ i → 𝒜) = REL[ i ∈ I ] 𝒜
+infix 6 REL-syntax
+```
+
+#### Respecting pointwise equivalence
+
+A continuous relation `R` on the carrier of a setoid `𝐴` *respects pointwise equivalence on tuples* if `R f` and `f ≈ g` (the pointwise lift of `_≈_ 𝐴` to tuples) imply `R g`.  Equivalently, `R Respects (_≈_ (⨅ˢ {I = I} (λ _ → 𝐴)))` against stdlib's `Relation.Unary._Respects_`.
+
+The predicates `Π-Respects-Rel` and `Π-Respects-REL` below name this property as an explicit assertion rather than bundling it into the relation type itself, leaving consumers free to demand it where it matters and ignore it elsewhere — for the polymorphism-clone machinery in #274, the infinitary-CSP work in #281, and the Scott-continuous-DCPO work in #282 it is load-bearing; for transient working relations it is overhead.  The setoid argument is *explicit* in both predicates: the projection `Carrier : Setoid α ρᵃ → Type α` is not injective in `ρᵃ`, so an implicit setoid argument would be undetermined at every call site.
+
+```agda
+Π-Respects-Rel :  (𝐴 : Setoid α ρᵃ){I : Type ι}{ρ : Level}
+  →                Rel (Carrier 𝐴) I {ρ} → Type (ι ⊔ α ⊔ ρᵃ ⊔ ρ)
+Π-Respects-Rel 𝐴 {I = I} R =
+  ∀ {f g} → ((i : I) → _≈_ 𝐴 (f i) (g i)) → R f → R g
+
+Π-Respects-REL :  {I : Type ι}(𝒜 : I → Setoid α ρᵃ){ρ : Level}
+  →                REL I (λ i → Carrier (𝒜 i)) {ρ} → Type (ι ⊔ α ⊔ ρᵃ ⊔ ρ)
+Π-Respects-REL {I = I} 𝒜 R =
+  ∀ {f g} → ((i : I) → _≈_ (𝒜 i) (f i) (g i)) → R f → R g
+```
+
+#### <a id="compatibility-with-general-relations">Compatibility of operations with continuous relations</a>
+
+The operation `eval-Rel` lifts an `I`-ary relation to an `(I → J)`-ary relation: the lifted relation relates an `I`-tuple of `J`-tuples just in case each `J`-indexed *row* of the tuple-of-tuples (viewed as a `J`-indexed family of `I`-tuples) belongs to the original relation.
+
+```agda
+eval-Rel :  {A : Type α}{I : Type ι}
+  →          Rel A I {ρ} → (J : Type ι) → (I → J → A) → Type (ι ⊔ ρ)
+eval-Rel R J t = (j : J) → R (λ i → t i j)
+```
+
+A relation `R` is *compatible* with an operation `f : Op A J` if, for every `I`-tuple-of-`J`-tuples whose `J`-indexed rows lie in `R`, applying `f` columnwise yields a tuple in `R`.
+
+```agda
+compatible-Rel :  {A : Type α}{I J : Type ι}
+  →                Op A J → Rel A I {ρ} → Type (ι ⊔ α ⊔ ρ)
+compatible-Rel f R = ∀ t → eval-Rel R arity[ f ] t → R (λ i → f (t i))
+```
+
+#### <a id="compatibility-of-operations-with-dependent-relations">Compatibility of operations with dependent relations</a>
+
+The multi-sorted analogues `eval-REL` and `compatible-REL` mirror the single-sorted versions exactly, with `Rel A I` replaced by `REL I 𝒜` and tuple types replaced by their dependent counterparts.  The definition of `compatible-REL` corrects the buggy form in the legacy module; see the module header.
+
+```agda
+eval-REL :  {I : Type ι}{𝒜 : I → Type α}{J : Type ι}
+  →          REL I 𝒜 {ρ}
+  →          ((i : I) → J → 𝒜 i)
+  →          Type (ι ⊔ ρ)
+eval-REL {J = J} R t = (j : J) → R (λ i → t i j)
+
+compatible-REL :  {I J : Type ι}{𝒜 : I → Type α}
+  →                (∀ i → Op (𝒜 i) J)
+  →                REL I 𝒜 {ρ}
+  →                Type (ι ⊔ α ⊔ ρ)
+compatible-REL 𝑓 R = ∀ t → eval-REL R t → R (λ i → 𝑓 i (t i))
+```
+
+--------------------------------------
+
+<span style="float:left;">[← Setoid.Relations.Quotients](Setoid.Relations.Quotients.html)</span>
+<span style="float:right;">[Setoid.Algebras →](Setoid.Algebras.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Relations/Discrete.lagda.md
+++ b/src/Setoid/Relations/Discrete.lagda.md
@@ -9,10 +9,7 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Relations.Discrete][] module of the [Agda Universal Algebra Library][].
 
-
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Relations.Discrete where
@@ -37,13 +34,9 @@ open import Overture using ( Π-syntax )
 private variable α β ρᵃ ρᵇ ℓ 𝓥 : Level
 ```
 
-
 Here is a function that is useful for defining poitwise equality of functions wrt a given equality.
 
-
 ```agda
-
-
 open _⟶_ renaming ( to to _⟨$⟩_ )
 module _ {𝐴 : Setoid α ρᵃ}{𝐵 : Setoid β ρᵇ} where
  open Setoid 𝐴  using () renaming ( Carrier to A ; _≈_ to _≈₁_ )
@@ -53,18 +46,13 @@ module _ {𝐴 : Setoid α ρᵃ}{𝐵 : Setoid β ρᵇ} where
  function-equality f g = ∀ x → f ⟨$⟩ x ≈₂ g ⟨$⟩ x
 ```
 
-
 Here is useful notation for asserting that the image of a function (the first argument)
 is contained in a predicate, the second argument (a "subset" of the codomain).
 
-
 ```agda
-
-
  Im_⊆_ : (𝐴 ⟶ 𝐵) → Pred B ℓ → Type (α ⊔ ℓ)
  Im f ⊆ S = ∀ x → f ⟨$⟩ x ∈ S
 ```
-
 
 
 #### <a id="kernels">Kernels on setoids</a>
@@ -72,10 +60,7 @@ is contained in a predicate, the second argument (a "subset" of the codomain).
 Given setoids 𝐴 and 𝐵 (with carriers A and B, resp), the *kernel* of a function `f : 𝐴 ⟶ 𝐵` is defined
 informally by `{(x , y) ∈ A × A : f ⟨$⟩ x ≈₂ f ⟨$⟩ y}`.
 
-
 ```agda
-
-
  fker : (𝐴 ⟶ 𝐵) → BinRel A ρᵇ
  fker g x y = g ⟨$⟩ x ≈₂ g ⟨$⟩ y
 
@@ -91,7 +76,6 @@ informally by `{(x , y) ∈ A × A : f ⟨$⟩ x ≈₂ f ⟨$⟩ y}`.
  0rel : {ℓ : Level} → BinRel A (ρᵃ ⊔ ℓ)
  0rel {ℓ} = λ x y → Lift ℓ (x ≈₁ y)
 ```
-
 
 --------------------------------------
 

--- a/src/Setoid/Relations/Quotients.lagda.md
+++ b/src/Setoid/Relations/Quotients.lagda.md
@@ -9,10 +9,7 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Relations.Quotients][] module of the [Agda Universal Algebra Library][].
 
-
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Relations.Quotients where
@@ -35,15 +32,11 @@ open import Setoid.Relations.Discrete  using ( fker )
 private variable α β ρᵃ ρᵇ ℓ : Level
 ```
 
-
 #### <a id="kernels">Kernels</a>
 
 A prominent example of an equivalence relation is the kernel of any function.
 
-
 ```agda
-
-
 open _⟶_ using ( cong ) renaming ( to to _⟨$⟩_ )
 
 module _ {𝐴 : Setoid α ρᵃ}{𝐵 : Setoid β ρᵇ} where
@@ -65,15 +58,11 @@ record IsBlock  {A : Type α}{ρ : Level}
 open IsBlock
 ```
 
-
 If `R` is an equivalence relation on `A`, then the *quotient* of `A` modulo `R` is
 denoted by `A / R` and is defined to be the collection `{[ u ] ∣  y : A}` of all
 `R`-blocks.
 
-
 ```agda
-
-
 Quotient : (A : Type α) → Equivalence A{ℓ} → Type(α ⊔ suc ℓ)
 Quotient A R = Σ[ P ∈ Pred A _ ] IsBlock P {∣ R ∣}
 
@@ -83,13 +72,9 @@ A / R = record { Carrier = A ; _≈_ = ∣ R ∣ ; isEquivalence = ∥ R ∥ }
 infix -1 _/_
 ```
 
-
 We use the following type to represent an R-block with a designated representative.
 
-
 ```agda
-
-
 open Setoid
 ⟪_⟫ : {α : Level}{A : Type α} → A → {R : Equivalence A{ℓ}} → Carrier (A / R)
 ⟪ a ⟫{R} = a
@@ -107,8 +92,6 @@ module _ {A : Type α}{R : Equivalence A{ℓ} } where
 ≡→⊆ : {A : Type α}{ρ : Level}(Q R : Pred A ρ) → Q ≡ R → Q ⊆ R
 ≡→⊆ Q .Q ≡.refl {x} Qx = Qx
 ```
-
-
 
 -------------------------------------
 


### PR DESCRIPTION
## Summary

Ports the continuous-relation API from `Legacy.Base.Relations.Continuous` to its canonical home at `Setoid.Relations.Continuous`.  This is the M2-7d child of the orphan-port parent #302 and unblocks substantive work on the M9 issues #281 (infinitary CSP over ω-categorical templates) and #282 (Scott-continuous relations on DCPOs), both of which depend on the canonical-path location of this API.

## Related issues

Closes #308

## Design

The "non-trivial" design question flagged in #308 — what `I`-tuple type to use as the natural setoid analog of the legacy `(I → A)` — is resolved in favour of the **Π-setoid** `⨅ˢ : (I → Setoid α ρᵃ) → Setoid (α ⊔ ι) (ρᵃ ⊔ ι)`.  The level signature matches `Setoid.Algebras.Products.⨅` exactly; the inlined `Domain` of `⨅` *is* `⨅ˢ` applied to the algebras' domain setoids, so the two compose by definitional unfolding.  This makes the new module the natural counterpart to `Setoid.Algebras.Products` for relational developments and provides the bridge for the Galois-connection machinery in #274 (M7-1) and downstream `Setoid.Subalgebras.*` work.

The relation types `Rel` and `REL` are bare predicates on the carrier of `⨅ˢ`, with setoid-respect asserted as a separate predicate (`Π-Respects-Rel` / `Π-Respects-REL`) rather than bundled into the type.  This keeps the legacy carrier shape unchanged — the consumer-side migration is a single-line import rename — mirrors how `Setoid.Relations.Quotients` uses bare `Pred` types, and stays compositional: a transient relation has no obligation to respect pointwise equivalence, while a stable downstream relation can be required to do so.  The bare-predicate plus external-overlay shape is also Cubical-friendly, since `⨅ˢ` is defined against `Setoid`'s public interface and a path-equality port replaces only the equivalence layer.

`compatible-REL` corrects a latent bug in the legacy definition: the legacy form `compatible-REL 𝑓 R = Π[ t ∈ … ] eval-REL R t` is unconditional in `t` and never references `𝑓`, making the predicate independent of the operations.  The canonical port mirrors the structure of the (correct) single-sorted `compatible-Rel`: `∀ t → eval-REL R t → R (λ i → 𝑓 i (t i))`.  Documented in the new module's header.

The destination decision aligns with #303 (M2-6) precedent: the Setoid-flavoured continuous API lives in `Setoid/`, not `Overture/`, because the Π-setoid construction is genuinely setoid-flavoured and a hypothetical `Overture.Relations.Continuous` would be a different module — bare types, bare predicates, no Π-setoid.  An `Overture/` placement remains a reasonable design moment to revisit during the v4.0 Cubical canonicalization, when the same definitions will need to be expressible cubically.

## Changes

+  **NEW** `src/Setoid/Relations/Continuous.lagda.md` — the canonical port.  Defines `⨅ˢ`, `Rel`/`REL` (with `Rel-syntax`/`REL-syntax`), `Π-Respects-Rel`/`Π-Respects-REL`, and `eval-Rel`/`compatible-Rel`/`eval-REL`/`compatible-REL`.
+  `src/Setoid/Relations.lagda.md` — re-exports `Setoid.Relations.Continuous`.
+  `src/Legacy/Base/Relations/Continuous.lagda.md` — adds a deprecation banner at the top, plus `WARNING_ON_USAGE` pragmas on every public name.
+  `src/Legacy/Base/DEPRECATED.md` — moves the `Continuous` row from Category B to Category A; updates the partial-replacement parenthetical on the `Legacy.Base.Relations` aggregator row.
+  `src/Setoid/Complexity/CSP.lagda.md` — redirects the import from `Legacy.Base.Relations.Continuous` to `Setoid.Relations.Continuous`, drops the temporary note that #307 left in place, and adjusts `Constraint.rel`'s type to use the new `REL-syntax` shape (passes a setoid family directly rather than a carrier-type family).

`Exercises.Complexity.FiniteCSP` is intentionally not migrated in this PR; it is tracked under #304.  Its other imports are Category-B legacy `Structures.*` modules (M3 territory), and a partial migration of just the `Rel` import would leave the file in a mixed Setoid-canonical / Legacy state.

## Acceptance criteria

+  [x] Canonical-path module exists, type-checks, and documents the indexed-setoid-respecting design in its header.
+  [x] `Legacy.Base.Relations.Continuous` carries `WARNING_ON_USAGE` pragmas.
+  [x] `DEPRECATED.md` reflects the move; no `#TBD` cell remains for the `Continuous` row.
+  [x] M9-1 (#282) and M9-2 (#281) can import from the canonical path without changes (verified against the design discussions in those issues; the bare-predicate-with-overlay design directly accommodates Scott-continuous relations on DCPOs and infinitary CSP relations).
+  [x] `make check` and `EverythingLegacy` both pass under `nix develop`.

## References

+  Closes #308.
+  Parent — #302.
+  Setoid-foundations precedent — #303 (M2-6).  Followed for the destination logic.
+  Sibling complexity port — #307 (M2-7c).  This PR removes the temporary `Legacy.Base.Relations.Continuous` import that #307 left in `Setoid.Complexity.CSP`.
+  Downstream consumers (M9 design discussion) — #281, #282, #283.
+  Exercises migration — #304.  Will adopt the canonical path in due course.

---

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [x] Refactoring / cleanup ~~(no user-facing change)~~
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches the `src/` tree, the change is targeted at `Base/`, `Setoid/`, or the shared `Overture/` foundation.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.
