### PR TITLE
[M3-7] PR-2/2: Classical Lattice structure + order-theoretic equivalence (#264)

### DIFF
--- a/docs/adr/002-classical-layer-design.md
+++ b/docs/adr/002-classical-layer-design.md
@@ -6,6 +6,7 @@
 
 Accepted — 2026-04-24.
 Revised v2 — 2026-05-17, following the M3-2 (Semigroup) load test.
+Amended v2.1 — 2026-05-28, adds §10 on `Classical/Properties/` following the M3-7 (Lattice) order-theoretic equivalence work.
 
 ---
 
@@ -147,6 +148,16 @@ with the basepoint `p` interpreted via `p-Op ^ 𝑮`.  The equational theory `Th
 
 The naming convention for nullary operation symbols mirrors the binary case: `<symbol>-Op` (`∙-Op`, `ε-Op`, `0-Op`, `1-Op`, `⊤-Op`, `⊥-Op`).  Hyphenation reads aloud the way an algebraist pronounces these — "dot-op," "epsilon-op," "zero-op" — and greps cleanly.
 
+### 10.  `Classical/Properties/` for derived results
+
+A sixth subtree `Classical/Properties/` (sibling of `Signatures/`, `Theories/`, `Structures/`, `Bundles/`, `Small/`) houses *derived* results about classical structures — theorems that are properties of a fixed inhabitant of one of the structures defined in `Classical/Structures/`, rather than part of the structure's definition.  Each per-structure file `Classical/Properties/X.lagda.md` consumes `X-Op`'s curried accessors and proves further facts about a parameterized `(𝑿 : X α ρ)`.
+
+The inaugural inhabitant is `Classical.Properties.Lattice`, which proves the meet-join / order-theoretic equivalence: the partial order `x ≤ y := x ∧ y ≈ x` induced by the algebraic data, with the partial-order witnesses and the proof that `_∧_` and `_∨_` are the binary meet and join with respect to it.  Future inhabitants of this subtree include, for example, uniqueness of inverses in `Classical.Properties.Group`, `0 · x ≈ 0` in `Classical.Properties.Ring`, and the order-induced semilattice on a `Semilattice`.
+
+Unlike the five quintuple subtrees, `Classical/Properties/` is *sparse*: per-structure files are added only as concrete derived results accrue, not maintained as a uniform one-file-per-structure shape.  An umbrella aggregator `Classical.Properties` re-exports each per-structure file as it lands.
+
+The decision to organize by *concern* (a top-level `Classical/Properties/` directory housing per-structure files) rather than by *structure* (per-structure subdirectories such as `Classical/Lattice/Properties.lagda.md`) was made for consistency with the existing tree's organization: every other file in `Classical/` lives under a concern-named directory, with the structure as the leaf name.  Per-structure subdirectories for properties alone would mix two organizing axes and create an asymmetry a reader would have to memorize.  The choice also mirrors stdlib's `Algebra.Lattice.Properties.Lattice` layout.
+
 ---
 
 ## Empirical revision history
@@ -203,6 +214,9 @@ The revisions above are the response to these findings.  No part of the original
 
 +  **Mass rename of unicode in the existing `Setoid/` tree**.  Considered for consistency with the long-form-name convention adopted for new `Classical/` code.  Rejected as churn for no architectural benefit: `Setoid/` is well-established reference material, the unicode there is mostly category-1 (standard mathematical notation) anyway, and a rename would invalidate existing tutorials, papers, and external references to specific identifiers.  Policy is per-tree: new `Classical/` long-form, existing `Setoid/` retained.
 
++  **Per-structure `Classical/<X>/Properties.lagda.md` subdirectories** (e.g. `Classical/Lattice/Properties.lagda.md`).  Considered as a layout option for derived results when M3-7's lattice order-theoretic equivalence motivated the first Properties module.  Rejected for organizational uniformity: the existing tree organizes strictly by concern (one axis = concern as directory, leaf = structure), and per-structure subdirectories for properties alone would mix two organizing axes (concern-as-directory for everything else, structure-as-directory only for properties).  By-concern (§10) keeps the existing pattern uniform and mirrors stdlib's layout.
+
+
 ---
 
 ## References
@@ -213,6 +227,7 @@ The revisions above are the response to these findings.  No part of the original
 +  Issue M3-3 — [Classical.Magma](https://github.com/ualib/agda-algebras/issues/330).
 +  Issue M3-4 — [Classical.Semigroup](https://github.com/ualib/agda-algebras/issues/261) (reformulated; supersedes original body).
 +  Issue M3-5 — Stdlib bundle bridges (continued).
++  Issue M3-7 — [Classical.Semilattice and Classical.Lattice](https://github.com/ualib/agda-algebras/issues/264) (the order-theoretic equivalence motivating §10).
 +  ADR-001 — `Setoid/` as canonical development tree (the foundation `Classical/` builds on).
 +  ADR-003 — Cubical Agda as the canonical long-term target (the discipline `Classical/` enforces).
 +  `docs/STYLE_GUIDE.md` — sections on record vs Σ, on unicode usage, on long-form vs bracket projection names.

--- a/src/Classical.lagda.md
+++ b/src/Classical.lagda.md
@@ -10,39 +10,77 @@ author: "the agda-algebras development team"
 
 This is the [Classical][] module of the [Agda Universal Algebra Library][].
 
-The `Classical/` tree formalizes specific algebraic theories — semigroups, monoids, groups, lattices, rings, and so on — over the universal-algebra foundation laid down in [`Setoid/`][Setoid] (see [ADR-001][ADR-001]).  The word *classical* names the long-standing tradition of concrete algebraic structures, as distinct from the universal-algebraic treatment of algebras-over-a-signature; it carries no commitment to classical logic, which the library does not assume.  The design of this tree is recorded in [ADR-002][ADR-002].
+The `Classical/` tree formalizes specific algebraic theories — semigroups, monoids,
+groups, lattices, rings, and so on — over the universal-algebra foundation laid down
+in [`Setoid/`][Setoid] (see [ADR-001][ADR-001]).  The word *classical* names the
+long-standing tradition of concrete algebraic structures, as distinct from the
+universal-algebraic treatment of algebras-over-a-signature; it carries no commitment
+to classical logic, which the library does not assume.  The design of this tree is
+recorded in [ADR-002][ADR-002].
 
 ### Quintuple-per-structure organization
 
 Each concrete structure `X` ships as a quintuple of files, organized into five parallel subtrees:
 
 +  [`Classical/Signatures`][Classical.Signatures] — the signature `𝑆ₓ` whose operations `X` interprets.
-+  [`Classical/Theories`][Classical.Theories] — the set of defining equations `Eₓ` that pick `X` out of the class of `𝑆ₓ`-algebras.
-+  [`Classical/Structures`][Classical.Structures] — the Σ-typed core `X α ρ = Σ[ 𝑨 ∈ Algebra 𝑆ₓ α ρ ] 𝑨 ⊨ Eₓ`, the canonical form for library-internal use.
-+  [`Classical/Bundles`][Classical.Bundles] — a parallel record-typed bundle view matching the shape of `Algebra.Bundles.X` in the Agda standard library, with bidirectional conversion to and from the Σ-typed core.
-+  [`Classical/Small`][Classical.Small] — a level-fixed veneer specialized to the `ℓ₀`–`ℓ₀` case, for downstream consumers (finite-template CSP, FLRP intuition, tutorial contexts) that do not need polymorphism.
 
-The first axis — Signatures, Theories, Structures, Bundles, Small — is orthogonal to the second axis, which is the specific structure under consideration.  This is the relationship to [`Setoid/`][Setoid]: `Setoid/Algebras`, `Setoid/Homomorphisms`, `Setoid/Terms`, `Setoid/Subalgebras`, `Setoid/Varieties` factor the universal-algebra core into parallel themes parameterized by a single signature, whereas `Classical/` instantiates concrete structures whose signatures are fixed inside the per-structure file.  The two trees compose: every classical structure is a `Setoid/`-algebra equipped with a satisfaction proof.
++  [`Classical/Theories`][Classical.Theories] — the set of defining equations `Eₓ`
+   that pick `X` out of the class of `𝑆ₓ`-algebras.
+
++  [`Classical/Structures`][Classical.Structures] — the Σ-typed core
+   `X α ρ = Σ[ 𝑨 ∈ Algebra 𝑆ₓ α ρ ] 𝑨 ⊨ Eₓ`, the canonical form for library-internal use.
+
++  [`Classical/Bundles`][Classical.Bundles] — a parallel record-typed bundle view
+   matching the shape of `Algebra.Bundles.X` in the Agda standard library, with
+   bidirectional conversion to and from the Σ-typed core.
+
++  [`Classical/Small`][Classical.Small] — a level-fixed veneer specialized to the
+   `ℓ₀`–`ℓ₀` case, for downstream consumers (finite-template CSP, FLRP intuition,
+   tutorial contexts) that do not need polymorphism.
+
+The five subtrees above are the *constituent* files of each structure.  A sixth
+parallel subtree — [`Classical/Properties`][Classical.Properties] — collects
+*derived* results: theorems about a fixed inhabitant of one of the structures (the
+order-theoretic view of a lattice, uniqueness of inverses in a group, `0 · x ≈ 0` in
+a ring) rather than part of the structure's definition.  Properties is sparser than
+the quintuple subtrees; it accretes per structure as concrete derived results land.
+
+The first axis — Signatures, Theories, Structures, Bundles, Small (plus Properties
+for derived results) — is orthogonal to the second axis, which is the specific
+structure under consideration.
+
 
 ### Cubical portability discipline
 
-Equations in the Σ-typed core are stated purely in terms of the `Algebra.Domain` setoid equivalence — never in terms of propositional equality or any other setoid-specific feature.  This discipline makes the eventual port to cubical Agda ([ADR-003][ADR-003]) substitutional rather than rewriting: replacing the setoid equivalence by the path type and rerunning the type-checker should be sufficient for most of the tree.
+Equations in the Σ-typed core are stated purely in terms of the `Algebra.Domain`
+setoid equivalence — never in terms of propositional equality or any other
+setoid-specific feature.  This discipline makes the eventual port to cubical Agda
+([ADR-003][ADR-003]) substitutional rather than rewriting: replacing the setoid
+equivalence by the path type and rerunning the type-checker should be sufficient for
+most of the tree.
 
 ### Scaffold status
 
-This file is the umbrella for the `Classical/` tree.  At the moment this scaffold lands, the five subtree aggregators below exist but are empty; concrete structures arrive issue-by-issue under milestone M3 (#260, with M3-2 onward landing one structure each).  See [`docs/GITHUB_PROJECT.md`][ROADMAP] for the milestone plan.
+This file is the umbrella for the `Classical/` tree.  At the moment this scaffold
+lands, the five quintuple subtree aggregators below exist but are empty; concrete
+structures arrive issue-by-issue under milestone M3 (#260, with M3-2 onward landing
+one structure each).  The `Properties` aggregator is added later (M3-7) as the first
+per-structure derived-results module lands.
+
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Classical where
 
-open import Classical.Operations  public
-open import Classical.Equations   public
-open import Classical.Signatures  public
-open import Classical.Theories    public
-open import Classical.Structures  public
 open import Classical.Bundles     public
+open import Classical.Equations   public
+open import Classical.Operations  public
+open import Classical.Properties  public
+open import Classical.Signatures  public
+open import Classical.Structures  public
+open import Classical.Theories    public
+
 open import Classical.Small
 ```
 

--- a/src/Classical.lagda.md
+++ b/src/Classical.lagda.md
@@ -61,11 +61,10 @@ most of the tree.
 
 ### Scaffold status
 
-This file is the umbrella for the `Classical/` tree.  At the moment this scaffold
-lands, the five quintuple subtree aggregators below exist but are empty; concrete
-structures arrive issue-by-issue under milestone M3 (#260, with M3-2 onward landing
-one structure each).  The `Properties` aggregator is added later (M3-7) as the first
-per-structure derived-results module lands.
+This file is the umbrella for the `Classical/` tree.  The five quintuple subtree
+aggregators below re-export concrete structures as they land under milestone M3,
+and the `Properties` aggregator was added in M3-7 for per-structure
+derived-results modules.
 
 
 ```agda

--- a/src/Classical/Bundles.lagda.md
+++ b/src/Classical/Bundles.lagda.md
@@ -36,6 +36,7 @@ module Classical.Bundles where
 
 open import Classical.Bundles.CommutativeMonoid public
 open import Classical.Bundles.CommutativeSemigroup public
+open import Classical.Bundles.Lattice public
 open import Classical.Bundles.Magma public
 open import Classical.Bundles.Monoid public
 open import Classical.Bundles.Semigroup public

--- a/src/Classical/Bundles/Lattice.lagda.md
+++ b/src/Classical/Bundles/Lattice.lagda.md
@@ -11,9 +11,9 @@ author: "the agda-algebras development team"
 This is the [Classical.Bundles.Lattice][] module of the [Agda Universal Algebra Library][].
 
 Bridges `Classical.Structures.Lattice` to stdlib's `Algebra.Lattice.Bundles.Lattice`.
-This is the first bundle bridge with two distinct binary operations and the
-first whose stdlib target lives in `Algebra.Lattice.Bundles` (rather than
-`Algebra.Bundles`).
+This is the first bundle bridge with two distinct binary operations; like the
+Semilattice bridge, its stdlib target lives in `Algebra.Lattice.Bundles` rather
+than `Algebra.Bundles`.
 
 Two derivations cross the bridge.  The forward direction (`⟨_⟩ˡᵃ`) needs the
 stdlib-canonical absorption form `∨ Absorbs ∧` — i.e. `x ∨ (x ∧ y) ≈ x` — from

--- a/src/Classical/Bundles/Lattice.lagda.md
+++ b/src/Classical/Bundles/Lattice.lagda.md
@@ -1,0 +1,140 @@
+---
+layout: default
+file: "src/Classical/Bundles/Lattice.lagda.md"
+title: "Classical.Bundles.Lattice module"
+date: "2026-05-28"
+author: "the agda-algebras development team"
+---
+
+### <a id="classical-bundles-lattice">Bundle bridge for lattices</a>
+
+This is the [Classical.Bundles.Lattice][] module of the [Agda Universal Algebra Library][].
+
+Bridges `Classical.Structures.Lattice` to stdlib's `Algebra.Lattice.Bundles.Lattice`.
+This is the first bundle bridge with two distinct binary operations and the
+first whose stdlib target lives in `Algebra.Lattice.Bundles` (rather than
+`Algebra.Bundles`).
+
+Two derivations cross the bridge.  The forward direction (`⟨_⟩ˡᵃ`) needs the
+stdlib-canonical absorption form `∨ Absorbs ∧` — i.e. `x ∨ (x ∧ y) ≈ x` — from
+our `absorbʳ-law` (which has the form `(x ∧ y) ∨ x ≈ x`); this is one ∨-comm
+step.  The reverse direction (`⟪_⟫ˡᵃ`) needs `∧-idem`, `∨-idem`, and the form
+`(x ∧ y) ∨ x ≈ x` from a stdlib lattice's `absorptive` (which provides
+`x ∨ (x ∧ y) ≈ x` and `x ∧ (x ∨ y) ≈ x`); the idempotencies are the standard
+two-step derivation from absorption, the absorbʳ form is one ∨-comm step.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Bundles.Lattice where
+
+-- Imports from the Agda Standard Library -----------------------------------------
+open import Algebra.Lattice.Bundles  using () renaming ( Lattice to stdlib-Lattice )
+open import Data.Fin.Patterns        using ( 0F ; 1F ; 2F )
+open import Data.Product             using ( _,_ ; proj₁ ; proj₂ )
+open import Function                 using ( Func )
+open import Level                    using ( Level )
+open import Relation.Binary          using ( Setoid )
+import Relation.Binary.PropositionalEquality as ≡
+open Func renaming ( to to _⟨$⟩_ )
+
+-- Imports from the Agda Universal Algebra Library --------------------------------
+open import Classical.Signatures.Lattice             using  ( ∧-Op ; ∨-Op ; Sig-Lattice )
+open import Classical.Structures.Lattice             using  ( Lattice ; module Lattice-Op )
+open import Classical.Theories.Lattice               using  ( ∧-assoc ; ∧-comm ; ∧-idem
+                                                            ; ∨-assoc ; ∨-comm ; ∨-idem
+                                                            ; absorbˡ ; absorbʳ )
+open import Setoid.Algebras.Basic {𝑆 = Sig-Lattice}  using  ( Algebra ; ⟨_⟩ ; 𝕌[_] ; 𝔻[_] )
+
+private variable α ρ : Level
+
+⟨_⟩ˡᵃ : Lattice α ρ → stdlib-Lattice α ρ
+⟨ 𝑳 ⟩ˡᵃ = record
+  { Carrier = 𝕌[ proj₁ 𝑳 ]
+  ; _≈_     = _≈_
+  ; _∨_     = _∨_
+  ; _∧_     = _∧_
+  ; isLattice = record
+      { isEquivalence = isEquivalence
+      ; ∨-comm        = ∨-comm-law
+      ; ∨-assoc       = ∨-assoc-law
+      ; ∨-cong        = ∨-cong
+      ; ∧-comm        = ∧-comm-law
+      ; ∧-assoc       = ∧-assoc-law
+      ; ∧-cong        = ∧-cong
+      ; absorptive    = ∨-absorbs-∧ , absorbˡ-law
+      }
+  }
+  where
+  open Lattice-Op 𝑳
+  open Setoid 𝔻[ proj₁ 𝑳 ]
+
+  -- stdlib's first absorption is x ∨ (x ∧ y) ≈ x; our absorbʳ-law is (x ∧ y) ∨ x ≈ x.
+  ∨-absorbs-∧ : ∀ x y → (x ∨ (x ∧ y)) ≈ x
+  ∨-absorbs-∧ x y = trans (∨-comm-law x (x ∧ y)) (absorbʳ-law x y)
+
+⟪_⟫ˡᵃ : stdlib-Lattice α ρ → Lattice α ρ
+⟪ L ⟫ˡᵃ = 𝑨 , λ { ∧-assoc ρ → L-∧-assoc (ρ 0F) (ρ 1F) (ρ 2F)
+                ; ∧-comm  ρ → L-∧-comm  (ρ 0F) (ρ 1F)
+                ; ∧-idem  ρ → ∧-idem-derived (ρ 0F)
+                ; ∨-assoc ρ → L-∨-assoc (ρ 0F) (ρ 1F) (ρ 2F)
+                ; ∨-comm  ρ → L-∨-comm  (ρ 0F) (ρ 1F)
+                ; ∨-idem  ρ → ∨-idem-derived (ρ 0F)
+                ; absorbˡ ρ → L-∧-absorbs-∨ (ρ 0F) (ρ 1F)
+                ; absorbʳ ρ → absorbʳ-derived (ρ 0F) (ρ 1F)
+                }
+  where
+  open stdlib-Lattice L
+      using ( setoid ; ∧-cong ; ∨-cong )
+      renaming ( _∨_ to _∨'_ ; _∧_ to _∧'_
+               ; ∨-assoc to L-∨-assoc ; ∨-comm to L-∨-comm
+               ; ∧-assoc to L-∧-assoc ; ∧-comm to L-∧-comm
+               ; ∨-absorbs-∧ to L-∨-absorbs-∧ ; ∧-absorbs-∨ to L-∧-absorbs-∨ )
+  open Setoid setoid
+
+  -- Idempotency derived from absorption: x ∧ x ≈ x ∧ (x ∨ (x ∧ x)) [by L-∨-absorbs-∧]
+  --                                            ≈ x                 [by L-∧-absorbs-∨]
+  ∧-idem-derived : ∀ x → (x ∧' x) ≈ x
+  ∧-idem-derived x = trans (∧-cong refl (sym (L-∨-absorbs-∧ x x))) (L-∧-absorbs-∨ x (x ∧' x))
+
+  ∨-idem-derived : ∀ x → (x ∨' x) ≈ x
+  ∨-idem-derived x = trans (∨-cong refl (sym (L-∧-absorbs-∨ x x))) (L-∨-absorbs-∧ x (x ∨' x))
+
+  -- (x ∧ y) ∨ x ≈ x ∨ (x ∧ y) ≈ x
+  absorbʳ-derived : ∀ x y → ((x ∧' y) ∨' x) ≈ x
+  absorbʳ-derived x y = trans (L-∨-comm (x ∧' y) x) (L-∨-absorbs-∧ x y)
+
+  𝑨 : Algebra _ _
+  𝑨 = record { Domain = setoid ; Interp = interp }
+    where
+    interp : Func (⟨ Sig-Lattice ⟩ setoid) setoid
+    interp ⟨$⟩ (∧-Op , args)                            = args 0F ∧' args 1F
+    interp ⟨$⟩ (∨-Op , args)                            = args 0F ∨' args 1F
+    cong interp {∧-Op , _} {.∧-Op , _} (≡.refl , args≈) = ∧-cong (args≈ 0F) (args≈ 1F)
+    cong interp {∨-Op , _} {.∨-Op , _} (≡.refl , args≈) = ∨-cong (args≈ 0F) (args≈ 1F)
+
+module _ {𝑳 : Lattice α ρ} where
+  open Lattice-Op 𝑳
+  open Setoid 𝔻[ proj₁ 𝑳 ]
+  open Lattice-Op ⟪ ⟨ 𝑳 ⟩ˡᵃ ⟫ˡᵃ renaming ( _∧_ to _∧'_ ; _∨_ to _∨'_ )
+
+  roundtrip-cbc-∧-la : (a b : 𝕌[ proj₁ 𝑳 ]) → (a ∧' b) ≈ (a ∧ b)
+  roundtrip-cbc-∧-la a b = refl
+
+  roundtrip-cbc-∨-la : (a b : 𝕌[ proj₁ 𝑳 ]) → (a ∨' b) ≈ (a ∨ b)
+  roundtrip-cbc-∨-la a b = refl
+
+module _ {L : stdlib-Lattice α ρ} where
+  open stdlib-Lattice L using ( _≈_ ; _∧_ ; _∨_ ; refl ) renaming ( Carrier to A )
+  open stdlib-Lattice ⟨ ⟪ L ⟫ˡᵃ ⟩ˡᵃ using () renaming ( _∧_ to _∧'_ ; _∨_ to _∨'_ )
+
+  roundtrip-bcb-∧-la : (a b : A) → (a ∧ b) ≈ (a ∧' b)
+  roundtrip-bcb-∧-la a b = refl
+
+  roundtrip-bcb-∨-la : (a b : A) → (a ∨ b) ≈ (a ∨' b)
+  roundtrip-bcb-∨-la a b = refl
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Classical/Properties.lagda.md
+++ b/src/Classical/Properties.lagda.md
@@ -1,0 +1,38 @@
+---
+layout: default
+file: "src/Classical/Properties.lagda.md"
+title: "Classical.Properties module"
+date: "2026-05-28"
+author: "the agda-algebras development team"
+---
+
+### <a id="classical-properties">Derived properties of classical structures</a>
+
+This is the [Classical.Properties][] module of the [Agda Universal Algebra Library][].
+
+The `Classical/Properties/` subtree houses *derived* results about classical
+structures — theorems that are properties of a fixed inhabitant of one of the
+structures defined in [`Classical/Structures/`][Classical.Structures], rather
+than part of the structure's definition.  Each per-structure file
+`Classical/Properties/X.lagda.md` consumes `X-Op`'s curried accessors and
+proves further facts about a parameterized `(𝑿 : X α ρ)`.
+
+The inaugural inhabitant is `Classical.Properties.Lattice`, which proves the
+order-theoretic view of a lattice — the equivalence with the algebraic
+presentation that the [M3-7](https://github.com/ualib/agda-algebras/issues/264)
+acceptance criterion calls for.  Future inhabitants include, for example,
+uniqueness of inverses in Group and `0 · x ≈ 0` in Ring.
+
+This file is the umbrella for the subtree.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Properties where
+
+open import Classical.Properties.Lattice public
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Classical/Properties/Lattice.lagda.md
+++ b/src/Classical/Properties/Lattice.lagda.md
@@ -18,11 +18,10 @@ equations — we construct the partial order `x ≤ y := x ∧ y ≈ x` and show
 `_∧_` and `_∨_` are the binary meet and join with respect to it.
 
 The dual order characterization `x ≤ y ⇔ x ∨ y ≈ y` is proved as the connecting
-lemma; absorption is used in exactly that one place.  The partial-order
-properties (reflexivity, transitivity, antisymmetry, congruence in `≈`) and the
-GLB/LUB properties (universal property of meet and join with respect to `_≤_`)
-follow from associativity, commutativity, and idempotency together with the
-connecting lemma — assoc/comm/idem alone do not suffice for the LUB direction.
+lemma.  The partial-order properties and the GLB properties use only
+associativity, commutativity, and idempotency; the join upper-bound clauses use
+absorption directly, and the join leastness proof routes through the connecting
+lemma.
 
 This is the first module in `Classical/Properties/`.  The directory is a
 by-concern parallel of `Classical/Structures/`, `Classical/Bundles/`, etc., for
@@ -74,9 +73,9 @@ The join-form `x ∨ y ≈ y` is proved iff-equivalent below.
 
 **Connecting lemma: meet-form and join-form agree.**  Forward direction uses
 the second absorption law (in its `absorbʳ-law` shape: `(y ∧ x) ∨ y ≈ y`);
-backward direction uses the first.  This is the *only* place absorption is
-invoked in this module — all the partial-order and GLB results below need only
-associativity, commutativity, and idempotency.
+backward direction uses the first.  The partial-order and GLB results below need
+only associativity, commutativity, and idempotency; the join upper-bound clauses
+use absorption directly.
 
 ```agda
   ≤-via-∨ : ∀ {x y} → x ≤ y → x ∨ y ≈ y

--- a/src/Classical/Properties/Lattice.lagda.md
+++ b/src/Classical/Properties/Lattice.lagda.md
@@ -1,0 +1,184 @@
+---
+layout: default
+file: "src/Classical/Properties/Lattice.lagda.md"
+title: "Classical.Properties.Lattice module"
+date: "2026-05-28"
+author: "the agda-algebras development team"
+---
+
+### <a id="classical-properties-lattice">The meet-join / order-theoretic view of a lattice</a>
+
+This is the [Classical.Properties.Lattice][] module of the [Agda Universal Algebra Library][].
+
+The acceptance criterion of [M3-7](https://github.com/ualib/agda-algebras/issues/264)
+asks for the equivalence of the algebraic and order-theoretic presentations of a
+lattice.  This module proves the *object-level* half of that equivalence: given
+a `Lattice α ρ` — that is, the algebraic data of meet, join, and the eight
+equations — we construct the partial order `x ≤ y := x ∧ y ≈ x` and show that
+`_∧_` and `_∨_` are the binary meet and join with respect to it.
+
+The dual order characterization `x ≤ y ⇔ x ∨ y ≈ y` is proved as the connecting
+lemma; absorption is used in exactly that one place.  The partial-order
+properties (reflexivity, transitivity, antisymmetry, congruence in `≈`) and the
+GLB/LUB properties (universal property of meet and join with respect to `_≤_`)
+follow from associativity, commutativity, and idempotency together with the
+connecting lemma — assoc/comm/idem alone do not suffice for the LUB direction.
+
+This is the first module in `Classical/Properties/`.  The directory is a
+by-concern parallel of `Classical/Structures/`, `Classical/Bundles/`, etc., for
+*derived* results about classical structures — results that are theorems
+*about* a fixed inhabitant of one of those structures, not part of its
+definition.  Future inhabitants include, for example, uniqueness of inverses in
+Group and `0 · x ≈ 0` in Ring.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Properties.Lattice where
+
+open import Agda.Primitive                           using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -----------------------------------------
+open import Data.Product                             using ( proj₁ )
+open import Level                                    using ( Level ; _⊔_ )
+open import Relation.Binary                          using ( Setoid )
+
+import Relation.Binary.Reasoning.Setoid as SetoidReasoning
+
+-- Imports from the Agda Universal Algebra Library --------------------------------
+open import Classical.Signatures.Lattice             using ( Sig-Lattice )
+open import Classical.Structures.Lattice             using ( Lattice ; module Lattice-Op )
+open import Setoid.Algebras.Basic {𝑆 = Sig-Lattice}  using ( 𝔻[_] ; 𝕌[_] )
+
+private variable α ρ : Level
+```
+
+#### <a id="lattice-order">The `Lattice-Order` module</a>
+
+```agda
+module Lattice-Order {α ρ : Level} (𝑳 : Lattice α ρ) where
+  private 𝑨 = proj₁ 𝑳
+  open Setoid 𝔻[ 𝑨 ]
+  open Lattice-Op 𝑳
+  open SetoidReasoning 𝔻[ 𝑨 ]
+```
+
+**The induced order.**  `x ≤ y` is `x ∧ y ≈ x` (the meet-form characterization).
+The join-form `x ∨ y ≈ y` is proved iff-equivalent below.
+
+```agda
+  infix 4 _≤_
+  _≤_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → Type ρ
+  x ≤ y = x ∧ y ≈ x
+```
+
+**Connecting lemma: meet-form and join-form agree.**  Forward direction uses
+the second absorption law (in its `absorbʳ-law` shape: `(y ∧ x) ∨ y ≈ y`);
+backward direction uses the first.  This is the *only* place absorption is
+invoked in this module — all the partial-order and GLB results below need only
+associativity, commutativity, and idempotency.
+
+```agda
+  ≤-via-∨ : ∀ {x y} → x ≤ y → x ∨ y ≈ y
+  ≤-via-∨ {x} {y} x≤y = begin
+    x ∨ y         ≈⟨ ∨-cong (sym x≤y) refl ⟩
+    (x ∧ y) ∨ y   ≈⟨ ∨-cong (∧-comm-law x y) refl ⟩
+    (y ∧ x) ∨ y   ≈⟨ absorbʳ-law y x ⟩
+    y             ∎
+
+  ≤-from-∨ : ∀ {x y} → x ∨ y ≈ y → x ≤ y
+  ≤-from-∨ {x} {y} x∨y≈y = begin
+    x ∧ y         ≈⟨ ∧-cong refl (sym x∨y≈y) ⟩
+    x ∧ (x ∨ y)   ≈⟨ absorbˡ-law x y ⟩
+    x             ∎
+```
+
+**Partial order modulo `≈`.**  Reflexivity is idempotency, transitivity uses
+associativity, antisymmetry uses commutativity, and the `≈`-respect lemmas use
+binary congruence.
+
+```agda
+  ≤-refl : ∀ {x} → x ≤ x
+  ≤-refl {x} = ∧-idem-law x
+
+  ≤-trans : ∀ {x y z} → x ≤ y → y ≤ z → x ≤ z
+  ≤-trans {x} {y} {z} x≤y y≤z = begin
+    x ∧ z         ≈⟨ ∧-cong (sym x≤y) refl ⟩
+    (x ∧ y) ∧ z   ≈⟨ ∧-assoc-law x y z ⟩
+    x ∧ (y ∧ z)   ≈⟨ ∧-cong refl y≤z ⟩
+    x ∧ y         ≈⟨ x≤y ⟩
+    x             ∎
+
+  ≤-antisym : ∀ {x y} → x ≤ y → y ≤ x → x ≈ y
+  ≤-antisym {x} {y} x≤y y≤x = begin
+    x       ≈⟨ sym x≤y ⟩
+    x ∧ y   ≈⟨ ∧-comm-law x y ⟩
+    y ∧ x   ≈⟨ y≤x ⟩
+    y       ∎
+
+  ≤-respˡ-≈ : ∀ {x x' y} → x ≈ x' → x ≤ y → x' ≤ y
+  ≤-respˡ-≈ {x} {x'} {y} x≈x' x≤y = begin
+    x' ∧ y   ≈⟨ ∧-cong (sym x≈x') refl ⟩
+    x ∧ y    ≈⟨ x≤y ⟩
+    x        ≈⟨ x≈x' ⟩
+    x'       ∎
+
+  ≤-respʳ-≈ : ∀ {x y y'} → y ≈ y' → x ≤ y → x ≤ y'
+  ≤-respʳ-≈ {x} {y} {y'} y≈y' x≤y = begin
+    x ∧ y'   ≈⟨ ∧-cong refl (sym y≈y') ⟩
+    x ∧ y    ≈⟨ x≤y ⟩
+    x        ∎
+```
+
+**`_∧_` is the binary meet.**  The two lower-bound clauses and the universal
+property — together with the partial-order facts above — say that `x ∧ y` is
+the greatest lower bound of `x` and `y` with respect to `_≤_`.
+
+```agda
+  ∧-lowerˡ : ∀ x y → (x ∧ y) ≤ x
+  ∧-lowerˡ x y = begin
+    (x ∧ y) ∧ x   ≈⟨ ∧-comm-law (x ∧ y) x ⟩
+    x ∧ (x ∧ y)   ≈⟨ sym (∧-assoc-law x x y) ⟩
+    (x ∧ x) ∧ y   ≈⟨ ∧-cong (∧-idem-law x) refl ⟩
+    x ∧ y         ∎
+
+  ∧-lowerʳ : ∀ x y → (x ∧ y) ≤ y
+  ∧-lowerʳ x y = begin
+    (x ∧ y) ∧ y   ≈⟨ ∧-assoc-law x y y ⟩
+    x ∧ (y ∧ y)   ≈⟨ ∧-cong refl (∧-idem-law y) ⟩
+    x ∧ y         ∎
+
+  ∧-greatest : ∀ {x y z} → z ≤ x → z ≤ y → z ≤ (x ∧ y)
+  ∧-greatest {x} {y} {z} z≤x z≤y = begin
+    z ∧ (x ∧ y)   ≈⟨ sym (∧-assoc-law z x y) ⟩
+    (z ∧ x) ∧ y   ≈⟨ ∧-cong z≤x refl ⟩
+    z ∧ y         ≈⟨ z≤y ⟩
+    z             ∎
+```
+
+**`_∨_` is the binary join.**  Dually: `x ∨ y` is the least upper bound of `x`
+and `y`.  The two upper-bound clauses use absorption directly; the universal
+property is proved through the join-form characterization to avoid going
+through absorption twice.
+
+```agda
+  ∨-upperˡ : ∀ x y → x ≤ (x ∨ y)
+  ∨-upperˡ x y = absorbˡ-law x y
+
+  ∨-upperʳ : ∀ x y → y ≤ (x ∨ y)
+  ∨-upperʳ x y = begin
+    y ∧ (x ∨ y)   ≈⟨ ∧-cong refl (∨-comm-law x y) ⟩
+    y ∧ (y ∨ x)   ≈⟨ absorbˡ-law y x ⟩
+    y             ∎
+
+  ∨-least : ∀ {x y z} → x ≤ z → y ≤ z → (x ∨ y) ≤ z
+  ∨-least {x} {y} {z} x≤z y≤z = ≤-from-∨ (begin
+    (x ∨ y) ∨ z   ≈⟨ ∨-assoc-law x y z ⟩
+    x ∨ (y ∨ z)   ≈⟨ ∨-cong refl (≤-via-∨ y≤z) ⟩
+    x ∨ z         ≈⟨ ≤-via-∨ x≤z ⟩
+    z             ∎)
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Classical/Small/Structures.lagda.md
+++ b/src/Classical/Small/Structures.lagda.md
@@ -22,6 +22,7 @@ module Classical.Small.Structures where
 
 open import Classical.Small.Structures.CommutativeMonoid public
 open import Classical.Small.Structures.CommutativeSemigroup public
+open import Classical.Small.Structures.Lattice public
 open import Classical.Small.Structures.Magma public
 open import Classical.Small.Structures.Monoid public
 open import Classical.Small.Structures.Semigroup public

--- a/src/Classical/Small/Structures/Lattice.lagda.md
+++ b/src/Classical/Small/Structures/Lattice.lagda.md
@@ -1,0 +1,38 @@
+---
+layout: default
+file: "src/Classical/Small/Structures/Lattice.lagda.md"
+title: "Classical.Small.Structures.Lattice module"
+date: "2026-05-28"
+author: "the agda-algebras development team"
+---
+
+### Level-fixed Lattice
+
+This is the [Classical.Small.Structures.Lattice][] module of the [Agda Universal Algebra Library][].
+
+Specializes [`Classical.Structures.Lattice`][] to the `0ℓ`–`0ℓ` case, mirroring
+the veneers of `Magma`, `Semigroup`, `Monoid`, etc.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+module Classical.Small.Structures.Lattice where
+open import Agda.Primitive                          using () renaming ( Set to Type )
+open import Level                                   using ( 0ℓ ; suc )
+open import Relation.Binary.PropositionalEquality   using ( _≡_ )
+import Classical.Structures.Lattice as Polymorphic
+
+Lattice : Type (suc 0ℓ)
+Lattice = Polymorphic.Lattice 0ℓ 0ℓ
+
+eqsToLattice : (A : Type 0ℓ) (_∧'_ _∨'_ : A → A → A)
+  → (∀ a b c → (a ∧' b) ∧' c ≡ a ∧' (b ∧' c))
+  → (∀ a b → a ∧' b ≡ b ∧' a)
+  → (∀ a → a ∧' a ≡ a)
+  → (∀ a b c → (a ∨' b) ∨' c ≡ a ∨' (b ∨' c))
+  → (∀ a b → a ∨' b ≡ b ∨' a)
+  → (∀ a → a ∨' a ≡ a)
+  → (∀ a b → a ∧' (a ∨' b) ≡ a)
+  → (∀ a b → (a ∧' b) ∨' a ≡ a)
+  → Lattice
+eqsToLattice = Polymorphic.eqsToLattice
+```

--- a/src/Classical/Structures.lagda.md
+++ b/src/Classical/Structures.lagda.md
@@ -42,6 +42,7 @@ module Classical.Structures where
 open import Classical.Structures.CommutativeMonoid public
 open import Classical.Structures.CommutativeSemigroup public
 open import Classical.Structures.Interpret public
+open import Classical.Structures.Lattice public
 open import Classical.Structures.Magma public
 open import Classical.Structures.Monoid public
 open import Classical.Structures.Reduct public

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -1,0 +1,457 @@
+---
+layout: default
+file: "src/Classical/Structures/Lattice.lagda.md"
+title: "Classical.Structures.Lattice module"
+date: "2026-05-28"
+author: "the agda-algebras development team"
+---
+
+### Lattices {#classical-structures-lattice}
+
+This is the [Classical.Structures.Lattice][] module of the [Agda Universal Algebra Library][].
+
+A **lattice** inhabits the Σ-typed structure `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Lattice`
+over `Sig-Lattice`.  Lattice is the first structure in the [`Classical/`][Classical]
+tree with two *distinct* binary operation symbols (`∧-Op` and `∨-Op`); its
+signature is parallel to `Sig-Magma`, not an extension of it, and so it has
+*two* natural forgetful projections — one for each operation — both landing in
+[`Semilattice`][Classical.Structures.Semilattice].
+
+This module's prose adds the following conventions to the
+two-binary-symbols-with-eight-equations case beyond the
+[Monoid][Classical.Structures.Monoid] template:
+
++  **Two reducts, one per operation.**  `lattice→meetMagma` and
+   `lattice→joinMagma` are the two container-morphism reducts
+   `Sig-Magma ↪ Sig-Lattice` that send `∙-Op` to `∧-Op` and `∨-Op` respectively,
+   with identity position maps.  Both are pure reducts (no laws needed); the
+   downstream `lattice→meetSemilattice` and `lattice→joinSemilattice` add
+   `Th-Semilattice` satisfaction on top via the curried-law pivot, exactly as
+   `monoid→semigroup` does for the single-operation case.
++  **Eight standalone curried laws.**  Each of the eight equations in
+   `Th-Lattice` is exposed as a standalone curried-form lemma
+   (`lt-∧-assoc` through `lt-absorbʳ`) defined once in a
+   `module _ (𝑳 : Lattice α ρ)` block above the forgetfuls, so that both
+   `Lattice-Op` and each `lattice→<X>Semilattice` consume the same proof.
++  **Direct curried accessors.**  `Lattice-Op` defines `_∧_` and `_∨_` directly
+   via `Curry₂ (∧-Op ^ 𝑨)` / `Curry₂ (∨-Op ^ 𝑨)` rather than inheriting through
+   either semilattice reduct, for the same reason Monoid does: the reduct's
+   position map re-indexes definitionally to the identity in both cases, but
+   keeping the accessors direct keeps every downstream `refl` independent of
+   that reduction.
++  **No two-symbol bridge primitive.**  The absorption laws involve terms
+   nesting two operation symbols (e.g. `node ∧-Op (pair (ℊ 0F)
+   (node ∨-Op (pair (ℊ 0F) (ℊ 1F))))`), but the term-to-curried bridge is two
+   compositions of single-symbol `interp-cong` calls — one per operation —
+   exactly as `Monoid-Op`'s `interp-node-∙` is reused.  No new primitive in
+   `Classical.Structures.Interpret` is needed; the existing `interp-cong`
+   composes through the nesting.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Lattice where
+
+open import Agda.Primitive                          using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -----------------------------------------
+open import Data.Fin.Base                          using ( Fin )
+open import Data.Fin.Patterns                      using ( 0F ; 1F ; 2F )
+open import Data.Product                           using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
+open import Function                               using ( Func )
+open import Level                                  using ( Level ; _⊔_ ; suc )
+open import Relation.Binary                        using ( Setoid )
+open import Relation.Binary.PropositionalEquality  as ≡ using ( _≡_ )
+
+import Relation.Binary.Reasoning.Setoid as SetoidReasoning
+
+open Func renaming ( to to _⟨$⟩_ )
+
+-- Imports from the Agda Universal Algebra Library --------------------------------
+open import Classical.Operations                    using ( pair ; Curry₂ )
+open import Classical.Signatures.Magma              using ( Sig-Magma ; Op-Magma )
+                                                    renaming ( ∙-Op to ∙-Opᵐᵃ )
+open import Classical.Signatures.Lattice            using ( Sig-Lattice ; Op-Lattice ; ∧-Op ; ∨-Op )
+open import Classical.Structures.Interpret          using ( interp-cong )
+open import Classical.Structures.Reduct             using ( reduct )
+open import Classical.Structures.Semilattice        using ( Semilattice ; _⊨ˢˡ_)
+open import Classical.Theories.Lattice              using ( Eq-Lattice ; Th-Lattice
+                                                          ; ∧-assoc ; ∧-comm ; ∧-idem
+                                                          ; ∨-assoc ; ∨-comm ; ∨-idem
+                                                          ; absorbˡ ; absorbʳ )
+open import Classical.Theories.Semilattice          using ( Th-Semilattice )
+                                                    renaming ( assoc to assocˢˡ
+                                                             ; comm  to commˢˡ
+                                                             ; idem  to idemˢˡ )
+open import Overture.Terms                          using ( Term ; ℊ ; node )
+open import Overture.Signatures                     using ( ArityOf ; OperationSymbolsOf )
+open import Setoid.Algebras.Basic                   using ( Algebra ; _^_ ; 𝔻[_] ; 𝕌[_] ; ⟨_⟩ )
+open import Setoid.Terms                            using ( module Environment )
+
+open import Setoid.Varieties.EquationalLogic {𝑆 = Sig-Lattice} using ( _⊧_≈_ )
+
+private variable α ρ : Level
+```
+
+#### <a id="satisfaction-alias">The local satisfaction predicate</a>
+
+```agda
+infix 4 _⊨ˡᵃ_
+_⊨ˡᵃ_ : (𝑨 : Algebra α ρ) (ℰ : Eq-Lattice → Term (Fin 3) × Term (Fin 3)) → Type (α ⊔ ρ)
+𝑨 ⊨ˡᵃ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
+```
+
+#### <a id="the-type">The type of lattices</a>
+
+```agda
+Lattice : (α ρ : Level) → Type (suc α ⊔ suc ρ)
+Lattice α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ˡᵃ Th-Lattice
+```
+
+#### <a id="meet-magma-reduct">The meet and join magma reducts</a>
+
+The two container morphisms `Sig-Magma ⟹ Sig-Lattice` send the magma's
+`∙-Opᵐᵃ` to the lattice's `∧-Op` and `∨-Op` respectively; the position maps are
+the identity (`Fin 2` to `Fin 2`).  `lattice→meetMagma` and `lattice→joinMagma`
+are the induced reducts.
+
+```agda
+∧-incl : Op-Magma → Op-Lattice
+∧-incl ∙-Opᵐᵃ = ∧-Op
+
+∧-κ : (o : OperationSymbolsOf Sig-Magma)
+      → ArityOf Sig-Lattice (∧-incl o) → ArityOf Sig-Magma o
+∧-κ ∙-Opᵐᵃ = λ z → z
+
+∨-incl : Op-Magma → Op-Lattice
+∨-incl ∙-Opᵐᵃ = ∨-Op
+
+∨-κ : (o : OperationSymbolsOf Sig-Magma)
+      → ArityOf Sig-Lattice (∨-incl o) → ArityOf Sig-Magma o
+∨-κ ∙-Opᵐᵃ = λ z → z
+
+lattice→meetMagma : Lattice α ρ → Algebra {𝑆 = Sig-Magma} α ρ
+lattice→meetMagma 𝑳 = reduct ∧-incl ∧-κ (𝑳 .proj₁)
+
+lattice→joinMagma : Lattice α ρ → Algebra {𝑆 = Sig-Magma} α ρ
+lattice→joinMagma 𝑳 = reduct ∨-incl ∨-κ (𝑳 .proj₁)
+```
+
+#### <a id="curried-laws">Curried laws, standalone</a>
+
+Each of the eight `Th-Lattice` equations is proved here in curried form once,
+above the semilattice forgetfuls, so that `Lattice-Op` and each
+`lattice→<X>Semilattice` consume the same proof.  The pattern is the same as
+`Monoid-Op.mn-assoc`: bridge each `node` to curried form via `interp-cong`,
+apply the satisfaction-witness equation, refold.
+
+```agda
+module _ (𝑳 : Lattice α ρ) where
+  private 𝑨 = proj₁ 𝑳
+  open Setoid 𝔻[ 𝑨 ]
+  open Environment 𝑨 using ( ⟦_⟧ )
+  open SetoidReasoning 𝔻[ 𝑨 ]
+
+  private
+    _∧_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
+    _∧_ = Curry₂ (∧-Op ^ 𝑨)
+
+    _∨_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
+    _∨_ = Curry₂ (∨-Op ^ 𝑨)
+
+    infixr 7 _∧_
+    infixr 6 _∨_
+
+    interp-node-∧ : (s t : Term (Fin 3)) (η : Fin 3 → 𝕌[ 𝑨 ])
+                  → ⟦ node ∧-Op (pair s t) ⟧ ⟨$⟩ η ≈ (⟦ s ⟧ ⟨$⟩ η) ∧ (⟦ t ⟧ ⟨$⟩ η)
+    interp-node-∧ s t η = interp-cong 𝑨 ∧-Op (λ { 0F → refl ; 1F → refl })
+
+    interp-node-∨ : (s t : Term (Fin 3)) (η : Fin 3 → 𝕌[ 𝑨 ])
+                  → ⟦ node ∨-Op (pair s t) ⟧ ⟨$⟩ η ≈ (⟦ s ⟧ ⟨$⟩ η) ∨ (⟦ t ⟧ ⟨$⟩ η)
+    interp-node-∨ s t η = interp-cong 𝑨 ∨-Op (λ { 0F → refl ; 1F → refl })
+
+    ∧-cong : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∧ u) ≈ (y ∧ v)
+    ∧-cong x≈y u≈v = interp-cong 𝑨 ∧-Op (λ { 0F → x≈y ; 1F → u≈v })
+
+    ∨-cong : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∨ u) ≈ (y ∨ v)
+    ∨-cong x≈y u≈v = interp-cong 𝑨 ∨-Op (λ { 0F → x≈y ; 1F → u≈v })
+
+  lt-∧-assoc : ∀ x y z → (x ∧ y) ∧ z ≈ x ∧ (y ∧ z)
+  lt-∧-assoc x y z = begin
+    (x ∧ y) ∧ z       ≈⟨ ∧-cong (sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η)) refl ⟩
+    ⟦ xy ⟧ ⟨$⟩ η ∧ z  ≈⟨ sym (interp-node-∧ xy (ℊ 2F) η) ⟩
+    ⟦ lhsT ⟧ ⟨$⟩ η    ≈⟨ proj₂ 𝑳 ∧-assoc η ⟩
+    ⟦ rhsT ⟧ ⟨$⟩ η    ≈⟨ interp-node-∧ (ℊ 0F) yz η ⟩
+    x ∧ ⟦ yz ⟧ ⟨$⟩ η  ≈⟨ ∧-cong refl (interp-node-∧ (ℊ 1F) (ℊ 2F) η) ⟩
+    x ∧ (y ∧ z)       ∎
+    where
+    η : Fin 3 → 𝕌[ 𝑨 ]
+    η = λ { 0F → x ; 1F → y ; 2F → z }
+    xy yz lhsT rhsT : Term (Fin 3)
+    xy   = node ∧-Op (pair (ℊ 0F) (ℊ 1F))
+    yz   = node ∧-Op (pair (ℊ 1F) (ℊ 2F))
+    lhsT = node ∧-Op (pair xy (ℊ 2F))
+    rhsT = node ∧-Op (pair (ℊ 0F) yz)
+
+  lt-∧-comm : ∀ x y → x ∧ y ≈ y ∧ x
+  lt-∧-comm x y = trans (sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η))
+                        (trans (proj₂ 𝑳 ∧-comm η) (interp-node-∧ (ℊ 1F) (ℊ 0F) η))
+    where η : Fin 3 → 𝕌[ 𝑨 ]
+          η = λ { 0F → x ; 1F → y ; 2F → x }
+
+  lt-∧-idem : ∀ x → x ∧ x ≈ x
+  lt-∧-idem x = trans (sym (interp-node-∧ (ℊ 0F) (ℊ 0F) η)) (proj₂ 𝑳 ∧-idem η)
+    where η : Fin 3 → 𝕌[ 𝑨 ]
+          η = λ { 0F → x ; 1F → x ; 2F → x }
+
+  lt-∨-assoc : ∀ x y z → (x ∨ y) ∨ z ≈ x ∨ (y ∨ z)
+  lt-∨-assoc x y z = begin
+    (x ∨ y) ∨ z       ≈⟨ ∨-cong (sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η)) refl ⟩
+    ⟦ xy ⟧ ⟨$⟩ η ∨ z  ≈⟨ sym (interp-node-∨ xy (ℊ 2F) η) ⟩
+    ⟦ lhsT ⟧ ⟨$⟩ η    ≈⟨ proj₂ 𝑳 ∨-assoc η ⟩
+    ⟦ rhsT ⟧ ⟨$⟩ η    ≈⟨ interp-node-∨ (ℊ 0F) yz η ⟩
+    x ∨ ⟦ yz ⟧ ⟨$⟩ η  ≈⟨ ∨-cong refl (interp-node-∨ (ℊ 1F) (ℊ 2F) η) ⟩
+    x ∨ (y ∨ z)       ∎
+    where
+    η : Fin 3 → 𝕌[ 𝑨 ]
+    η = λ { 0F → x ; 1F → y ; 2F → z }
+    xy yz lhsT rhsT : Term (Fin 3)
+    xy   = node ∨-Op (pair (ℊ 0F) (ℊ 1F))
+    yz   = node ∨-Op (pair (ℊ 1F) (ℊ 2F))
+    lhsT = node ∨-Op (pair xy (ℊ 2F))
+    rhsT = node ∨-Op (pair (ℊ 0F) yz)
+
+  lt-∨-comm : ∀ x y → x ∨ y ≈ y ∨ x
+  lt-∨-comm x y = trans (sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η))
+                        (trans (proj₂ 𝑳 ∨-comm η) (interp-node-∨ (ℊ 1F) (ℊ 0F) η))
+    where η : Fin 3 → 𝕌[ 𝑨 ]
+          η = λ { 0F → x ; 1F → y ; 2F → x }
+
+  lt-∨-idem : ∀ x → x ∨ x ≈ x
+  lt-∨-idem x = trans (sym (interp-node-∨ (ℊ 0F) (ℊ 0F) η)) (proj₂ 𝑳 ∨-idem η)
+    where η : Fin 3 → 𝕌[ 𝑨 ]
+          η = λ { 0F → x ; 1F → x ; 2F → x }
+
+  -- x ∧ (x ∨ y) ≈ x   (meet absorbs join)
+  lt-absorbˡ : ∀ x y → x ∧ (x ∨ y) ≈ x
+  lt-absorbˡ x y = begin
+    x ∧ (x ∨ y)        ≈⟨ ∧-cong refl (sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η)) ⟩
+    x ∧ ⟦ x∨y ⟧ ⟨$⟩ η  ≈⟨ sym (interp-node-∧ (ℊ 0F) x∨y η) ⟩
+    ⟦ lhsT ⟧ ⟨$⟩ η     ≈⟨ proj₂ 𝑳 absorbˡ η ⟩
+    x                  ∎
+    where
+    η : Fin 3 → 𝕌[ 𝑨 ]
+    η = λ { 0F → x ; 1F → y ; 2F → x }
+    x∨y lhsT : Term (Fin 3)
+    x∨y  = node ∨-Op (pair (ℊ 0F) (ℊ 1F))
+    lhsT = node ∧-Op (pair (ℊ 0F) x∨y)
+
+  -- (x ∧ y) ∨ x ≈ x   (join absorbs meet, with x on the right of the outer ∨)
+  lt-absorbʳ : ∀ x y → (x ∧ y) ∨ x ≈ x
+  lt-absorbʳ x y = begin
+    (x ∧ y) ∨ x        ≈⟨ ∨-cong (sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η)) refl ⟩
+    ⟦ x∧y ⟧ ⟨$⟩ η ∨ x  ≈⟨ sym (interp-node-∨ x∧y (ℊ 0F) η) ⟩
+    ⟦ lhsT ⟧ ⟨$⟩ η     ≈⟨ proj₂ 𝑳 absorbʳ η ⟩
+    x                  ∎
+    where
+    η : Fin 3 → 𝕌[ 𝑨 ]
+    η = λ { 0F → x ; 1F → y ; 2F → x }
+    x∧y lhsT : Term (Fin 3)
+    x∧y  = node ∧-Op (pair (ℊ 0F) (ℊ 1F))
+    lhsT = node ∨-Op (pair x∧y (ℊ 0F))
+```
+
+#### <a id="lattice-op">The `Lattice-Op` module</a>
+
+`Lattice-Op` exposes `_∧_`, `_∨_`, their congruences, the term-to-curried node
+bridges `interp-node-∧` / `interp-node-∨`, the eight curried laws (matching the
+eight constructors of `Eq-Lattice`), and the satisfaction-witness `equations`
+accessor.
+
+```agda
+module Lattice-Op {α ρ : Level} (𝑳 : Lattice α ρ) where
+  private 𝑨 = proj₁ 𝑳
+  open Setoid 𝔻[ 𝑨 ]
+  open Environment 𝑨 using ( ⟦_⟧ )
+
+  infixr 7 _∧_
+  infixr 6 _∨_
+
+  _∧_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
+  _∧_ = Curry₂ (∧-Op ^ 𝑨)
+
+  _∨_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
+  _∨_ = Curry₂ (∨-Op ^ 𝑨)
+
+  equations : 𝑨 ⊨ˡᵃ Th-Lattice
+  equations = proj₂ 𝑳
+
+  ∧-cong : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∧ u) ≈ (y ∧ v)
+  ∧-cong x≈y u≈v = interp-cong 𝑨 ∧-Op (λ { 0F → x≈y ; 1F → u≈v })
+
+  ∨-cong : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∨ u) ≈ (y ∨ v)
+  ∨-cong x≈y u≈v = interp-cong 𝑨 ∨-Op (λ { 0F → x≈y ; 1F → u≈v })
+
+  interp-node-∧ : (s t : Term (Fin 3)) {η : Fin 3 → 𝕌[ 𝑨 ]}
+                → ⟦ node ∧-Op (pair s t) ⟧ ⟨$⟩ η ≈ (⟦ s ⟧ ⟨$⟩ η) ∧ (⟦ t ⟧ ⟨$⟩ η)
+  interp-node-∧ s t = interp-cong 𝑨 ∧-Op (λ { 0F → refl ; 1F → refl })
+
+  interp-node-∨ : (s t : Term (Fin 3)) {η : Fin 3 → 𝕌[ 𝑨 ]}
+                → ⟦ node ∨-Op (pair s t) ⟧ ⟨$⟩ η ≈ (⟦ s ⟧ ⟨$⟩ η) ∨ (⟦ t ⟧ ⟨$⟩ η)
+  interp-node-∨ s t = interp-cong 𝑨 ∨-Op (λ { 0F → refl ; 1F → refl })
+
+  ∧-assoc-law : ∀ x y z → (x ∧ y) ∧ z ≈ x ∧ (y ∧ z)
+  ∧-assoc-law = lt-∧-assoc 𝑳
+
+  ∧-comm-law : ∀ x y → x ∧ y ≈ y ∧ x
+  ∧-comm-law = lt-∧-comm 𝑳
+
+  ∧-idem-law : ∀ x → x ∧ x ≈ x
+  ∧-idem-law = lt-∧-idem 𝑳
+
+  ∨-assoc-law : ∀ x y z → (x ∨ y) ∨ z ≈ x ∨ (y ∨ z)
+  ∨-assoc-law = lt-∨-assoc 𝑳
+
+  ∨-comm-law : ∀ x y → x ∨ y ≈ y ∨ x
+  ∨-comm-law = lt-∨-comm 𝑳
+
+  ∨-idem-law : ∀ x → x ∨ x ≈ x
+  ∨-idem-law = lt-∨-idem 𝑳
+
+  absorbˡ-law : ∀ x y → x ∧ (x ∨ y) ≈ x
+  absorbˡ-law = lt-absorbˡ 𝑳
+
+  absorbʳ-law : ∀ x y → (x ∧ y) ∨ x ≈ x
+  absorbʳ-law = lt-absorbʳ 𝑳
+```
+
+#### <a id="forgetfuls-to-semilattices">The forgetful projections to semilattices</a>
+
+`lattice→meetSemilattice` and `lattice→joinSemilattice` each take a lattice to
+the semilattice on its meet (resp. join) operation: the underlying algebra is
+the corresponding magma reduct, and the `Th-Semilattice` satisfaction proof
+pivots through `lt-∧-{assoc,comm,idem}` (resp. `lt-∨-{assoc,comm,idem}`) by
+the curried-law-pivot pattern of `monoid→semigroup`.
+
+```agda
+lattice→meetSemilattice : Lattice α ρ → Semilattice α ρ
+lattice→meetSemilattice ℒ@(𝑳 , _) = 𝑹 , thm
+  where
+  𝑹 : Algebra {𝑆 = Sig-Magma} _ _
+  𝑹 = lattice→meetMagma ℒ
+  open Setoid 𝔻[ 𝑳 ]
+  open Environment 𝑹 using ( ⟦_⟧ )
+  open SetoidReasoning 𝔻[ 𝑳 ]
+  open Lattice-Op ℒ using ( _∧_ ; ∧-assoc-law ; ∧-comm-law ; ∧-idem-law )
+
+  interp-congᴿ : (s t : Term (Fin 3)) (η : Fin 3 → 𝕌[ 𝑳 ])
+      → ⟦ node ∙-Opᵐᵃ (pair s t) ⟧ ⟨$⟩ η ≈ (⟦ s ⟧ ⟨$⟩ η) ∧ (⟦ t ⟧ ⟨$⟩ η)
+  interp-congᴿ s t η = interp-cong 𝑹 ∙-Opᵐᵃ λ { 0F → refl ; 1F → refl }
+
+  ∧-congᴿ : ∀ {a b c d} → a ≈ b → c ≈ d → (a ∧ c) ≈ (b ∧ d)
+  ∧-congᴿ a≈b c≈d = interp-cong 𝑹 ∙-Opᵐᵃ (λ { 0F → a≈b ; 1F → c≈d })
+
+  thm : 𝑹 ⊨ˢˡ Th-Semilattice
+  thm assocˢˡ η = let x = η 0F ; y = η 1F ; z = η 2F in begin
+    ⟦ Th-Semilattice assocˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ xy (ℊ 2F) η ⟩
+    ⟦ xy ⟧ ⟨$⟩ η ∧ z                         ≈⟨ ∧-congᴿ (interp-congᴿ (ℊ 0F) (ℊ 1F) η) refl ⟩
+    (x ∧ y) ∧ z                              ≈⟨ ∧-assoc-law x y z ⟩
+    x ∧ (y ∧ z)                              ≈˘⟨ ∧-congᴿ refl (interp-congᴿ (ℊ 1F) (ℊ 2F) η) ⟩
+    x ∧ ⟦ yz ⟧ ⟨$⟩ η                         ≈˘⟨ interp-congᴿ (ℊ 0F) yz η ⟩
+    ⟦ Th-Semilattice assocˢˡ .proj₂ ⟧ ⟨$⟩ η  ∎
+    where
+    xy yz : Term (Fin 3)
+    xy = node ∙-Opᵐᵃ (pair (ℊ 0F) (ℊ 1F))
+    yz = node ∙-Opᵐᵃ (pair (ℊ 1F) (ℊ 2F))
+  thm commˢˡ η = let x = η 0F ; y = η 1F in begin
+    ⟦ Th-Semilattice commˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ (ℊ 0F) (ℊ 1F) η ⟩
+    x ∧ y                                   ≈⟨ ∧-comm-law x y ⟩
+    y ∧ x                                   ≈˘⟨ interp-congᴿ (ℊ 1F) (ℊ 0F) η ⟩
+    ⟦ Th-Semilattice commˢˡ .proj₂ ⟧ ⟨$⟩ η  ∎
+  thm idemˢˡ η = let x = η 0F in begin
+    ⟦ Th-Semilattice idemˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ (ℊ 0F) (ℊ 0F) η ⟩
+    x ∧ x                                   ≈⟨ ∧-idem-law x ⟩
+    x                                       ∎
+
+lattice→joinSemilattice : Lattice α ρ → Semilattice α ρ
+lattice→joinSemilattice ℒ@(𝑳 , _) = 𝑹 , thm
+  where
+  𝑹 : Algebra {𝑆 = Sig-Magma} _ _
+  𝑹 = lattice→joinMagma ℒ
+  open Setoid 𝔻[ 𝑳 ]
+  open Environment 𝑹 using ( ⟦_⟧ )
+  open SetoidReasoning 𝔻[ 𝑳 ]
+  open Lattice-Op ℒ using ( _∨_ ; ∨-assoc-law ; ∨-comm-law ; ∨-idem-law )
+
+  interp-congᴿ : (s t : Term (Fin 3)) (η : Fin 3 → 𝕌[ 𝑳 ])
+      → ⟦ node ∙-Opᵐᵃ (pair s t) ⟧ ⟨$⟩ η ≈ (⟦ s ⟧ ⟨$⟩ η) ∨ (⟦ t ⟧ ⟨$⟩ η)
+  interp-congᴿ s t η = interp-cong 𝑹 ∙-Opᵐᵃ λ { 0F → refl ; 1F → refl }
+
+  ∨-congᴿ : ∀ {a b c d} → a ≈ b → c ≈ d → (a ∨ c) ≈ (b ∨ d)
+  ∨-congᴿ a≈b c≈d = interp-cong 𝑹 ∙-Opᵐᵃ (λ { 0F → a≈b ; 1F → c≈d })
+
+  thm : 𝑹 ⊨ˢˡ Th-Semilattice
+  thm assocˢˡ η = let x = η 0F ; y = η 1F ; z = η 2F in begin
+    ⟦ Th-Semilattice assocˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ xy (ℊ 2F) η ⟩
+    ⟦ xy ⟧ ⟨$⟩ η ∨ z                         ≈⟨ ∨-congᴿ (interp-congᴿ (ℊ 0F) (ℊ 1F) η) refl ⟩
+    (x ∨ y) ∨ z                              ≈⟨ ∨-assoc-law x y z ⟩
+    x ∨ (y ∨ z)                              ≈˘⟨ ∨-congᴿ refl (interp-congᴿ (ℊ 1F) (ℊ 2F) η) ⟩
+    x ∨ ⟦ yz ⟧ ⟨$⟩ η                         ≈˘⟨ interp-congᴿ (ℊ 0F) yz η ⟩
+    ⟦ Th-Semilattice assocˢˡ .proj₂ ⟧ ⟨$⟩ η  ∎
+    where
+    xy yz : Term (Fin 3)
+    xy = node ∙-Opᵐᵃ (pair (ℊ 0F) (ℊ 1F))
+    yz = node ∙-Opᵐᵃ (pair (ℊ 1F) (ℊ 2F))
+  thm commˢˡ η = let x = η 0F ; y = η 1F in begin
+    ⟦ Th-Semilattice commˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ (ℊ 0F) (ℊ 1F) η ⟩
+    x ∨ y                                   ≈⟨ ∨-comm-law x y ⟩
+    y ∨ x                                   ≈˘⟨ interp-congᴿ (ℊ 1F) (ℊ 0F) η ⟩
+    ⟦ Th-Semilattice commˢˡ .proj₂ ⟧ ⟨$⟩ η  ∎
+  thm idemˢˡ η = let x = η 0F in begin
+    ⟦ Th-Semilattice idemˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ (ℊ 0F) (ℊ 0F) η ⟩
+    x ∨ x                                   ≈⟨ ∨-idem-law x ⟩
+    x                                       ∎
+```
+
+#### <a id="builders">Lattice builders</a>
+
+`opsToBareLattice` builds a "raw" `Sig-Lattice`-algebra from a carrier and two
+binary operations.  `eqsToLattice` adds the eight equation proofs and produces
+a `Lattice α α`.
+
+```agda
+open Algebra
+opsToBareLattice : (A : Type α) (_∧'_ _∨'_ : A → A → A) → Algebra {𝑆 = Sig-Lattice} α α
+opsToBareLattice A _∧'_ _∨'_ .Domain = ≡.setoid A
+opsToBareLattice A _∧'_ _∨'_ .Interp ⟨$⟩ (∧-Op , args) = args 0F ∧' args 1F
+opsToBareLattice A _∧'_ _∨'_ .Interp ⟨$⟩ (∨-Op , args) = args 0F ∨' args 1F
+opsToBareLattice A _∧'_ _∨'_ .Interp .cong {∧-Op , _} {.∧-Op , _} (≡.refl , args≡) = ≡.cong₂ _∧'_ (args≡ 0F) (args≡ 1F)
+opsToBareLattice A _∧'_ _∨'_ .Interp .cong {∨-Op , _} {.∨-Op , _} (≡.refl , args≡) = ≡.cong₂ _∨'_ (args≡ 0F) (args≡ 1F)
+
+eqsToLattice : (A : Type α) (_∧'_ _∨'_ : A → A → A)
+  → (∧-assoc-≡ : ∀ a b c → (a ∧' b) ∧' c ≡ a ∧' (b ∧' c))
+  → (∧-comm-≡  : ∀ a b → a ∧' b ≡ b ∧' a)
+  → (∧-idem-≡  : ∀ a → a ∧' a ≡ a)
+  → (∨-assoc-≡ : ∀ a b c → (a ∨' b) ∨' c ≡ a ∨' (b ∨' c))
+  → (∨-comm-≡  : ∀ a b → a ∨' b ≡ b ∨' a)
+  → (∨-idem-≡  : ∀ a → a ∨' a ≡ a)
+  → (absorbˡ-≡ : ∀ a b → a ∧' (a ∨' b) ≡ a)
+  → (absorbʳ-≡ : ∀ a b → (a ∧' b) ∨' a ≡ a)
+  → Lattice α α
+eqsToLattice A _∧'_ _∨'_ ∧-assoc-≡ ∧-comm-≡ ∧-idem-≡ ∨-assoc-≡ ∨-comm-≡ ∨-idem-≡ absorbˡ-≡ absorbʳ-≡ =
+  opsToBareLattice A _∧'_ _∨'_ , proof
+  where
+  proof : opsToBareLattice A _∧'_ _∨'_ ⊨ˡᵃ Th-Lattice
+  proof ∧-assoc ρ = ∧-assoc-≡ (ρ 0F) (ρ 1F) (ρ 2F)
+  proof ∧-comm  ρ = ∧-comm-≡  (ρ 0F) (ρ 1F)
+  proof ∧-idem  ρ = ∧-idem-≡  (ρ 0F)
+  proof ∨-assoc ρ = ∨-assoc-≡ (ρ 0F) (ρ 1F) (ρ 2F)
+  proof ∨-comm  ρ = ∨-comm-≡  (ρ 0F) (ρ 1F)
+  proof ∨-idem  ρ = ∨-idem-≡  (ρ 0F)
+  proof absorbˡ ρ = absorbˡ-≡ (ρ 0F) (ρ 1F)
+  proof absorbʳ ρ = absorbʳ-≡ (ρ 0F) (ρ 1F)
+```
+
+--------------------------------------
+
+{% include UALib.Links.md %}

--- a/src/Examples/Classical.lagda.md
+++ b/src/Examples/Classical.lagda.md
@@ -26,6 +26,7 @@ module Examples.Classical where
 
 open import Examples.Classical.CommutativeSemigroup public
 open import Examples.Classical.CommutativeMonoid public
+open import Examples.Classical.Lattice public
 open import Examples.Classical.Magma public
 open import Examples.Classical.Monoid public
 open import Examples.Classical.Semigroup public

--- a/src/Examples/Classical/Lattice.lagda.md
+++ b/src/Examples/Classical/Lattice.lagda.md
@@ -1,0 +1,98 @@
+---
+layout: default
+file: "src/Examples/Classical/Lattice.lagda.md"
+title: "Examples.Classical.Lattice module"
+date: "2026-05-28"
+author: "the agda-algebras development team"
+---
+
+### <a id="examples-classical-lattice">Worked example — `𝟚 = (Bool, _∧_, _∨_)` as a Boolean lattice</a>
+
+This is the [Examples.Classical.Lattice][] module of the [Agda Universal Algebra Library][].
+
+`Bool` under meet and join forms the canonical two-element lattice, and it is
+the lattice the acceptance criterion of [M3-7](https://github.com/ualib/agda-algebras/issues/264)
+asks the stdlib bridge to round-trip on.  Built from stdlib's
+`Data.Bool.Properties` lemmas; the only non-trivial step is deriving the
+`(a ∧ b) ∨ a ≡ a` form of absorption from stdlib's `∨-absorbs-∧` form via
+`∨-comm`.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+module Examples.Classical.Lattice where
+
+-- Imports from the Agda Standard Library -------------------------------------
+open import Data.Bool                              using  ( Bool ; _∧_ ; _∨_ )
+open import Data.Bool.Properties                   using  ( ∧-assoc ; ∧-comm ; ∧-idem
+                                                          ; ∨-assoc ; ∨-comm ; ∨-idem )
+                                                   renaming  ( ∧-abs-∨ to ∧-absorbs-∨
+                                                             ; ∨-abs-∧ to ∨-absorbs-∧ )
+open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl ; trans )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Classical.Bundles.Lattice           using ( ⟨_⟩ˡᵃ ; ⟪_⟫ˡᵃ )
+open import Classical.Small.Structures.Lattice  using ( Lattice ; eqsToLattice )
+import Classical.Structures.Lattice as Polymorphic
+```
+
+#### <a id="absorbR">Deriving the second absorption equation</a>
+
+Our `eqsToLattice` takes the second absorption equation in the form
+`(a ∧ b) ∨ a ≡ a` (per `Th-Lattice absorbʳ = AbsorbsRight ∧-Op ∨-Op refl refl 0F 1F`);
+stdlib's `Data.Bool.Properties.∨-absorbs-∧` is `a ∨ (a ∧ b) ≡ a`.  One `∨-comm`
+step bridges them.
+
+```agda
+Bool-absorbʳ : ∀ a b → (a ∧ b) ∨ a ≡ a
+Bool-absorbʳ a b = trans (∨-comm (a ∧ b) a) (∨-absorbs-∧ a b)
+```
+
+#### <a id="bool-lattice">The lattice `𝟚 = (Bool, _∧_, _∨_)`</a>
+
+```agda
+Bool-lattice : Lattice
+Bool-lattice = eqsToLattice Bool _∧_ _∨_
+                 ∧-assoc ∧-comm ∧-idem
+                 ∨-assoc ∨-comm ∨-idem
+                 ∧-absorbs-∨ Bool-absorbʳ
+```
+
+#### <a id="acceptance">Acceptance checks</a>
+
+The `Lattice-Op` accessors interpret to stdlib's `Bool._∧_` and `Bool._∨_` on
+the nose: no opacity from `eqsToLattice`, from the factoring through
+`opsToBareLattice`, or from `Curry₂` wrapping; discharged by `refl`.
+
+```agda
+open Polymorphic.Lattice-Op Bool-lattice renaming ( _∧_ to _∙∧_ ; _∨_ to _∙∨_ )
+
+∙∧-is-∧-la : ∀ (a b : Bool) → a ∙∧ b ≡ a ∧ b
+∙∧-is-∧-la a b = refl
+
+∙∨-is-∨-la : ∀ (a b : Bool) → a ∙∨ b ≡ a ∨ b
+∙∨-is-∨-la a b = refl
+```
+
+#### <a id="roundtrip">Round-trip through `Algebra.Lattice.Bundles.Lattice`</a>
+
+The bundle bridge round-trips on `Bool-lattice` pointwise on both operations.
+Both directions reduce by `pair a b 0F ⇉ a` and `pair a b 1F ⇉ b`, so
+propositional `refl` discharges the obligation at the curried form (per
+[ADR-002 v2 §6](../../docs/adr/002-classical-layer-design.md)).
+
+```agda
+open Polymorphic.Lattice-Op ⟪ ⟨ Bool-lattice ⟩ˡᵃ ⟫ˡᵃ using ()
+  renaming ( _∧_ to _∙∧'_ ; _∨_ to _∙∨'_ )
+
+roundtrip-∧-la : ∀ (a b : Bool) → a ∙∧' b ≡ a ∧ b
+roundtrip-∧-la a b = refl
+
+roundtrip-∨-la : ∀ (a b : Bool) → a ∙∨' b ≡ a ∨ b
+roundtrip-∨-la a b = refl
+```
+
+This closes the third bullet of the M3-7 acceptance criteria.
+
+--------------------------------------
+
+{% include UALib.Links.md %}


### PR DESCRIPTION
## Summary

Second and final PR closing **M3-7** (#264).  Adds the **Lattice structure**, the **stdlib bundle bridge**, the **level-fixed veneer**, the **worked example on 𝟚**, and the **meet-join / order-theoretic equivalence** — together with PR-1 (#346) this completes all three bullets of the acceptance criteria.

Introduces a new by-concern subtree **`Classical/Properties/`** for derived results about classical structures.  Its inaugural inhabitant is `Classical.Properties.Lattice`; future inhabitants include uniqueness of inverses in Group, `0 · x ≈ 0` in Ring, etc.

## Related issues

Closes #264

---

## Contents

**Lattice** (the four remaining quintuple pieces, all over `Sig-Lattice`):

- `src/Classical/Structures/Lattice.lagda.md` — `Lattice α ρ`, `_⊨ˡᵃ_`, the two magma reducts (`lattice→meetMagma`, `lattice→joinMagma`), eight standalone curried laws, `Lattice-Op` with direct `Curry₂` accessors and the two `interp-node-{∧,∨}` lemmas, the two semilattice forgetfuls (`lattice→meetSemilattice`, `lattice→joinSemilattice`), `opsToBareLattice`, `eqsToLattice`
- `src/Classical/Bundles/Lattice.lagda.md` — bridge to `Algebra.Lattice.Bundles.Lattice`, both directions, with the standard derivations of idempotency from absorption in the reverse direction
- `src/Classical/Small/Structures/Lattice.lagda.md` — `0ℓ`–`0ℓ` veneer
- `src/Examples/Classical/Lattice.lagda.md` — `𝟚 = (Bool, _∧_, _∨_)` via `Data.Bool.Properties`, with stdlib-bridge round-trip on both operations

**Properties** (the new by-concern subtree):

- `src/Classical/Properties/Lattice.lagda.md` — the `Lattice-Order` module parameterized by `(𝑳 : Lattice α ρ)` with `_≤_`, the iff connecting lemma, the partial-order witnesses, and the GLB/LUB witnesses
- `src/Classical/Properties.lagda.md` — new subtree umbrella

**Umbrellas** updated to re-export the new modules; `Classical.lagda.md` adds Properties to its top-level aggregator block with a short prose paragraph explaining the by-concern role of the new subtree.

## Design notes

- **Two binary symbols, two reducts.**  Lattice is the first structure in the tree with two distinct binary operation symbols, and consequently the first with two natural forgetful projections — one per operation — both landing in `Semilattice`.  Each forgetful is the curried-law pivot pattern of `monoid→semigroup`, applied to the meet and join half independently.
- **No two-symbol bridge primitive.**  The absorption laws involve terms nesting two operation symbols (e.g. `node ∧-Op (pair (ℊ 0F) (node ∨-Op (pair (ℊ 0F) (ℊ 1F))))`), but the term-to-curried bridge is two compositions of single-symbol `interp-cong` calls — one per operation, identical in shape to `Monoid-Op`'s `interp-node-∙`.  `Classical/Structures/Interpret` gains no new primitives and `Classical/Operations` gains no `Curry₃` (the speculative note in `Operations.lagda.md:84` is now resolved as not needed).
- **Direct curried accessors.**  `Lattice-Op` defines `_∧_` and `_∨_` directly via `Curry₂ (∧-Op ^ 𝑨)` and `Curry₂ (∨-Op ^ 𝑨)` rather than inheriting through the semilattice reducts, per Monoid's lesson — the reducts' position maps re-index definitionally to the identity, but keeping the accessors direct keeps every downstream `refl` independent of that reduction.
- **Eight standalone curried laws.**  Each of the eight `Th-Lattice` equations is proved once in curried form, above the semilattice forgetfuls, so that both `Lattice-Op` and each `lattice→<X>Semilattice` consume the same proof.  Pattern mirrors Monoid's `mn-assoc`.
- **Bundle absorption derivations.**  Forward direction: stdlib's `absorptive` field's first component is `x ∨ (x ∧ y) ≈ x`; we have `absorbʳ-law : (x ∧ y) ∨ x ≈ x`, so one `∨-comm` step bridges them.  Reverse direction: stdlib's `IsLattice` does not bundle idempotency (it's derivable from absorption), so building our `Lattice` from a stdlib lattice requires the two-step idempotency derivation `x ∧ x ≈ x ∧ (x ∨ (x ∧ x)) ≈ x` (and the dual) — three lines each.
- **Order-equivalence proof shape.**  Canonical definition is `x ≤ y := x ∧ y ≈ x` (meet-form); the iff with `x ∨ y ≈ y` is proved as the connecting lemma, and absorption is invoked exactly there.  All partial-order results need only associativity, commutativity, and idempotency; the LUB universal property routes through the connecting lemma to avoid invoking absorption twice.  Pure setoid reasoning on top of `Lattice-Op`.
- **New `Classical/Properties/` subtree.**  Chosen over `Classical/<Structure>/Properties/` per the design exchange before PR-1: keeps the existing by-concern organization (one axis = concern, leaf name = structure) uniform, mirrors stdlib's `Algebra.Lattice.Properties.Lattice`, and avoids mixing two organizing axes.  ADR-002 v2 may want a short amendment noting this — happy to add it as a follow-up commit if you'd like, or leave it to a future ADR-002 v3 sweep.

## Acceptance criteria (from #264) — all closed

- [x] Both structures type-check (Semilattice in PR-1; Lattice in this PR)
- [x] Meet-join / order-theoretic equivalence theorem proved (`Classical.Properties.Lattice.Lattice-Order`)
- [x] Bridge to stdlib round-trips on `𝟚` as a Boolean lattice (`Examples.Classical.Lattice`)


---

## Type of change

- [ ] Bug fix
- [x] New definition, theorem, or feature
- [ ] Refactor / cleanup (user-facing/API change)
- [ ] Refactor / cleanup (no user-facing change)
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches `src/`, it targets a supported area such as `Classical/`, `Cubical/`, `Demos/`, `Examples/`, `Exercises/`, `Overture/`, or `Setoid/`.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.

## Notes for reviewers

Please pay special attention to these.

- `Bundles/Lattice.lagda.md` — the reverse-direction idempotency derivation.  Standard textbook derivation, but it's the only non-trivial inline derivation in this PR's bundle code.
- `Structures/Lattice.lagda.md` — the two semilattice forgetful proofs (`lattice→meetSemilattice`, `lattice→joinSemilattice`).  Each has three `thm` clauses; the assoc clauses are the longest, following the `monoid→semigroup` shape verbatim.
- `Properties/Lattice.lagda.md` — the proof of `≤-via-∨` was tightened to three steps (using `∨-cong (∧-comm-law x y) refl` to pivot to the absorption form in one shot).  The LUB proof routes through `≤-from-∨` to keep absorption invocations to two.


