### PR TITLE
Subalgebra lattice: algebra-parametrized named module (write `B ≤ C`, not `_≤_ 𝑨 ℓ₀ B C`)

### DIFF
--- a/src/Examples/Setoid/SubalgebraLattice.lagda.md
+++ b/src/Examples/Setoid/SubalgebraLattice.lagda.md
@@ -55,26 +55,22 @@ open import Setoid.Algebras {𝑆 = 𝑆₀} using ( Algebra ; 𝕌[_] ; ⟨_⟩
 -- The two-element algebra: carrier Bool with ≡, and no operations to interpret.
 𝟚 : Algebra 0ℓ 0ℓ
 𝟚 = record { Domain = ≡.setoid Bool ; Interp = interp }
- where
- interp : Func (⟨ 𝑆₀ ⟩ (≡.setoid Bool)) (≡.setoid Bool)
- interp ⟨$⟩ (() , _)
- cong interp {() , _}
+  where
+  interp : Func (⟨ 𝑆₀ ⟩ (≡.setoid Bool)) (≡.setoid Bool)
+  interp ⟨$⟩ (() , _)
+  cong interp {() , _}
 ```
 
 #### Instantiating the bundles {#the-bundles}
 
 With base level `ℓ₀ = 0ℓ` the absorbing level `L` is `0ℓ`, so the subalgebra lattice
-of `𝟚` lives on `Subᴸ`.  We `open SubLattice 𝟚 0ℓ` to bring the order, operations,
+of `𝟚` lives on `Subᴸ`.  We `open Sublattice 𝟚 0ℓ` to bring the order, operations,
 bounds, and bundles into scope specialized to `𝟚` — so we may write `B ≤ C` rather
 than `_≤_ 𝟚 0ℓ B C`.  All three bundles type-check.
 
 ```agda
-open import Setoid.Subalgebras.CompleteLattice {𝑆 = 𝑆₀} using ( module SubLattice )
-open SubLattice 𝟚 0ℓ
-
-Sub𝟚-Lattice          = Sub-Lattice
-Sub𝟚-BoundedLattice   = Sub-BoundedLattice
-Sub𝟚-CompleteLattice  = Sub-CompleteLattice
+open import Setoid.Subalgebras.CompleteLattice {𝑆 = 𝑆₀} using ( module Sublattice )
+open Sublattice 𝟚 0ℓ
 ```
 
 #### Nontriviality: `⊤ ⋬ ⊥` {#nontriviality}

--- a/src/Examples/Setoid/SubalgebraLattice.lagda.md
+++ b/src/Examples/Setoid/SubalgebraLattice.lagda.md
@@ -64,16 +64,17 @@ open import Setoid.Algebras {𝑆 = 𝑆₀} using ( Algebra ; 𝕌[_] ; ⟨_⟩
 #### Instantiating the bundles {#the-bundles}
 
 With base level `ℓ₀ = 0ℓ` the absorbing level `L` is `0ℓ`, so the subalgebra lattice
-of `𝟚` lives on `Subᴸ 𝟚 0ℓ`.  All three bundles type-check.
+of `𝟚` lives on `Subᴸ`.  We `open SubLattice 𝟚 0ℓ` to bring the order, operations,
+bounds, and bundles into scope specialized to `𝟚` — so we may write `B ≤ C` rather
+than `_≤_ 𝟚 0ℓ B C`.  All three bundles type-check.
 
 ```agda
-open import Setoid.Subalgebras.CompleteLattice {𝑆 = 𝑆₀}
-  using ( Subᴸ ; _≤_ ; Sub-Lattice ; Sub-BoundedLattice ; Sub-CompleteLattice
-        ; 1ˢ ; 0ˢ ; 0ˢ-minimum )
+open import Setoid.Subalgebras.CompleteLattice {𝑆 = 𝑆₀} using ( module SubLattice )
+open SubLattice 𝟚 0ℓ
 
-Sub𝟚-Lattice          = Sub-Lattice         𝟚 0ℓ
-Sub𝟚-BoundedLattice   = Sub-BoundedLattice  𝟚 0ℓ
-Sub𝟚-CompleteLattice  = Sub-CompleteLattice 𝟚 0ℓ
+Sub𝟚-Lattice          = Sub-Lattice
+Sub𝟚-BoundedLattice   = Sub-BoundedLattice
+Sub𝟚-CompleteLattice  = Sub-CompleteLattice
 ```
 
 #### Nontriviality: `⊤ ⋬ ⊥` {#nontriviality}
@@ -83,12 +84,12 @@ operations).  If we had `⊤ ≤ ⊥`, then since `⊥` is the *least* subuniver
 `∅`, so `true ∈ ⊤` would force `true ∈ ∅` — impossible.
 
 ```agda
--- The empty subuniverse, as an element of Subᴸ 𝟚 0ℓ.
-∅ˢ : Subᴸ 𝟚 0ℓ
+-- The empty subuniverse, as an element of Subᴸ.
+∅ˢ : Subᴸ
 ∅ˢ = (λ _ → Lift 0ℓ ⊥) , λ ()
 
-Sub𝟚-nontrivial : ¬ ( _≤_ 𝟚 0ℓ (1ˢ 𝟚 0ℓ) (0ˢ 𝟚 0ℓ) )
-Sub𝟚-nontrivial 1≤0 = lower (0ˢ-minimum 𝟚 0ℓ ∅ˢ (1≤0 {true} (lift tt)))
+Sub𝟚-nontrivial : ¬ ( 1ˢ ≤ 0ˢ )
+Sub𝟚-nontrivial 1≤0 = lower (0ˢ-minimum ∅ˢ (1≤0 {true} (lift tt)))
 ```
 
 --------------------------------------

--- a/src/Setoid/Subalgebras/CompleteLattice.lagda.md
+++ b/src/Setoid/Subalgebras/CompleteLattice.lagda.md
@@ -60,50 +60,53 @@ private variable α ρᵃ : Level
 
 #### The subuniverse lattice at the absorbing level `L`
 
+The subuniverse lattice of an algebra is formalized here and packaged inside a module
+called `Sublattice`, which is parametrized by the algebra `𝑨` and a base level `ℓ₀`.
+This way openning the `Sublattice` module at a use site (with, e.g., `open Sublattice 𝑨 ℓ₀`)
+makes available `_≤_`, `_∧_`, `_∨_`, the bounds, and the bundles specialized to `𝑨`.
+One can then write `B ≤ C`, instead of `_≤_ 𝑨 ℓ₀ B C`.
+
 ```agda
--- All of the following is parametrized by the algebra `𝑨` and a base level `ℓ₀`.
--- Open it at a use site (`open SubLattice 𝑨 ℓ₀`) to get `_≤_`, `_∧_`, `_∨_`, the
--- bounds, and the bundles specialized to `𝑨` — so one writes `B ≤ C`, not `_≤_ 𝑨 ℓ₀ B C`.
-module SubLattice (𝑨 : Algebra α ρᵃ) (ℓ₀ : Level) where
- private A = 𝕌[ 𝑨 ]
+module Sublattice (𝑨 : Algebra α ρᵃ) (ℓ₀ : Level) where
+  private A = 𝕌[ 𝑨 ]
 
- L : Level
- L = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ₀
+  L : Level
+  L = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ₀
 
- -- A subuniverse, as its underlying predicate together with a proof of closure.
- Subᴸ : Type (α ⊔ ov L)
- Subᴸ = Σ[ B ∈ Pred A L ] B ∈ Subuniverses 𝑨
+  -- A subuniverse, as its underlying predicate together with a proof of closure.
+  Subᴸ : Type (α ⊔ ov L)
+  Subᴸ = Σ[ B ∈ Pred A L ] B ∈ Subuniverses 𝑨
 ```
 
 The order is inclusion of the underlying predicates, and the associated equality is
 mutual inclusion.
 
 ```agda
- infix 4 _≤_ _≈_
+  infix 4 _≤_ _≈_
 
- _≤_ : Subᴸ → Subᴸ → Type (α ⊔ L)
- B ≤ C = proj₁ B ⊆ proj₁ C
+  _≤_ : Subᴸ → Subᴸ → Type (α ⊔ L)
+  B ≤ C = proj₁ B ⊆ proj₁ C
 
- _≈_ : Subᴸ → Subᴸ → Type (α ⊔ L)
- B ≈ C = (B ≤ C) × (C ≤ B)
+  _≈_ : Subᴸ → Subᴸ → Type (α ⊔ L)
+  B ≈ C = (B ≤ C) × (C ≤ B)
 
- -- The proofs are inlined (rather than routed through named ≤-lemmas) because
- -- _≤_ is a defined relation whose congruence arguments Agda cannot recover.
- ≈-isEquivalence : IsEquivalence _≈_
- ≈-isEquivalence = record
-  { refl   = (λ z → z) , (λ z → z)
-  ; sym    = λ (p , q) → q , p
-  ; trans  = λ (p , q) (p′ , q′) → (λ z → p′ (p z)) , (λ z → q (q′ z))
-  }
+  -- The proofs are inlined (rather than routed through named ≤-lemmas) because
+  -- _≤_ is a defined relation whose congruence arguments Agda cannot recover.
+  ≈-isEquivalence : IsEquivalence _≈_
+  ≈-isEquivalence = record
+   { refl   = (λ z → z) , (λ z → z)
+   ; sym    = λ (p , q) → q , p
+   ; trans  = λ (p , q) (p′ , q′) → (λ z → p′ (p z)) , (λ z → q (q′ z))
+   }
 
- ≤-isPartialOrder : IsPartialOrder _≈_ _≤_
- ≤-isPartialOrder = record
-  { isPreorder = record  { isEquivalence  = ≈-isEquivalence
-                         ; reflexive      = proj₁
-                         ; trans          = λ p q z → q (p z)
-                         }
-  ; antisym = λ p q → p , q
-  }
+  ≤-isPartialOrder : IsPartialOrder _≈_ _≤_
+  ≤-isPartialOrder = record
+   { isPreorder = record  { isEquivalence  = ≈-isEquivalence
+                          ; reflexive      = proj₁
+                          ; trans          = λ p q z → q (p z)
+                          }
+   ; antisym = λ p q → p , q
+   }
 ```
 
 #### Meet and join
@@ -112,49 +115,49 @@ The meet is the intersection of the underlying predicates (a subuniverse,
 componentwise), and the join is the subuniverse *generated* by the union.
 
 ```agda
- infixr 7 _∧_
- infixr 6 _∨_
+  infixr 7 _∧_
+  infixr 6 _∨_
 
- _∧_ : Subᴸ → Subᴸ → Subᴸ
- B ∧ C = (proj₁ B ∩ proj₁ C)
-       , λ f a im → proj₂ B f a (λ i → proj₁ (im i))
-                  , proj₂ C f a (λ i → proj₂ (im i))
+  _∧_ : Subᴸ → Subᴸ → Subᴸ
+  B ∧ C = (proj₁ B ∩ proj₁ C)
+        , λ f a im → proj₂ B f a (λ i → proj₁ (im i))
+                   , proj₂ C f a (λ i → proj₂ (im i))
 
- _∨_ : Subᴸ → Subᴸ → Subᴸ
- B ∨ C = Sg 𝑨 (proj₁ B ∪ proj₁ C) , sgIsSub 𝑨
+  _∨_ : Subᴸ → Subᴸ → Subᴸ
+  B ∨ C = Sg 𝑨 (proj₁ B ∪ proj₁ C) , sgIsSub 𝑨
 
- -- The meet is the greatest lower bound.
- ∧-infimum : Infimum _≤_ _∧_
- ∧-infimum B C =  (λ z → proj₁ z)
-               ,  (λ z → proj₂ z)
-               ,  λ D D≤B D≤C z → D≤B z , D≤C z
+  -- The meet is the greatest lower bound.
+  ∧-infimum : Infimum _≤_ _∧_
+  ∧-infimum B C =  (λ z → proj₁ z)
+                ,  (λ z → proj₂ z)
+                ,  λ D D≤B D≤C z → D≤B z , D≤C z
 
- -- The join is the least upper bound (upper bounds via `var`, universality via
- -- `sgIsSmallest`, since the union is below any subuniverse above both arguments).
- ∨-supremum : Supremum _≤_ _∨_
- ∨-supremum B C =  (λ z → var (inj₁ z))
-                ,  (λ z → var (inj₂ z))
-                ,  λ D B≤D C≤D → sgIsSmallest 𝑨 (proj₁ D) (proj₂ D)
-                                   (λ { (inj₁ x) → B≤D x ; (inj₂ x) → C≤D x })
+  -- The join is the least upper bound (upper bounds via `var`, universality via
+  -- `sgIsSmallest`, since the union is below any subuniverse above both arguments).
+  ∨-supremum : Supremum _≤_ _∨_
+  ∨-supremum B C =  (λ z → var (inj₁ z))
+                 ,  (λ z → var (inj₂ z))
+                 ,  λ D B≤D C≤D → sgIsSmallest 𝑨 (proj₁ D) (proj₂ D)
+                                    (λ { (inj₁ x) → B≤D x ; (inj₂ x) → C≤D x })
 ```
 
 #### The lattice
 
 ```agda
- Sub-isLattice : IsLattice _≈_ _≤_ _∨_ _∧_
- Sub-isLattice = record  { isPartialOrder  = ≤-isPartialOrder
-                         ; supremum        = ∨-supremum
-                         ; infimum         = ∧-infimum
-                         }
+  Sub-isLattice : IsLattice _≈_ _≤_ _∨_ _∧_
+  Sub-isLattice = record  { isPartialOrder  = ≤-isPartialOrder
+                          ; supremum        = ∨-supremum
+                          ; infimum         = ∧-infimum
+                          }
 
- Sub-Lattice : Lattice (α ⊔ ov L) (α ⊔ L) (α ⊔ L)
- Sub-Lattice = record  { Carrier    = Subᴸ
-                       ; _≈_        = _≈_
-                       ; _≤_        = _≤_
-                       ; _∨_        = _∨_
-                       ; _∧_        = _∧_
-                       ; isLattice  = Sub-isLattice
-                       }
+  Sub-Lattice : Lattice (α ⊔ ov L) (α ⊔ L) (α ⊔ L)
+  Sub-Lattice = record  { Carrier    = Subᴸ
+                        ; _≈_        = _≈_
+                        ; _≤_        = _≤_
+                        ; _∨_        = _∨_
+                        ; _∧_        = _∧_
+                        ; isLattice  = Sub-isLattice
+                        }
 ```
 
 #### The bounds: empty and full subuniverses
@@ -164,41 +167,41 @@ by the empty predicate (`0ˢ = Sg ∅`); its minimality is immediate from `sgIsS
 The top subuniverse `1ˢ` is the whole carrier, trivially closed under the operations.
 
 ```agda
- private
-  0R : Pred A L
-  0R _ = Lift L ⊥
+  private
+   0R : Pred A L
+   0R _ = Lift L ⊥
 
-  1R : Pred A L
-  1R _ = Lift L ⊤
+   1R : Pred A L
+   1R _ = Lift L ⊤
 
- 0ˢ : Subᴸ
- 0ˢ = Sg 𝑨 0R , sgIsSub 𝑨
+  0ˢ : Subᴸ
+  0ˢ = Sg 𝑨 0R , sgIsSub 𝑨
 
- 1ˢ : Subᴸ
- 1ˢ = 1R , λ _ _ _ → lift tt
+  1ˢ : Subᴸ
+  1ˢ = 1R , λ _ _ _ → lift tt
 
- 0ˢ-minimum : Minimum _≤_ 0ˢ
- 0ˢ-minimum B = sgIsSmallest 𝑨 (proj₁ B) (proj₂ B) (λ { (lift ()) })
+  0ˢ-minimum : Minimum _≤_ 0ˢ
+  0ˢ-minimum B = sgIsSmallest 𝑨 (proj₁ B) (proj₂ B) (λ { (lift ()) })
 
- 1ˢ-maximum : Maximum _≤_ 1ˢ
- 1ˢ-maximum B _ = lift tt
+  1ˢ-maximum : Maximum _≤_ 1ˢ
+  1ˢ-maximum B _ = lift tt
 
- Sub-isBoundedLattice : IsBoundedLattice _≈_ _≤_ _∨_ _∧_ 1ˢ 0ˢ
- Sub-isBoundedLattice = record  { isLattice  = Sub-isLattice
-                                ; maximum    = 1ˢ-maximum
-                                ; minimum    = 0ˢ-minimum
-                                }
+  Sub-isBoundedLattice : IsBoundedLattice _≈_ _≤_ _∨_ _∧_ 1ˢ 0ˢ
+  Sub-isBoundedLattice = record  { isLattice  = Sub-isLattice
+                                 ; maximum    = 1ˢ-maximum
+                                 ; minimum    = 0ˢ-minimum
+                                 }
 
- Sub-BoundedLattice : BoundedLattice (α ⊔ ov L) (α ⊔ L) (α ⊔ L)
- Sub-BoundedLattice = record  { Carrier           = Subᴸ
-                              ; _≈_               = _≈_
-                              ; _≤_               = _≤_
-                              ; _∨_               = _∨_
-                              ; _∧_               = _∧_
-                              ; ⊤                 = 1ˢ
-                              ; ⊥                 = 0ˢ
-                              ; isBoundedLattice  = Sub-isBoundedLattice
-                              }
+  Sub-BoundedLattice : BoundedLattice (α ⊔ ov L) (α ⊔ L) (α ⊔ L)
+  Sub-BoundedLattice = record  { Carrier           = Subᴸ
+                               ; _≈_               = _≈_
+                               ; _≤_               = _≤_
+                               ; _∨_               = _∨_
+                               ; _∧_               = _∧_
+                               ; ⊤                 = 1ˢ
+                               ; ⊥                 = 0ˢ
+                               ; isBoundedLattice  = Sub-isBoundedLattice
+                               }
 ```
 
 #### Infinitary meets and joins
@@ -209,42 +212,42 @@ is the subuniverse generated by the union, `⨆ 𝒜 = Sg(⋃ 𝒜)`.  Both stay
 because `I` is `ℓ₀`-small.
 
 ```agda
- ⨅ : {I : Type ℓ₀} → (I → Subᴸ) → Subᴸ
- ⨅ {I} 𝒜 = ⋂ I (λ i → proj₁ (𝒜 i))
-          , ⋂s {𝑨 = 𝑨} I {𝒜 = λ i → proj₁ (𝒜 i)} (λ i → proj₂ (𝒜 i))
+  ⨅ : {I : Type ℓ₀} → (I → Subᴸ) → Subᴸ
+  ⨅ {I} 𝒜 = ⋂ I (λ i → proj₁ (𝒜 i))
+           , ⋂s {𝑨 = 𝑨} I {𝒜 = λ i → proj₁ (𝒜 i)} (λ i → proj₂ (𝒜 i))
 
- ⨆ : {I : Type ℓ₀} → (I → Subᴸ) → Subᴸ
- ⨆ {I} 𝒜 = Sg 𝑨 (⋃ I (λ i → proj₁ (𝒜 i))) , sgIsSub 𝑨
+  ⨆ : {I : Type ℓ₀} → (I → Subᴸ) → Subᴸ
+  ⨆ {I} 𝒜 = Sg 𝑨 (⋃ I (λ i → proj₁ (𝒜 i))) , sgIsSub 𝑨
 
- ⨅-lower : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (i : I) → (⨅ 𝒜) ≤ (𝒜 i)
- ⨅-lower 𝒜 i z = z i
+  ⨅-lower : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (i : I) → (⨅ 𝒜) ≤ (𝒜 i)
+  ⨅-lower 𝒜 i z = z i
 
- ⨅-greatest : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (D : Subᴸ) → (∀ i → D ≤ (𝒜 i)) → D ≤ (⨅ 𝒜)
- ⨅-greatest 𝒜 D D≤𝒜 z i = D≤𝒜 i z
+  ⨅-greatest : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (D : Subᴸ) → (∀ i → D ≤ (𝒜 i)) → D ≤ (⨅ 𝒜)
+  ⨅-greatest 𝒜 D D≤𝒜 z i = D≤𝒜 i z
 
- ⨆-upper : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (i : I) → (𝒜 i) ≤ (⨆ 𝒜)
- ⨆-upper 𝒜 i z = var (i , z)
+  ⨆-upper : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (i : I) → (𝒜 i) ≤ (⨆ 𝒜)
+  ⨆-upper 𝒜 i z = var (i , z)
 
- ⨆-least : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (D : Subᴸ) → (∀ i → (𝒜 i) ≤ D) → (⨆ 𝒜) ≤ D
- ⨆-least 𝒜 D 𝒜≤D = sgIsSmallest 𝑨 (proj₁ D) (proj₂ D) (λ (i , z) → 𝒜≤D i z)
+  ⨆-least : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (D : Subᴸ) → (∀ i → (𝒜 i) ≤ D) → (⨆ 𝒜) ≤ D
+  ⨆-least 𝒜 D 𝒜≤D = sgIsSmallest 𝑨 (proj₁ D) (proj₂ D) (λ (i , z) → 𝒜≤D i z)
 ```
 
 #### The complete lattice
 
 ```agda
- Sub-CompleteLattice : CompleteLattice (α ⊔ ov L) (α ⊔ L) (α ⊔ L) ℓ₀
- Sub-CompleteLattice = record
-  { Carrier          = Subᴸ
-  ; _≈_              = _≈_
-  ; _≤_              = _≤_
-  ; isPartialOrder   = ≤-isPartialOrder
-  ; ⨆                = ⨆
-  ; ⨅                = ⨅
-  ; ⨆-upper          = ⨆-upper
-  ; ⨆-least          = ⨆-least
-  ; ⨅-lower          = ⨅-lower
-  ; ⨅-greatest       = ⨅-greatest
-  }
+  Sub-CompleteLattice : CompleteLattice (α ⊔ ov L) (α ⊔ L) (α ⊔ L) ℓ₀
+  Sub-CompleteLattice = record
+   { Carrier          = Subᴸ
+   ; _≈_              = _≈_
+   ; _≤_              = _≤_
+   ; isPartialOrder   = ≤-isPartialOrder
+   ; ⨆                = ⨆
+   ; ⨅                = ⨅
+   ; ⨆-upper          = ⨆-upper
+   ; ⨆-least          = ⨆-least
+   ; ⨅-lower          = ⨅-lower
+   ; ⨅-greatest       = ⨅-greatest
+   }
 ```
 
 --------------------------------------

--- a/src/Setoid/Subalgebras/CompleteLattice.lagda.md
+++ b/src/Setoid/Subalgebras/CompleteLattice.lagda.md
@@ -61,7 +61,10 @@ private variable α ρᵃ : Level
 #### The subuniverse lattice at the absorbing level `L`
 
 ```agda
-module _ (𝑨 : Algebra α ρᵃ) (ℓ₀ : Level) where
+-- All of the following is parametrized by the algebra `𝑨` and a base level `ℓ₀`.
+-- Open it at a use site (`open SubLattice 𝑨 ℓ₀`) to get `_≤_`, `_∧_`, `_∨_`, the
+-- bounds, and the bundles specialized to `𝑨` — so one writes `B ≤ C`, not `_≤_ 𝑨 ℓ₀ B C`.
+module SubLattice (𝑨 : Algebra α ρᵃ) (ℓ₀ : Level) where
  private A = 𝕌[ 𝑨 ]
 
  L : Level

--- a/src/Setoid/Subalgebras/CompleteLattice.lagda.md
+++ b/src/Setoid/Subalgebras/CompleteLattice.lagda.md
@@ -62,7 +62,7 @@ private variable α ρᵃ : Level
 
 The subuniverse lattice of an algebra is formalized here and packaged inside a module
 called `Sublattice`, which is parametrized by the algebra `𝑨` and a base level `ℓ₀`.
-This way openning the `Sublattice` module at a use site (with, e.g., `open Sublattice 𝑨 ℓ₀`)
+This way opening the `Sublattice` module at a use site (with, e.g., `open Sublattice 𝑨 ℓ₀`)
 makes available `_≤_`, `_∧_`, `_∨_`, the bounds, and the bundles specialized to `𝑨`.
 One can then write `B ≤ C`, instead of `_≤_ 𝑨 ℓ₀ B C`.
 


### PR DESCRIPTION
## Summary

Redesigns `Setoid.Subalgebras.CompleteLattice` so its subalgebra-lattice API can be used with natural infix syntax — `B ≤ C`, `B ∧ C`, `0ˢ`, `1ˢ` — instead of `_≤_ 𝑨 ℓ₀ B C`.

The per-algebra content is now wrapped in a **named, algebra-parametrized submodule** `Sublattice`:

```agda
module Sublattice (𝑨 : Algebra α ρᵃ) (ℓ₀ : Level) where
  Subᴸ : Type _ ; _≤_ ; _≈_ ; _∧_ ; _∨_ ; 0ˢ ; 1ˢ ; 0ˢ-minimum ; 1ˢ-maximum
  Sub-Lattice ; Sub-BoundedLattice ; Sub-CompleteLattice
```

so a use site does `open Sublattice 𝑨 ℓ₀` once and then writes everything param-free.  The diff to the module is essentially a header change; the rest is the consumer update.

## Why a named module, not implicit `𝑨`/`ℓ₀`

I considered making `𝑨` and `ℓ₀` implicit and letting Agda infer them (as the congruence lattice does — there `θ ≤ φ` works with implicit `𝑨`).  That is **not reliable here**, and the difference is instructive:

+  `Con 𝑨 {ℓ}`'s second Σ-component is `IsCongruence 𝑨 θ` — an **injective record type former**, so Agda recovers `𝑨` from a `Con 𝑨`-typed argument.
+  `Subᴸ 𝑨 ℓ₀`'s second component is `B ∈ Subuniverses 𝑨` — a **defined function** (not injective), and `ℓ₀` appears only through the absorbing level `L = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ₀`.  Neither `𝑨` nor `ℓ₀` is recoverable from a `Subᴸ`-typed argument.

I verified this empirically: an implicit-argument `_≤_` leaves **both** `𝑨` and `ℓ₀` as unsolved metavariables at the use site.  So the named module is the reliable choice (and the standard idiom for "fix the parameters near the use site").

## Coordination with #376 (please read)

This changes the `Subalgebras.CompleteLattice` API, so its other consumer — `Examples.Setoid.SubgroupLattice`, which lives on the **open PR #376** — must get the matching update (`open Sublattice V₄ 0ℓ` + infix).  That file isn't on `master` yet, so it isn't in this PR.

To keep `master` green, the simplest order is: **merge this PR first**, then when #376 rebases onto the updated `master` I'll convert `SubgroupLattice` to the new API (it also makes its `M₃` proofs much prettier — `𝑯₁ ∧ 𝑯₂ ≈ 0ˢ`).  Happy to do that update the moment this lands, or to re-base this onto #376 instead if you'd prefer a single combined change — your call on sequencing.

## Testing

+  `nix develop --command make check` — full library type-checks (exit 0; only pre-existing `Legacy/` warnings).

https://claude.ai/code/session_01G4tpHdXCG422mPWF8NFTuD