### PR TITLE
[M2-8a] Migrate Continuous import in FiniteCSP; fix stale paper input (#304)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,8 @@ Closes #
 
 - [ ] Bug fix
 - [ ] New definition, theorem, or feature
-- [ ] Refactoring / cleanup (no user-facing change)
+- [ ] Refactor / cleanup (user-facing/API change)
+- [ ] Refactor / cleanup (no user-facing change)
 - [ ] Documentation
 - [ ] Infrastructure (CI, Nix, build)
 - [ ] Other

--- a/docs/papers/EverythingFunc.tex
+++ b/docs/papers/EverythingFunc.tex
@@ -128,6 +128,6 @@
 
 \input{../latex/Examples.Structures.Basic}
 \input{../latex/Examples.Structures.Signatures}
-\input{../latex/Examples.Categories.Functors}
+\input{../latex/Examples.PolynomialFunctors.Functors}
 
 \input{../latex/Exercises.Complexity.FiniteCSP}

--- a/src/Examples/PolynomialFunctors/Functors.lagda.md
+++ b/src/Examples/PolynomialFunctors/Functors.lagda.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title : "Examples.PolynomialFunctors.Functors module (The Agda Universal Algebra Library)"
-date : "2026-05-09"
+file: "src/Examples/PolynomialFunctors/Functors.lagda.md"
+title: "Examples.PolynomialFunctors.Functors module (The Agda Universal Algebra Library)"
+date: "2026-05-09"
 author: "the agda-algebras development team"
 ---
 

--- a/src/Exercises/Complexity/FiniteCSP.lagda.md
+++ b/src/Exercises/Complexity/FiniteCSP.lagda.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title : "Exercises.Complexity.FiniteCSP module (The Agda Universal Algebra Library)"
-date : "2021-07-26"
+file: "src/Exercises/Complexity/FiniteCSP.lagda.md"
+title: "Exercises.Complexity.FiniteCSP module (The Agda Universal Algebra Library)"
+date: "2026-05-11"
 author: "agda-algebras development team and Libor Barto"
 ---
 
@@ -26,10 +27,15 @@ open import Relation.Unary  using ( Pred ; _∈_ )
 
 -- Imports from agda-algebras --------------------------------------------------------------
 open import Overture.Basic                  using ( 𝟚 ; 𝟛 )
-open import Legacy.Base.Relations.Continuous       using ( Rel )
-open import Legacy.Base.Structures.Basic           using ( signature ; structure )
+open import Setoid.Relations.Continuous     using ( Rel )
 open import Examples.Structures.Signatures  using ( S∅ ; S001 ; S021)
+
+-- TODO(#M2-8c): the two imports below await the M3-1 (#260) Classical/ scaffold;
+-- the canonical destinations for `signature`, `structure`, and `hom` will live
+-- under Classical/ once M3 lands.
+open import Legacy.Base.Structures.Basic           using ( signature ; structure )
 open import Legacy.Base.Structures.Homs            using ( hom )
+
 open signature
 open structure
 ```

--- a/src/Legacy/Base/Categories.lagda.md
+++ b/src/Legacy/Base/Categories.lagda.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title : "Base.Categories module (The Agda Universal Algebra Library)"
-date : "2021-08-31"
+file: "src/Legacy/Base/Categories.lagda.md"
+title: "Base.Categories module (The Agda Universal Algebra Library)"
+date: "2021-08-31"
 author: "agda-algebras development team"
 ---
 
@@ -15,15 +16,12 @@ The purpose of this effort twofold. First, we hope it makes the types defined in
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Legacy.Base.Categories where
 
 open import Legacy.Base.Categories.Functors  public
 ```
-
 
 --------------------------------------
 

--- a/src/Legacy/Base/Categories/Functors.lagda.md
+++ b/src/Legacy/Base/Categories/Functors.lagda.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title : "Base.Categories.Functors module (The Agda Universal Algebra Library)"
-date : "2021-08-30"
+file: "src/Legacy/Base/Categories/Functors.lagda.md"
+title: "Base.Categories.Functors module (The Agda Universal Algebra Library)"
+date: "2021-08-30"
 author: "agda-algebras development team"
 ---
 


### PR DESCRIPTION
## Summary

Partial closure of #304.  The original M2-8 scope was four files; three of the four bullets in the issue body were either already resolved out-of-band (Categories.Functors was relocated to Examples.PolynomialFunctors.Functors under #306, leaving only a stale LaTeX `\input` behind) or are blocked on M3-1 (the two Structures examples and two of the three FiniteCSP imports).  This PR resolves what is resolvable today; the M3-gated residue is split out into M2-8b and M2-8c, and the issue body is updated to reflect the actual state.

## Related issues

Part of #304.

## Changes

+  **`src/Exercises/Complexity/FiniteCSP.lagda.md`**.  `Legacy.Base.Relations.Continuous` → `Setoid.Relations.Continuous` (canonical path landed under #308 / M2-7d).  The replacement `Rel` is bare-carrier and signature-compatible with the legacy version; the body of the exercise type-checks unchanged.  A `TODO(#M2-8c)` marker is added at the two remaining `Legacy.Base.Structures.*` imports.
+  **`docs/papers/EverythingFunc.tex`**.  Stale `\input{../latex/Examples.Categories.Functors}` → `\input{../latex/Examples.PolynomialFunctors.Functors}`, matching the relocation under #306.

In addition, very minor edits were made to the YAML header of two files, and a minor change was made to the PR template.

## Verification

+  `grep -rn 'Examples\.Categories' src/ docs/` returns no matches.
+  `grep -rn 'open import Legacy.Base.Relations.Continuous' src/Examples src/Exercises` returns no matches.
+  `make check` passes locally.

## Follow-ups filed

+  M2-8b — migrate `Examples/Structures/{Basic,Signatures}.lagda.md` once M3-1 lands.
+  M2-8c — migrate the remaining `Legacy.Base.Structures.{Basic,Homs}` imports in FiniteCSP once M3-1 lands.

Closes none of these directly; #304 stays open until M2-8b and M2-8c complete, at which point its second acceptance criterion (`grep -rn 'open import Legacy.Base' src/Examples src/Exercises` empty) will hold.

---

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [x] Refactoring / cleanup ~~(no user-facing change)~~
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches the `src/` tree, the change is targeted at `Base/`, `Setoid/`, or the shared `Overture/` foundation.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.
