### PR TITLE
[M3-7] (Part 1 of 2) Classical Semilattice + Lattice signature/theory (#264)

### DIFF
--- a/src/Classical/Bundles.lagda.md
+++ b/src/Classical/Bundles.lagda.md
@@ -34,11 +34,12 @@ umbrellas can `public`-export every structure's witnesses without collision.
 
 module Classical.Bundles where
 
-open import Classical.Bundles.Magma public
-open import Classical.Bundles.Semigroup public
-open import Classical.Bundles.Monoid public
-open import Classical.Bundles.CommutativeSemigroup public
 open import Classical.Bundles.CommutativeMonoid public
+open import Classical.Bundles.CommutativeSemigroup public
+open import Classical.Bundles.Magma public
+open import Classical.Bundles.Monoid public
+open import Classical.Bundles.Semigroup public
+open import Classical.Bundles.Semilattice public
 ```
 
 --------------------------------------

--- a/src/Classical/Bundles/Semilattice.lagda.md
+++ b/src/Classical/Bundles/Semilattice.lagda.md
@@ -1,0 +1,95 @@
+---
+layout: default
+file: "src/Classical/Bundles/Semilattice.lagda.md"
+title: "Classical.Bundles.Semilattice module"
+date: "2026-05-27"
+author: "the agda-algebras development team"
+---
+
+### <a id="classical-bundles-semilattice">Bundle bridge for semilattices</a>
+
+This is the [Classical.Bundles.Semilattice][] module of the [Agda Universal Algebra Library][].
+
+Bridges `Classical.Structures.Semilattice` to stdlib's `Algebra.Lattice.Bundles.Semilattice`.
+`Algebra.Lattice.Bundles.Semilattice` is the *unsigned* semilattice (operation
+`_∙_`, neither meet nor join); the bridge is over `Sig-Magma` with the same
+operation.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Bundles.Semilattice where
+
+-- Imports from the Agda Standard Library -----------------------------------------
+open import Algebra.Lattice.Bundles  using () renaming ( Semilattice to stdlib-Semilattice )
+open import Data.Fin.Patterns        using ( 0F ; 1F ; 2F )
+open import Data.Product             using ( _,_ ; proj₁ )
+open import Function                 using ( Func )
+open import Level                    using ( Level )
+open import Relation.Binary          using ( Setoid )
+import Relation.Binary.PropositionalEquality as ≡
+open Func renaming ( to to _⟨$⟩_ )
+
+-- Imports from the Agda Universal Algebra Library --------------------------------
+open import Classical.Signatures.Magma         using  ( ∙-Op ; Sig-Magma )
+open import Classical.Structures.Semilattice   using  ( Semilattice ; module Semilattice-Op )
+open import Classical.Theories.Semilattice     using  ( assoc ; comm ; idem )
+open import Setoid.Algebras.Basic {𝑆 = Sig-Magma} using ( Algebra ; ⟨_⟩ ; 𝕌[_] ; 𝔻[_] )
+
+private variable α ρ : Level
+
+⟨_⟩ˢˡ : Semilattice α ρ → stdlib-Semilattice α ρ
+⟨ 𝑺 ⟩ˢˡ = record
+  { Carrier = 𝕌[ proj₁ 𝑺 ]
+  ; _≈_     = _≈_
+  ; _∙_     = _∙_
+  ; isSemilattice = record
+      { isBand = record
+          { isSemigroup = record
+              { isMagma = record { isEquivalence = isEquivalence ; ∙-cong = ∙-cong }
+              ; assoc   = assoc-law
+              }
+          ; idem    = idem-law
+          }
+      ; comm    = comm-law
+      }
+  }
+  where
+  open Semilattice-Op 𝑺
+  open Setoid 𝔻[ proj₁ 𝑺 ]
+
+⟪_⟫ˢˡ : stdlib-Semilattice α ρ → Semilattice α ρ
+⟪ S ⟫ˢˡ = 𝑨 , λ { assoc ρ → S-assoc (ρ 0F) (ρ 1F) (ρ 2F)
+                ; comm  ρ → S-comm  (ρ 0F) (ρ 1F)
+                ; idem  ρ → S-idem  (ρ 0F) }
+  where
+  open stdlib-Semilattice S
+      using ( setoid ; ∙-cong )
+      renaming ( _∙_ to _·_ ; assoc to S-assoc ; comm to S-comm ; idem to S-idem )
+
+  𝑨 : Algebra _ _
+  𝑨 = record { Domain = setoid ; Interp = interp }
+    where
+    interp : Func (⟨ Sig-Magma ⟩ setoid) setoid
+    interp ⟨$⟩ (∙-Op , args) = args 0F · args 1F
+    cong interp {∙-Op , _} {.∙-Op , _} (≡.refl , args≈) = ∙-cong (args≈ 0F) (args≈ 1F)
+
+module _ {𝑺 : Semilattice α ρ} where
+  open Semilattice-Op 𝑺
+  open Setoid 𝔻[ proj₁ 𝑺 ]
+  open Semilattice-Op ⟪ ⟨ 𝑺 ⟩ˢˡ ⟫ˢˡ renaming ( _∙_ to _∙'_ )
+
+  roundtrip-cbc-sl : (a b : 𝕌[ proj₁ 𝑺 ]) → a ∙' b ≈ a ∙ b
+  roundtrip-cbc-sl a b = refl
+
+module _ {S : stdlib-Semilattice α ρ} where
+  open stdlib-Semilattice S using ( _≈_ ; _∙_ ; refl ) renaming ( Carrier to A )
+  open stdlib-Semilattice ⟨ ⟪ S ⟫ˢˡ ⟩ˢˡ using () renaming ( _∙_ to _∙'_ )
+
+  roundtrip-bcb-sl : (a b : A) → a ∙ b ≈ a ∙' b
+  roundtrip-bcb-sl a b = refl
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Classical/Signatures.lagda.md
+++ b/src/Classical/Signatures.lagda.md
@@ -25,6 +25,7 @@ This file is the umbrella for the subtree.
 
 module Classical.Signatures where
 
+open import Classical.Signatures.Lattice public
 open import Classical.Signatures.Magma public
 open import Classical.Signatures.Monoid public
 ```

--- a/src/Classical/Signatures/Lattice.lagda.md
+++ b/src/Classical/Signatures/Lattice.lagda.md
@@ -1,0 +1,50 @@
+---
+layout: default
+file: "src/Classical/Signatures/Lattice.lagda.md"
+title: "Classical.Signatures.Lattice module"
+date: "2026-05-27"
+author: "the agda-algebras development team"
+---
+
+### <a id="classical-signatures-lattice">The signature of lattices</a>
+
+This is the [Classical.Signatures.Lattice][] module of the [Agda Universal Algebra Library][].
+
+A lattice's signature has two binary operation symbols, `∧-Op` (meet) and `∨-Op`
+(join), both of arity `Fin 2`.  This is the first signature in the
+[`Classical/`][Classical] tree with *two distinct binary symbols* and the first
+that does not extend `Sig-Magma` or `Sig-Monoid` by a single symbol — it stands
+alone, parallel to them rather than over them.  The decision to carry both symbols
+in the signature, rather than treating one as the primitive and the other as
+derived, is recorded in
+[ADR-002 v2 §5, §9](../../docs/adr/002-classical-layer-design.md): each operation
+that participates in the variety's equations gets its own signature symbol.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Signatures.Lattice where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Agda.Primitive using () renaming ( Set to Type )
+open import Data.Fin.Base  using ( Fin )
+open import Data.Product   using ( _,_ )
+open import Level          using ( 0ℓ )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture.Signatures using ( Signature )
+
+data Op-Lattice : Type where
+  ∧-Op ∨-Op : Op-Lattice
+
+ar-Lattice : Op-Lattice → Type
+ar-Lattice ∧-Op = Fin 2
+ar-Lattice ∨-Op = Fin 2
+
+Sig-Lattice : Signature 0ℓ 0ℓ
+Sig-Lattice = Op-Lattice , ar-Lattice
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Classical/Small/Structures.lagda.md
+++ b/src/Classical/Small/Structures.lagda.md
@@ -20,11 +20,12 @@ M3.  See [ADR-002][] for the design rationale.
 
 module Classical.Small.Structures where
 
-open import Classical.Small.Structures.Magma public
-open import Classical.Small.Structures.Semigroup public
-open import Classical.Small.Structures.Monoid public
-open import Classical.Small.Structures.CommutativeSemigroup public
 open import Classical.Small.Structures.CommutativeMonoid public
+open import Classical.Small.Structures.CommutativeSemigroup public
+open import Classical.Small.Structures.Magma public
+open import Classical.Small.Structures.Monoid public
+open import Classical.Small.Structures.Semigroup public
+open import Classical.Small.Structures.Semilattice public
 ```
 
 --------------------------------------

--- a/src/Classical/Small/Structures/Semilattice.lagda.md
+++ b/src/Classical/Small/Structures/Semilattice.lagda.md
@@ -1,0 +1,33 @@
+---
+layout: default
+file: "src/Classical/Small/Structures/Semilattice.lagda.md"
+title: "Classical.Small.Structures.Semilattice module"
+date: "2026-05-27"
+author: "the agda-algebras development team"
+---
+
+### Level-fixed Semilattice
+
+This is the [Classical.Small.Structures.Semilattice][] module of the [Agda Universal Algebra Library][].
+
+Specializes [`Classical.Structures.Semilattice`][] to the `0ℓ`–`0ℓ` case, mirroring
+the veneers of `Magma`, `Semigroup`, `CommutativeSemigroup`, etc.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+module Classical.Small.Structures.Semilattice where
+open import Agda.Primitive                          using () renaming ( Set to Type )
+open import Level                                   using ( 0ℓ ; suc )
+open import Relation.Binary.PropositionalEquality   using ( _≡_ )
+import Classical.Structures.Semilattice as Polymorphic
+
+Semilattice : Type (suc 0ℓ)
+Semilattice = Polymorphic.Semilattice 0ℓ 0ℓ
+
+eqsToSemilattice : (A : Type 0ℓ) (_·_ : A → A → A)
+  → (∀ a b c → (a · b) · c ≡ a · (b · c))
+  → (∀ a b → a · b ≡ b · a)
+  → (∀ a → a · a ≡ a)
+  → Semilattice
+eqsToSemilattice = Polymorphic.eqsToSemilattice
+```

--- a/src/Classical/Structures.lagda.md
+++ b/src/Classical/Structures.lagda.md
@@ -39,13 +39,14 @@ submodules are the initial, pattern-setting structures.
 
 module Classical.Structures where
 
+open import Classical.Structures.CommutativeMonoid public
+open import Classical.Structures.CommutativeSemigroup public
 open import Classical.Structures.Interpret public
 open import Classical.Structures.Magma public
+open import Classical.Structures.Monoid public
 open import Classical.Structures.Reduct public
 open import Classical.Structures.Semigroup public
-open import Classical.Structures.Monoid public
-open import Classical.Structures.CommutativeSemigroup public
-open import Classical.Structures.CommutativeMonoid public
+open import Classical.Structures.Semilattice public
 ```
 
 --------------------------------------

--- a/src/Classical/Structures/Semilattice.lagda.md
+++ b/src/Classical/Structures/Semilattice.lagda.md
@@ -1,0 +1,116 @@
+---
+layout: default
+file: "src/Classical/Structures/Semilattice.lagda.md"
+title: "Classical.Structures.Semilattice module"
+date: "2026-05-27"
+author: "the agda-algebras development team"
+---
+
+### Semilattices
+
+This is the [Classical.Structures.Semilattice][] module of the [Agda Universal Algebra Library][].
+
+A semilattice is `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Semilattice` over `Sig-Magma`.
+Equationally, a semilattice is an idempotent commutative semigroup: its theory
+extends `Th-CommutativeSemigroup` by the single `idem` equation.  The forgetful
+projection `semilattice→commutativeSemigroup` is therefore a pure theory-reindex
+(ADR-002 v2 §5): the algebra is kept; only the satisfaction proof is restricted to
+the predecessor's `assoc` and `comm` equations.  `Semilattice-Op` inherits `_∙_`,
+`∙-cong`, `interp-node`, `assoc-law`, and `comm-law` through the reindex, and adds
+the curried `idem-law`.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Semilattice where
+
+open import Agda.Primitive                          using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -----------------------------------------
+open import Data.Fin.Base                          using ( Fin )
+open import Data.Fin.Patterns                      using ( 0F ; 1F ; 2F )
+open import Data.Product                           using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
+open import Level                                  using ( Level ; _⊔_ ; suc )
+open import Relation.Binary                        using ( Setoid )
+open import Relation.Binary.PropositionalEquality  using ( _≡_ )
+
+-- Imports from the Agda Universal Algebra Library --------------------------------
+open import Classical.Signatures.Magma                 using  ( Sig-Magma )
+open import Classical.Structures.Magma                 using  ( opsToMagma )
+open import Classical.Structures.CommutativeSemigroup  using  ( CommutativeSemigroup
+                                                              ; module CommutativeSemigroup-Op )
+open import Classical.Theories.CommutativeSemigroup    using  ( Th-CommutativeSemigroup
+                                                              ; assoc ; comm )
+open import Classical.Theories.Semilattice             using  ( Eq-Semilattice
+                                                              ; Th-Semilattice ; idem )
+                                                       renaming ( assoc to assocˢˡ
+                                                                ; comm  to commˢˡ )
+open import Overture.Terms {𝑆 = Sig-Magma}             using  ( Term ; ℊ )
+open import Setoid.Algebras.Basic {𝑆 = Sig-Magma}      using  ( Algebra ; 𝔻[_] ; 𝕌[_] )
+open import Setoid.Varieties.EquationalLogic {𝑆 = Sig-Magma} using ( _⊧_≈_ )
+
+private variable α ρ : Level
+```
+
+#### <a id="satisfaction-alias">Satisfaction predicate and the type</a>
+
+```agda
+infix 4 _⊨ˢˡ_
+_⊨ˢˡ_ : (𝑨 : Algebra α ρ) (ℰ : Eq-Semilattice → Term (Fin 3) × Term (Fin 3)) → Type (α ⊔ ρ)
+𝑨 ⊨ˢˡ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
+
+Semilattice : (α ρ : Level) → Type (suc α ⊔ suc ρ)
+Semilattice α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ˢˡ Th-Semilattice
+```
+
+#### <a id="forgetful">The forgetful projection to commutative semigroups (pure reindex)</a>
+
+`Th-Semilattice` extends `Th-CommutativeSemigroup` by the single `idem` equation,
+over the same `Sig-Magma` signature; the forgetful is the identity on the underlying
+algebra and discards the `idem` witness, projecting only `assoc` and `comm`.
+
+```agda
+semilattice→commutativeSemigroup : Semilattice α ρ → CommutativeSemigroup α ρ
+semilattice→commutativeSemigroup (𝑨 , mod) = 𝑨 , λ { assoc → mod assocˢˡ
+                                                   ; comm  → mod commˢˡ }
+```
+
+#### The `Semilattice-Op` module
+
+```agda
+module Semilattice-Op {α ρ : Level} (𝑺 : Semilattice α ρ) where
+  private 𝑨 = proj₁ 𝑺
+  open Setoid 𝔻[ 𝑨 ]
+
+  -- Inherit through the (proj₁-on-algebra) reindex forgetful.
+  open CommutativeSemigroup-Op (semilattice→commutativeSemigroup 𝑺) public
+    using ( _∙_ ; ∙-cong ; interp-node ; assoc-law ; comm-law )
+
+  equations : 𝑨 ⊨ˢˡ Th-Semilattice
+  equations = proj₂ 𝑺
+
+  idem-law : ∀ x → x ∙ x ≈ x
+  idem-law x = trans (sym (interp-node (ℊ 0F) (ℊ 0F) η)) (equations idem η)
+    where η : Fin 3 → 𝕌[ 𝑨 ]
+          η = λ { 0F → x ; 1F → x ; 2F → x }
+```
+
+#### `eqsToSemilattice`
+
+```agda
+eqsToSemilattice : (A : Type α) (_·_ : A → A → A)
+  → (·-assoc : ∀ a b c → (a · b) · c ≡ a · (b · c))
+  → (·-comm  : ∀ a b → a · b ≡ b · a)
+  → (·-idem  : ∀ a → a · a ≡ a)
+  → Semilattice α α
+eqsToSemilattice A _·_ ·-assoc ·-comm ·-idem = opsToMagma A _·_ , proof
+  where
+  proof : opsToMagma A _·_ ⊨ˢˡ Th-Semilattice
+  proof assocˢˡ ρ = ·-assoc (ρ 0F) (ρ 1F) (ρ 2F)
+  proof commˢˡ  ρ = ·-comm  (ρ 0F) (ρ 1F)
+  proof idem    ρ = ·-idem  (ρ 0F)
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Classical/Theories.lagda.md
+++ b/src/Classical/Theories.lagda.md
@@ -31,10 +31,12 @@ under milestone M3, each paired with a corresponding
 
 module Classical.Theories where
 
-open import Classical.Theories.Semigroup public
-open import Classical.Theories.Monoid public
-open import Classical.Theories.CommutativeSemigroup public
 open import Classical.Theories.CommutativeMonoid public
+open import Classical.Theories.CommutativeSemigroup public
+open import Classical.Theories.Lattice public
+open import Classical.Theories.Monoid public
+open import Classical.Theories.Semigroup public
+open import Classical.Theories.Semilattice public
 ```
 
 --------------------------------------

--- a/src/Classical/Theories/Lattice.lagda.md
+++ b/src/Classical/Theories/Lattice.lagda.md
@@ -1,0 +1,69 @@
+---
+layout: default
+file: "src/Classical/Theories/Lattice.lagda.md"
+title: "Classical.Theories.Lattice module"
+date: "2026-05-27"
+author: "the agda-algebras development team"
+---
+
+### <a id="classical-theories-lattice">The equational theory of lattices</a>
+
+This is the [Classical.Theories.Lattice][] module of the [Agda Universal Algebra Library][].
+
+`Th-Lattice` has eight equations: associativity, commutativity, and idempotency for
+each of the two binary operations `∧-Op` and `∨-Op`, plus the two absorption laws
+relating them.  All equations are composed from the generic builders of
+[`Classical.Equations`][] applied to `Sig-Lattice`'s symbols.  The constructor
+names hyphenate the operation as a prefix (`∧-assoc`, `∨-comm`, …) so that the
+underlying operation is visible at every use site of the equational logic.
+
+Idempotency is included as a separate equation despite being derivable from
+absorption in any structure satisfying the rest (stdlib's `Algebra.Lattice.Structures.IsLattice`
+omits it for that reason); the presentation is uniform with `Th-Semilattice` and
+makes the bridge to `Algebra.Lattice.Bundles.Lattice`'s record cheaper in one
+direction without preventing the derivation in the other.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Theories.Lattice where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Agda.Primitive                         using () renaming ( Set to Type )
+open import Data.Fin.Base                          using ( Fin )
+open import Data.Fin.Patterns                      using ( 0F ; 1F ; 2F )
+open import Data.Product                           using ( _×_ )
+open import Relation.Binary.PropositionalEquality  using ( refl )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Classical.Signatures.Lattice           using ( Sig-Lattice ; ∧-Op ; ∨-Op )
+open import Classical.Equations                    using ( Associative ; Commutative ; Idempotent
+                                                         ; AbsorbsLeft ; AbsorbsRight )
+open import Overture.Terms {𝑆 = Sig-Lattice}       using ( Term )
+
+data Eq-Lattice : Type where
+  ∧-assoc ∧-comm ∧-idem : Eq-Lattice
+  ∨-assoc ∨-comm ∨-idem : Eq-Lattice
+  absorbˡ absorbʳ       : Eq-Lattice
+
+Th-Lattice : Eq-Lattice → Term (Fin 3) × Term (Fin 3)
+Th-Lattice ∧-assoc = Associative  ∧-Op refl 0F 1F 2F
+Th-Lattice ∧-comm  = Commutative  ∧-Op refl 0F 1F
+Th-Lattice ∧-idem  = Idempotent   ∧-Op refl 0F
+Th-Lattice ∨-assoc = Associative  ∨-Op refl 0F 1F 2F
+Th-Lattice ∨-comm  = Commutative  ∨-Op refl 0F 1F
+Th-Lattice ∨-idem  = Idempotent   ∨-Op refl 0F
+Th-Lattice absorbˡ = AbsorbsLeft  ∧-Op ∨-Op refl refl 0F 1F
+Th-Lattice absorbʳ = AbsorbsRight ∧-Op ∨-Op refl refl 0F 1F
+```
+
+Unfolding the absorption builders (per [`Classical.Equations`][]):
+`Th-Lattice absorbˡ` is the pair
+`(node ∧-Op (pair (ℊ 0F) (node ∨-Op (pair (ℊ 0F) (ℊ 1F)))) , ℊ 0F)` — i.e.
+`x ∧ (x ∨ y) ≈ x` — and `Th-Lattice absorbʳ` is
+`(node ∨-Op (pair (node ∧-Op (pair (ℊ 0F) (ℊ 1F))) (ℊ 0F)) , ℊ 0F)` — i.e.
+`(x ∧ y) ∨ x ≈ x`.
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Classical/Theories/Semilattice.lagda.md
+++ b/src/Classical/Theories/Semilattice.lagda.md
@@ -1,0 +1,44 @@
+---
+layout: default
+file: "src/Classical/Theories/Semilattice.lagda.md"
+title: "Classical.Theories.Semilattice module"
+date: "2026-05-27"
+author: "the agda-algebras development team"
+---
+
+### The equational theory of semilattices
+
+This is the [Classical.Theories.Semilattice][] module of the [Agda Universal Algebra Library][].
+
+A semilattice is an idempotent commutative semigroup: its theory adds idempotency to
+commutativity and associativity, over the same `Sig-Magma` signature (no new symbols).
+`Th-Semilattice` therefore has three equations, all composed from the generic builders
+of [`Classical.Equations`][].
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Theories.Semilattice where
+
+open import Agda.Primitive                         using () renaming ( Set to Type )
+open import Data.Fin.Base                          using ( Fin )
+open import Data.Fin.Patterns                      using ( 0F ; 1F ; 2F )
+open import Data.Product                           using ( _×_ )
+open import Relation.Binary.PropositionalEquality  using ( refl )
+
+open import Classical.Signatures.Magma             using ( Sig-Magma ; ∙-Op )
+open import Classical.Equations                    using ( Associative ; Commutative ; Idempotent )
+open import Overture.Terms {𝑆 = Sig-Magma}         using ( Term )
+
+data Eq-Semilattice : Type where
+  assoc comm idem : Eq-Semilattice
+
+Th-Semilattice : Eq-Semilattice → Term (Fin 3) × Term (Fin 3)
+Th-Semilattice assoc = Associative ∙-Op refl 0F 1F 2F
+Th-Semilattice comm  = Commutative ∙-Op refl 0F 1F
+Th-Semilattice idem  = Idempotent  ∙-Op refl 0F
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Examples/Classical.lagda.md
+++ b/src/Examples/Classical.lagda.md
@@ -24,11 +24,12 @@ and continues issue-by-issue under milestone M3.
 
 module Examples.Classical where
 
-open import Examples.Classical.Magma public
-open import Examples.Classical.Semigroup public
-open import Examples.Classical.Monoid public
-open import Examples.Classical.CommutativeMonoid public
 open import Examples.Classical.CommutativeSemigroup public
+open import Examples.Classical.CommutativeMonoid public
+open import Examples.Classical.Magma public
+open import Examples.Classical.Monoid public
+open import Examples.Classical.Semigroup public
+open import Examples.Classical.Semilattice public
 ```
 
 --------------------------------------

--- a/src/Examples/Classical/Semilattice.lagda.md
+++ b/src/Examples/Classical/Semilattice.lagda.md
@@ -1,0 +1,41 @@
+---
+layout: default
+file: "src/Examples/Classical/Semilattice.lagda.md"
+title: "Examples.Classical.Semilattice module"
+date: "2026-05-27"
+author: "the agda-algebras development team"
+---
+
+### Worked Example: `(Bool, _∧_)` as a semilattice
+
+This is the [Examples.Classical.Semilattice][] module of the [Agda Universal Algebra Library][].
+
+Booleans under conjunction form the canonical small semilattice — idempotent,
+commutative, associative.  Built directly from stdlib's `∧-assoc`, `∧-comm`,
+`∧-idem` in `Data.Bool.Properties`.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+module Examples.Classical.Semilattice where
+
+open import Data.Bool                              using ( Bool ; _∧_ )
+open import Data.Bool.Properties                   using ( ∧-assoc ; ∧-comm ; ∧-idem )
+open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl )
+
+open import Classical.Small.Structures.Semilattice
+  using ( Semilattice ; eqsToSemilattice )
+
+import Classical.Structures.Semilattice as Polymorphic
+
+Bool-meet-semilattice : Semilattice
+Bool-meet-semilattice = eqsToSemilattice Bool _∧_ ∧-assoc ∧-comm ∧-idem
+
+open Polymorphic.Semilattice-Op Bool-meet-semilattice using ( _∙_ )
+
+∙-is-∧-sl : ∀ (a b : Bool) → a ∙ b ≡ a ∧ b
+∙-is-∧-sl a b = refl
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}


### PR DESCRIPTION
## Summary

First of two PRs closing **M3-7** (#264). Adds the **Semilattice quintuple** — idempotent commutative semigroup over `Sig-Magma` — and the bare bones (**signature + theory**) of **Lattice**. The Lattice structure, bundle, small veneer, example, and the meet-join / order-theoretic equivalence theorem (the acceptance criterion) follow in PR-2.

## Contents

**Semilattice** (full quintuple, over `Sig-Magma`):

- `src/Classical/Theories/Semilattice.lagda.md` — `Eq-Semilattice = assoc | comm | idem`, `Th-Semilattice` from `Associative`/`Commutative`/`Idempotent`
- `src/Classical/Structures/Semilattice.lagda.md` — `Semilattice α ρ`, `_⊨ˢˡ_`, `semilattice→commutativeSemigroup` (pure reindex), `Semilattice-Op` adding `idem-law`, `eqsToSemilattice`
- `src/Classical/Bundles/Semilattice.lagda.md` — bridge to `Algebra.Lattice.Bundles.Semilattice`
- `src/Classical/Small/Structures/Semilattice.lagda.md` — `0ℓ`–`0ℓ` veneer
- `src/Examples/Classical/Semilattice.lagda.md` — `(Bool, _∧_)` via `Data.Bool.Properties`

**Lattice** (signature + theory only; structure/bundle/veneer/example/properties in PR-2):

- `src/Classical/Signatures/Lattice.lagda.md` — `Op-Lattice = ∧-Op | ∨-Op`, both binary
- `src/Classical/Theories/Lattice.lagda.md` — eight equations: assoc/comm/idem for each operation, `AbsorbsLeft`, `AbsorbsRight`

**Umbrellas** updated to re-export the new modules.

## Design notes

- **Semilattice as theory-only extension.** Per ADR-002 v2 §5, `semilattice→commutativeSemigroup` is the identity on the underlying algebra and just restricts the satisfaction proof to `assoc` and `comm`. `Semilattice-Op` consequently inherits `_∙_`, `∙-cong`, `interp-node`, `assoc-law`, `comm-law` through the forgetful and adds only the curried `idem-law`. No new infrastructure required.
- **Two-symbol lattice signature.** `Sig-Lattice` carries both `∧-Op` and `∨-Op` rather than treating one as primitive and the other as derived, per ADR-002 v2 §5/§9 — each operation participating in the variety's equations gets its own signature symbol. Settled by the issue v2 amendment.
- **Idempotency in `Th-Lattice`.** Kept as a separate equation despite being derivable from absorption (stdlib's `Algebra.Lattice.Structures.IsLattice` omits it for that reason). The presentation is uniform with `Th-Semilattice` and makes the forward bridge to `Algebra.Lattice.Bundles.Lattice` (in PR-2) cheaper; the derivation in the converse direction remains a few lines.
- **No new `Curry₃`, no two-symbol `interp-node`.** The absorption laws nest two operation symbols at the term level, but the curried laws (`∀ x y → x ∧ (x ∨ y) ≈ x`) are still binary-in-variables, so `Curry₂` suffices. The term-to-curried bridge is two compositions of single-symbol `interp-cong` calls (one per operation), matching the existing `Monoid-Op` pattern; no new primitive needed in `Classical/Structures/Interpret`.

## Acceptance criteria (from #264) — status

- [x] Semilattice type-checks (this PR)
- [ ] Lattice type-checks — PR-2
- [ ] Meet-join / order-theoretic equivalence theorem proved — PR-2
- [ ] Bridge to stdlib round-trips on `𝟚` as a Boolean lattice — PR-2

## Deferred to PR-2

- `Classical/Structures/Lattice.lagda.md` — the Σ-core with `Lattice-Op` (the two `interp-node-{∧,∨}` lemmas, eight curried laws, `eqsToLattice`)
- `Classical/Bundles/Lattice.lagda.md` — bridge to `Algebra.Lattice.Bundles.Lattice`
- `Classical/Small/Structures/Lattice.lagda.md`
- `Examples/Classical/Lattice.lagda.md` — `𝟚` as a Boolean lattice, round-tripping through the stdlib bridge
- `Classical/Properties/Lattice.lagda.md` — the meet-join / order-theoretic equivalence theorem; introduces a new `Classical/Properties/` directory as an extension point for future per-structure derived results (open architectural decision pending design exchange)

---

## Type of change

- [ ] Bug fix
- [x] New definition, theorem, or feature
- [ ] Refactor / cleanup (user-facing/API change)
- [ ] Refactor / cleanup (no user-facing change)
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches `src/`, it targets a supported area such as `Classical/`, `Cubical/`, `Demos/`, `Examples/`, `Exercises/`, `Overture/`, or `Setoid/`.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.

