### PR TITLE
[M4-1e] Normalize code-fence whitespace

### DIFF
--- a/src/Demos.lagda.md
+++ b/src/Demos.lagda.md
@@ -9,8 +9,6 @@ author: "the agda-algebras development team"
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Demos where

--- a/src/Demos/ContraX.lagda.md
+++ b/src/Demos/ContraX.lagda.md
@@ -9,7 +9,6 @@ author: "the agda-algebras development team"
 
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using ( 𝓞 ; 𝓥 ; Signature )

--- a/src/Demos/GeneralOperationsAndRelations.lagda.md
+++ b/src/Demos/GeneralOperationsAndRelations.lagda.md
@@ -23,8 +23,6 @@ author: "the agda-algebras development team"
 
 <!--
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Demos.GeneralOperationsAndRelations where

--- a/src/Demos/HSP.lagda.md
+++ b/src/Demos/HSP.lagda.md
@@ -53,7 +53,6 @@ theory and a proof assistant like [Agda][]. On the other hand, this paper is pro
 To best emulate [MLTT][], we use
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 ```
 
@@ -76,7 +75,6 @@ We also make use of the following definitions from [Agda][]'s standard library (
 
 
 ```agda
-
 -- Import universe levels and Signature type (described below) from the agda-algebras library.
 open import Overture using ( 𝓞 ; 𝓥 ; Signature )
 module Demos.HSP {𝑆 : Signature 𝓞 𝓥} where
@@ -121,7 +119,6 @@ reference="setoid-functions"} below), and the symbol `_⟨$⟩_` in place of `f`
 
 
 ```agda
-
 module _ {A : Type α }{B : A → Type β} where
  ∣_∣ : Σ[ x ∈ A ] B x → A
  ∣_∣ = fst
@@ -146,8 +143,6 @@ An example of a setoid function is the identity function from a setoid to itself
 
 
 ```agda
-
-
 𝑖𝑑 : {A : Setoid α ρᵃ} → A ⟶ A
 𝑖𝑑 {A} = record { to = id ; cong = id }
 
@@ -167,8 +162,6 @@ We define the *inverse* of a setoid function in terms of the image of the functi
 
 
 ```agda
-
-
 module _ {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ} where
  open Setoid 𝑩 using ( _≈_ ; sym ) renaming ( Carrier to B )
 
@@ -182,8 +175,6 @@ certainty, is accompanied by a proof that it gives such a right-inverse.
 
 
 ```agda
-
-
  Inv : (f : 𝑨 ⟶ 𝑩){b : B} → Image f ∋ b → Carrier 𝑨
  Inv _ (eq a _) = a
 
@@ -205,8 +196,6 @@ We reproduce the definitions and prove some of their properties inside the next 
 
 
 ```agda
-
-
 module _ {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ} where
  open Setoid 𝑨 using () renaming ( _≈_ to _≈ᴬ_ )
  open Setoid 𝑩 using () renaming ( _≈_ to _≈ᴮ_ )
@@ -227,8 +216,6 @@ Proving that the composition of injective setoid functions is again injective is
 
 
 ```agda
-
-
 module _  {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ}{𝑪 : Setoid γ ρᶜ}
           (f : 𝑨 ⟶ 𝑩)(g : 𝑩 ⟶ 𝑪) where
 
@@ -258,8 +245,6 @@ by an injective map `fromIm : Im f ⟶ B`.
 
 
 ```agda
-
-
 module _ {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ} where
 
  Im : (f : 𝑨 ⟶ 𝑩) → Setoid _ _
@@ -315,8 +300,6 @@ We need to augment our `Signature` type so that it supports algebras over setoid
 
 
 ```agda
-
-
 EqArgs :  {𝑆 : Signature 𝓞 𝓥}{ξ : Setoid α ρᵃ}
  →        ∀ {f g} → f ≡ g → (∥ 𝑆 ∥ f → Carrier ξ) → (∥ 𝑆 ∥ g → Carrier ξ) → Type (𝓥 ⊔ ρᵃ)
 EqArgs {ξ = ξ} ≡.refl u v = ∀ i → u i ≈ v i where open Setoid ξ using ( _≈_ )
@@ -327,8 +310,6 @@ This makes it possible to define an operator which translates a signature for al
 
 
 ```agda
-
-
 ⟨_⟩ : Signature 𝓞 𝓥 → Setoid α ρᵃ → Setoid _ _
 
 Carrier  (⟨ 𝑆 ⟩ ξ)                = Σ[ f ∈ ∣ 𝑆 ∣ ] (∥ 𝑆 ∥ f → ξ .Carrier)
@@ -351,8 +332,6 @@ Our [Agda][] implementation represents algebras as inhabitants of a record type 
 
 
 ```agda
-
-
 record Algebra α ρ : Type (𝓞 ⊔ 𝓥 ⊔ suc (α ⊔ ρ)) where
  field  Domain  : Setoid α ρ
         Interp  : ⟨ 𝑆 ⟩ Domain ⟶ Domain
@@ -366,8 +345,6 @@ Thus, for each operation symbol in `𝑆` we have a setoid function `f` whose do
 
 
 ```agda
-
-
 open Algebra
 𝔻[_] : Algebra α ρᵃ →  Setoid α ρᵃ
 𝔻[ 𝑨 ] = Domain 𝑨
@@ -402,8 +379,6 @@ The `Lift` operation of the standard library embeds a type into a higher univers
 
 
 ```agda
-
-
 module _ (𝑨 : Algebra α ρᵃ) where
  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ; refl ; sym ; trans ) ; open Level
  Lift-Algˡ : (ℓ : Level) → Algebra (α ⊔ ℓ) ρᵃ
@@ -464,8 +439,6 @@ Here is the formal definition of the product algebra type in [Agda][].
 
 
 ```agda
-
-
 module _ {ι : Level}{I : Type ι } where
 
  ⨅ : (𝒜 : I → Algebra α ρᵃ) → Algebra (α ⊔ ι) (ρᵃ ⊔ ι)
@@ -507,8 +480,6 @@ of) `𝑨` to (the domain of) `𝑩`.
 
 
 ```agda
-
-
 module _ (𝑨 : Algebra α ρᵃ)(𝑩 : Algebra β ρᵇ) where
 
  compatible-map-op : (𝔻[ 𝑨 ] ⟶ 𝔻[ 𝑩 ]) → ∣ 𝑆 ∣ → Type _
@@ -525,8 +496,6 @@ finally the type (`hom`) of homomorphisms from `𝑨` to `𝑩`.
 
 
 ```agda
-
-
  record IsHom (h : 𝔻[ 𝑨 ] ⟶ 𝔻[ 𝑩 ]) : Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵇ) where
   constructor  mkhom
   field        compatible : compatible-map h
@@ -546,8 +515,6 @@ well as and for the corresponding types.
 
 
 ```agda
-
-
  record IsMon (h : 𝔻[ 𝑨 ] ⟶ 𝔻[ 𝑩 ]) : Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵃ ⊔ ρᵇ) where
   field  isHom : IsHom h
          isInjective : IsInjective h
@@ -565,8 +532,6 @@ monomorphism.
 
 
 ```agda
-
-
  record IsEpi (h : 𝔻[ 𝑨 ] ⟶ 𝔻[ 𝑩 ]) : Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ β ⊔ ρᵇ) where
   field  isHom : IsHom h
          isSurjective : IsSurjective h
@@ -582,8 +547,6 @@ Here are two utilities that are useful for translating between types.
 
 
 ```agda
-
-
 open IsHom ; open IsMon ; open IsEpi
 module _ (𝑨 : Algebra α ρᵃ)(𝑩 : Algebra β ρᵇ) where
  mon→intohom : mon 𝑨 𝑩 → Σ[ h ∈ hom 𝑨 𝑩 ] IsInjective ∣ h ∣
@@ -603,8 +566,6 @@ straightforward.
 
 
 ```agda
-
-
 module _  {𝑨 : Algebra α ρᵃ} {𝑩 : Algebra β ρᵇ} {𝑪 : Algebra γ ρᶜ}
           {g : 𝔻[ 𝑨 ] ⟶ 𝔻[ 𝑩 ]}{h : 𝔻[ 𝑩 ] ⟶ 𝔻[ 𝑪 ]} where
   open Setoid 𝔻[ 𝑪 ] using ( trans )
@@ -636,8 +597,6 @@ the operations of lifting and lowering of a setoid algebra are homomorphisms.
 
 
 ```agda
-
-
 𝒾𝒹 : {𝑨 : Algebra α ρᵃ} → hom 𝑨 𝑨
 𝒾𝒹 {𝑨 = 𝑨} =  𝑖𝑑 , mkhom (reflexive ≡.refl)
               where open Setoid ( Domain 𝑨 ) using ( reflexive )
@@ -707,8 +666,6 @@ latter in dependent type theory as follows.
 
 
 ```agda
-
-
 module _ {ι : Level}{I : Type ι}{𝑨 : Algebra α ρᵃ}(ℬ : I → Algebra β ρᵇ) where
  ⨅-hom-co : (∀(i : I) → hom 𝑨 (ℬ i)) → hom 𝑨 (⨅ ℬ)
  ⨅-hom-co 𝒽 = h , hhom where  h : 𝔻[ 𝑨 ] ⟶ 𝔻[ ⨅ ℬ ]
@@ -727,8 +684,6 @@ accessible.
 
 
 ```agda
-
-
 module _ (𝑨 : Algebra α ρᵃ) (𝑩 : Algebra β ρᵇ) where
  open Setoid 𝔻[ 𝑨 ]  using ()  renaming ( _≈_ to _≈ᴬ_ )
  open Setoid 𝔻[ 𝑩 ]  using ()  renaming ( _≈_ to _≈ᴮ_ )
@@ -758,8 +713,6 @@ It is easy to prove that `\au{`{.AgdaRecord}≅``{.AgdaArgument}} is an equivale
 
 
 ```agda
-
-
 ≅-refl : Reflexive (_≅_ {α}{ρᵃ})
 ≅-refl {α}{ρᵃ}{𝑨} =
  mkiso 𝒾𝒹 𝒾𝒹 (λ b → refl) λ a → refl where open Setoid 𝔻[ 𝑨 ] using ( refl )
@@ -792,8 +745,6 @@ image via the identity hom.
 
 
 ```agda
-
-
 ov : Level → Level         -- shorthand for a common level transformation
 ov α = 𝓞 ⊔ 𝓥 ⊔ suc α
 
@@ -821,8 +772,6 @@ below.[^8]
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
 
  HomIm : (h : hom 𝑨 𝑩) → Algebra _ _
@@ -855,8 +804,6 @@ non-cumulativity because isomorphism classes of algebras are closed under
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ}{ℓ : Level} where
  Lift-≅ˡ : 𝑨 ≅ (Lift-Algˡ 𝑨 ℓ)
  Lift-≅ˡ = mkiso ToLiftˡ FromLiftˡ (ToFromLiftˡ{𝑨 = 𝑨}) (FromToLiftˡ{𝑨 = 𝑨}{ℓ})
@@ -875,8 +822,6 @@ embedded* in `𝑩`; in other terms, `𝑨 ≤ 𝑩` iff there exists an injecti
 
 
 ```agda
-
-
 _≤_ : Algebra α ρᵃ → Algebra β ρᵇ → Type _
 𝑨 ≤ 𝑩 = Σ[ h ∈ hom 𝑨 𝑩 ] IsInjective ∣ h ∣
 ```
@@ -885,8 +830,6 @@ The subalgebra relation is reflexive, by the identity monomorphism (and transiti
 
 
 ```agda
-
-
 ≤-reflexive   :  {𝑨 : Algebra α ρᵃ} → 𝑨 ≤ 𝑨
 ≤-reflexive = 𝒾𝒹 , id
 ```
@@ -898,8 +841,6 @@ We conclude this section with a definition that will be useful later; it simply 
 
 
 ```agda
-
-
 mon→≤ : {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} → mon 𝑨 𝑩 → 𝑨 ≤ 𝑩
 mon→≤ {𝑨 = 𝑨}{𝑩} x = mon→intohom 𝑨 𝑩 x
 ```
@@ -918,8 +859,6 @@ each leaf `ℊ`; hence the constructor names (`ℊ` for "generator" and `node` f
 
 
 ```agda
-
-
 data Term (X : Type χ) : Type (ov χ)  where
  ℊ : X → Term X
  node : (f : ∣ 𝑆 ∣)(t : ∥ 𝑆 ∥ f → Term X) → Term X
@@ -933,8 +872,6 @@ We enrich the `Term` type to a setoid of `𝑆`-terms, which will ultimately be 
 
 
 ```agda
-
-
 module _ {X : Type χ } where
 
  data _≃_ : Term X → Term X → Type (ov χ) where
@@ -947,8 +884,6 @@ It is easy to show that `_≃_` is an equivalence relation as follows.
 
 
 ```agda
-
-
  ≃-isRefl   : Reflexive      _≃_
  ≃-isRefl {ℊ _} = rfl ≡.refl
  ≃-isRefl {node _ _} = gnl λ _ → ≃-isRefl
@@ -973,8 +908,6 @@ term `f t`.
 
 
 ```agda
-
-
 TermSetoid : (X : Type χ) → Setoid _ _
 TermSetoid X = record { Carrier = Term X ; _≈_ = _≃_ ; isEquivalence = ≃-isEquiv }
 
@@ -995,8 +928,6 @@ Abel uses to formalize Birkhoff's completeness theorem.
 
 
 ```agda
-
-
 module Environment (𝑨 : Algebra α ℓ) where
  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ; refl ; sym ; trans )
 
@@ -1012,8 +943,6 @@ The *interpretation* of a term *evaluated* in a particular environment is define
 
 
 ```agda
-
-
  ⟦_⟧ : {X : Type χ}(t : Term X) → (Env X) ⟶ 𝔻[ 𝑨 ]
  ⟦ ℊ x ⟧          ⟨$⟩ ρ    = ρ x
  ⟦ node f args ⟧  ⟨$⟩ ρ    = (Interp 𝑨) ⟨$⟩ (f , λ i → ⟦ args i ⟧ ⟨$⟩ ρ)
@@ -1025,8 +954,6 @@ Two terms are proclaimed *equal* if they are equal for all environments.
 
 
 ```agda
-
-
  Equal : {X : Type χ}(s t : Term X) → Type _
  Equal {X = X} s t = ∀ (ρ : Carrier (Env X)) → ⟦ s ⟧ ⟨$⟩ ρ ≈ ⟦ t ⟧ ⟨$⟩ ρ
 ```
@@ -1035,8 +962,6 @@ Proof that `Equal` is an equivalence relation, and that the implication `s ≃ t
 
 
 ```agda
-
-
  ≃→Equal : {X : Type χ}(s t : Term X) → s ≃ t → Equal s t
  ≃→Equal .(ℊ _) .(ℊ _) (rfl ≡.refl) = λ _ → refl
  ≃→Equal (node _ s)(node _ t)(gnl x) =
@@ -1060,8 +985,6 @@ the second (`interp-prod`) is the interpretation of a term in a product algebra.
 
 
 ```agda
-
-
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}(hh : hom 𝑨 𝑩) where
  open Environment 𝑨  using ( ⟦_⟧ )
  open Environment 𝑩  using () renaming ( ⟦_⟧ to ⟦_⟧ᴮ )
@@ -1101,8 +1024,6 @@ If `𝒦` is a class of algebras of a given signature, then we write `𝒦 ⊫ p
 
 
 ```agda
-
-
 module _ {X : Type χ} where
  _⊧_≈_ : Algebra α ρᵃ → Term X → Term X → Type _
  𝑨 ⊧ p ≈ q = Equal p q where open Environment 𝑨
@@ -1115,8 +1036,6 @@ We represent a set of term identities as a predicate over pairs of terms, say, `
 
 
 ```agda
-
-
  _⊨_ : (𝑨 : Algebra α ρᵃ) → Pred(Term X × Term X)(ov χ) → Type _
  𝑨 ⊨ ℰ = ∀ {p q} → (p , q) ∈ ℰ → Equal p q where open Environment 𝑨
 ```
@@ -1131,8 +1050,6 @@ invariance under isomorphism).  We formalize this property as follows.
 
 
 ```agda
-
-
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}(𝑩 : Algebra β ρᵇ)(p q : Term X) where
  ⊧-I-invar : 𝑨 ⊧ p ≈ q  →  𝑨 ≅ 𝑩  →  𝑩 ⊧ p ≈ q
  ⊧-I-invar Apq (mkiso fh gh f∼g g∼f) ρ = begin
@@ -1152,8 +1069,6 @@ the class of algebras modeling `ℰ`, denoted `Mod ℰ`, is called the *equation
 
 
 ```agda
-
-
 Th : {X : Type χ} → Pred (Algebra α ρᵃ) ℓ → Pred(Term X × Term X) _
 Th 𝒦 = λ (p , q) → 𝒦 ⊫ p ≈ q
 
@@ -1176,8 +1091,6 @@ provided `H 𝒦 ⊆ 𝒦`. Similarly, `𝒦` is *closed under the taking of sub
 
 
 ```agda
-
-
 module _ {α ρᵃ β ρᵇ : Level} where
  private a = α ⊔ ρᵃ
  H : ∀ ℓ → Pred(Algebra α ρᵃ) (a ⊔ ov ℓ) → Pred(Algebra β ρᵇ) _
@@ -1195,8 +1108,6 @@ Identities modeled by an algebra `𝑨` are also modeled by every homomorphic im
 
 
 ```agda
-
-
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}{p q : Term X} where
  ⊧-H-invar : 𝑨 ⊧ p ≈ q → 𝑩 IsHomImageOf 𝑨 → 𝑩 ⊧ p ≈ q
  ⊧-H-invar Apq (φh , φE) ρ = begin
@@ -1231,8 +1142,6 @@ An identity satisfied by all algebras in an indexed collection is also satisfied
 
 
 ```agda
-
-
 module _ {X : Type χ}{I : Type ℓ}(𝒜 : I → Algebra α ρᵃ){p q : Term X} where
  ⊧-P-invar : (∀ i → 𝒜 i ⊧ p ≈ q) → ⨅ 𝒜 ⊧ p ≈ q
  ⊧-P-invar 𝒜pq a = begin
@@ -1254,8 +1163,6 @@ The class `V 𝒦` is called the *varietal closure* of `𝒦`. Here is how we de
 
 
 ```agda
-
-
 module _  {α ρᵃ β ρᵇ γ ρᶜ δ ρᵈ : Level} where
  private a = α ⊔ ρᵃ ; b = β ⊔ ρᵇ
  V : ∀ ℓ ι → Pred(Algebra α ρᵃ) (a ⊔ ov ℓ) →  Pred(Algebra δ ρᵈ) _
@@ -1269,8 +1176,6 @@ assertion. (The others are included in the `Setoid.Varieties.Preservation` modul
 
 
 ```agda
-
-
 module _  {X : Type χ}{𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)}{p q : Term X} where
  H-id1 : 𝒦 ⊫ p ≈ q → H{β = α}{ρᵃ}ℓ 𝒦 ⊫ p ≈ q
  H-id1 σ 𝑩 (𝑨 , kA , BimgA) = ⊧-H-invar{p = p}{q} (σ 𝑨 kA) BimgA
@@ -1280,8 +1185,6 @@ The analogous preservation result for `S` is a consequence of the invariance lem
 
 
 ```agda
-
-
  S-id1 : 𝒦 ⊫ p ≈ q → S{β = α}{ρᵃ}ℓ 𝒦 ⊫ p ≈ q
  S-id1 σ 𝑩 (𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (σ 𝑨 kA) B≤A
 
@@ -1293,8 +1196,6 @@ The [agda-algebras][] library includes analogous pairs of implications for `P`, 
 
 
 ```agda
-
-
  P-id1 : ∀{ι} → 𝒦 ⊫ p ≈ q → P{β = α}{ρᵃ}ℓ ι 𝒦 ⊫ p ≈ q
  P-id1 σ 𝑨 (I , 𝒜 , kA , A≅⨅A) = ⊧-I-invar 𝑨 p q IH (≅-sym A≅⨅A) where
   IH : ⨅ 𝒜 ⊧ p ≈ q
@@ -1328,8 +1229,6 @@ and its setoid analog `free-lift-func`, and then proving the latter is a homomor
 
 
 ```agda
-
-
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}(h : X → 𝕌[ 𝑨 ]) where
  free-lift : 𝕌[ 𝑻 X ] → 𝕌[ 𝑨 ]
  free-lift (ℊ x)       = h x
@@ -1354,8 +1253,6 @@ as the free lift of `η` evaluated at `p`. We apply this fact a number of times 
 
 
 ```agda
-
-
 module _  {X : Type χ} {𝑨 : Algebra α ρᵃ}   where
  open Setoid 𝔻[ 𝑨 ]  using ( _≈_ ; refl )
  open Environment 𝑨  using ( ⟦_⟧ )
@@ -1393,8 +1290,6 @@ To do so, we contrive an index type for the product; each index is a triple `(�
 
 
 ```agda
-
-
 module FreeAlgebra (𝒦 : Pred (Algebra α ρᵃ) ℓ) where
  private c = α ⊔ ρᵃ ; ι = ov c ⊔ ℓ
  ℑ : {χ : Level} → Type χ → Type (ι ⊔ χ)
@@ -1408,8 +1303,6 @@ We then define `𝔽[ X ]` to be the image of a homomorphism from `𝑻 X` to `�
 
 
 ```agda
-
-
  homC : (X : Type χ) → hom (𝑻 X) (𝑪 X)
  homC X = ⨅-hom-co _ (λ i → lift-hom (snd ∥ i ∥))
 
@@ -1422,8 +1315,6 @@ is defined as follows.
 
 
 ```agda
-
-
 module FreeHom {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)} where
  private c = α ⊔ ρᵃ ; ι = ov c ⊔ ℓ
  open FreeAlgebra 𝒦 using ( 𝔽[_] ; homC )
@@ -1442,8 +1333,6 @@ then there exists an epimorphism from `𝔽[ A ]` onto `𝑨`, where `A` denotes
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra (α ⊔ ρᵃ ⊔ ℓ)(α ⊔ ρᵃ ⊔ ℓ)}{𝒦 : Pred(Algebra α ρᵃ)(α ⊔ ρᵃ ⊔ ov ℓ)} where
  private c = α ⊔ ρᵃ ⊔ ℓ ; ι = ov c
  open FreeAlgebra 𝒦 using ( 𝔽[_] ; 𝑪 )
@@ -1486,8 +1375,6 @@ Actually, we will need the following lifted version of this result.
 
 
 ```agda
-
-
  F-ModTh-epi-lift : 𝑨 ∈ Mod (Th (V ℓ ι 𝒦)) → epi 𝔽[ A ] (Lift-Alg 𝑨 ι ι)
  F-ModTh-epi-lift A∈ModThK = ∘-epi (F-ModThV-epi λ {p q} → A∈ModThK{p = p}{q} ) ToLift-epi
 ```
@@ -1530,8 +1417,6 @@ We need an arbitrary equational class, which we obtain by starting with an arbit
 
 
 ```agda
-
-
 module _ (𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)) where
  V-expa : 𝒦 ⊆ V ℓ (ov (α ⊔ ρᵃ ⊔ ℓ)) 𝒦
  V-expa {x = 𝑨}kA = 𝑨 , (𝑨 , (⊤ , (λ _ → 𝑨), (λ _ → kA), Goal), ≤-reflexive), IdHomImage
@@ -1554,8 +1439,6 @@ For the inclusion `V 𝒦 ⊆ 𝒦`, recall lemma `V-id1` which asserts that `�
 
 
 ```agda
-
-
 module _ {ℓ : Level}{X : Type ℓ}{ℰ : {Y : Type ℓ} → Pred (Term Y × Term Y) (ov ℓ)} where
  private 𝒦 = Mod{α = ℓ}{ℓ}{X} ℰ     -- an arbitrary equational class
 
@@ -1570,8 +1453,6 @@ To fix an arbitrary variety, start with an arbitrary class `𝒦` of `𝑆`-alge
 
 
 ```agda
-
-
 module _ (𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)){X : Type (α ⊔ ρᵃ ⊔ ℓ)} where
  private c = α ⊔ ρᵃ ⊔ ℓ ; ι = ov c
 
@@ -1592,8 +1473,6 @@ so `𝔽[ X ]` is (isomorphic to) a subalgebra of `𝑪 X`.
 
 
 ```agda
-
-
  open FreeHom {ℓ = ℓ}{𝒦}
  open FreeAlgebra 𝒦 using (homC ;  𝔽[_] ; 𝑪 )
  homFC : hom 𝔽[ X ] (𝑪 X)
@@ -1616,8 +1495,6 @@ Next we prove that every algebra in `Mod (Th (V 𝒦))` is a homomorphic image o
 
 
 ```agda
-
-
 module _ {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)} where
  private c = α ⊔ ρᵃ ⊔ ℓ ; ι = ov c
 

--- a/src/Examples.lagda.md
+++ b/src/Examples.lagda.md
@@ -11,8 +11,6 @@ This is the [Examples][] module of the [Agda Universal Algebra Library][].
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Examples where

--- a/src/Examples/PolynomialFunctors.lagda.md
+++ b/src/Examples/PolynomialFunctors.lagda.md
@@ -17,7 +17,6 @@ from `Legacy.Base.Categories.*`; nothing in the canonical `Setoid/`, `Classical/
 planned `Cubical/` development depends on it.
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Examples.PolynomialFunctors where

--- a/src/Examples/Structures.lagda.md
+++ b/src/Examples/Structures.lagda.md
@@ -11,8 +11,6 @@ This is the [Examples.Structures][] module of the [Agda Universal Algebra Librar
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Examples.Structures where

--- a/src/Examples/Structures/Basic.lagda.md
+++ b/src/Examples/Structures/Basic.lagda.md
@@ -9,8 +9,6 @@ author: "agda-algebras development team"
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Examples.Structures.Basic where
@@ -52,8 +50,6 @@ the ternary NAE-3-SAT relation, R = S³ - {(0,0,0), (1,1,1)} (where S = {0, 1}).
 
 
 ```agda
-
-
 data NAE3SAT : Pred (𝟚 × 𝟚 × 𝟚) 0ℓ where
  r1 : (𝟚.𝟎 , 𝟚.𝟎 , 𝟚.𝟏) ∈ NAE3SAT
  r2 : (𝟚.𝟎 , 𝟚.𝟏 , 𝟚.𝟎) ∈ NAE3SAT

--- a/src/Exercises.lagda.md
+++ b/src/Exercises.lagda.md
@@ -11,8 +11,6 @@ This is the [Exercises][] module of the [Agda Universal Algebra Library][].
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Exercises where

--- a/src/Exercises/Complexity.lagda.md
+++ b/src/Exercises/Complexity.lagda.md
@@ -11,8 +11,6 @@ This is the [Exercises.Complexity][] module of the [Agda Universal Algebra Libra
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Exercises.Complexity where

--- a/src/Overture.lagda.md
+++ b/src/Overture.lagda.md
@@ -11,8 +11,6 @@ This is the [Overture][] module of the [Agda Universal Algebra Library][].
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Overture where

--- a/src/Overture/Adjunction.lagda.md
+++ b/src/Overture/Adjunction.lagda.md
@@ -14,7 +14,6 @@ This subtree collects the order-theoretic adjunction infrastructure used across 
 This module is a Category-A relocation under #305 (M2-7a).  See [`src/Legacy/Base/DEPRECATED.md`](../Legacy/Base/DEPRECATED.md) for the inventory and migration guidance.
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Overture.Adjunction where

--- a/src/Overture/Adjunction/Closure.lagda.md
+++ b/src/Overture/Adjunction/Closure.lagda.md
@@ -11,7 +11,6 @@ This is the [Overture.Adjunction.Closure][] module of the [Agda Universal Algebr
 
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Overture.Adjunction.Closure where
@@ -50,7 +49,6 @@ Some examples of closure systems are the following:
 
 
 ```agda
-
 Extensive : Rel a ρ → (a → a) → Type _
 Extensive _≤_ C = ∀{x} → x ≤ C x
 -- (We might propose a new stdlib equivalent to Extensive in, e.g., `Relation.Binary.Core`.)
@@ -77,7 +75,6 @@ Thus, a closure operator is an extensive, idempotent poset endomorphism.
 
 
 ```agda
-
 -- ClOp, the inhabitants of which denote closure operators.
 record ClOp {ℓ ℓ₁ ℓ₂ : Level}(𝑨 : Poset ℓ ℓ₁ ℓ₂) : Type  (ℓ ⊔ ℓ₂ ⊔ ℓ₁) where
  open Poset 𝑨
@@ -95,7 +92,6 @@ record ClOp {ℓ ℓ₁ ℓ₂ : Level}(𝑨 : Poset ℓ ℓ₁ ℓ₂) : Type  
 
 
 ```agda
-
 open ClOp
 open Inverse
 
@@ -112,7 +108,6 @@ module _ {𝑨 : Poset ℓ ℓ₁ ℓ₂}(𝑪 : ClOp 𝑨) where
 
 
 ```agda
-
  clop→law⇒ : (x y : A) → x ≤ (c y) → (c x) ≤ (c y)
  clop→law⇒ x y x≤cy = begin
    c x      ≤⟨ isOrderPreserving 𝑪 x≤cy ⟩
@@ -133,7 +128,6 @@ The converse of Theorem 1 also holds.  That is,
 
 
 ```agda
-
 module _ {𝑨 : Poset ℓ ℓ₁ ℓ₂} where
  open Poset 𝑨
  private A = Carrier

--- a/src/Overture/Adjunction/Galois.lagda.md
+++ b/src/Overture/Adjunction/Galois.lagda.md
@@ -11,7 +11,6 @@ This is the [Overture.Adjunction.Galois][] module of the [Agda Universal Algebra
 
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Overture.Adjunction.Galois where
@@ -42,7 +41,6 @@ In other terms, `F` is a *left adjoint* of `G` and `G` is a *right adjoint* of `
 
 
 ```agda
-
 module _ (A : Poset α ℓᵃ ρᵃ)(B : Poset β ℓᵇ ρᵇ) where
  open Poset
  private
@@ -95,7 +93,6 @@ Here we define a type that represents the poset of subsets of a given set equipp
 
 
 ```agda
-
 open Poset
 
 module _ {α ρ : Level} {𝒜 : Type α} where
@@ -131,7 +128,6 @@ A binary relation from one poset to another induces a Galois connection.  This i
 
 
 ```agda
-
 module _ {ℓ : Level}{𝒜 : Type ℓ} {ℬ : Type ℓ} where
 
  𝒫𝒜 : Poset (suc ℓ) ℓ ℓ

--- a/src/Overture/Adjunction/Residuation.lagda.md
+++ b/src/Overture/Adjunction/Residuation.lagda.md
@@ -11,7 +11,6 @@ This is the [Overture.Adjunction.Residuation][] module of the [Agda Universal Al
 
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Overture.Adjunction.Residuation where
@@ -50,7 +49,6 @@ module _ (A : Poset a ιᵃ α)(B : Poset b ιᵇ β) where
 
 
 ```agda
-
 open Residuation
 open Poset
 
@@ -74,7 +72,6 @@ In a ring `R`, if `x y : R` and if `x y x = x`, then `y` is called a *weak inver
 
 
 ```agda
-
  -- 𝑔 is a weak inverse for 𝑓
  weak-inverse : (𝑓 ∘ 𝑔 ∘ 𝑓) ≈̇B 𝑓
  weak-inverse a = antisym B lt gt

--- a/src/Overture/Functions.lagda.md
+++ b/src/Overture/Functions.lagda.md
@@ -104,7 +104,6 @@ A right-inverse of a surjective `f` is obtained by composing `Inv` with the surj
 The composition law for surjective functions: if `f` factors through `g` via `h`, and `f` is surjective, then so is `h`.  This is consumed in `Setoid.Homomorphisms.Factor` to lift surjectivity through the homomorphism factorization diagram.
 
 ```agda
-
 module _ {A : Type a}{B : Type b}{C : Type c} where
 
  epic-factor :  (f : A → B)(g : A → C)(h : C → B)
@@ -147,7 +146,6 @@ Given an indexed family `B : I → Type b` and a "default" point `bs₀ : ∀ i 
 The auxiliary `update` modifies the default point at the single coordinate `j` to take a given value `b`, leaving the other coordinates alone.  The auxiliary `update-id` says that `update bs₀ (j , b)` evaluated at `j` gives back `b`, regardless of which proof of `j ≡ j` the decision procedure happens to produce.  The latter is where uniqueness-of-identity-proofs (UIP) for the index type `I` enters: `update-id` cannot be proved without it, because the "yes" case has to handle a propositionally-but-not-definitionally trivial equality proof.  The `Decidable⇒UIP` module from stdlib gives us UIP for any type with decidable equality, which is the assumption already made on `I`.
 
 ```agda
-
 module _  {I : Type ι}(_≟_ : Decidable {A = I} _≡_)
           {B : I → Type b}
           (bs₀ : ∀ i → B i)

--- a/src/Overture/Operations.lagda.md
+++ b/src/Overture/Operations.lagda.md
@@ -23,8 +23,6 @@ domain `I → A` (the type of "tuples") and codomain `A`.
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Overture.Operations where
@@ -45,8 +43,6 @@ For example, the `I`-*ary projection operations* on `A` are represented as inhab
 
 
 ```agda
-
-
 -- Example (projections)
 π : {I : Type 𝓥} {A : Type a } → I → Op A I
 π i = λ x → x i
@@ -57,8 +53,6 @@ Occasionally we want to extract the arity of a given operation symbol.
 
 
 ```agda
-
-
 -- return the arity of a given operation symbol
 arity[_] : {I : Type 𝓥} {A : Type a } → Op A I → Type 𝓥
 arity[_] {I = I} f = I

--- a/src/Overture/Preface.lagda.md
+++ b/src/Overture/Preface.lagda.md
@@ -13,7 +13,6 @@ This is the [Overture.Preface][] module of the [Agda Universal Algebra Library][
 
 <!--
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 module Overture.Preface where
 ```

--- a/src/Setoid.lagda.md
+++ b/src/Setoid.lagda.md
@@ -12,8 +12,6 @@ as opposed to "bare" types (see [Base.lagda][]).
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid where

--- a/src/Setoid/Algebras/Products.lagda.md
+++ b/src/Setoid/Algebras/Products.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Algebras.Products][] module of the [Agda Universal Algebra L
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -64,8 +62,6 @@ cong (Interp (⨅ {I} 𝒜)) (refl , f=g ) = λ i → cong  (Interp (𝒜 i)) (r
 
 
 ```agda
-
-
 module _ {𝒦 : Pred (Algebra α ρ) (ov α)} where
 
  ℑ : Type (ov (α ⊔ ρ))
@@ -96,8 +92,6 @@ projection of a product of algebras over such an index type is surjective.
 
 
 ```agda
-
-
 module _  {I : Type ι}                  -- index type
           {_≟_ : Decidable{A = I} _≡_}  -- with decidable equality
           {𝒜 : I → Algebra α ρ}         -- indexed collection of algebras

--- a/src/Setoid/Complexity.lagda.md
+++ b/src/Setoid/Complexity.lagda.md
@@ -14,7 +14,6 @@ This subtree collects the setoid-canonical formulation of computational complexi
 This module is the canonical home for the content previously developed in `Legacy.Base.Complexity.*`, ported under #307 (M2-7c).  See [`src/Legacy/Base/DEPRECATED.md`](../Legacy/Base/DEPRECATED.md) for the inventory and migration guidance.  Substantial extensions — polymorphism clones as a first-class type, the Jeavons Galois connection, Post's lattice, Bulatov–Zhuk — are tracked under #274 (M7-1) and build on this module.
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using ( 𝓞 ; 𝓥 ; Signature )

--- a/src/Setoid/Complexity/Basic.lagda.md
+++ b/src/Setoid/Complexity/Basic.lagda.md
@@ -12,7 +12,6 @@ This is the [Setoid.Complexity.Basic][] module of the [Agda Universal Algebra Li
 This module is the canonical home for the content previously developed in `Legacy.Base.Complexity.Basic`, ported under #307 (M2-7c).  Its present scope is the prose definitions of words, algorithms, and polynomial-time computability that frame the CSP development in [`Setoid.Complexity.CSP`](Setoid.Complexity.CSP.html); concrete Agda content is intentionally deferred to #274 (M7-1, "Extend Complexity module beyond Basic and CSP"), which is the substantive sequel to this canonical-path migration.
 
 ```agda
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Complexity.Basic where

--- a/src/Setoid/Functions.lagda.md
+++ b/src/Setoid/Functions.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Functions][] module of the [Agda Universal Algebra Library][
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Functions where

--- a/src/Setoid/Functions/Basic.lagda.md
+++ b/src/Setoid/Functions/Basic.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Functions.Basic][] module of the [Agda Universal Algebra Lib
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Functions.Basic where

--- a/src/Setoid/Functions/Bijective.lagda.md
+++ b/src/Setoid/Functions/Bijective.lagda.md
@@ -13,8 +13,6 @@ A *bijective function* from a setoid `𝑨 = (A, ≈₀)` to a setoid `𝑩 = (B
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Relation.Binary using ( Setoid )

--- a/src/Setoid/Functions/Injective.lagda.md
+++ b/src/Setoid/Functions/Injective.lagda.md
@@ -13,8 +13,6 @@ We say that a function `f : A → B` from one setoid (A , ≈₀) to another (B 
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Relation.Binary using ( Setoid )
@@ -48,8 +46,6 @@ setoids (called `IsInjective`).
 
 
 ```agda
-
-
 module _ {𝑨 : Setoid a α}{𝑩 : Setoid b β} where
 
  open Setoid 𝑨  using ()               renaming (Carrier to A; _≈_ to _≈₁_)
@@ -85,8 +81,6 @@ of the setoids; an alternative for setoid functions, called `∘-injective`, is 
 
 
 ```agda
-
-
 module compose  {A : Type a}(_≈₁_ : Rel A α)
                 {B : Type b}(_≈₂_ : Rel B β)
                 {C : Type c}(_≈₃_ : Rel C γ) where
@@ -108,8 +102,6 @@ lines which give each instance of injectivity a different name.
 
 
 ```agda
-
-
 module _ {𝑨 : Setoid a α}{𝑩 : Setoid b β}{𝑪 : Setoid c γ} where
 
  ⊙-injective :  (f : 𝑨 ⟶ 𝑩)(g : 𝑩 ⟶ 𝑪)

--- a/src/Setoid/Functions/Inverses.lagda.md
+++ b/src/Setoid/Functions/Inverses.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Functions.Inverses][] module of the [agda-algebras][] librar
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Functions.Inverses where
@@ -47,8 +45,6 @@ the second is for functions on setoids.
 
 
 ```agda
-
-
  data Img_∋_ (f : A → B) : B → Type (α ⊔ β ⊔ ρᵇ) where
   eq : {b : B} → (a : A) → b ≈₂ (f a) → Img f ∋ b
 
@@ -128,8 +124,6 @@ An inhabitant of `Image f ∋ b` is a dependent pair `(a , p)`, where `a : A` an
 
 
 ```agda
-
-
  inv : (f : A → B){b : B} → Img f ∋ b → A
  inv _ (eq a _) = a
 
@@ -155,8 +149,6 @@ We can prove that `Inv f` is the range-restricted right-inverse of `f`, as follo
 
 
 ```agda
-
-
  invIsInvʳ : {f : A → B}{b : B}(q : Img f ∋ b) → (f (inv f q)) ≈₂ b
  invIsInvʳ (eq _ p) = sym₂ p
 
@@ -174,8 +166,6 @@ In the following sense, `Inv f` is also a (range-restricted) *left-inverse*.
 
 
 ```agda
-
-
  InvIsInverseˡ : ∀ {F a} → Inv F {b = F ⟨$⟩ a} Imagef∋f ≈₁ a
  InvIsInverseˡ = refl₁
 

--- a/src/Setoid/Functions/Surjective.lagda.md
+++ b/src/Setoid/Functions/Surjective.lagda.md
@@ -13,8 +13,6 @@ A *surjective function* from a setoid `𝑨 = (A, ≈₀)` to a setoid `𝑩 = (
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Functions.Surjective where
@@ -94,8 +92,6 @@ With the next definition we represent a *right-inverse* of a surjective setoid f
 
 
 ```agda
-
-
  SurjInv : (f : 𝑨 ⟶ 𝑩) → IsSurjective f → B → A
  SurjInv f fE b = Inv f (fE {b})
 ```
@@ -105,8 +101,6 @@ Thus, a right-inverse of `f` is obtained by applying `Inv` to `f` and a proof of
 
 
 ```agda
-
-
  SurjInvIsInverseʳ :  (f : 𝑨 ⟶ 𝑩)(fE : IsSurjective f)
   →                   ∀ {b} → f ⟨$⟩ (SurjInv f fE) b ≈₂ b
 
@@ -118,8 +112,6 @@ Next, we prove composition laws for epics.
 
 
 ```agda
-
-
 module _ {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ}{𝑪 : Setoid γ ρᶜ} where
 
  open Setoid 𝑨  using ()               renaming (Carrier to A; _≈_ to _≈₁_)

--- a/src/Setoid/Homomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms][] module of the [Agda Universal Algebra Libra
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)

--- a/src/Setoid/Homomorphisms/Basic.lagda.md
+++ b/src/Setoid/Homomorphisms/Basic.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms.Basic][] module of the [Agda Universal Algebra
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature )
@@ -63,8 +61,6 @@ module _ (𝑨 : Algebra α ρᵃ)(𝑩 : Algebra β ρᵇ) where
 
 
 ```agda
-
-
  record IsMon (h : A ⟶ B) : Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵃ ⊔ β ⊔ ρᵇ) where
   field
    isHom : IsHom h

--- a/src/Setoid/Homomorphisms/Factor.lagda.md
+++ b/src/Setoid/Homomorphisms/Factor.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms.Factor][] module of the [Agda Universal Algebr
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -56,8 +54,6 @@ We will prove this in case h is both surjective and injective.
 
 
 ```agda
-
-
 module _  {𝑨 : Algebra α ρᵃ} (𝑩 : Algebra β ρᵇ) {𝑪 : Algebra γ ρᶜ}
           (gh : hom 𝑨 𝑩)(hh : hom 𝑨 𝑪) where
 
@@ -127,8 +123,6 @@ If, in addition, `g` is surjective, then so will be the factor `φ`.
 
 
 ```agda
-
-
  HomFactorEpi :  kernelRel _≈₃_ h ⊆ kernelRel _≈₂_ g
   →              IsSurjective hfunc → IsSurjective gfunc
                  -------------------------------------------------

--- a/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
+++ b/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms.HomomorphicImages][] module of the [Agda Unive
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -56,8 +54,6 @@ class of *homomorphic images* of an algebra in dependent type theory.
 
 
 ```agda
-
-
 open IsHom
 
 _IsHomImageOf_ : (𝑩 : Algebra β ρᵇ)(𝑨 : Algebra α ρᵃ) → Type _
@@ -84,8 +80,6 @@ the image of given hom.
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
  open Algebra 𝑨  renaming (Domain to A )                      using (Interp)
  open Setoid A   renaming ( _≈_ to _≈₁_ ; Carrier to ∣A∣)     using ()
@@ -131,8 +125,6 @@ Given a class `𝒦` of `𝑆`-algebras, we need a type that expresses the asser
 
 
 ```agda
-
-
 IsHomImageOfClass : {𝒦 : Pred (Algebra α ρᵃ)(suc α)} → Algebra α ρᵃ → Type (ov (α ⊔ ρᵃ))
 IsHomImageOfClass {𝒦 = 𝒦} 𝑩 = Σ[ 𝑨 ∈ Algebra _ _ ] ((𝑨 ∈ 𝒦) ∧ (𝑩 IsHomImageOf 𝑨))
 
@@ -147,8 +139,6 @@ Here are some tools that have been useful (e.g., in the road to the proof of Bir
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
  open Algebra 𝑨  using ()               renaming ( Domain to A )
  open Algebra 𝑩  using ()               renaming ( Domain to B )

--- a/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms.Factor][] module of the [Agda Universal Algebr
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -60,8 +58,6 @@ However, with four components, an equivalent record type is easier to work with.
 
 
 ```agda
-
-
 module _ (𝑨 : Algebra α ρᵃ) (𝑩 : Algebra β ρᵇ) where
  open Setoid (Domain 𝑨) using ( sym ; trans ) renaming ( _≈_ to _≈₁_ )
  open Setoid (Domain 𝑩) using () renaming ( _≈_ to _≈₂_ ; sym to sym₂ ; trans to trans₂)
@@ -106,8 +102,6 @@ That is, two structures are *isomorphic* provided there are homomorphisms going 
 
 
 ```agda
-
-
 open _≅_
 
 ≅-refl : Reflexive (_≅_ {α}{ρᵃ})
@@ -165,8 +159,6 @@ from the noncumulativity of Agda's universe hierarchy.
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ}{ℓ : Level} where
  Lift-≅ˡ : 𝑨 ≅ (Lift-Algˡ 𝑨 ℓ)
  Lift-≅ˡ = mkiso ToLiftˡ FromLiftˡ (ToFromLiftˡ{𝑨 = 𝑨}) (FromToLiftˡ{𝑨 = 𝑨}{ℓ})
@@ -199,8 +191,6 @@ The lift is also associative, up to isomorphism at least.
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ}{ℓ₁ ℓ₂ : Level} where
 
  Lift-assocˡ : Lift-Algˡ 𝑨 (ℓ₁ ⊔ ℓ₂) ≅  Lift-Algˡ (Lift-Algˡ 𝑨 ℓ₁) ℓ₂
@@ -224,8 +214,6 @@ looks a bit technical, but it is as straightforward as it ought to be.
 
 
 ```agda
-
-
 module _ {𝓘 : Level}{I : Type 𝓘} {𝒜 : I → Algebra α ρᵃ} {ℬ : I → Algebra β ρᵇ} where
  open Algebra (⨅ 𝒜)  using () renaming (Domain to ⨅A )
  open Setoid ⨅A      using () renaming ( _≈_ to _≈₁_ )
@@ -264,8 +252,6 @@ A nearly identical proof goes through for isomorphisms of lifted products.
 
 
 ```agda
-
-
 module _  {𝓘 : Level}{I : Type 𝓘}
           {𝒜 : I → Algebra α ρᵃ}
           {ℬ : (Lift γ I) → Algebra β ρᵇ} where

--- a/src/Setoid/Homomorphisms/Kernels.lagda.md
+++ b/src/Setoid/Homomorphisms/Kernels.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms.Kernels][] module of the [Agda Universal Algeb
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -57,8 +55,6 @@ That is, if each `(u i, v i)` belongs to the kernel, then so does the pair `((f 
 
 
 ```agda
-
-
  HomKerComp : 𝑨 ∣≈ kerRel _≈₂_ h
  HomKerComp f {u}{v} kuv = Goal
   where
@@ -80,8 +76,6 @@ The kernel of a homomorphism is a congruence of the domain, which we construct a
 
 
 ```agda
-
-
  kercon : Con 𝑨 ρᵇ
  kercon =  kerRel _≈₂_ h ,
            mkcon (λ x → cong ∣ hh ∣ x)(kerRelOfEquiv isEquivalence h)(HomKerComp)
@@ -92,8 +86,6 @@ Now that we have a congruence, we can construct the quotient relative to the ker
 
 
 ```agda
-
-
  kerquo : Algebra α ρᵇ
  kerquo = 𝑨 ╱ kercon
 
@@ -109,8 +101,6 @@ Given an algebra `𝑨` and a congruence `θ`, the *canonical projection* is a m
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} (h : hom 𝑨 𝑩) where
  open IsCongruence
 
@@ -138,8 +128,6 @@ This is obtained by applying `epi-to-hom`, like so.
 
 
 ```agda
-
-
  πhom : (θ : Con 𝑨 ℓ) → hom 𝑨 (𝑨 ╱ θ)
  πhom θ = epi→hom 𝑨 (𝑨 ╱ θ) (πepi θ)
 ```
@@ -152,8 +140,6 @@ above for the quotient of `𝑨` modulo the kernel of `h`.)
 
 
 ```agda
-
-
  πker : epi 𝑨 (ker[ 𝑨 ⇒ 𝑩 ] h)
  πker = πepi (kercon h)
 ```
@@ -167,8 +153,6 @@ the one we need later.
 
 
 ```agda
-
-
  open IsCongruence
 
  ker-in-con : {θ : Con 𝑨 ℓ} → ∀ {x}{y} → ∣ kercon (πhom θ) ∣ x y →  ∣ θ ∣ x y

--- a/src/Setoid/Homomorphisms/Noether.lagda.md
+++ b/src/Setoid/Homomorphisms/Noether.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms.Noether][] module of the [Agda Universal Algeb
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -45,8 +43,6 @@ private variable α ρᵃ β ρᵇ γ ρᶜ ι : Level
 
 
 ```agda
-
-
 open _⟶_ using ( cong ) renaming ( to to _⟨$⟩_ )
 open Algebra using ( Domain )
 
@@ -82,8 +78,6 @@ Now we prove that the homomorphism whose existence is guaranteed by `FirstHomThe
 
 
 ```agda
-
-
  FirstHomUnique :  (f g : hom (kerquo hh) 𝑩)
   →                ( ∀ a →  h a ≈ ∣ f ∣ ⟨$⟩ (∣ πker hh ∣ ⟨$⟩ a) )
   →                ( ∀ a →  h a ≈ ∣ g ∣ ⟨$⟩ (∣ πker hh ∣ ⟨$⟩ a) )

--- a/src/Setoid/Homomorphisms/Products.lagda.md
+++ b/src/Setoid/Homomorphisms/Products.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms.Products][] module of the [Agda Universal Alge
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -47,8 +45,6 @@ we can construct a homomorphism from `𝑨` to the product `⨅ ℬ` in the natu
 
 
 ```agda
-
-
 module _ {I : Type 𝓘}{𝑨 : Algebra a α }(ℬ : I → Algebra b β)  where
  open Algebra 𝑨      using ()        renaming ( Domain to A )
  open Algebra (⨅ ℬ)  using ()        renaming ( Domain to ⨅B )
@@ -84,8 +80,6 @@ a homomorphism from `⨅ 𝒜` to `⨅ ℬ` in the following natural way.
 
 
 ```agda
-
-
  ⨅-hom : (𝒜 : I → Algebra a α) → (∀ (i : I) → hom (𝒜 i) (ℬ i)) → hom (⨅ 𝒜)(⨅ ℬ)
  ⨅-hom 𝒜 𝒽 = F , isHom
   where
@@ -108,8 +102,6 @@ onto one of its factors is a homomorphism.
 
 
 ```agda
-
-
  ⨅-projection-hom : (i : I) → hom (⨅ ℬ) (ℬ i)
  ⨅-projection-hom i = F , isHom
   where

--- a/src/Setoid/Homomorphisms/Properties.lagda.md
+++ b/src/Setoid/Homomorphisms/Properties.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Homomorphisms.Properties][] module of the [Agda Universal Al
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -46,8 +44,6 @@ private variable α β γ ρᵃ ρᵇ ρᶜ ℓ : Level
 
 
 ```agda
-
-
 module _  {𝑨 : Algebra α ρᵃ} {𝑩 : Algebra β ρᵇ} {𝑪 : Algebra γ ρᶜ} where
   open Algebra 𝑨  renaming (Domain to A )   using ()
   open Algebra 𝑩  renaming (Domain to B )   using ()
@@ -99,8 +95,6 @@ First we define the identity homomorphism for setoid algebras and then we prove 
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ} where
  open Algebra 𝑨  renaming (Domain to A )                   using ()
  open Setoid A   renaming ( _≈_ to _≈₁_ ; refl to refl₁ )  using ( reflexive )
@@ -171,8 +165,6 @@ Next we formalize the fact that a homomorphism from `𝑨` to `𝑩` can be lift
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ} {𝑩 : Algebra β ρᵇ} where
  open Algebra            using ( Domain )
  open Setoid (Domain 𝑨)  using ( reflexive )  renaming ( _≈_ to _≈₁_ )

--- a/src/Setoid/Subalgebras.lagda.md
+++ b/src/Setoid/Subalgebras.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Subalgebras][] module of the [Agda Universal Algebra Library
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)

--- a/src/Setoid/Subalgebras/Properties.lagda.md
+++ b/src/Setoid/Subalgebras/Properties.lagda.md
@@ -12,8 +12,6 @@ This is the [Setoid.Subalgebras.Properties][] module of the [Agda Universal Alge
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -53,8 +51,6 @@ The subalgebra relation is a *preorder*, i.e., a reflexive, transitive binary re
 
 
 ```agda
-
-
 open _≅_
 
 ≅→≤ : {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} → 𝑨 ≅ 𝑩 → 𝑨 ≤ 𝑩
@@ -150,8 +146,6 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
 
 
 ```agda
-
-
 module _ {𝒦 : Pred (Algebra α ρᵃ)(ov α)}{𝑩 : Algebra β ρᵇ}{ℓ : Level} where
 
  Lift-is-sub : 𝑩 ≤c 𝒦 → (Lift-Algˡ 𝑩 ℓ) ≤c 𝒦
@@ -196,8 +190,6 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
 
 
 ```agda
-
-
 module _ {I : Type ι}{𝒜 : I → Algebra α ρᵃ}{ℬ : I → Algebra β ρᵇ} where
  open Algebra (⨅ 𝒜)  using () renaming ( Domain to ⨅A )
  open Algebra (⨅ ℬ)  using () renaming ( Domain to ⨅B )

--- a/src/Setoid/Subalgebras/Subalgebras.lagda.md
+++ b/src/Setoid/Subalgebras/Subalgebras.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Subalgebras.Subalgebras][] module of the [Agda Universal Alg
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -87,8 +85,6 @@ The next type we define allows us to express this assertion as
 
 
 ```agda
-
-
 _≤c_
  _IsSubalgebraOfClass_ : Algebra β ρᵇ → Pred (Algebra α ρᵃ) ℓ → Type _
 𝑩 IsSubalgebraOfClass 𝒦 = Σ[ 𝑨 ∈ Algebra _ _ ] ((𝑨 ∈ 𝒦) ∧ (𝑩 ≤ 𝑨))
@@ -126,8 +122,6 @@ is (isomorphic to) a subalgebra of `𝑩`.
 
 
 ```agda
-
-
 FirstHomCorollary :  {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}
                      (hh : hom 𝑨 𝑩) → (kerquo hh) IsSubalgebraOf 𝑩
 

--- a/src/Setoid/Subalgebras/Subuniverses.lagda.md
+++ b/src/Setoid/Subalgebras/Subuniverses.lagda.md
@@ -45,8 +45,6 @@ We first show how to represent in [Agda][] the collection of subuniverses of an 
 
 
 ```agda
-
-
 module _ (𝑨 : Algebra α ρᵃ) where
  private A = 𝕌[ 𝑨 ] -- the forgetful functor
 
@@ -75,8 +73,6 @@ inductive type `Sg` is trivial, as we see here.
 
 
 ```agda
-
-
  sgIsSub : {G : Pred A ℓ} → Sg G ∈ Subuniverses
  sgIsSub = app
 ```
@@ -86,8 +82,6 @@ Next we prove by structural induction that `Sg X` is the smallest subuniverse of
 
 
 ```agda
-
-
  sgIsSmallest :  {G : Pred A ℓ}(B : Pred A ρᵇ)
   →              B ∈ Subuniverses  →  G ⊆ B  →  Sg G ⊆ B
 
@@ -106,8 +100,6 @@ When the element of `Sg G` is constructed as `app f a SgGa`, we may assume (the 
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ} where
  private A = 𝕌[ 𝑨 ]
 
@@ -134,8 +126,6 @@ yet."  We should fix the implementation to resolve this.
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ} where
  private A = 𝕌[ 𝑨 ]
  open Setoid using ( Carrier )
@@ -172,8 +162,6 @@ Alternatively, we could express the preceeding fact using an inductive type repr
 
 
 ```agda
-
-
  data TermImage (B : Pred A ρᵃ) : Pred A (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵃ) where
   var : ∀ {b : A} → b ∈ B → b ∈ TermImage B
   app : ∀ f ts →  ((i : ∥ 𝑆 ∥ f) → ts i ∈ TermImage B)  → (f ̂ 𝑨) ts ∈ TermImage B
@@ -197,8 +185,6 @@ we call `hom-unique`.
 
 
 ```agda
-
-
  module _ {𝑩 : Algebra β ρᵇ} (gh hh : hom 𝑨 𝑩) where
   open Algebra 𝑩  using ( Interp )  renaming ( Domain to B )
   open Setoid B   using ( _≈_ ; sym )

--- a/src/Setoid/Terms.lagda.md
+++ b/src/Setoid/Terms.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Terms][] module of the [Agda Universal Algebra Library][].
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)

--- a/src/Setoid/Terms/Basic.lagda.md
+++ b/src/Setoid/Terms/Basic.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Terms.Basic][] module of the [Agda Universal Algebra Library
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -56,8 +54,6 @@ as a Algebra whose carrier is the setoid of terms.
 
 
 ```agda
-
-
 module _ {X : Type χ } where
 
  -- Equality of terms as an inductive datatype
@@ -105,8 +101,6 @@ A substitution from `Δ` to `Γ` associates a term in `Γ` with each variable in
 
 
 ```agda
-
-
 -- Parallel substitutions.
 Sub : Type χ → Type χ → Type (ov χ)
 Sub X Y = (y : Y) → Term X
@@ -122,8 +116,6 @@ An environment for `Γ` maps each variable `x : Γ` to an element of `A`, and eq
 
 
 ```agda
-
-
 module Environment (𝑨 : Algebra α ℓ) where
  open Algebra 𝑨  renaming( Domain to A ; Interp  to InterpA )  using()
  open Setoid A   renaming( _≈_ to _≈ₐ_ ; Carrier to ∣A∣ )      using( refl ; sym ; trans )
@@ -150,8 +142,6 @@ Interpretation of terms is iteration on the W-type. The standard library offers 
 
 
 ```agda
-
-
  ⟦_⟧ : {X : Type χ}(t : Term X) → Func (Env X) A
  ⟦ ℊ x ⟧ ⟨$⟩ ρ = ρ x
  ⟦ node f args ⟧ ⟨$⟩ ρ = InterpA ⟨$⟩ (f , λ i → ⟦ args i ⟧ ⟨$⟩ ρ)

--- a/src/Setoid/Terms/Operations.lagda.md
+++ b/src/Setoid/Terms/Operations.lagda.md
@@ -13,8 +13,6 @@ Here we define *term operations* which are simply terms interpreted in a particu
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -56,8 +54,6 @@ It turns out that the intepretation of a term is the same as the `free-lift`
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ} where
  open Algebra 𝑨      using ( Interp )      renaming (Domain to A )
  open Setoid A       using ( _≈_ ; refl )  renaming ( Carrier to ∣A∣ )
@@ -90,8 +86,6 @@ module _ {X : Type χ} where
 
 
 ```agda
-
-
 module _ {X : Type χ }{I : Type ι}(𝒜 : I → Algebra α ρᵃ) where
  open Algebra (⨅ 𝒜)      using (Interp)  renaming ( Domain to ⨅A )
  open Setoid ⨅A          using ( _≈_ ; refl )
@@ -112,8 +106,6 @@ We now prove two important facts about term operations.  The first of these, whi
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}(hh : hom 𝑨 𝑩) where
  open Algebra 𝑨      using () renaming (Domain to A ; Interp to Interp₁ )
  open Setoid A       using () renaming ( _≈_ to _≈₁_ ; Carrier to ∣A∣ )
@@ -150,8 +142,6 @@ A substitution from `Y` to `X` is simply a function from `Y` to `X`, and the app
 
 
 ```agda
-
-
 _[_]s : {χ : Level}{X Y : Type χ} → Term Y → (Y → X) → Term X
 (ℊ y) [ σ ]s = ℊ (σ y)
 (node f t)  [ σ ]s = node f λ i → t i [ σ ]s
@@ -162,8 +152,6 @@ Alternatively, we may want a substitution that replaces each variable symbol in 
 
 
 ```agda
-
-
 -- Substerm X Y, an inhabitant of which replaces each variable symbol in Y with a term from Term X.
 Substerm : (X Y : Type χ) → Type (ov χ)
 Substerm X Y = (y : Y) → Term X

--- a/src/Setoid/Terms/Properties.lagda.md
+++ b/src/Setoid/Terms/Properties.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Terms.Properties][] module of the [Agda Universal Algebra Li
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -60,8 +58,6 @@ on the structure of the given term.
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρ}(h : X → 𝕌[ 𝑨 ]) where
  open Algebra 𝑨      using ( Interp )                   renaming ( Domain to A )
  open Setoid A       using ( _≈_ ; reflexive ; trans )  renaming ( Carrier to ∣A∣ )
@@ -102,8 +98,6 @@ The free lift so defined is a homomorphism by construction. Indeed, here is the 
 
 
 ```agda
-
-
  lift-hom : hom (𝑻 X) 𝑨
  lift-hom = free-lift-func , hhom
   where
@@ -122,8 +116,6 @@ If we further assume that each of the mappings from `X` to `∣ 𝑨 ∣` is *su
 
 
 ```agda
-
-
  lift-of-epi-is-epi : isSurj{𝑨 = ≡.setoid X}{𝑩 = A} h → IsSurjective free-lift-func
  lift-of-epi-is-epi hE = isSurj→IsSurjective free-lift-func (free-lift-of-surj-isSurj hE)
 ```
@@ -135,8 +127,6 @@ we can omit the `swelldef` hypothesis we needed previously to prove `free-unique
 
 
 ```agda
-
-
 module _ {𝑨 : Algebra α ρ}{gh hh : hom (𝑻 X) 𝑨} where
  open Algebra 𝑨      using ( Interp )  renaming ( Domain to A )
  open Setoid A       using ( _≈_ ; trans ; sym )

--- a/src/Setoid/Varieties.lagda.md
+++ b/src/Setoid/Varieties.lagda.md
@@ -11,8 +11,6 @@ This is the [Setoid.Varieties][] module of the [Agda Universal Algebra Library][
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)

--- a/src/Setoid/Varieties/Closure.lagda.md
+++ b/src/Setoid/Varieties/Closure.lagda.md
@@ -15,8 +15,6 @@ Fix a signature 𝑆, let 𝒦 be a class of 𝑆-algebras, and define
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -89,8 +87,6 @@ With the closure operator V representing closure under HSP, we represent formall
 
 
 ```agda
-
-
 module _ {α ρᵃ ℓ ι : Level} where
 
  is-variety : (𝒱 : Pred (Algebra α ρᵃ)(α ⊔ ρᵃ ⊔ ov ℓ)) → Type (ov (α ⊔ ρᵃ ⊔ ℓ ⊔ ι))
@@ -107,7 +103,6 @@ module _ {α ρᵃ ℓ ι : Level} where
 
 
 ```agda
-
 module _ {α ρᵃ : Level} where
 
  private a = α ⊔ ρᵃ
@@ -124,8 +119,6 @@ Of course, this is proved by establishing two inclusions, but one of them is tri
 
 
 ```agda
-
-
  S-idem :  ∀{β ρᵇ γ ρᶜ ℓ} → {𝒦 : Pred (Algebra α ρᵃ)(a ⊔ ov ℓ)}
   →        S{β = γ}{ρᶜ} (a ⊔ ℓ) (S{β = β}{ρᵇ} ℓ 𝒦) ⊆ S{β = γ}{ρᶜ} ℓ 𝒦
 
@@ -140,8 +133,6 @@ Of course, this is proved by establishing two inclusions, but one of them is tri
 
 
 ```agda
-
-
  H-expa : ∀{ℓ} → {𝒦 : Pred (Algebra α ρᵃ)(a ⊔ ov ℓ)} → 𝒦 ⊆ H ℓ 𝒦
  H-expa {ℓ} {𝒦}{𝑨} kA = 𝑨 , kA , IdHomImage
 
@@ -192,8 +183,6 @@ We sometimes want to go back and forth between our two representations of subalg
 
 
 ```agda
-
-
 module _  {α ρᵃ β ρᵇ ℓ ι : Level}{𝒦 : Pred (Algebra α ρᵃ)(α ⊔ ρᵃ ⊔ ov ℓ)}
           {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
 
@@ -229,8 +218,6 @@ The remaining theorems in this file are as yet unused, but may be useful later a
 
 
 ```agda
-
-
 module _ {α ρᵃ ℓ ι : Level}{𝒦 : Pred (Algebra α ρᵃ)(α ⊔ ρᵃ ⊔ ov ℓ)} where
 
  -- For reference, some useful type levels:

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -9,8 +9,6 @@ author: "agda-algebras development team"
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -64,8 +62,6 @@ Alternatively, we could let `X` be the product of all algebras in the class `�
 
 
 ```agda
-
-
 module FreeHom (χ : Level){α ρᵃ ℓ : Level}
                {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)} where
  private
@@ -80,8 +76,6 @@ The relatively free algebra (relative to `Th 𝒦`) is called `M` and is derived
 
 
 ```agda
-
-
  -- ℐ indexes the collection of equations modeled by 𝒦
  ℐ : Type ι
  ℐ = Σ[ eq ∈ Eq{χ} ] 𝒦 ⊫ ((lhs eq) ≈̇ (rhs eq))
@@ -104,8 +98,6 @@ Finally, we define an epimorphism from `𝑻 X` onto the relatively free algebra
 
 
 ```agda
-
-
  epi𝔽[_] : (X : Type χ) → epi (𝑻 X) 𝔽[ X ]
  epi𝔽[ X ] = h , hepi
   where

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -13,8 +13,6 @@ same identities.
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -66,8 +64,6 @@ prove a handful of such properties that we need later.
 
 
 ```agda
-
-
 module _  {α ρᵃ ℓ : Level}{𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)} where
  private
   a = α ⊔ ρᵃ
@@ -100,8 +96,6 @@ in a class 𝒦 is a subalgebra of a product of algebras in 𝒦.
 
 
 ```agda
-
-
  PS⊆SP : P (a ⊔ ℓ) oaℓ (S{β = α}{ρᵃ} ℓ 𝒦) ⊆ S oaℓ (P ℓ oaℓ 𝒦)
  PS⊆SP {𝑩} (I , ( 𝒜 , sA , B≅⨅A )) = Goal
   where
@@ -122,8 +116,6 @@ First we prove that the closure operator H is compatible with identities that ho
 
 
 ```agda
-
-
 module _   {α ρᵃ ℓ χ : Level}
            {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)}
            {X : Type χ}
@@ -139,8 +131,6 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 ```agda
-
-
  H-id2 : H ℓ 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
  H-id2 Hpq 𝑨 kA = Hpq 𝑨 (𝑨 , (kA , IdHomImage))
 ```
@@ -151,8 +141,6 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 ```agda
-
-
  S-id1 : 𝒦 ⊫ (p ≈̇ q) → (S {β = α}{ρᵃ} ℓ 𝒦) ⊫ (p ≈̇ q)
  S-id1 σ 𝑩 (𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (σ 𝑨 kA) B≤A
 
@@ -167,8 +155,6 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 ```agda
-
-
  P-id1 : ∀{ι} → 𝒦 ⊫ (p ≈̇ q) → P {β = α}{ρᵃ}ℓ ι 𝒦 ⊫ (p ≈̇ q)
  P-id1 σ 𝑨 (I , 𝒜 , kA , A≅⨅A) = ⊧-I-invar 𝑨 p q IH (≅-sym A≅⨅A)
   where
@@ -189,8 +175,6 @@ Finally, we prove the analogous preservation lemmas for the closure operator `V`
 
 
 ```agda
-
-
 module _  {α ρᵃ ℓ ι χ : Level}
           {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)}
           {X : Type χ}
@@ -230,8 +214,6 @@ modeled by `𝒦`.   We formalize this observation as follows.
 
 
 ```agda
-
-
  classIds-⊆-VIds : 𝒦 ⊫ (p ≈̇ q)  → (p , q) ∈ Th (V ℓ ι 𝒦)
  classIds-⊆-VIds pKq 𝑨 = V-id1 pKq 𝑨
 

--- a/src/Setoid/Varieties/Properties.lagda.md
+++ b/src/Setoid/Varieties/Properties.lagda.md
@@ -18,8 +18,6 @@ We prove some closure and invariance properties of the relation `⊧`.  In parti
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -64,8 +62,6 @@ The binary relation ⊧ would be practically useless if it were not an *algebrai
 
 
 ```agda
-
-
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}(𝑩 : Algebra β ρᵇ)(p q : Term X) where
  open Environment 𝑨      using () renaming ( ⟦_⟧   to ⟦_⟧₁ )
  open Environment 𝑩      using () renaming ( ⟦_⟧   to ⟦_⟧₂ )
@@ -104,8 +100,6 @@ The ⊧ relation is also invariant under the algebraic lift and lower operations
 
 
 ```agda
-
-
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ} where
 
  ⊧-Lift-invar : (p q : Term X) → 𝑨 ⊧ (p ≈̇ q) → Lift-Algˡ 𝑨 β ⊧ (p ≈̇ q)
@@ -122,8 +116,6 @@ of `𝑨`, which fact can be formalized as follows.
 
 
 ```agda
-
-
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}{p q : Term X} where
 
  ⊧-H-invar : 𝑨 ⊧ (p ≈̇ q) → 𝑩 IsHomImageOf 𝑨 → 𝑩 ⊧ (p ≈̇ q)
@@ -151,8 +143,6 @@ Identities modeled by an algebra `𝑨` are also modeled by every subalgebra of 
 
 
 ```agda
-
-
 module _ {X : Type χ}{p q : Term X}{𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
  open Environment 𝑨      using () renaming ( ⟦_⟧ to ⟦_⟧₁ )
  open Environment 𝑩      using () renaming ( ⟦_⟧ to ⟦_⟧₂ )
@@ -184,8 +174,6 @@ all `𝑨 ∈ 𝒦` is also satisfied by every subalgebra of a member of `𝒦`.
 
 
 ```agda
-
-
 module _ {X : Type χ}{p q : Term X} where
 
  ⊧-S-class-invar :  {𝒦 : Pred (Algebra α ρᵃ) ℓ}
@@ -203,8 +191,6 @@ by the product of algebras in that collection.
 
 
 ```agda
-
-
 module _ {X : Type χ}{p q : Term X}{I : Type ℓ}(𝒜 : I → Algebra α ρᵃ) where
 
  ⊧-P-invar : (∀ i → 𝒜 i ⊧ (p ≈̇ q)) → ⨅ 𝒜 ⊧ (p ≈̇ q)
@@ -232,8 +218,6 @@ of algebras in the class.
 
 
 ```agda
-
-
  ⊧-P-class-invar :  (𝒦 : Pred (Algebra α ρᵃ)(ov α))
   →                 𝒦 ⊫ (p ≈̇ q) → (∀ i → 𝒜 i ∈ 𝒦) → ⨅ 𝒜 ⊧ (p ≈̇ q)
 
@@ -247,8 +231,6 @@ algebras models (p ≈̇ q) if the lift of each algebra in the collection models
 
 
 ```agda
-
-
  ⊧-P-lift-invar : (∀ i → Lift-Algˡ (𝒜 i) β ⊧ (p ≈̇ q))  →  ⨅ 𝒜 ⊧ (p ≈̇ q)
  ⊧-P-lift-invar α = ⊧-P-invar Aipq
   where
@@ -266,8 +248,6 @@ every homomorphism from 𝑻 X to 𝑨 maps p and q to the same element of 𝑨.
 
  
 ```agda
-
-
 module _ {X : Type χ}{p q : Term X}{𝑨 : Algebra α ρᵃ}(φh : hom (𝑻 X) 𝑨) where
  open Setoid (Domain 𝑨) using ( _≈_ )
  private φ = _⟨$⟩_ ∣ φh ∣

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -13,8 +13,6 @@ This module is based on [Andreas Abel's Agda formalization of Birkhoff's complet
 
 
 ```agda
-
-
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 open import Overture using (𝓞 ; 𝓥 ; Signature)
@@ -114,8 +112,6 @@ module _ {α}{ρᵃ}{ι}{I : Type ι} where
 
 
 ```agda
-
-
 module _ {χ ι : Level} where
 
  data _⊢_▹_≈_ {I : Type ι}(E : I → Eq) : (X : Type χ)(p q : Term X) → Type (ι ⊔ ov χ) where
@@ -137,8 +133,6 @@ module _ {χ ι : Level} where
 
 
 ```agda
-
-
 module Soundness  {χ α ι : Level}{I : Type ι} (E : I → Eq{χ})
                   (𝑨 : Algebra α ρᵃ)     -- We assume an algebra M
                   (V : 𝑨 ⊨ E)         -- that models all equations in E.
@@ -189,8 +183,6 @@ We denote by `𝔽[ X ]` the *relatively free algebra* over `X` (relative to `E`
 
 
 ```agda
-
-
 module FreeAlgebra {χ : Level}{ι : Level}{I : Type ι}(E : I → Eq) where
  open Algebra
 
@@ -231,8 +223,6 @@ the fact that these results are independent of the chosen variable symbol
 type `X` (or `Δ`, or `Γ`), which is an arbitrary inhabitant of `Type χ`.)
 
 ```agda
-
-
  module _ {X : Type χ} where
   open Environment 𝔽[ X ]
   evaluation : (t : Term Δ) (σ : Sub X Δ) → E ⊢ X ▹ (⟦ t ⟧ ⟨$⟩ σ) ≈ (t [ σ ])
@@ -259,8 +249,6 @@ We are finally ready to formally state and prove Birkhoff's Completeness Theorem
 
 
 ```agda
-
-
  module _ {Γ : Type χ} where
 
   completeness : ∀ p q → ModTuple E ⊫ (p ≈̇ q) → E ⊢ Γ ▹ p ≈ q


### PR DESCRIPTION
Closes #372.  Part of the M4-1 umbrella (#267).

The `.lagda` → `.lagda.md` conversion left blank lines between each fenced `agda` code-block opener and the first line of code.  This collapses them across the live trees (`Legacy/` stays frozen), via a `perl -0pi` substitution over `src/` minus `src/Legacy/`.

+  51 files, 419 blank lines removed (all deletions, no insertions).
+  Pure whitespace, semantically null for both Agda and kramdown; `make check` passes.
+  The acceptance grep over the live trees is now empty.

Branched off `master`.  This PR touches many of the same files as the notation PRs (#367, #368), so expect a trivial whitespace rebase whichever lands second.

https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM)_