### PR TITLE
Major revision to ADR-002 (no associated issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The 3.0 release is a major reconstruction of agda-algebras building on the Setoi
 
 ### Changed (BREAKING)
 
++  **ADR-002 revised to v2** (no associated issue; revision documented in [PR ref]).  The original ADR-002 was authored ahead of the M3-2 Semigroup load test; v2 incorporates the findings from that load test.  No higher-level architecture is overturned; the revisions clarify and refine the original decisions across nine numbered sections.  See the ADR's `Empirical revision history` section for the substantive content of the revision.
+
 +  **`src/Base/` frozen as `src/Legacy/Base/`** (M2-1, #256).  `Setoid/` is now the canonical development tree for agda-algebras 3.0.  The pre-3.0 bare-types tree has been moved to `src/Legacy/Base/`; the top-level aggregator `agda-algebras.lagda.md` re-exports it as `Legacy.Base`.  This is a breaking change for downstream users of `Base.*`.  The migration is mechanical for most imports; see `src/Legacy/Base/DEPRECATED.md` for the categorization (deprecated-with-replacement vs. pending-port vs. no-replacement-planned) and `docs/adr/001-setoid-as-canonical.md` for the rationale.
 
    Migration recipe (most imports):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The 3.0 release is a major reconstruction of agda-algebras building on the Setoi
 
 ### Changed (BREAKING)
 
-+  **ADR-002 revised to v2** (no associated issue; revision documented in [PR ref]).  The original ADR-002 was authored ahead of the M3-2 Semigroup load test; v2 incorporates the findings from that load test.  No higher-level architecture is overturned; the revisions clarify and refine the original decisions across nine numbered sections.  See the ADR's `Empirical revision history` section for the substantive content of the revision.
++  **ADR-002 revised to v2** (no associated issue; revision documented in the ADR itself).  The original ADR-002 was authored ahead of the M3-2 Semigroup load test; v2 incorporates the findings from that load test.  No higher-level architecture is overturned; the revisions clarify and refine the original decisions across nine numbered sections.  See the ADR's `Empirical revision history` section for the substantive content of the revision.
 
 +  **`src/Base/` frozen as `src/Legacy/Base/`** (M2-1, #256).  `Setoid/` is now the canonical development tree for agda-algebras 3.0.  The pre-3.0 bare-types tree has been moved to `src/Legacy/Base/`; the top-level aggregator `agda-algebras.lagda.md` re-exports it as `Legacy.Base`.  This is a breaking change for downstream users of `Base.*`.  The migration is mechanical for most imports; see `src/Legacy/Base/DEPRECATED.md` for the categorization (deprecated-with-replacement vs. pending-port vs. no-replacement-planned) and `docs/adr/001-setoid-as-canonical.md` for the rationale.
 

--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -1388,90 +1388,272 @@ The `Everything.agda` and `EverythingFunc.agda` generators are updated to walk t
 
 ---
 
-### Issue M3-2: Add Classical.Structures.Semigroup (pattern-setting first structure) (#261)
+### Issue M3-2: Classical.Operations and Classical.Equations infrastructure (#330)
 
-**Labels**: `enhancement`, `milestone-3-classical`
+**Labels**: `milestone-3-classical`, `design-discussion`
 
 ## Description
 
-After the M3-1 scaffold (#326, merged) lands, add Semigroup as the pattern-setting first concrete classical structure under the [`Classical/`](src/Classical.lagda.md) tree.  Every subsequent classical structure (Monoid, Group, Lattice, Ring, …) will imitate the file layout, conventions, and helper-shapes established here, so getting Semigroup right is disproportionately important.
+This issue introduces the two shared-infrastructure modules that every concrete `Classical/X` structure will depend on: [`Classical.Operations`](src/Classical/Operations.lagda.md), holding the per-arity `Curry`/`Uncurry` helpers that bridge the foundational tuple-indexed operation form `(I → A) → A` with the curried user-facing form `A → A → A`; and the seed of [`Classical.Equations`](src/Classical/Equations.lagda.md) (or `Classical.Identities.lagda.md` — name TBD in PR), holding generic equation builders parametric in a signature and operation symbols.
 
-Design context: [ADR-002 — Classical structures as Σ-typed cores with record-typed bundle views](docs/adr/002-classical-layer-design.md).
+Per [ADR-002 v2 §1](docs/adr/002-classical-layer-design.md), tuple-indexed operations live in `Setoid.Algebras` and downstream meta-theory; curried operations are the user-facing form across `Classical/`.  Per [ADR-002 v2 §3](docs/adr/002-classical-layer-design.md), generic equation builders form the syntactic dual of stdlib's `Algebra.Definitions` and feed the equational-logic substrate (`Modᵗ`) for every concrete theory.
 
-## Design decisions to record (resolved in the M3-2 PR description)
+Landing this infrastructure before any concrete structure means M3-3 (Magma) is purely about signature mechanics, M3-4 (Semigroup) is purely about adding one equation, and so on.  Each per-structure issue is a small composition rather than a re-derivation.
 
-These were settled in advance of implementation; record them in the PR description and in module-header prose so future structures inherit the conventions without re-litigation.
+This issue is the renumbered predecessor of what was originally M3-2 (Semigroup); the M3-2 issue body was reformulated to M3-4 after the v2 ADR.
 
-+  **Signature representation**.  Named operator via a one-constructor data type: `data Op-Semigroup : Type where ∙op : Op-Semigroup`, with `ar-Semigroup ∙op = Fin 2`.  Constructor-naming convention `<symbol>op` reserves the bare symbol for use-site infix sugar over `node`.  Rationale: proof terms self-document the operation being applied (training-corpus value), and the pattern generalizes uniformly to multi-operation signatures (Monoid adds `eop`; Group adds `invop`; Lattice adds `∧op`, `∨op`; Ring adds five operators).
-+  **Equational theory representation**.  Indexed form per `Setoid.Varieties.EquationalLogic` `Modᵗ`: `data Eq-Semigroup : Type where assoc : Eq-Semigroup`, with `Th-Semigroup : Eq-Semigroup → Term SemigroupVar × Term SemigroupVar`.  Symmetric with the signature convention.  The Σ-typed core uses `Modᵗ Th-Semigroup` (aliased as `_⊨_` locally; pull-up deferred).
-+  **Variable carrier for terms**.  Per-structure named enum: `data SemigroupVar : Type where x y z : SemigroupVar`.  Parallels the named-operation convention; keeps equations mathematically readable (`ℊ x` rather than `ℊ 0F`).  Naming convention for future structures: `<Structure>Var` with constructors drawn from the conventional metasyntactic letters for the structure's identities.
-+  **Named accessors next to the core**.  `Domain`, `Signature`, `equations` defined alongside `Semigroup α ρ` to offset Σ-projection ergonomic cost.  These get pulled up to a shared location (probably `Classical.Structures` itself, or a small `Classical.Accessors` module) once a second consumer exists; landing them locally in M3-2 is deliberate — premature shared abstraction is the failure mode #326's non-goals were drawn to avoid.
-+  **`fromPropEq` shape**.  Per-structure: `fromPropEq : (A : Type α) (_·_ : A → A → A) (assoc : ∀ x y z → (x · y) · z ≡ x · (y · z)) → Semigroup α α`.  Same pull-up policy as the accessors.
-+  **Morphisms of classical structures**.  No per-structure invariant required: any `Setoid.Homomorphisms` morphism between the underlying algebras already preserves operations, and the target inheriting the theory is automatic from the source side.  So "semigroup morphism" is definitionally an algebra hom of underlying algebras; nothing to define in M3-2.
-+  **Worked-example placement**.  The example lives in a sibling `Examples/Classical/Semigroup.lagda.md`, not co-located with the core.  Keeps the canonical `Classical/Structures/Semigroup.lagda.md` lean and gives a natural home for further semigroup examples (`(List A, _++_)`, free semigroups, presentations, …) as they accumulate, without bloating the core.
+## Design decisions
+
+These are the conventions established here; the same applies to every per-structure file that consumes this infrastructure.
+
++  **`Curry`/`Uncurry` helpers**.  One pair per arity: `Curry₀`/`Uncurry₀` for nullary, `Curry₁`/`Uncurry₁` for unary, `Curry₂`/`Uncurry₂` for binary.  Higher arities added as needed (Lattice in M3-7 may want `Curry₃` for the absorption-law statement; defer the decision until then).  Each helper is a two-line definition; the file is short.
++  **Fin n η-bridge containment**.  The Fin 2 η-failure under `--cubical-compatible` is contained inside `Uncurry₂` and `Curry₂` — at the use site, an `(I → A) → A` operation appears as `A → A → A` and the wrapping/unwrapping is invisible.  Per-structure files never write `pair`-style helpers inline.
++  **Generic equation builders**.  Parametric in signature `S : Signature 𝓞 𝓥` (or `Signature ℓ₁ ℓ₂` if the abstract over levels is undesirable; finalize during PR) and in operation symbols within `S`, with arity-conformance evidence as a `≡ Fin n` argument.  Inventory for M3-2:
+   +  `Associative : (f : OperationSymbolsOf S) → ArityOf f ≡ Fin 2 → ∀ {X} → X → X → X → Term X × Term X`
+   +  `Commutative : (f : OperationSymbolsOf S) → ArityOf f ≡ Fin 2 → ∀ {X} → X → X → Term X × Term X`
+   +  `LeftIdentity / RightIdentity : binary op + nullary op + their arity proofs → ∀ {X} → X → Term X × Term X`
+   +  `LeftInverse / RightInverse : binary op + nullary identity op + unary inverse op + arity proofs → ∀ {X} → X → Term X × Term X`
+   +  `Idempotent : (f : OperationSymbolsOf S) → ArityOf f ≡ Fin 2 → ∀ {X} → X → Term X × Term X`
+   +  `DistributesOverˡ / DistributesOverʳ : two binary ops + their arity proofs → ∀ {X} → X → X → X → Term X × Term X`
+   +  `Absorbs : two binary ops + their arity proofs → ∀ {X} → X → X → Term X × Term X`
+
+   This inventory covers every equation in `Th-Magma`, `Th-Semigroup`, `Th-Monoid`, `Th-Group`, `Th-Semilattice`, `Th-Lattice`, `Th-Semiring`, `Th-Ring`.  Builders for less-uniform equations (e.g., the medial law) deferred until a structure needs them.
++  **Self-documenting signature projections**.  This file also seeds `OperationSymbolsOf` and `ArityOf` aliases in `Overture.Signatures` (per [ADR-002 v2 §1](docs/adr/002-classical-layer-design.md)).  Two-line addition; bracket notation remains everywhere it already appears.
++  **Notation rename `̂` → `^`** (per [ADR-002 v2 §7](docs/adr/002-classical-layer-design.md)).  Add `WARNING_ON_USAGE` to the existing `̂` definition in `Setoid.Algebras.Basic`; introduce `^` as the new canonical infix.  Per-tree policy: new `Classical/` code uses `^` exclusively; existing `Setoid/` code is not retroactively renamed.
 
 ## Tasks
 
-### Core five-file quintuple
+### Core infrastructure files
 
-+  [ ] `src/Classical/Signatures/Semigroup.lagda.md`: `Op-Semigroup`, `ar-Semigroup`, `𝑆ₛₘ : Signature lzero lzero`.
-+  [ ] `src/Classical/Theories/Semigroup.lagda.md`: `SemigroupVar`, `Eq-Semigroup`, `Th-Semigroup : Eq-Semigroup → Term SemigroupVar × Term SemigroupVar` encoding associativity as the single identity.
-+  [ ] `src/Classical/Structures/Semigroup.lagda.md`:
-   +  the Σ-typed core `Semigroup α ρ = Σ[ 𝑨 ∈ Algebra 𝑆ₛₘ α ρ ] 𝑨 ⊨ Th-Semigroup`,
-   +  local `_⊨_` alias for `Modᵗ`-on-`Th-Semigroup`,
-   +  named accessors `Domain`, `Signature`, `equations`,
-   +  `fromPropEq` helper.
-+  [ ] `src/Classical/Bundles/Semigroup.lagda.md`: record matching `Algebra.Bundles.Semigroup` from stdlib 2.3, conversion functions `⟨_⟩ₛₘ`, `⟪_⟫ₛₘ` (Σ-core → bundle, bundle → Σ-core), round-trip lemma.  Coordinates with M3-3.
-+  [ ] `src/Classical/Small/Structures/Semigroup.lagda.md`: level-fixed veneer `Semigroup = Classical.Structures.Semigroup.Semigroup lzero lzero`, plus a re-export of the small-case `fromPropEq`.
++  [ ] `src/Classical/Operations.lagda.md` — `Curry₀`/`Uncurry₀`, `Curry₁`/`Uncurry₁`, `Curry₂`/`Uncurry₂` with prose explaining the design intent.
++  [ ] `src/Classical/Equations.lagda.md` — the generic equation builders above, with prose introducing the file as the syntactic dual of `Algebra.Definitions` and citing Bryant 1982 for the historical motivation that distinguishes syntactic from evaluated equation collections.
++  [ ] `src/Classical.lagda.md` umbrella — `open import Classical.Operations public` and `open import Classical.Equations public`.
 
-### Worked example (sibling under `Examples/`)
+### Signature-projection aliases
 
-+  [ ] `src/Examples/Classical/Semigroup.lagda.md`: `(ℕ, +)` as a `Classical.Small.Structures.Semigroup.Semigroup`, constructed via `fromPropEq` from stdlib's `+-assoc`.  File-header prose flags this as the home of all future semigroup-specific examples.
-+  [ ] `src/Examples/Classical.lagda.md`: new umbrella for the `Examples/Classical/` subtree (parallels how `src/Classical.lagda.md` umbrellas the `Classical/` tree).  Re-exports `Examples.Classical.Semigroup`; will grow as Monoid, Group, … examples land alongside their structures.
++  [ ] Update `src/Overture/Signatures.lagda.md` to export `OperationSymbolsOf` and `ArityOf`.  Definitionally identical to the existing `∣ 𝑆 ∣` and `∥ 𝑆 ∥` aliases; no behavioral change.
 
-### Umbrella updates
+### Notation rename
 
-+  [ ] Update the five `Classical/` subtree umbrellas to `open import ... public` the new modules: `Classical.Signatures`, `Classical.Theories`, `Classical.Structures`, `Classical.Bundles`.  Update `Classical.Small` to `open import Classical.Small.Structures public` once the small `Structures` aggregator exists.
-+  [ ] Create `src/Classical/Small/Structures.lagda.md` aggregator (one further file beyond the quintuple above): re-exports `Classical.Small.Structures.Semigroup`.
-+  [ ] Update `src/Examples.lagda.md` to `open import Examples.Classical`.
++  [ ] Update `src/Setoid/Algebras/Basic.lagda.md` to introduce `_^_` alongside `_̂_`, with a `WARNING_ON_USAGE _̂_` pragma announcing v3.1 removal.  Add an ADR-002 §7 cross-reference in the module-header prose.
 
 ### Documentation
 
-+  [ ] Module-header prose in `Classical/Structures/Semigroup.lagda.md` documents the conventions established here, so future structures (Monoid in M3-4, Group in M3-5, …) have a single normative reference.
++  [ ] Module-header prose in `Classical.Operations` and `Classical.Equations` documenting the design intent normatively, so M3-3 / M3-4 / M3-5 / M3-6 authors have a single reference for the conventions they're consuming.
++  [ ] Cross-reference `Classical.Equations` in `docs/STYLE_GUIDE.md` under a new section on "Generic equation builders for classical structures."
 +  [ ] `CHANGELOG.md` `[Unreleased] / Added` entry.
 
-## Non-goals (deferred to later milestones)
+## Non-goals
 
-+  Pull-up of `_⊨_`, named accessors, and `fromPropEq` to shared locations.  Deferred until at least one additional structure (Monoid, M3-4) confirms the shape generalizes.
-+  Stdlib bundle bridges generalized beyond the per-structure conversion functions.  M3-3.
-+  Anything to do with semigroup homomorphisms beyond the observation in the design-decisions section.  Homomorphisms of classical structures are just `Setoid.Homomorphisms` of underlying algebras.
-+  Free semigroups, semigroup varieties as a sub-class of varieties of `𝑆ₛₘ`-algebras, presentations, term rewriting, decidability of the word problem.  All later.
-+  Additional worked examples beyond `(ℕ, +)`.  The `Examples/Classical/Semigroup.lagda.md` file is the right home for these as they accumulate, but M3-2's scope is the one canonical example.
++  No concrete structure (Magma, Semigroup, Monoid, …) lands here.  Those are M3-3 onward.
++  No bundle-bridge infrastructure beyond what `Curry`/`Uncurry` enables.  Per-structure bundle bridges land with their structures.
++  Higher-arity `Curry`/`Uncurry` helpers (Curry₃, Curry₄, …) are added only when a concrete structure requires them.
++  Generic equation builders beyond the inventory above are added per-need.
 
 ## Acceptance criteria
 
-+  [ ] All eight new files type-check under `make check`.
-+  [ ] The worked example `ℕ-semigroup` in `Examples.Classical.Semigroup` type-checks.
-+  [ ] The interpretation of `∙op` in `ℕ-semigroup` reduces definitionally to `_+_` — no unfortunate opacity from the `fromPropEq` construction.
-+  [ ] The bridge to `Algebra.Bundles.Semigroup` round-trips on `ℕ-semigroup`: converting Σ-core → bundle → Σ-core gives back a structure propositionally equal to the original.
-+  [ ] Module-header prose in `Classical/Structures/Semigroup.lagda.md` documents the design conventions clearly enough that a contributor writing `Classical/Structures/Monoid.lagda.md` from scratch could do so without consulting M3-2's PR discussion.
++  [ ] All three new files (`Classical.Operations`, `Classical.Equations`, and the `Classical.lagda.md` umbrella update) type-check under `make check`.
++  [ ] `OperationSymbolsOf` and `ArityOf` aliases reduce definitionally to the bracket forms — `OperationSymbolsOf S ≡ ∣ S ∣` and `ArityOf {S} f ≡ ∥ S ∥ f` both inhabited by `refl`.
++  [ ] The `WARNING_ON_USAGE _̂_` pragma fires in a test module that imports the old notation, and `^` is available as the new canonical notation.  Existing `Setoid/` code continues to type-check (the warning is non-fatal).
++  [ ] Module-header prose in `Classical.Operations` and `Classical.Equations` is normative enough that a contributor authoring `Classical.Magma` from scratch can do so without consulting this PR.
 +  [ ] CHANGELOG entry under `[Unreleased] / Added`.
 
 ## References
 
 +  Parent — #260 (M3-1).
 +  Scaffold predecessor — #326 (M3-1a).
-+  Sibling — #262 (M3-3, stdlib bundle bridges; coordinates on the bundle pattern across structures).
-+  Design — [ADR-002](docs/adr/002-classical-layer-design.md).
-+  Equational-logic substrate — [`src/Setoid/Varieties/EquationalLogic.lagda.md`](src/Setoid/Varieties/EquationalLogic.lagda.md) (`Modᵗ`).
-+  Term substrate — [`src/Overture/Terms.lagda.md`](src/Overture/Terms.lagda.md) (`Term`, `ℊ`, `node`).
-+  Stdlib target for the bundle bridge — `Algebra.Bundles.Semigroup` in standard-library 2.3.
++  Design — [ADR-002 v2 §1, §3, §7](docs/adr/002-classical-layer-design.md).
++  Downstream — M3-3 (Magma, first consumer of this infrastructure), M3-4 (Semigroup, first equation-bearing consumer), M3-5 (stdlib bridges), M3-6/M3-7/M3-8 (Monoid/Group, Lattice, Ring).
++  Empirical motivation — the M3-2 (old) Semigroup load-test in branch `261-m3-2-classical-semigroup`, whose `cong (Interp 𝑨)` bridges and `assignment` plumbing live as evidence of what this infrastructure exists to remove.
++  Reference for the syntactic-vs-evaluated equation distinction — R. Bryant, *The laws of finite pointed groups*, Bull. London Math. Soc. 14 (1982), 119–123.
 
 ---
 
-### Issue M3-3: Bridges between Classical.Structures and Algebra.Bundles (#262)
+### Issue M3-3: Classical.Magma (#331)
+
+**Labels**: `enhancement`, `milestone-3-classical`
+
+## Description
+
+After [M3-2] (#330) lands, add Magma as the pattern-setting first concrete classical structure under [`Classical/`](src/Classical.lagda.md).  Magma is the right starting structure precisely because its equational theory is empty: this isolates the *signature mechanics* (operation-symbol naming, arity convention, signature assembly, signature-to-algebra interpretation) from the *equation mechanics* of subsequent structures.  Every signature convention established here propagates to Semigroup (M3-4), Monoid (M3-6), Group (M3-6), Lattice (M3-7), Ring (M3-8).
+
+Per [ADR-002 v2 §5](docs/adr/002-classical-layer-design.md), a structure with empty equational theory is encoded as `Magma α ρ = Algebra α ρ` directly — no Σ-wrapping over a trivial `⊤`-typed proof obligation.  Subsequent structures with equations follow the `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-X` pattern.
+
+This issue is the renumbered analog of the *pattern-setting* role that the original M3-2 (Semigroup) was meant to play.  The original M3-2 conflated signature mechanics with equation mechanics; the v2 ADR splits them out.
+
+## Design decisions
+
+These are normative for every subsequent structure (Semigroup in M3-4, Monoid + Group in M3-6, Lattice in M3-7, Ring in M3-8).  Per [ADR-002 v2](docs/adr/002-classical-layer-design.md).
+
++  **Signature representation**.  Named operator via a one-constructor data type: `data Op-Magma : Type where ∙-Op : Op-Magma`.  Constructor-naming convention `<symbol>-Op` (hyphen-separated, capital O).  Reserves the bare symbol for use-site infix sugar over `Curry₂ (∙-Op ^ _)`.
++  **Arity function**.  `ar-Magma ∙-Op = Fin 2`.  Naming convention: `ar-<Structure>` for the arity function of `<Structure>`'s signature.
++  **Signature value**.  `Sig-Magma : Signature lzero lzero` defined as `Sig-Magma = Op-Magma , ar-Magma`.  Hyphenated long-form name per [ADR-002 v2 §7](docs/adr/002-classical-layer-design.md); the original draft's `𝑆ₘₐ` subscript form is not adopted.
++  **No theory file**.  Magma has no equations, so no `src/Classical/Theories/Magma.lagda.md` file is created.  The umbrella `Classical.Theories` does not import a Magma theory.  Subsequent structures with theories will introduce their own `Theories/X.lagda.md` files.
++  **Σ-typed core absent**.  `Magma α ρ = Algebra α ρ` (after opening `Setoid.Algebras {𝑆 = Sig-Magma}`).  No `⊨` obligation since the theory is empty.  This is the only structure in the hierarchy with this property; from Semigroup onward, structures are Σ-typed.
++  **Named accessors next to the core**.  `Domain`, `Carrier`, `_∙_` defined alongside `Magma α ρ` to offset Σ/record-projection ergonomic cost.  `_∙_ : (𝑴 : Magma α ρ) → Carrier 𝑴 → Carrier 𝑴 → Carrier 𝑴` defined as `𝑴 ∙ a b = Curry₂ (∙-Op ^ 𝑴) a b`.  Per [ADR-002 v2 §1](docs/adr/002-classical-layer-design.md), this surfaces the operation in user-facing curried form; the tuple-indexed `∙-Op ^ 𝑴` form lives below the user interface.
++  **`fromOp` shape**.  Per-structure: `fromOp : (A : Type α) (_·_ : A → A → A) → Magma α α`.  No equation arguments because Magma's theory is empty.  Subsequent structures' `fromOp`-family constructors add an equation argument per equation in their theory.
++  **Morphisms**.  No per-structure invariant required: a magma morphism is definitionally an algebra homomorphism between the underlying `Algebra Sig-Magma`-algebras.  Per [ADR-002 v2 §5](docs/adr/002-classical-layer-design.md), this applies uniformly across the hierarchy.
++  **Worked-example placement**.  In sibling `src/Examples/Classical/Magma.lagda.md`, paralleling [ADR-002 v2 §5](docs/adr/002-classical-layer-design.md)'s policy.
+
+## Tasks
+
+### Core four-file quintuple (no theory file — see design decisions)
+
++  [ ] `src/Classical/Signatures/Magma.lagda.md` — `Op-Magma`, `ar-Magma`, `Sig-Magma : Signature lzero lzero`.
++  [ ] `src/Classical/Structures/Magma.lagda.md`:
+   +  the type-alias core `Magma α ρ = Algebra α ρ` inside `open Setoid.Algebras {𝑆 = Sig-Magma}`,
+   +  named accessors `Domain`, `Carrier`, `_∙_`,
+   +  the `fromOp` helper.
++  [ ] `src/Classical/Bundles/Magma.lagda.md` — record matching `Algebra.Bundles.Magma` from stdlib 2.3, conversion functions `⟨_⟩ₘₐ`, `⟪_⟫ₘₐ`, pointwise round-trip lemma per [ADR-002 v2 §6](docs/adr/002-classical-layer-design.md).
++  [ ] `src/Classical/Small/Structures/Magma.lagda.md` — level-fixed veneer `Magma = Classical.Structures.Magma.Magma lzero lzero`, plus the small-case `fromOp`.
+
+### Worked example
+
++  [ ] `src/Examples/Classical/Magma.lagda.md` — `(ℕ, _+_)` as `Classical.Small.Structures.Magma.Magma`, constructed via `fromOp`.  File-header prose flags this as the home of all future magma-specific examples.  No further example demands beyond this one for M3-3.
+
+### Umbrella updates
+
++  [ ] Update `src/Classical/Signatures.lagda.md` to `open import Classical.Signatures.Magma public`.
++  [ ] Update `src/Classical/Structures.lagda.md` to `open import Classical.Structures.Magma public`.
++  [ ] Update `src/Classical/Bundles.lagda.md` to `open import Classical.Bundles.Magma public`.
++  [ ] Update `src/Classical/Small/Structures.lagda.md` to `open import Classical.Small.Structures.Magma public`.  Create this aggregator if it does not exist.
++  [ ] Update `src/Examples/Classical.lagda.md` to `open import Examples.Classical.Magma`.  Create this umbrella if it does not exist.
+
+### Documentation
+
++  [ ] Module-header prose in `Classical/Structures/Magma.lagda.md` documents the conventions established here normatively, so future structures (Semigroup in M3-4, Monoid in M3-6, …) have a single normative reference for signature mechanics.  Explicitly: hyphen-separated `<symbol>-Op` constructor convention, `ar-<Structure>` arity-function convention, `Sig-<Structure>` signature-value convention, `_∙_ = Curry₂ (∙-Op ^ _)` user-facing curried-accessor convention, `fromOp`-family constructor convention.
++  [ ] `CHANGELOG.md` `[Unreleased] / Added` entry.
+
+## Non-goals
+
++  No equational theory.  Magma's defining feature is the empty theory; structures with equations are M3-4 onward.
++  No `Classical/Theories/Magma.lagda.md`.  The umbrella `Classical.Theories` remains empty after M3-3 lands; first concrete theory file is Semigroup's in M3-4.
++  No generic equation builders.  Those are M3-2.
++  No magma homomorphisms beyond the observation that they are definitionally algebra homomorphisms.
++  No free magma, magma varieties as a sub-class of varieties of `Sig-Magma`-algebras, presentations, term rewriting.  All later.
++  Additional worked examples beyond `(ℕ, +)`.  The `Examples.Classical.Magma` file is the right home for these as they accumulate.
+
+## Acceptance criteria
+
++  [ ] All new files type-check under `make check`.
++  [ ] The worked example `ℕ-magma` in `Examples.Classical.Magma` type-checks.
++  [ ] The interpretation of `∙-Op` in `ℕ-magma` reduces definitionally to `_+_` — no opacity from the `fromOp` construction or from the `Curry₂` wrapping.  Discharged by `refl`.
++  [ ] The bridge to `Algebra.Bundles.Magma` round-trips on `ℕ-magma` *pointwise*: for all `a, b : ℕ`, the round-tripped operation applied to `a, b` equals `a + b`.  Discharged by `refl` on the curried form.  Pointwise round-trip per [ADR-002 v2 §6](docs/adr/002-classical-layer-design.md); not propositional `≡` on the Σ-type.
++  [ ] Module-header prose in `Classical/Structures/Magma.lagda.md` documents the design conventions clearly enough that a contributor writing `Classical/Structures/Semigroup.lagda.md` (M3-4) from scratch could do so without consulting this PR's discussion.
++  [ ] CHANGELOG entry under `[Unreleased] / Added`.
+
+## References
+
++  Parent: [M3-1] #260 
++  Scaffold predecessor: [M3-1a] #326
++  Predecessor: [M3-2] #330
++  Successor: [M3-4] Semigroup #261 (first equation-bearing structure consuming this signature pattern).
++  Sibling: [M3-5] #262 (stdlib bundle bridges)
++  Design: [ADR-002 v2 §1, §5, §7, §8](docs/adr/002-classical-layer-design.md).
++  Stdlib target for the bundle bridge: `Algebra.Bundles.Magma` in standard-library 2.3.
+
+---
+
+### Issue M3-4: Classical.Semigroup (#261)
+
+**Labels**: `enhancement`, `milestone-3-classical`
+
+## Description
+
+After [M3-3] #331 (Magma) lands, add Semigroup as the first concrete classical structure with a non-empty equational theory.  Following [ADR-002 v2 §5](docs/adr/002-classical-layer-design.md), a semigroup is the Σ-typed structure `Semigroup α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Semigroup` over the same signature `Sig-Magma` introduced by Magma — semigroups and magmas share a signature; semigroups are precisely those magmas whose binary operation is associative.
+
+This issue is the reformulated body of #261 (originally M3-2).  The original body — which positioned Semigroup as the pattern-setting first structure with per-structure `SemigroupVar` enums and Σ-typed cores — is superseded by the v2 ADR.  The original branch `261-m3-2-classical-semigroup` is retained in repository history as evidence of the load test that motivated the v2 revisions.
+
+## Design decisions
+
+These are normative for every subsequent equation-bearing structure (Monoid in M3-6, Group in M3-6, …) and consume the conventions established in M3-2 (infrastructure) and M3-3 (Magma).  Per [ADR-002 v2](docs/adr/002-classical-layer-design.md).
+
++  **Signature reuse**.  Semigroup uses the magma signature `Sig-Magma` directly — there is no `Sig-Semigroup`.  Subsequent structures that *add* operations (Monoid adds an identity element, Group adds an inverse) get their own signature; structures that *only add equations* over a predecessor's signature reuse the predecessor's signature.
++  **Equational theory representation**.  Indexed form per [`Setoid.Varieties.EquationalLogic.Modᵗ`](src/Setoid/Varieties/EquationalLogic.lagda.md): `data Eq-Semigroup : Type where assoc : Eq-Semigroup`, with `Th-Semigroup : Eq-Semigroup → Term (Fin 3) × Term (Fin 3)` mapping `assoc` to the associativity term-pair via the generic builder `Associative ∙-Op refl 0F 1F 2F` from [`Classical.Equations`](src/Classical/Equations.lagda.md) (introduced in M3-2).
++  **Variable carrier `Fin 3`**.  Per [ADR-002 v2 §2](docs/adr/002-classical-layer-design.md).  No per-structure `SemigroupVar`-style enum.  Variable patterns at use sites are `0F`, `1F`, `2F` from `Data.Fin.Patterns`.
++  **Σ-typed core**.  `Semigroup α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] Modᵗ Th-Semigroup 𝑨` inside `open Setoid.Algebras {𝑆 = Sig-Magma}`.  Local `_⊨_` alias for `Modᵗ Th-Semigroup` is permitted but should spell out the codomain type explicitly to avoid the meta-resolution pitfall identified in the original M3-2 load test (`(Eq-Semigroup → Term (Fin 3) × Term (Fin 3))`, not `_`).
++  **Named accessors next to the core**.  `Domain`, `Carrier`, `_∙_`, `equations` defined alongside `Semigroup α ρ`.  The `_∙_` accessor delegates to `Magma._∙_` after the `semigroup→magma` forgetful, per [ADR-002 v2 §5](docs/adr/002-classical-layer-design.md).
++  **`fromPropEq` shape**.  Per-structure: `fromPropEq : (A : Type α) (_·_ : A → A → A) (·-assoc : ∀ a b c → (a · b) · c ≡ a · (b · c)) → Semigroup α α`.  Pull-up to a shared location deferred until Monoid (M3-6) confirms the shape generalizes — premature shared abstraction is the failure mode #326's non-goals warn against.
++  **`semigroup→magma` forgetful**.  `semigroup→magma : Semigroup α ρ → Magma α ρ` defined alongside the Σ-typed core, simply `proj₁`.  Per [ADR-002 v2 §5](docs/adr/002-classical-layer-design.md), forgetful projections are how the "a semigroup is a magma" inheritance manifests; subsequent structures define analogous forgetfuls (`monoid→semigroup`, `group→monoid`, etc.).
++  **Bundle bridge**.  Bidirectional `⟨_⟩ₛₘ` / `⟪_⟫ₛₘ` to `Algebra.Bundles.Semigroup` from stdlib 2.3, with a *pointwise* round-trip lemma per [ADR-002 v2 §6](docs/adr/002-classical-layer-design.md).  The Fin 2 η-bridge is contained in `Curry₂`/`Uncurry₂` from `Classical.Operations`; per-structure bridge files do not write inline `pair`-style wrappers.
++  **Worked-example placement**.  `src/Examples/Classical/Semigroup.lagda.md`, alongside the Magma example from M3-3.
+
+## Tasks
+
+### Core four-file quintuple
+
++  [ ] `src/Classical/Theories/Semigroup.lagda.md` — `Eq-Semigroup`, `Th-Semigroup` (composes `Associative ∙-Op refl 0F 1F 2F`).
++  [ ] `src/Classical/Structures/Semigroup.lagda.md`:
+   +  the Σ-typed core,
+   +  named accessors `Domain`, `Carrier`, `_∙_`, `equations`,
+   +  the `fromPropEq` helper,
+   +  the `semigroup→magma` forgetful projection.
++  [ ] `src/Classical/Bundles/Semigroup.lagda.md` — bidirectional bridge to `Algebra.Bundles.Semigroup` with pointwise round-trip.
++  [ ] `src/Classical/Small/Structures/Semigroup.lagda.md` — level-fixed veneer.
+
+### Worked example
+
++  [ ] `src/Examples/Classical/Semigroup.lagda.md` — `(ℕ, +)` as a `Classical.Small.Structures.Semigroup.Semigroup`, constructed via `fromPropEq` from stdlib's `+-assoc`.
+
+### Umbrella updates
+
++  [ ] Update `src/Classical/Theories.lagda.md` to `open import Classical.Theories.Semigroup public`.  First concrete theory module.
++  [ ] Update `src/Classical/Structures.lagda.md` to `open import Classical.Structures.Semigroup public`.
++  [ ] Update `src/Classical/Bundles.lagda.md` to `open import Classical.Bundles.Semigroup public`.
++  [ ] Update `src/Classical/Small/Structures.lagda.md` to `open import Classical.Small.Structures.Semigroup public`.
++  [ ] Update `src/Examples/Classical.lagda.md` to `open import Examples.Classical.Semigroup`.
+
+### Documentation
+
++  [ ] Module-header prose in `Classical/Structures/Semigroup.lagda.md` documents the equation-bearing-structure conventions established here normatively, complementing the signature-mechanics prose in `Classical/Structures/Magma.lagda.md` from M3-3.
++  [ ] `CHANGELOG.md` `[Unreleased] / Added` entry.
+
+## Non-goals
+
++  Pull-up of `fromPropEq` to a shared location.  Deferred until at least Monoid (M3-6) confirms the shape generalizes.
++  Pull-up of named accessors and forgetful projections to a shared location.  Same policy.
++  Generic bundle-bridge infrastructure beyond the per-structure conversion functions.  M3-5.
++  Semigroup homomorphisms beyond `semigroup→magma`-via-`Setoid.Homomorphisms`.  Per [ADR-002 v2 §5](docs/adr/002-classical-layer-design.md).
++  Free semigroups, semigroup varieties as a sub-class of varieties of `Sig-Magma`-algebras, presentations, term rewriting, decidability of the word problem.  All later.
++  Additional worked examples beyond `(ℕ, +)`.
+
+## Acceptance criteria
+
++  [ ] All new files type-check under `make check`.
++  [ ] The worked example `ℕ-semigroup` type-checks.
++  [ ] The interpretation of `∙-Op` in `ℕ-semigroup` reduces definitionally to `_+_`.  Discharged by `refl` on the curried form.
++  [ ] The bridge to `Algebra.Bundles.Semigroup` round-trips on `ℕ-semigroup` pointwise.  Discharged by `refl` on the curried form per [ADR-002 v2 §6](docs/adr/002-classical-layer-design.md).
++  [ ] The forgetful `semigroup→magma (ℕ-semigroup)` equals `ℕ-magma` (where `ℕ-magma` is from M3-3) up to the obvious equality.
++  [ ] Module-header prose in `Classical/Structures/Semigroup.lagda.md` documents the equation-bearing-structure conventions normatively.
++  [ ] CHANGELOG entry under `[Unreleased] / Added`.
+
+## References
+
++  Parent: [M3-1] #260.
++  Scaffold predecessor: [M3-1a] #326.
++  Predecessors: [M3-2] (infrastructure) #330, [M3-3] (Magma) #331.
++  Sibling:  [M3-5] (stdlib bundle bridges) #262.
++  Design: [ADR-002 v2 §2, §3, §4, §5, §6](docs/adr/002-classical-layer-design.md).
++  Empirical motivation: the original #261 branch `261-m3-2-classical-semigroup`, whose Σ-typed-with-`SemigroupVar` design surfaced the issues that the v2 ADR addresses.
++  Equational-logic substrate: [`src/Setoid/Varieties/EquationalLogic.lagda.md`](src/Setoid/Varieties/EquationalLogic.lagda.md) (`Modᵗ`).
++  Equation builder: `Associative` in [`src/Classical/Equations.lagda.md`](src/Classical/Equations.lagda.md) ([M3-2]).
++  Stdlib target for the bundle bridge: `Algebra.Bundles.Semigroup` in standard-library 2.3.
+
+---
+
+### Issue M3-5: Bridges between Classical.Structures and Algebra.Bundles (#262)
 
 **Labels**: `milestone-3-classical`, `stdlib-bridge`
+
+## v2 amendment (2026-05-17)
+
+Renumbered M3-3 → M3-5 following [revision of ADR-002 v2](https://github.com/ualib/agda-algebras/pull/332).  The original M3-2 (Semigroup pattern-setter) was split into [M3-2] (Operations + Equations infrastructure, #330), [M3-3] (Magma, #331), and M3-4 (reformulated Semigroup, this issue's predecessor in chronological order).
+
+Scope adjustment: the Magma and Semigroup bundle bridges land with their respective structure issues (M3-3 and M3-4), not in this issue.  This issue's scope is therefore reduced to Monoid, CommutativeMonoid, Group, AbelianGroup, Semilattice, Lattice, Semiring, Ring, CommutativeRing bridges — one per structure, mechanical following the patterns established in M3-3 and M3-4.
+
+The pointwise round-trip policy from [ADR-002 v2 §6](docs/adr/002-classical-layer-design.md) applies uniformly: no per-structure bundle bridge claims a propositional Σ-equality round-trip; the round-trip is stated pointwise.
+
+---
 
 ## Description
 
@@ -1504,9 +1686,23 @@ Phase 2:
 
 ---
 
-### Issue M3-4: Classical structures — Monoid, CommutativeMonoid, Group, AbelianGroup (#263)
+### Issue M3-6: Classical structures — Monoid, CommutativeMonoid, Group, AbelianGroup (#263)
 
 **Labels**: `milestone-3-classical`, `help-wanted`
+
+## v2 amendment (2026-05-17)
+
+Renumbered M3-4 → M3-6 following [revision of ADR-002 v2](https://github.com/ualib/agda-algebras/pull/332).
+
+Scope adjustment per [ADR-002 v2 §5](docs/adr/002-classical-layer-design.md): each structure is self-contained over its own signature, with forgetful projections for inheritance.  Concretely:
+
++  `Sig-Monoid` adds a nullary identity-element symbol `ε-Op` (arity `Fin 0`) to `Sig-Magma`.  `Th-Monoid` includes `assoc`, `id-l`, `id-r`.  Forgetful `monoid→semigroup`.
++  `Sig-Group` adds a unary inverse symbol `⁻¹-Op` (arity `Fin 1`) to `Sig-Monoid`.  `Th-Group` includes `assoc`, `id-l`, `id-r`, `inv-l`, `inv-r`.  Forgetful `group→monoid` (composes downward to `group→semigroup`, `group→magma`).
++  `Sig-CommutativeMonoid` and `Sig-AbelianGroup` reuse `Sig-Monoid` and `Sig-Group` respectively; the only addition is `comm` to the theory.
+
+All equations come from the generic builders in `Classical.Equations` (M3-2).  Distinguished elements (the identity, the inverse) are nullary/unary operation symbols of the signature, per [ADR-002 v2 §9](docs/adr/002-classical-layer-design.md).
+
+---
 
 ## Description
 
@@ -1528,9 +1724,19 @@ Follow the pattern established in M3-2 to add the monoid-and-group family, with 
 
 ---
 
-### Issue M3-5: Classical.Semilattice and Classical.Lattice (#264)
+### Issue M3-7: Classical.Semilattice and Classical.Lattice (#264)
 
 **Labels**: `milestone-3-classical`
+
+## v2 amendment (2026-05-17)
+
+Renumbered M3-5 → M3-7 following [revision of ADR-002 v2](https://github.com/ualib/agda-algebras/pull/332).
+
+Scope is unchanged.  Conventions inherit from M3-2 / M3-3 / M3-4: hyphen-separated `∧-Op`, `∨-Op` constructors; `Sig-Semilattice` and `Sig-Lattice` signatures; equations composed from `Associative`, `Commutative`, `Idempotent`, `Absorbs` builders in `Classical.Equations`.
+
+The "two binary ops" vs "one binary op with the other defined" representational question for Lattice — flagged in the original issue — is settled in favor of *two binary operation symbols* (`∧-Op` and `∨-Op`), consistent with the signature-extension policy: each operation that participates in the variety's equations gets its own signature symbol.
+
+---
 
 ## Description
 
@@ -1553,9 +1759,19 @@ Lattices are centrally important because `Con 𝑨` and `Sub 𝑨` are naturally
 
 ---
 
-### Issue M3-6: Classical.Ring and Classical.CommutativeRing (#265)
+### Issue M3-8: Classical.Ring and Classical.CommutativeRing (#265)
 
 **Labels**: `milestone-3-classical`, `help-wanted`
+
+## v2 amendment (2026-05-17)
+
+Renumbered M3-6 → M3-8 following [revision of ADR-002 v2](https://github.com/ualib/agda-algebras/pull/332).
+
+Scope is unchanged.  Conventions inherit from M3-6 (Monoid/Group/AbelianGroup) and from M3-7 (the precedent for multiple binary operations in one signature).
+
+`Sig-Ring` has signature symbols `+-Op` (binary), `0-Op` (nullary, the additive identity), `-Op` (unary, the additive inverse), `·-Op` (binary), `1-Op` (nullary, the multiplicative identity).  `Th-Ring` composes the abelian-group equations on `(+-Op, 0-Op, -Op)`, the monoid equations on `(·-Op, 1-Op)`, and the distributivity equations from `DistributesOverˡ`/`DistributesOverʳ`.  Forgetful `ring→abelianGroup` (additive structure) and an additional forgetful `ring→monoid` (multiplicative structure) defined alongside the core.
+
+---
 
 ## Description
 
@@ -1578,9 +1794,19 @@ Rings depend on AbelianGroup for the additive structure, so this issue comes aft
 
 ---
 
-### Issue M3-7: Expand Examples/ with worked classical-structure instances (#266)
+### Issue M3-9: Expand Examples/ with worked classical-structure instances (#266)
 
 **Labels**: `documentation`, `milestone-3-classical`
+
+## v2 amendment (2026-05-17)
+
+Renumbered M3-7 → M3-9 following [revision of ADR-002 v2](https://github.com/ualib/agda-algebras/pull/332).
+
+Scope is unchanged.  Per-structure worked examples land *with their structure issues* (M3-3 ships `ℕ-magma`; M3-4 ships `ℕ-semigroup`; M3-6 ships `ℕ-monoid` and `ℤ-group`; etc.).  This issue is therefore reduced to *cross-structure and richer examples*: free magmas, free semigroups, term-rewriting demonstrations, presentations, finite-quotient examples for use as Demos/ companion material, etc.
+
+The reduction in scope reflects the M3-3-onward convention that one canonical worked example per structure ships with the structure itself; this issue exists for the *additional* examples that wouldn't fit cleanly in any one structure's file.
+
+---
 
 ## Description
 

--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -1603,30 +1603,34 @@ The `Examples/` directory is thin.  Add worked examples that exercise the Classi
 
 ### Milestone 3 Dependencies
 
-M3-2 (Semigroup) is the pattern-setter — the design choices made there propagate to every other structure.  M3-4 (Monoid/Group) and M3-5 (Lattice) are the mid-level hubs; M3-6 (Ring) needs M3-4 because rings are abelian groups with extra structure, and M3-7 (Examples) aggregates from several of the structure issues.
+The pattern-setters are M3-2 (infrastructure), M3-3 (no-equation pattern), M3-4 (one-equation pattern) — the design choices made there propagate to every other structure.  M3-6 (Monoid/Group) and M3-7 (Lattice) are the mid-level hubs; M3-8 (Ring) needs M3-6 because rings are abelian groups with extra structure, and M3-9 (Examples) aggregates from several of the structure issues.
 
 ```mermaid
 graph TD
   M2_1["M2-1: Freeze Base"]:::ext
   M2_6["M2-6: Extract Setoid foundations"]:::ext
   M3_1["M3-1: Classical/ scaffold"]
-  M3_2["M3-2: Semigroup (pattern-setting)"]
-  M3_3["M3-3: Stdlib bridges"]
-  M3_4["M3-4: Monoid / Group"]
-  M3_5["M3-5: Lattice"]
-  M3_6["M3-6: Ring"]
-  M3_7["M3-7: Examples"]
+  M3_2["M3-2: Operations + Equations infra"]
+  M3_3["M3-3: Magma (no-equation pattern)"]
+  M3_4["M3-4: Semigroup (one-equation pattern)"]
+  M3_5["M3-5: Stdlib bridges (continued)"]
+  M3_6["M3-6: Monoid / Group"]
+  M3_7["M3-7: Lattice"]
+  M3_8["M3-8: Ring"]
+  M3_9["M3-9: Examples"]
   M2_1 --> M3_1
   M2_6 --> M3_1
   M3_1 --> M3_2
   M3_2 --> M3_3
-  M3_2 --> M3_4
-  M3_3 --> M3_5
+  M3_3 --> M3_4
   M3_4 --> M3_5
   M3_4 --> M3_6
-  M3_2 --> M3_7
-  M3_4 --> M3_7
   M3_5 --> M3_7
+  M3_6 --> M3_7
+  M3_6 --> M3_8
+  M3_4 --> M3_9
+  M3_6 --> M3_9
+  M3_7 --> M3_9
   classDef ext fill:#f0f0f0,stroke:#999,stroke-dasharray: 4 3,color:#555
 ```
 

--- a/docs/adr/002-classical-layer-design.md
+++ b/docs/adr/002-classical-layer-design.md
@@ -1,83 +1,221 @@
 <!-- File: docs/adr/002-classical-layer-design.md -->
 
-# ADR-002: Classical structures as Σ-typed cores with record-typed bundle views
+# ADR-002: Classical structures over the universal-algebra foundation
 
 ## Status
 
 Accepted — 2026-04-24.
+Revised v2 — 2026-05-17, following the M3-2 (Semigroup) load test.
 
 ---
 
 ## Context
 
-The 3.0 reconstruction adds a `src/Classical/` tree holding specific algebraic theories — semigroups, monoids, groups, lattices, rings — built on the universal-algebra foundation established in `src/Setoid/`.  Every classical structure `X` must answer three questions about its representation:
+The 3.0 reconstruction adds a `src/Classical/` tree holding specific algebraic theories — magmas, semigroups, monoids, groups, lattices, rings — built on the universal-algebra foundation in `src/Setoid/`.  This ADR records the architectural decisions that determine how each classical structure is represented, how it interoperates with the Agda standard library's `Algebra.Bundles`, how it stays portable to the eventual cubical Agda formulation (ADR-003), and — equally importantly — what set of *user-facing* affordances each structure exposes so that working with classical structures in `agda-algebras` is at least as ergonomic as working with `Algebra.Bundles` directly.
 
-1.  What is the type-theoretic shape of `X`?  A record with named projections, or a Σ-type pairing an algebra with a proof it satisfies the `X`-theory?
-2.  How does `X` interoperate with the Agda standard library's `Algebra.Bundles`?  Stdlib provides `Algebra.Bundles.Semigroup`, `Monoid`, and so on as records; anyone interoperating with stdlib-typed code must convert.
-3.  How is `X` kept portable to the eventual cubical Agda formulation (ADR-003), where the equivalence underlying the algebra becomes a path type?
+Eight interacting questions get answered below:
 
-These three questions interact.  A record-typed core is easier to read at use sites (named projections, instance arguments) but commits the library to a specific projection vocabulary that fights the stdlib-shaped bundle idiom when we want bidirectional conversion.  A Σ-typed core matches the mathematical reading "`X` *is* an algebra equipped with a proof it satisfies the `X`-theory" and is also the formulation most robust to changes in the underlying equivalence — crucial for the cubical port.
++  How is an operation symbol's interpretation represented — as a tuple-indexed function `(I → A) → A` or in curried form `A → A → A`?  The universal-algebra meta-theory requires the former for arity-uniform recursion (Birkhoff, HSP, varieties); the user-facing syntax working algebraists use is the latter (`x ∙ y`, not `pair x y`).
++  How are the variables in an equation represented at the term level?  A per-structure named-enum carrier is locally readable but proliferates across structures and leaks into bundle bridges.
++  How are equational identities represented?  A per-structure copy of associativity, identity laws, etc. is what stdlib's `Algebra.Definitions` provides at the *evaluated* level; we need an analogous library at the *syntactic* (term-pair) level so the meta-theory's `Modᵗ` can consume them.
++  How is each concrete structure related to weaker structures in the hierarchy?  Mathematically a monoid is a semigroup with an identity; type-theoretically the signature changes between levels, so direct Σ-over-predecessor nesting does not work.
++  What is the type-theoretic shape of a structure `X`?  A record with named projections or a Σ-type pairing an algebra with a proof it satisfies the `X`-theory?
++  How does `X` interoperate with `Algebra.Bundles`?  Stdlib provides `Semigroup`, `Monoid`, etc. as records; anyone interoperating with stdlib-typed code must convert.
++  What does "round trip" mean for the bundle bridge under setoid semantics?  Propositional `≡` on the Σ-type is naive — it loses to Fin n η under `--cubical-compatible`; pointwise agreement is what's mathematically meant by "the same semigroup."
++  How are distinguished elements (identity of a monoid, zero of a ring, basepoints of pointed structures) represented?
 
-A related question: what does "classical" mean in this subtree?  It does not mean "classical logic" — the library stays constructive throughout.  `Classical/` names the *tradition* of concrete algebraic structures (groups, rings, lattices) as distinct from the universal-algebraic treatment of algebras-over-a-signature that lives in `Setoid/`.  An alternative name considered was `Concrete/`; `Classical/` was retained because "classical algebraic structures" is standard terminology in the universal-algebra literature (Burris and Sankappanavar use it throughout).
+A related question: what does "classical" mean in this subtree?  It does not mean "classical logic" — the library stays constructive throughout.  `Classical/` names the *tradition* of concrete algebraic structures (groups, rings, lattices) as distinct from the universal-algebraic treatment of algebras-over-a-signature that lives in `Setoid/`.  `Classical/` was chosen over `Concrete/` because the term is standard in the universal-algebra literature (Burris and Sankappanavar use it throughout).
 
 ---
 
 ## Decision
 
-Each classical structure `X` is represented in two parallel forms:
+### 1.  Operation representation: tuple-indexed at the foundation, curried at the user interface
 
-+  **Core (Σ-typed)** at `Classical/Structures/X.agda`:
+The foundational layer — `Overture.Operations`, `Setoid.Algebras`, `Overture.Terms`, and everything downstream that participates in the universal-algebra meta-theory — uses the tuple-indexed form `(I → A) → A`.  This is non-negotiable: variety closure operators, the term algebra as a W-type, Birkhoff's HSP theorem, and the equational-logic substrate (`Modᵗ`) all recurse on arity and require operations in this form.
 
-    ```agda
-    X : (α ρ : Level) → Type _
-    X α ρ = Σ[ 𝑨 ∈ Algebra 𝑆ₓ α ρ ] 𝑨 ⊨ Eₓ
-    ```
+The user-facing layer — every accessor exported from `Classical/Structures/X` and `Classical/Bundles/X` — exposes operations in *curried* form: a binary operation as `A → A → A`, a nullary operation as `A`, a unary operation as `A → A`.  The wrappers between the two forms are provided once, generically, by `Curry`/`Uncurry` helpers in a shared `Classical.Operations` module, one helper per arity.  Per-structure files do not redefine these helpers and do not write `pair`-style wrappers inline.
 
-    where `𝑆ₓ` is the signature of `X` (in `Classical/Signatures/X.agda`) and `Eₓ` is the set of defining equations (in `Classical/Theories/X.agda`).
-+  **Bundle view (record-typed)** at `Classical/Bundles/X.agda`, matching the stdlib shape `Algebra.Bundles.X`, with bidirectional conversion functions to and from the Σ-typed core.
+The bare type-class formulation of curried operations (à la Haskell's `Num` hierarchy via Agda instance arguments) is *not* introduced in 3.0.  Instance arguments in Agda are heavier than type classes in Lean or Haskell, and the use sites we care about are served well by `open Magma 𝑴 using (_∙_)`-style named-accessor opens.  If a future revision finds that pattern too verbose, instance arguments can layer on top of the named-accessor API without re-architecting.
 
-The core is the canonical form for library-internal definitions and theorems.  The bundle view exists solely for stdlib interoperability.
+The arity-first ordering `Op : Type 𝓥 → Type α → Type (𝓥 ⊔ α)` with `Op I A = (I → A) → A` is preferred over the carrier-first alternative — `Op (Fin 2)` partially applies as "binary operation," independent of any carrier.
 
-Equations in the Σ-typed core are stated purely in terms of the `Algebra.Domain` equivalence (the setoid's `_≈_`), never in terms of propositional equality or any other setoid-specific feature.  This is the portability discipline that makes the eventual cubical port (ADR-003) mechanical.
+**Self-documenting projections for signatures**.  The Σ-type encoding of `Signature 𝓞 𝓥 = Σ (Type 𝓞) (λ Op → Op → Type 𝓥)` is mathematically clean but reads opaquely at use sites — `f : ∣ 𝑆 ∣` and `∥ 𝑆 ∥ f` do not telegraph their meaning to a reader without the encoding cached.  The `Overture.Signatures` module exposes long-form aliases:
 
-A helper `fromPropEq : (A : Type α) → ... → X α α` lets users construct classical structures from propositional-equality-based definitions without writing explicit setoid wrapping.
+```agda
+OperationSymbolsOf : Signature 𝓞 𝓥 → Type 𝓞
+OperationSymbolsOf 𝑆 = ∣ 𝑆 ∣
 
-Each classical structure ships as a quintuple: `Classical/Signatures/X.agda`, `Classical/Theories/X.agda`, `Classical/Structures/X.agda`, `Classical/Bundles/X.agda`, and a level-fixed veneer `Classical/Small/Structures/X.agda` specialized to the common `ℓ₀`–`ℓ₀` case.
+ArityOf : {𝑆 : Signature 𝓞 𝓥} → OperationSymbolsOf 𝑆 → Type 𝓥
+ArityOf {𝑆 = 𝑆} f = ∥ 𝑆 ∥ f
+```
 
-The `Small` subtree exists because most downstream consumers — finite-template CSP (M7), the finite cases that motivate FLRP intuition (M6), and tutorial-pedagogical contexts in `Examples/` and `Demos/` — will likely want the carrier and equivalence to live at `Set` rather than at a polymorphic `Set α` / `Set ρ` family.  The level polymorphism in the core is necessary for the substantive theorems but is a distraction at use sites for the small case.  Pulling the level-fixed specialization into its own subtree keeps the polymorphic core unencumbered while giving small-case users a one-import path.
+These are definitionally identical to the bracket notation.  New `Classical/` code uses the long forms by default; the bracket notation is retained indefinitely for the existing `Setoid/`-tree code and remains available everywhere.
 
+### 2.  Variable carrier for equations: `Fin n`, not per-structure named enums
+
+The variable carrier for equations in `Th-X` is `Fin n`, with `n` the number of distinct variables the equations require — `Fin 2` for commutativity, `Fin 3` for associativity, and so on.  No per-structure `<Structure>Var` enums are introduced.  Readable patterns at use sites come from `Data.Fin.Patterns` (`0F`, `1F`, `2F`); where additional readability is wanted, per-equation locally bound names inside `Theories/X` files are encouraged.
+
+The original M3-2 design (per-structure `SemigroupVar` with constructors `x`, `y`, `z`) was rejected on load-test grounds.  The per-structure enum leaked from `Classical/Theories/Semigroup` into the bundle bridge's variable-assignment machinery and into the worked-example's variable plumbing, and would have re-leaked at every subsequent structure.  Generic `Fin n` confines structure-specific naming to projections of carrier elements, where it belongs.
+
+### 3.  Equation builders: generic, parametric in signature and operation symbol
+
+A subtree `Classical/Equations/` (sibling of `Signatures/`, `Theories/`, `Structures/`, `Bundles/`, `Small/`) houses generic equation builders parametric in a signature `𝑆` and operation symbols within it.  Examples:
+
+```text
+Associative     : (f : OperationSymbolsOf 𝑆) → ArityOf f ≡ Fin 2
+                → ∀ {X} → X → X → X → Term X × Term X
+
+Commutative     : (f : OperationSymbolsOf 𝑆) → ArityOf f ≡ Fin 2
+                → ∀ {X} → X → X → Term X × Term X
+
+LeftIdentity    : (f : OperationSymbolsOf 𝑆) → ArityOf f ≡ Fin 2
+                → (e : OperationSymbolsOf 𝑆) → ArityOf e ≡ Fin 0
+                → ∀ {X} → X → Term X × Term X
+
+DistributesOverˡ : (· : OperationSymbolsOf 𝑆) → ArityOf · ≡ Fin 2
+                 → (+ : OperationSymbolsOf 𝑆) → ArityOf + ≡ Fin 2
+                 → ∀ {X} → X → X → X → Term X × Term X
+```
+
+Each per-structure `Classical/Theories/X.lagda.md` file composes these builders with `X`'s operation symbols; it does not redefine the underlying equation shapes.  `Classical.Equations` is the *syntactic dual* of stdlib's `Algebra.Definitions`, which provides the same inventory at the evaluated (carrier-quantified) level.  Having both views is genuinely additive: `Algebra.Definitions` is what `IsSemigroup.assoc` returns and what users prove for concrete algebras; `Classical.Equations` is what feeds `Modᵗ` and the variety machinery.  Neither subsumes the other.
+
+This module is the concrete answer — beyond pedagogy and corpus quality — to "why does `Classical/` exist as a parallel hierarchy rather than as a stdlib shim?"
+
+### 4.  Theory index: `Eq-X` indexes equations, not variables
+
+Each `Classical/Theories/X.lagda.md` file defines `Th-X : Eq-X → Term (Fin n) × Term (Fin n)`, where `Eq-X` is a small named enum whose constructors name the equations of `X`'s theory — `assoc`, `id-l`, `id-r`, `inv-l`, `inv-r`, `dist-l`, `dist-r`, etc.  For single-equation theories (semigroup: associativity only) the index degenerates to `⊤` rather than introducing a redundant one-constructor enum.
+
+### 5.  Structure encoding: self-contained over the structure's own signature, with forgetful projections for inheritance
+
+Each classical structure `X` is fully characterized by the pair `(Sig-X , Th-X)` — its own signature and its own complete equational theory in that signature — and is encoded as
+
+```text
+X α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-X
+```
+
+inside an `open Setoid.Algebras {𝑆 = Sig-X}` block that fixes the signature parameter.  The degenerate case `Magma α ρ = Algebra α ρ` covers the empty-theory base — no Σ wrapping a trivial `⊤`-typed proof obligation.
+
+The mathematical inheritance relationships between structures — "a monoid is a semigroup," "a group is a monoid," "a ring is an abelian group with extra structure" — are *not* encoded by Σ-nesting one structure's definition inside another.  Σ-over-predecessor was considered and rejected because each level carries a different signature: monoid adds a nullary identity symbol, group adds a unary inverse symbol, ring adds an entire second operation cluster.  Nesting would require signature-extension functors woven through every structure's definition, which is exactly the cumbersome scaffolding the user-facing layer is meant to avoid.
+
+Inheritance instead manifests as *forgetful-functor projections* defined alongside each structure: `monoid→semigroup : Monoid α ρ → Semigroup α ρ`, `group→monoid : Group α ρ → Monoid α ρ`, `ring→abelianGroup : Ring α ρ → AbelianGroup α ρ`.  Each forgetful is a small theorem: drop the operations the weaker structure does not have, and re-extract the weaker theory's equations from the stronger structure's `Th-X`.  Forgetful projections compose, so chains like `group→semigroup` are derived rather than primitive.
+
+The benefit of self-contained encoding: "what equations does a group satisfy?" has a single-location answer, `Th-Group`.  No walking up an inheritance chain to collect equations.  Trade-off: a theorem proved for semigroups applied to a group requires an explicit `theorem (group→semigroup 𝑮)` rather than `theorem (proj₁ 𝑮)`.  This is the same trade `Algebra.Bundles` makes in the standard library, on the same grounds: it keeps each structure cleanly self-describing.
+
+### 6.  Bundle bridge: pointwise equivalence, not propositional Σ-equality
+
+The bidirectional conversion functions `⟨_⟩ₓ` (Σ-core → stdlib bundle) and `⟪_⟫ₓ` (stdlib bundle → Σ-core) form a *pointwise inverse pair*: the round-tripped algebra has the same underlying setoid as the original and interprets each operation symbol identically on every input.  The round-trip is *not* claimed as an inhabitant of `_≡_` on the Σ-type — under `--cubical-compatible`, the lack of η on `Fin n`-pattern lambdas makes the operation-tuple-vs-curried repackaging propositionally but not definitionally equal, and demanding `≡` on the Σ-type forces a funext appeal that the `--safe` regime forbids.
+
+Pointwise agreement is the mathematically correct notion of "same semigroup" under setoid semantics: two semigroups are the same exactly when their underlying setoids coincide and their operations agree on every input.  Each bundle bridge module exports a `roundtrip-X` lemma stating this pointwise agreement; nothing stronger is claimed.
+
+### 7.  Notation policy
+
+**Operation-symbol interpretation**: `f ^ 𝑨` replaces `f ̂ 𝑨`.  The carrot combining-character is unicode-Tetris that breaks grep, sed, and shell-pipeline tooling; ASCII `^` survives every text-processing tool.  The two notations coexist for one minor version under a `WARNING_ON_USAGE` pragma on `̂`, then `̂` is removed.
+
+**Unicode usage across the library**: three categories, with three different policies.
+
++  *Standard mathematical notation* — `≈`, `⊨`, `⊧`, `⊫`, `≅`, `≤`, `⨅`, `≡`, the bold-italic letters denoting algebraic structures (`𝑨` for an algebra, `𝑴` for a magma, `𝑮` for a group), the script letters for level variables (`𝓞`, `𝓥`), the blackboard letters for forgetful accessors (`𝔻[_]` for `Domain`, `𝕌[_]` for `Carrier`).  These mirror conventions in McKenzie–McNulty–Taylor and Burris–Sankappanavar; algebraists recognize them on sight, and the bold-italic/Roman distinction between an algebra `𝑨` and its universe `A` is mathematically load-bearing, not decorative.  Keep.
+
++  *Subscripted Latin used to name structure-specific entities* — `𝑆ₓ`, `Thₓ`, `Eqₓ` in the original draft.  Replaced by hyphen-separated long forms: `Sig-X`, `Th-X`, `Eq-X`.  Hyphen-separated forms grep cleanly, display in any monospaced font, read aloud sensibly, and don't require an Agda-input-mode dance per occurrence.  New `Classical/` code uses the long forms exclusively.
+
++  *Bracket notation for Σ-projections* — `∣ 𝑆 ∣`, `∥ 𝑆 ∥ f`, `𝔻[ 𝑨 ]`, `𝕌[ 𝑨 ]`.  Kept available everywhere; supplemented by self-documenting long-form aliases (`OperationSymbolsOf`, `ArityOf`, `Domain`, `Carrier`) that new `Classical/` code uses by default.  No retroactive rename of existing `Setoid/` / `Overture/` code.
+
+No mass rename is performed.  The policy is: new `Classical/` code adopts the cleaner long-form conventions; the existing universal-algebra meta-theory in `Setoid/` retains its existing bracket-and-subscript notation, which is well-established reference material.
+
+### 8.  First concrete structure: Magma
+
+The pattern-setting first concrete structure under `Classical/` is `Magma`, not `Semigroup`.  Magma has an empty equational theory, which separates the *signature mechanics* (operation-symbol naming, arity convention, signature assembly) from the *equation mechanics* (term-level equations, model-of-theory predicate, generic equation builders).  Establishing signature mechanics first, in isolation, prevents the conflation that drove the original M3-2 attempt's diagnostic burden.
+
+### 9.  Distinguished elements and pointed expansions
+
+Distinguished elements of an algebra — the identity of a monoid, zero of a ring, top/bottom of a bounded lattice, basepoints of pointed structures — are represented as **nullary operation symbols** of the structure's signature.  The user-facing layer surfaces them as constants of carrier type via the `Curry₀` helper.  Equations involving distinguished elements (the monoid identity laws, the ring annihilation law) are standard term-level equations whose terms contain the nullary symbol as a leaf, via the same `Classical.Equations` builders that handle higher-arity operation symbols.
+
+This choice is mandated by the equational-logic substrate: the variety machinery (`Modᵗ`, `Th`, the closure operators) characterizes a variety as algebras satisfying a set of identities *over the signature*.  A monoid's identity element must appear in identities involving the operation `∙` (specifically, `ε ∙ x ≈ x` and `x ∙ ε ≈ x`), hence must be a syntactic symbol of the signature.  Encoding the identity as a distinguished carrier element of an algebra (rather than a signature symbol) would make those identity equations inexpressible in the variety framework.
+
+A "pointed" variant of an algebraic structure is a signature extension by an additional nullary symbol denoting the basepoint.  Concretely, a pointed group has signature
+
+```agda
+data Op-PointedGroup : Type where
+  ∙-Op ε-Op ⁻¹-Op p-Op : Op-PointedGroup
+ar-PointedGroup ∙-Op  = Fin 2
+ar-PointedGroup ε-Op  = Fin 0
+ar-PointedGroup ⁻¹-Op = Fin 1
+ar-PointedGroup p-Op  = Fin 0
+```
+
+with the basepoint `p` interpreted via `p-Op ^ 𝑮`.  The equational theory `Th-PointedGroup` includes the group axioms unchanged plus whatever equations specify the basepoint's behavior; the variety of pointed groups is, in general, *not* the same variety as ungroup-pointed groups, and known results (Bryant, *The laws of finite pointed groups*, Bull. LMS 14 (1982), 119–123; in light of Oates–Powell's finite-basis theorem for finite groups) show pointed expansions can change decidability and finite-axiomatizability properties.  The encoding accommodates the distinction without architectural change.
+
+The naming convention for nullary operation symbols mirrors the binary case: `<symbol>-Op` (`∙-Op`, `ε-Op`, `0-Op`, `1-Op`, `⊤-Op`, `⊥-Op`).  Hyphenation reads aloud the way an algebraist pronounces these — "dot-op," "epsilon-op," "zero-op" — and greps cleanly.
+
+---
+
+## Empirical revision history
+
+The original ADR-002 (2026-04-24) was authored ahead of any implementation.  The M3-2 (Semigroup) load test in 2026-05 surfaced five issues with the original design:
+
++  The per-structure `SemigroupVar` enum was conceptually load-bearing but practically leaked from `Classical/Theories/` into the bundle bridge's variable-assignment machinery, foreshadowing analogous leaks at every subsequent structure.  Generic `Fin n` resolves this (revised §2).
++  The `Fin 2` η-failure under `--cubical-compatible` forced the bundle bridge's `assoc` proof into a four-step setoid-reasoning sandwich with `cong (Interp 𝑨)` calls at two levels of nesting, even on the simplest associativity equation.  The root cause is that operation arguments enter as a tuple `(Fin 2 → A)` on one side and as curried `A → A → A` on the other; generic `Curry`/`Uncurry` helpers contain the η-bridge to one location instead of forcing it into every per-structure proof (revised §1).
++  The propositional-equality round-trip lemma did not hold even on the concrete `ℕ-semigroup`: the bundle's `_∙_` was built by partial application of `(Interp 𝑨) ⟨$⟩ (∙-Op , …)`, and the round-trip re-interpreted operation arguments through a fresh `λ {0F → … ; 1F → …}` repackaging, with no η to collapse the two.  Pointwise equivalence (revised §6) is what is mathematically meant by "same semigroup" under setoid semantics.
++  Starting the concrete-structures pipeline at Semigroup rather than Magma forced the first implementation to handle signature mechanics and equation mechanics simultaneously, with diagnostic burden distinguishing which class an error belonged to.  Magma-first (revised §8) cleanly isolates the two.
++  The original ADR did not address the representation of distinguished elements at all, leaving Monoid's identity and Ring's zero as undefined design questions.  Resolved as nullary operation symbols of the signature (new §9), with pointed-expansion semantics following the same pattern.
+
+The revisions above are the response to these findings.  No part of the original ADR's higher-level architecture (Σ-typed cores, bundle views for stdlib interop, level-fixed veneers in `Small/`, the cubical-portability discipline) is overturned.
 
 ---
 
 ## Consequences
 
-+  **Definitions read the way a universal algebraist thinks**.  "A monoid is a magma satisfying the monoid equations" is exactly what `Σ[ 𝑨 ∈ Algebra 𝑆ₘ α ρ ] 𝑨 ⊨ Eₘ` types.  This is pedagogically valuable for the library-as-training-corpus role.
-+  **`fromPropEq` bridges bare-type definitions to the Σ-typed core**.  Users with an algebraic structure presented over a bare `A : Type α` (rather than over a setoid) construct the corresponding classical structure without manually setoid-wrapping the carrier.  The return type necessarily collapses to `X α α` because propositional equality at type `A : Type α` lives in `Type α`; consumers who need `α ≠ ρ` work directly with the underlying setoid.
-+  **Stdlib interop has a fixed cost paid once per structure**.  Every `Classical/Bundles/X.agda` is a small, mechanical file: one record definition, two conversion functions, a round-trip proof.  The cost is predictable and the pattern is copy-paste.
-+  **Cubical portability is a property of the code, not a retrofit**.  Since no theorem in `Classical/Structures/X.agda` may reach for setoid-specific machinery, the 4.0 port (ADR-003) is substitutional — replace the setoid equivalence with the path type, rerun the type-checker, fix any fallout — rather than a second rewrite.  Enforcing this discipline is a design cost paid up front.
-+  **Use-site ergonomics are slightly worse than with a record-typed core**.  A proof that works against a Σ-typed monoid projects with `proj₁` and `proj₂` rather than named fields.  This is annoying in short proofs; we offset it with named convenience accessors (`Domain`, `Signature`, `equations`) defined next to each structure.
-+  **The core `Algebra` type stays a record**.  This is not inconsistent with the Σ-for-classical-structures choice: `Algebra` has multiple meaningful named projections (`Domain`, `Interp`, …) and is inhabited many times across the library; `Semigroup` naturally decomposes as "algebra + proof," which a Σ expresses directly.  The rule for future decisions is in `docs/STYLE_GUIDE.md` — record when there are three or more meaningful named projections or when stdlib interop demands it, Σ when the structure has a "bundled-together" mathematical reading.
-+  **A parallel record implementation of any classical structure is a bug**.  The `Base/Structures/Basic` vs `Base/Structures/Sigma` dual is exactly the mistake this ADR codifies against; see the STYLE_GUIDE for the explicit rule.
++  **Definitions read the way a universal algebraist thinks**.  "A semigroup is a magma satisfying associativity" is exactly what `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Semigroup` types, with `Th-Semigroup _ = Associative ∙-Op refl 0F 1F 2F`.  The generic-builder layer makes each per-structure theory file a short composition, not a re-derivation.
+
++  **The library uniquely answers what stdlib does not**.  Generic equation builders that compose to populate `Th-X` for any `X` form the syntactic dual of `Algebra.Definitions` and feed the meta-theory's `Modᵗ` in a way that stdlib's evaluated-form predicates cannot.  This is the concrete justification — beyond pedagogy and corpus quality — for `Classical/` existing as a parallel hierarchy rather than a stdlib shim.
+
++  **Curried user-facing operations match working-algebraist syntax**.  `_∙_ : A → A → A` is what `x ∙ y` expects.  Tuple-indexed operations live below the user interface, surfaced only when interfacing with the universal-algebra meta-theory.
+
++  **`fromOp`-family constructors bridge bare-type definitions to the Σ-typed core**.  Users construct a magma from `(A : Type α) → (_·_ : A → A → A)`, a semigroup additionally from `(·-assoc : ∀ a b c → (a · b) · c ≡ a · (b · c))`, a monoid additionally from `(ε : A)` and the identity laws, and so on.  The return type collapses to `X α α` because propositional equality at carrier `A : Type α` lives in `Type α`; consumers needing `α ≠ ρ` work directly with the underlying setoid.
+
++  **Stdlib bundle interop is a fixed, per-structure cost**.  Each `Classical/Bundles/X.lagda.md` is one record definition, two conversion functions, a pointwise round-trip lemma — uniformly small thanks to the generic `Curry`/`Uncurry` helpers absorbing the Fin n η-bridge once.
+
++  **Cubical portability remains substitutional**.  No theorem in `Classical/Structures/X.lagda.md` reaches for setoid-specific machinery; the 4.0 cubical port replaces the setoid equivalence with the path type and reruns the type-checker.  Pointwise equivalence at the bundle bridge survives this port unchanged.
+
++  **Use-site ergonomics are comparable to stdlib's**.  One `proj₁` to reach the underlying algebra, then named accessors (`Domain`, `Carrier`, `_∙_`, `ε`, `_⁻¹`) of the algebra.  Same projection depth as stdlib's `Group.semigroup.magma.Carrier`-style chains.
+
++  **The core `Algebra` type stays a record**.  Σ-for-classical-structures is not inconsistent: `Algebra` has multiple meaningful named projections and many inhabitants; `Semigroup` decomposes as "algebra + proof of theory" which a Σ types directly.  See `docs/STYLE_GUIDE.md` for the general record-vs-Σ rule.
+
++  **A parallel record implementation of any classical structure is a bug**.  The `Base/Structures/Basic` vs `Base/Structures/Sigma` duplication in the legacy tree is exactly the mistake this ADR codifies against.
 
 ---
 
 ## Alternatives considered
 
-+  **Record-typed core, no Σ-typed variant**.  Rejected because (i) the stdlib bundle idiom already exists and we would effectively be re-deriving it with our vocabulary, (ii) the mathematical reading is weaker, (iii) the record-typed core is more fragile under the cubical port since record projection definitions mention the underlying equivalence more intrusively than Σ projection does.
-+  **Two record variants in parallel (one library-internal, one stdlib-shaped)**.  Rejected for the same reason the `Base/Structures/Basic` + `Base/Structures/Sigma` split in the legacy tree is a maintenance hazard: two type-level representations of the same mathematical object doubles every theorem's cost.  The Σ + bundle split is not two representations of the same object; it is a canonical core with a narrow interop view.
-+  **`Classical/` built directly on `Base/` instead of `Setoid/`**.  Rejected because (i) `Base/` is frozen (ADR-001), (ii) `Base/` postulates extensionality, breaking the constructivity commitment, and (iii) `Base/`'s propositional-equality setting is not cubical-portable without further rework.
++  **Record-typed core, no Σ-typed variant**.  Rejected because stdlib's bundle idiom already exists and we would be re-deriving it; the mathematical reading is weaker; record-typed cores are more fragile under the cubical port since record projections mention the underlying equivalence more intrusively than Σ projection does.
+
++  **Two record variants in parallel (one library-internal, one stdlib-shaped)**.  Rejected: same maintenance hazard as the legacy `Base/Structures/Basic` + `Base/Structures/Sigma` split.  The Σ + bundle split is not two representations of the same object; it is a canonical core with a narrow interop view.
+
++  **`Classical/` built directly on `Base/` instead of `Setoid/`**.  Rejected because `Base/` is frozen (ADR-001), postulates extensionality (breaking the constructivity commitment), and is not cubical-portable without further rework.
+
++  **Σ-over-predecessor inheritance** (`Monoid α ρ = Σ[ 𝑺 ∈ Semigroup α ρ ] … extras`).  Considered as a way to enforce the mathematical "a monoid is a semigroup" reading at the type level.  Rejected because each level of the hierarchy carries a different signature; Σ-over-predecessor cannot smoothly accommodate signature extension.  Encoding it would require signature-extension functors woven through every structure's definition — the opposite of the user-facing-simplicity goal.  Self-contained encoding (revised §5) keeps each structure cleanly characterized by `(Sig-X , Th-X)` and expresses inheritance via forgetful projections that compose downward.
+
++  **Per-structure named-enum variable carriers** (e.g., `data SemigroupVar : Type where x y z : SemigroupVar`).  Considered for local-readability reasons.  Rejected because per-structure enums leak from `Classical/Theories/X` into bundle bridges and worked-example plumbing, and proliferate across structures.  Generic `Fin n` with `Data.Fin.Patterns`-style readability resolves the leak without sacrificing readability.
+
++  **Propositional `≡` on the Σ-type as the bundle-bridge round-trip statement**.  Considered as the natural-looking statement.  Rejected because under `--cubical-compatible` the lack of η on `Fin n`-pattern lambdas makes the operation-tuple-vs-curried repackaging propositionally but not definitionally equal, and demanding `≡` forces a funext appeal that `--safe` forbids.  Pointwise equivalence is the mathematically correct statement and types in `--safe`.
+
++  **Distinguished elements as algebra-level distinguished carrier elements rather than nullary operation symbols**.  Considered for the apparent simplicity of "a pointed group is a group with a chosen basepoint."  Rejected because the equational-logic substrate (`Modᵗ`, the variety machinery) characterizes a variety as algebras satisfying identities *over the signature*: if a distinguished element does not appear as a signature symbol, no identity can mention it, and the structure's theory cannot constrain it.  Nullary-symbol encoding (revised §9) is what makes the variety of monoids a proper variety and what makes pointed-group expansions a meaningful distinct variety.
+
++  **Mass rename of unicode in the existing `Setoid/` tree**.  Considered for consistency with the long-form-name convention adopted for new `Classical/` code.  Rejected as churn for no architectural benefit: `Setoid/` is well-established reference material, the unicode there is mostly category-1 (standard mathematical notation) anyway, and a rename would invalidate existing tutorials, papers, and external references to specific identifiers.  Policy is per-tree: new `Classical/` long-form, existing `Setoid/` retained.
 
 ---
 
 ## References
 
 +  Issue M3-1 — [Introduce the Classical/ tree](https://github.com/ualib/agda-algebras/issues/260).
-+  Issue M3-2 — `Classical.Structures.Semigroup` as the pattern-setting first structure.
-+  Issue M3-3 — Stdlib bundle bridges.
++  Issue M3-1a — [Scaffold the Classical/ tree](https://github.com/ualib/agda-algebras/issues/326).
++  Issue M3-2 — [Classical.Operations and Classical.Equations infrastructure](https://github.com/ualib/agda-algebras/issues/330).
++  Issue M3-3 — [Classical.Magma](https://github.com/ualib/agda-algebras/issues/330).
++  Issue M3-4 — [Classical.Semigroup](https://github.com/ualib/agda-algebras/issues/261) (reformulated; supersedes original body).
++  Issue M3-5 — Stdlib bundle bridges (continued).
 +  ADR-001 — `Setoid/` as canonical development tree (the foundation `Classical/` builds on).
 +  ADR-003 — Cubical Agda as the canonical long-term target (the discipline `Classical/` enforces).
-+  `docs/STYLE_GUIDE.md` — section on record vs Σ.
-+  Agda standard library, `Algebra.Bundles`.
++  `docs/STYLE_GUIDE.md` — sections on record vs Σ, on unicode usage, on long-form vs bracket projection names.
++  Agda standard library, `Algebra.Bundles` and `Algebra.Definitions`.
 +  Burris and Sankappanavar, *A Course in Universal Algebra*, chapter II.
-
-
++  R. Bryant, *The laws of finite pointed groups*, Bull. London Math. Soc. **14** (1982), 119–123 — for §9 on pointed expansions and the connection to Oates–Powell's finite-basis theorem.

--- a/docs/adr/002-classical-layer-design.md
+++ b/docs/adr/002-classical-layer-design.md
@@ -110,7 +110,7 @@ Pointwise agreement is the mathematically correct notion of "same semigroup" und
 
 ### 7.  Notation policy
 
-**Operation-symbol interpretation**: `f ^ 𝑨` replaces `f ̂ 𝑨`.  The carrot combining-character is unicode-Tetris that breaks grep, sed, and shell-pipeline tooling; ASCII `^` survives every text-processing tool.  The two notations coexist for one minor version under a `WARNING_ON_USAGE` pragma on `̂`, then `̂` is removed.
+**Operation-symbol interpretation**: `f ^ 𝑨` replaces `f ̂ 𝑨`.  The caret combining character is unicode-Tetris that breaks grep, sed, and shell-pipeline tooling; ASCII `^` survives every text-processing tool.  The two notations coexist for one minor version under a `WARNING_ON_USAGE` pragma on `̂`, then `̂` is removed.
 
 **Unicode usage across the library**: three categories, with three different policies.
 


### PR DESCRIPTION
## Summary

Major revision to ADR-002 about design and integration of classical structures.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [ ] Refactor / cleanup (user-facing/API change)
- [ ] Refactor / cleanup (no user-facing change)
- [x] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches `src/`, it targets a supported area such as `Classical/`, `Cubical/`, `Demos/`, `Examples/`, `Exercises/`, `Overture/`, or `Setoid/`.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.
