### PR TITLE
[M3-9] Finite-group examples via Cayley tables (ℤ/3ℤ, Klein four, S₃)

### DIFF
--- a/src/Examples/Classical/CyclicGroup3.lagda.md
+++ b/src/Examples/Classical/CyclicGroup3.lagda.md
@@ -1,0 +1,139 @@
+---
+layout: default
+file: "src/Examples/Classical/CyclicGroup3.lagda.md"
+title: "Examples.Classical.CyclicGroup3 module"
+date: "2026-05-31"
+author: "the agda-algebras development team"
+---
+
+### Worked example — the cyclic group `ℤ/3ℤ` from a Cayley table
+
+This is the [Examples.Classical.CyclicGroup3][] module of the [Agda Universal Algebra Library][].
+
+The integers modulo `3` under addition form the smallest non-trivial cyclic group.
+We build it on the carrier `Fin 3`{.AgdaDatatype} from its addition table, using the
+Cayley-table machinery of [`Overture.Cayley`][]: the group axioms are decidable over
+the finite carrier, so associativity, the identity laws, and the inverse laws are each
+discharged by `from-yes`{.AgdaFunction} applied to the corresponding decision.  This is
+the first example to exercise the `Associative?`{.AgdaFunction},
+`LeftIdentity?`{.AgdaFunction}, `RightIdentity?`{.AgdaFunction},
+`LeftInverse?`{.AgdaFunction}, and `RightInverse?`{.AgdaFunction} checkers, and the
+first to feed a tabulated operation to `eqsToGroup`{.AgdaFunction}.
+
+The addition table (rows indexed by the left summand, columns by the right; entry
+`a , b` is `(a + b) mod 3`):
+
+| + | 0 | 1 | 2 |
+|---|---|---|---|
+| 0 | 0 | 1 | 2 |
+| 1 | 1 | 2 | 0 |
+| 2 | 2 | 0 | 1 |
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Examples.Classical.CyclicGroup3 where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Data.Fin                                using ( Fin )
+open import Data.Fin.Patterns                       using ( 0F ; 1F ; 2F )
+open import Data.Vec.Base                           using ( _∷_ ; [] )
+open import Relation.Binary.PropositionalEquality   using ( _≡_ ; refl )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture.Cayley                     using ( Table ; ⟦_⟧ ; from-yes
+                                                      ; Associative? ; Commutative?
+                                                      ; LeftIdentity? ; RightIdentity?
+                                                      ; LeftInverse? ; RightInverse? )
+open import Classical.Bundles.Group             using ( ⟨_⟩ᵍᵖ ; ⟪_⟫ᵍᵖ )
+open import Classical.Small.Structures.Group    using ( Group ; eqsToGroup )
+import      Classical.Structures.Group          as Polymorphic
+```
+
+#### The Cayley table, the operation, and the inverse map
+
+```agda
+-- The addition-mod-3 table.
+z3-table : Table 3
+z3-table = (0F ∷ 1F ∷ 2F ∷ [])
+         ∷ (1F ∷ 2F ∷ 0F ∷ [])
+         ∷ (2F ∷ 0F ∷ 1F ∷ [])
+         ∷ []
+
+-- The operation it denotes.
+_·_ : Fin 3 → Fin 3 → Fin 3
+_·_ = ⟦ z3-table ⟧
+
+-- The inverse map: 0 ↦ 0, 1 ↦ 2, 2 ↦ 1 (negation mod 3).
+z3-inv : Fin 3 → Fin 3
+z3-inv 0F = 0F
+z3-inv 1F = 2F
+z3-inv 2F = 1F
+```
+
+#### The group `ℤ/3ℤ`
+
+The five group axioms are decidable; `from-yes`{.AgdaFunction} extracts each proof.
+If the table were not associative, or `0F`{.AgdaInductiveConstructor} were not an
+identity, or `z3-inv`{.AgdaFunction} were not an inverse, the corresponding decision
+would reduce to `no`{.AgdaInductiveConstructor} and this definition would fail to
+type-check.
+
+```agda
+z3-group : Group
+z3-group = eqsToGroup (Fin 3) _·_ 0F z3-inv
+             (from-yes (Associative?   _·_))
+             (from-yes (LeftIdentity?  _·_ 0F))
+             (from-yes (RightIdentity? _·_ 0F))
+             (from-yes (LeftInverse?   _·_ 0F z3-inv))
+             (from-yes (RightInverse?  _·_ 0F z3-inv))
+
+open Polymorphic.Group-Op z3-group using ( _∙_ ; ε ; _⁻¹ )
+```
+
+#### `ℤ/3ℤ` is abelian
+
+```agda
+·-comm : ∀ a b → a · b ≡ b · a
+·-comm = from-yes (Commutative? _·_)
+```
+
+#### Acceptance checks
+
+The `Group-Op`{.AgdaModule} accessors interpret to the tabulated operation, to
+`0F`{.AgdaInductiveConstructor}, and to `z3-inv`{.AgdaFunction} on the nose; discharged
+by `refl`{.AgdaInductiveConstructor}.
+
+```agda
+∙-is-· : ∀ (a b : Fin 3) → a ∙ b ≡ a · b
+∙-is-· a b = refl
+
+ε-is-0 : ε ≡ 0F
+ε-is-0 = refl
+
+⁻¹-is-inv : ∀ (a : Fin 3) → a ⁻¹ ≡ z3-inv a
+⁻¹-is-inv a = refl
+```
+
+The bundle bridge round-trips on `z3-group`{.AgdaFunction} pointwise on the operation,
+the identity, and the inverse.
+
+```agda
+open Polymorphic.Group-Op ⟪ ⟨ z3-group ⟩ᵍᵖ ⟫ᵍᵖ using ()
+  renaming ( _∙_ to _·′_ ; ε to ε′ ; _⁻¹ to _⁻¹′ )
+
+roundtrip-∙ : ∀ (a b : Fin 3) → a ·′ b ≡ a · b
+roundtrip-∙ a b = refl
+
+roundtrip-ε : ε′ ≡ 0F
+roundtrip-ε = refl
+
+roundtrip-⁻¹ : ∀ (a : Fin 3) → a ⁻¹′ ≡ z3-inv a
+roundtrip-⁻¹ a = refl
+```
+
+--------------------------------------
+
+<span style="float:left;">[← Examples.Classical](Examples.Classical.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Examples/Classical/CyclicGroup3.lagda.md
+++ b/src/Examples/Classical/CyclicGroup3.lagda.md
@@ -6,16 +6,16 @@ date: "2026-05-31"
 author: "the agda-algebras development team"
 ---
 
-### Worked example — the cyclic group `ℤ/3ℤ` from a Cayley table
+### Worked example: the cyclic group `ℤ/3ℤ` from a Cayley table
 
 This is the [Examples.Classical.CyclicGroup3][] module of the [Agda Universal Algebra Library][].
 
 The integers modulo `3` under addition form the smallest non-trivial cyclic group.
-We build it on the carrier `Fin 3`{.AgdaDatatype} from its addition table, using the
-Cayley-table machinery of [`Overture.Cayley`][]: the group axioms are decidable over
-the finite carrier, so associativity, the identity laws, and the inverse laws are each
-discharged by `from-yes`{.AgdaFunction} applied to the corresponding decision.  This is
-the first example to exercise the `Associative?`{.AgdaFunction},
+We build it on the carrier `Fin 3` from its addition table, using the Cayley-table
+machinery of [`Overture.Cayley`][]: the group axioms are decidable over the finite
+carrier, so associativity, the identity laws, and the inverse laws are each
+discharged by `from-yes`{.AgdaFunction} applied to the corresponding decision.  This
+is the first example to exercise the `Associative?`{.AgdaFunction},
 `LeftIdentity?`{.AgdaFunction}, `RightIdentity?`{.AgdaFunction},
 `LeftInverse?`{.AgdaFunction}, and `RightInverse?`{.AgdaFunction} checkers, and the
 first to feed a tabulated operation to `eqsToGroup`{.AgdaFunction}.

--- a/src/Examples/Classical/KleinFourGroup.lagda.md
+++ b/src/Examples/Classical/KleinFourGroup.lagda.md
@@ -1,0 +1,132 @@
+---
+layout: default
+file: "src/Examples/Classical/KleinFourGroup.lagda.md"
+title: "Examples.Classical.KleinFourGroup module"
+date: "2026-05-31"
+author: "the agda-algebras development team"
+---
+
+### Worked example — the Klein four-group `V₄` from a Cayley table
+
+This is the [Examples.Classical.KleinFourGroup][] module of the [Agda Universal Algebra Library][].
+
+The Klein four-group `V₄ ≅ ℤ/2ℤ × ℤ/2ℤ`{.AgdaFunction} is the smallest non-cyclic group.
+We build it on the carrier `Fin 4`{.AgdaDatatype}, identifying the four elements with
+the two-bit codes `0 = (0,0)`, `1 = (1,0)`, `2 = (0,1)`, `3 = (1,1)`, so the group
+operation is component-wise addition mod 2 — equivalently, bitwise *exclusive or* on
+the index.  As with [`Examples.Classical.CyclicGroup3`][], the group axioms are
+discharged by decision over the finite carrier.
+
+The defining feature, in contrast to `ℤ/3ℤ`, is that every element is its own inverse
+(the group has exponent `2`), so the inverse map is the identity.
+
+The operation table (entry `a , b` is `a xor b`):
+
+| · | 0 | 1 | 2 | 3 |
+|---|---|---|---|---|
+| 0 | 0 | 1 | 2 | 3 |
+| 1 | 1 | 0 | 3 | 2 |
+| 2 | 2 | 3 | 0 | 1 |
+| 3 | 3 | 2 | 1 | 0 |
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Examples.Classical.KleinFourGroup where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Data.Fin                                using ( Fin )
+open import Data.Fin.Patterns                       using ( 0F ; 1F ; 2F ; 3F )
+open import Data.Vec.Base                           using ( _∷_ ; [] )
+open import Relation.Binary.PropositionalEquality   using ( _≡_ ; refl )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture.Cayley                     using ( Table ; ⟦_⟧ ; from-yes
+                                                      ; Associative? ; Commutative?
+                                                      ; LeftIdentity? ; RightIdentity?
+                                                      ; LeftInverse? ; RightInverse? )
+open import Classical.Bundles.Group             using ( ⟨_⟩ᵍᵖ ; ⟪_⟫ᵍᵖ )
+open import Classical.Small.Structures.Group    using ( Group ; eqsToGroup )
+import      Classical.Structures.Group          as Polymorphic
+```
+
+#### The Cayley table, the operation, and the inverse map
+
+```agda
+-- The bitwise-xor table on the two-bit codes 0..3.
+v4-table : Table 4
+v4-table = (0F ∷ 1F ∷ 2F ∷ 3F ∷ [])
+         ∷ (1F ∷ 0F ∷ 3F ∷ 2F ∷ [])
+         ∷ (2F ∷ 3F ∷ 0F ∷ 1F ∷ [])
+         ∷ (3F ∷ 2F ∷ 1F ∷ 0F ∷ [])
+         ∷ []
+
+-- The operation it denotes.
+_·_ : Fin 4 → Fin 4 → Fin 4
+_·_ = ⟦ v4-table ⟧
+
+-- Every element is its own inverse, so the inverse map is the identity.
+v4-inv : Fin 4 → Fin 4
+v4-inv x = x
+```
+
+#### The group `V₄`
+
+```agda
+v4-group : Group
+v4-group = eqsToGroup (Fin 4) _·_ 0F v4-inv
+             (from-yes (Associative?   _·_))
+             (from-yes (LeftIdentity?  _·_ 0F))
+             (from-yes (RightIdentity? _·_ 0F))
+             (from-yes (LeftInverse?   _·_ 0F v4-inv))
+             (from-yes (RightInverse?  _·_ 0F v4-inv))
+
+open Polymorphic.Group-Op v4-group using ( _∙_ ; ε ; _⁻¹ )
+```
+
+#### `V₄` is abelian and has exponent 2
+
+```agda
+·-comm : ∀ a b → a · b ≡ b · a
+·-comm = from-yes (Commutative? _·_)
+```
+
+#### Acceptance checks
+
+The `Group-Op`{.AgdaModule} accessors interpret to the tabulated operation, to
+`0F`{.AgdaInductiveConstructor}, and to the identity inverse map on the nose; discharged
+by `refl`{.AgdaInductiveConstructor}.  In particular every element is its own inverse.
+
+```agda
+∙-is-· : ∀ (a b : Fin 4) → a ∙ b ≡ a · b
+∙-is-· a b = refl
+
+ε-is-0 : ε ≡ 0F
+ε-is-0 = refl
+
+⁻¹-is-self : ∀ (a : Fin 4) → a ⁻¹ ≡ a
+⁻¹-is-self a = refl
+```
+
+The bundle bridge round-trips on `v4-group`{.AgdaFunction} pointwise on the operation,
+the identity, and the inverse.
+
+```agda
+open Polymorphic.Group-Op ⟪ ⟨ v4-group ⟩ᵍᵖ ⟫ᵍᵖ using ()
+  renaming ( _∙_ to _·′_ ; ε to ε′ ; _⁻¹ to _⁻¹′ )
+
+roundtrip-∙ : ∀ (a b : Fin 4) → a ·′ b ≡ a · b
+roundtrip-∙ a b = refl
+
+roundtrip-ε : ε′ ≡ 0F
+roundtrip-ε = refl
+
+roundtrip-⁻¹ : ∀ (a : Fin 4) → a ⁻¹′ ≡ a
+roundtrip-⁻¹ a = refl
+```
+
+--------------------------------------
+
+<span style="float:left;">[← Examples.Classical](Examples.Classical.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Examples/Classical/KleinFourGroup.lagda.md
+++ b/src/Examples/Classical/KleinFourGroup.lagda.md
@@ -6,12 +6,12 @@ date: "2026-05-31"
 author: "the agda-algebras development team"
 ---
 
-### Worked example — the Klein four-group `V₄` from a Cayley table
+### Worked Example: the Klein four-group `V₄` from a Cayley table
 
 This is the [Examples.Classical.KleinFourGroup][] module of the [Agda Universal Algebra Library][].
 
-The Klein four-group `V₄ ≅ ℤ/2ℤ × ℤ/2ℤ`{.AgdaFunction} is the smallest non-cyclic group.
-We build it on the carrier `Fin 4`{.AgdaDatatype}, identifying the four elements with
+The Klein four-group `V₄ ≅ ℤ/2ℤ × ℤ/2ℤ` is the smallest non-cyclic group.
+We build it on the carrier `Fin 4`, identifying the four elements with
 the two-bit codes `0 = (0,0)`, `1 = (1,0)`, `2 = (0,1)`, `3 = (1,1)`, so the group
 operation is component-wise addition mod 2 — equivalently, bitwise *exclusive or* on
 the index.  As with [`Examples.Classical.CyclicGroup3`][], the group axioms are

--- a/src/Examples/Classical/SymmetricGroup3.lagda.md
+++ b/src/Examples/Classical/SymmetricGroup3.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-31"
 author: "the agda-algebras development team"
 ---
 
-### Worked example — the symmetric group `S₃` from a Cayley table
+### Worked Example: the symmetric group `S₃` from a Cayley table
 
 This is the [Examples.Classical.SymmetricGroup3][] module of the [Agda Universal Algebra Library][].
 
@@ -14,13 +14,12 @@ The symmetric group `S₃` on three letters — equivalently the dihedral group 
 symmetries of an equilateral triangle — is the smallest *non-abelian* group.  The
 canonical `Group`{.AgdaRecord} example in [`Examples.Classical.Group`][] is the
 integers under addition, which is abelian; this module supplies a genuinely
-non-commutative companion, fulfilling the corresponding task of issue #266.
+non-commutative companion.
 
-We present `S₃` through the dihedral generators: a rotation `r`{.AgdaBound} with
-`r³ = e`{.AgdaFunction} and a reflection `s`{.AgdaBound} with `s² = e`{.AgdaFunction}
-and `s r = r² s`{.AgdaFunction}.  Every element is uniquely `rⁱ sʲ`{.AgdaFunction}
-with `i ∈ {0,1,2}`, `j ∈ {0,1}`, and we encode it as the index `i + 3j` in
-`Fin 6`{.AgdaDatatype}:
+We present `S₃` through the dihedral generators: a rotation `r` with `r³ = e` and a
+reflection `s` with `s² = e` and `s r = r² s`.  Every element is uniquely `rⁱ sʲ`
+with `i ∈ {0,1,2}`, `j ∈ {0,1}`, and we encode it as the index `i + 3j` in `Fin 6` as
+follows:
 
 | index | 0 | 1 | 2 | 3 | 4 | 5 |
 |-------|---|---|---|---|---|---|
@@ -109,10 +108,9 @@ open Polymorphic.Group-Op s3-group using ( _∙_ ; ε ; _⁻¹ )
 
 #### `S₃` is not abelian
 
-The product `r · s = rs`{.AgdaFunction} (index `1 · 3 = 4`) differs from
-`s · r = r²s`{.AgdaFunction} (index `3 · 1 = 5`), so the rotation and the reflection do
-not commute.  The witnessing inequality is the absurd pattern `λ ()`{.AgdaFunction},
-since `4 ≡ 5`{.AgdaFunction} is uninhabited.
+The product `r · s = rs` (index `1 · 3 = 4`) differs from `s · r = r²s`
+(index `3 · 1 = 5`), so the rotation and the reflection do not commute.
+The witnessing inequality is the absurd pattern `λ ()`, since `4 ≡ 5` is uninhabited.
 
 ```agda
 s3-noncomm : ∃[ a ] ∃[ b ] a · b ≢ b · a

--- a/src/Examples/Classical/SymmetricGroup3.lagda.md
+++ b/src/Examples/Classical/SymmetricGroup3.lagda.md
@@ -1,0 +1,168 @@
+---
+layout: default
+file: "src/Examples/Classical/SymmetricGroup3.lagda.md"
+title: "Examples.Classical.SymmetricGroup3 module"
+date: "2026-05-31"
+author: "the agda-algebras development team"
+---
+
+### Worked example — the symmetric group `S₃` from a Cayley table
+
+This is the [Examples.Classical.SymmetricGroup3][] module of the [Agda Universal Algebra Library][].
+
+The symmetric group `S₃` on three letters — equivalently the dihedral group `D₃` of
+symmetries of an equilateral triangle — is the smallest *non-abelian* group.  The
+canonical `Group`{.AgdaRecord} example in [`Examples.Classical.Group`][] is the
+integers under addition, which is abelian; this module supplies a genuinely
+non-commutative companion, fulfilling the corresponding task of issue #266.
+
+We present `S₃` through the dihedral generators: a rotation `r`{.AgdaBound} with
+`r³ = e`{.AgdaFunction} and a reflection `s`{.AgdaBound} with `s² = e`{.AgdaFunction}
+and `s r = r² s`{.AgdaFunction}.  Every element is uniquely `rⁱ sʲ`{.AgdaFunction}
+with `i ∈ {0,1,2}`, `j ∈ {0,1}`, and we encode it as the index `i + 3j` in
+`Fin 6`{.AgdaDatatype}:
+
+| index | 0 | 1 | 2 | 3 | 4 | 5 |
+|-------|---|---|---|---|---|---|
+| element | `e` | `r` | `r²` | `s` | `rs` | `r²s` |
+
+The full multiplication table (entry `a , b` is the product `a · b`):
+
+| · | 0 | 1 | 2 | 3 | 4 | 5 |
+|---|---|---|---|---|---|---|
+| 0 | 0 | 1 | 2 | 3 | 4 | 5 |
+| 1 | 1 | 2 | 0 | 4 | 5 | 3 |
+| 2 | 2 | 0 | 1 | 5 | 3 | 4 |
+| 3 | 3 | 5 | 4 | 0 | 2 | 1 |
+| 4 | 4 | 3 | 5 | 1 | 0 | 2 |
+| 5 | 5 | 4 | 3 | 2 | 1 | 0 |
+
+As before, the group axioms are decidable over the finite carrier and are discharged
+by `from-yes`{.AgdaFunction}.  Associativity here is a decision over all `6³ = 216`
+triples — exactly the case where a hand-written proof would be unreasonable and the
+`Overture.Cayley`{.AgdaModule} approach pays off.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Examples.Classical.SymmetricGroup3 where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Data.Fin                                using ( Fin )
+open import Data.Fin.Patterns                       using ( 0F ; 1F ; 2F ; 3F ; 4F ; 5F )
+open import Data.Product                            using ( ∃-syntax ; _,_ )
+open import Data.Vec.Base                           using ( _∷_ ; [] )
+open import Relation.Binary.PropositionalEquality   using ( _≡_ ; _≢_ ; refl )
+open import Relation.Nullary.Negation.Core          using ( ¬_ ; contradiction )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture.Cayley                     using ( Table ; ⟦_⟧ ; from-yes
+                                                      ; Associative? ; Commutative?
+                                                      ; LeftIdentity? ; RightIdentity?
+                                                      ; LeftInverse? ; RightInverse? )
+open import Classical.Bundles.Group             using ( ⟨_⟩ᵍᵖ ; ⟪_⟫ᵍᵖ )
+open import Classical.Small.Structures.Group    using ( Group ; eqsToGroup )
+import      Classical.Structures.Group          as Polymorphic
+```
+
+#### The Cayley table, the operation, and the inverse map
+
+```agda
+-- The S₃ ≅ D₃ multiplication table on the encoding e,r,r²,s,rs,r²s = 0..5.
+s3-table : Table 6
+s3-table = (0F ∷ 1F ∷ 2F ∷ 3F ∷ 4F ∷ 5F ∷ [])
+         ∷ (1F ∷ 2F ∷ 0F ∷ 4F ∷ 5F ∷ 3F ∷ [])
+         ∷ (2F ∷ 0F ∷ 1F ∷ 5F ∷ 3F ∷ 4F ∷ [])
+         ∷ (3F ∷ 5F ∷ 4F ∷ 0F ∷ 2F ∷ 1F ∷ [])
+         ∷ (4F ∷ 3F ∷ 5F ∷ 1F ∷ 0F ∷ 2F ∷ [])
+         ∷ (5F ∷ 4F ∷ 3F ∷ 2F ∷ 1F ∷ 0F ∷ [])
+         ∷ []
+
+-- The operation it denotes.
+_·_ : Fin 6 → Fin 6 → Fin 6
+_·_ = ⟦ s3-table ⟧
+
+-- The inverse map.  The rotations r, r² invert each other; e and the three
+-- reflections s, rs, r²s are each their own inverse.
+s3-inv : Fin 6 → Fin 6
+s3-inv 0F = 0F
+s3-inv 1F = 2F
+s3-inv 2F = 1F
+s3-inv 3F = 3F
+s3-inv 4F = 4F
+s3-inv 5F = 5F
+```
+
+#### The group `S₃`
+
+```agda
+s3-group : Group
+s3-group = eqsToGroup (Fin 6) _·_ 0F s3-inv
+             (from-yes (Associative?   _·_))
+             (from-yes (LeftIdentity?  _·_ 0F))
+             (from-yes (RightIdentity? _·_ 0F))
+             (from-yes (LeftInverse?   _·_ 0F s3-inv))
+             (from-yes (RightInverse?  _·_ 0F s3-inv))
+
+open Polymorphic.Group-Op s3-group using ( _∙_ ; ε ; _⁻¹ )
+```
+
+#### `S₃` is not abelian
+
+The product `r · s = rs`{.AgdaFunction} (index `1 · 3 = 4`) differs from
+`s · r = r²s`{.AgdaFunction} (index `3 · 1 = 5`), so the rotation and the reflection do
+not commute.  The witnessing inequality is the absurd pattern `λ ()`{.AgdaFunction},
+since `4 ≡ 5`{.AgdaFunction} is uninhabited.
+
+```agda
+s3-noncomm : ∃[ a ] ∃[ b ] a · b ≢ b · a
+s3-noncomm = 1F , 3F , λ ()
+```
+
+In negated-universal form — `S₃` admits no proof of commutativity — this follows by
+feeding the witnessing pair to the assumed commutativity and deriving a contradiction.
+
+```agda
+s3-not-abelian : ¬ (∀ a b → a · b ≡ b · a)
+s3-not-abelian comm = contradiction (comm 1F 3F) λ ()
+```
+
+#### Acceptance checks
+
+The `Group-Op`{.AgdaModule} accessors interpret to the tabulated operation, to
+`0F`{.AgdaInductiveConstructor}, and to `s3-inv`{.AgdaFunction} on the nose; discharged
+by `refl`{.AgdaInductiveConstructor}.
+
+```agda
+∙-is-· : ∀ (a b : Fin 6) → a ∙ b ≡ a · b
+∙-is-· a b = refl
+
+ε-is-0 : ε ≡ 0F
+ε-is-0 = refl
+
+⁻¹-is-inv : ∀ (a : Fin 6) → a ⁻¹ ≡ s3-inv a
+⁻¹-is-inv a = refl
+```
+
+The bundle bridge round-trips on `s3-group`{.AgdaFunction} pointwise on the operation,
+the identity, and the inverse.
+
+```agda
+open Polymorphic.Group-Op ⟪ ⟨ s3-group ⟩ᵍᵖ ⟫ᵍᵖ using ()
+  renaming ( _∙_ to _·′_ ; ε to ε′ ; _⁻¹ to _⁻¹′ )
+
+roundtrip-∙ : ∀ (a b : Fin 6) → a ·′ b ≡ a · b
+roundtrip-∙ a b = refl
+
+roundtrip-ε : ε′ ≡ 0F
+roundtrip-ε = refl
+
+roundtrip-⁻¹ : ∀ (a : Fin 6) → a ⁻¹′ ≡ s3-inv a
+roundtrip-⁻¹ a = refl
+```
+
+--------------------------------------
+
+<span style="float:left;">[← Examples.Classical](Examples.Classical.html)</span>
+
+{% include UALib.Links.md %}


### PR DESCRIPTION
## Summary

Second increment toward #266, building on the `Overture.Cayley` machinery merged in #353.  Three worked finite groups, each defined by its multiplication table, with the group axioms discharged by *decision* (`from-yes`) rather than by hand.  These exercise the `Associative?` / `LeftIdentity?` / `RightIdentity?` / `LeftInverse?` / `RightInverse?` checkers that the commutative-idempotent-magma example did not reach.

## What's here

+  **`Examples.Classical.CyclicGroup3`** — `ℤ/3ℤ`, the smallest non-trivial cyclic group; shown abelian.  First example to feed a tabulated operation to `eqsToGroup`.
+  **`Examples.Classical.KleinFourGroup`** — `V₄ ≅ ℤ/2ℤ × ℤ/2ℤ`, the smallest non-cyclic group; abelian, of exponent 2 (so the inverse map is the identity).
+  **`Examples.Classical.SymmetricGroup3`** — `S₃ ≅ D₃`, the smallest **non-abelian** group, with an explicit noncommutativity witness `∃[ a ] ∃[ b ] a · b ≢ b · a` (concretely `r · s ≠ s · r`) and the negated-universal form.  This is the nonabelian-group task added to #266.  Associativity is a decision over all `6³ = 216` triples — exactly the case where a hand-written proof would be unreasonable and the Cayley approach earns its keep.

Each module also confirms the `Group-Op` accessors reduce to the tabulated operation, identity, and inverse (by `refl`), and that the stdlib bundle bridge round-trips.

## Notes

+  The group modules are intentionally **not** added to the `Examples.Classical` barrel: they export example-local names (e.g. `_·_`) that would clash on re-export.  This matches the existing `Group` / `AbelianGroup` / `CommutativeRing` examples, which are likewise not barrelled.  They are type-checked via the `Everything` aggregator and are directly importable.
+  Every table was generated and verified as a group out-of-band, and the `from-yes` deciders independently re-verify each axiom at type-check time — a wrong table simply would not compile.

## Testing

+  `nix develop --command make check` passes (exit 0; only the expected `Legacy/` deprecation warnings).

## Remaining (from #266, for later increments)

+  `(ℕ, ∸)` as a magma that is not a semigroup; `(ℕ, ·, 1)` as a `CommutativeMonoid`.
+  `𝟚` distributivity (completing the `DistributiveLattice` task); the 3-element chain as a finite Heyting algebra.
+  `ℤ/3ℤ` congruence lattice (stretch; needs new congruence infrastructure).

Part of #266.

https://claude.ai/code/session_019FmaZSGNJUFCnm5CarkfdL

---
_Generated by [Claude Code](https://claude.ai/code/session_019FmaZSGNJUFCnm5CarkfdL)_