### PR TITLE
[M2-7] Port orphan Base modules to canonical paths (#302)

### DIFF
--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -970,7 +970,7 @@ The natural destination is `Setoid.Complexity/`, mirroring the existing `Legacy.
 
 ---
 
-### Issue M2-7d: Port Legacy.Base.Relations.Continuous to canonical paths (#308)
+### Issue M2-7d: Port Legacy.Base.Relations.Continuous to canonical paths (#308, closed)
 
 **Labels**: `milestone-2-consolidation`, `milestone-9-apps`
 
@@ -1022,7 +1022,7 @@ Unlike most of Category A, where the propositional-equality version maps mechani
 
 ---
 
-### Issue M2-7e: Port Legacy.Base.Relations.Properties to Setoid.Relations.Properties (#309)
+### Issue M2-7e: Port Legacy.Base.Relations.Properties to Setoid.Relations.Properties (#309, closed)
 
 **Labels**: `milestone-2-consolidation`
 
@@ -1056,7 +1056,7 @@ The M2-1 inventory found no consumers of `Base.Relations.Properties` outside `sr
 
 ---
 
-### Issue M2-7f: Port Legacy.Base.Functions.Transformers to canonical paths (#310)
+### Issue M2-7f: Port Legacy.Base.Functions.Transformers to canonical paths (#310, closed)
 
 **Labels**: `milestone-2-consolidation`, `design-discussion`
 
@@ -1099,7 +1099,7 @@ Recommendation: audit first; the right answer is likely "stdlib redirect" for mo
 
 ---
 
-### Issue M2-7g: Port Legacy.Base.Varieties.Invariants to Setoid.Varieties.Invariants (#311)
+### Issue M2-7g: Port Legacy.Base.Varieties.Invariants to Setoid.Varieties.Invariants (#311, closed)
 
 **Labels**: `milestone-2-consolidation`
 


### PR DESCRIPTION
## Summary

Closing parent issue with updated project plan.

All seven children closed.  Final dispositions:

+  **M2-7a (#305)** — `Legacy.Base.Adjunction.*` (4 modules) → `Overture.Adjunction.*`.  Promoted to `Overture/` rather than `Setoid/` because the abstract order-theoretic content is needed identically across `Setoid/`, `Classical/`, and `Cubical/`.
+  **M2-7b (#306)** — `Legacy.Base.Categories.*` (2 modules) → `Examples.PolynomialFunctors.*`.  Relocated to `Examples/` rather than ported into the canonical universal-algebra core; established the precedent now documented in DEPRECATED.md for Category-A relocations to `Examples/`.
+  **M2-7c (#307)** — `Legacy.Base.Complexity.*` (3 modules) → `Setoid.Complexity.*`.  Landed in M2 rather than deferred to M9; M9-2 (#281) and M7-1 (#274) now consume the canonical path directly.
+  **M2-7d (#308)** — `Legacy.Base.Relations.Continuous` → `Setoid.Relations.Continuous`, with the arity-many indexed-setoid `cong` design documented in the module header.  Landed in M2; M9-1 (#282) and M9-2 (#281) now consume the canonical path directly.
+  **M2-7e (#309)** — `Legacy.Base.Relations.Properties` → `Setoid.Relations.Properties`.
+  **M2-7f (#310)** — `Legacy.Base.Functions.Transformers` → `Examples.FunctionTypeBijections`.  Audit against stdlib's `Function.*` confirmed the content was illustrative bijection-construction material rather than a load-bearing API; same `Examples/` precedent as M2-7b.
+  **M2-7g (#311)** — `Legacy.Base.Varieties.Invariants` → `Setoid.Varieties.Invariants`.

## Related issues

Closes #302

## More Details

For each port, the legacy module was retained with a `{-# WARNING_ON_USAGE #-}` pragma naming the canonical home and the closing-issue number; removal is scheduled for v3.1, giving downstream users one full minor cycle to migrate.

+  [x] Every orphan listed above has a closed child issue (port complete).
+  [x] DEPRECATED.md's Category B table contains no row whose `Tracking issue` column reads `#TBD`.
+  [x] The only Category-B residual content is the `Structures.*` subtree (handled by M3); the `Equality.*` subtree is Category C (no replacement planned).

+  ADR-001 — `docs/adr/001-setoid-as-canonical.md`
+  DEPRECATED.md — `src/Legacy/Base/DEPRECATED.md`
+  M2-1 — #256
+  Children — #305, #306, #307, #308, #309, #310, #311

---

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [x] Refactoring / cleanup ~~(no user-facing change)~~
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches the `src/` tree, the change is targeted at `Base/`, `Setoid/`, or the shared `Overture/` foundation.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.
