### PR TITLE
[M4-1b] Complete the _̂_ → _^_ interpretation migration

### DIFF
--- a/src/Setoid/Congruences/Basic.lagda.md
+++ b/src/Setoid/Congruences/Basic.lagda.md
@@ -30,7 +30,7 @@ open import Relation.Binary.PropositionalEquality using ( refl )
 -- Imports from the Agda Universal Algebras Library ------------------------------
 open import Overture          using ( ∣_∣  ; ∥_∥ ; 0[_] ; _|:_ ; Equivalence )
 open import Setoid.Relations  using ( ⟪_⟫ ; _/_ ; ⟪_∼_⟫-elim )
-open import Setoid.Algebras.Basic {𝑆 = 𝑆} using ( ov ; Algebra ; 𝕌[_] ; _̂_ )
+open import Setoid.Algebras.Basic {𝑆 = 𝑆} using ( ov ; Algebra ; 𝕌[_] ; _^_ )
 
 private variable α ρ ℓ : Level
 ```
@@ -44,7 +44,7 @@ since all the work is done by the relation `|:`, which we defined above (see
 ```agda
 -- Algebra compatibility with binary relation
 _∣≈_ : (𝑨 : Algebra α ρ) → BinRel 𝕌[ 𝑨 ] ℓ → Type _
-𝑨 ∣≈ R = ∀ 𝑓 → (𝑓 ̂ 𝑨) |: R
+𝑨 ∣≈ R = ∀ 𝑓 → (𝑓 ^ 𝑨) |: R
 ```
 
 A *congruence relation* of an algebra `𝑨` is defined to be an equivalence relation
@@ -109,7 +109,7 @@ open Func     using ( cong ) renaming ( to to _⟨$⟩_ )
 
 _╱_ : (𝑨 : Algebra α ρ) → Con 𝑨 ℓ → Algebra α ℓ
 Domain (𝑨 ╱ θ) = 𝕌[ 𝑨 ] / (Eqv ∥ θ ∥)
-(Interp (𝑨 ╱ θ)) ⟨$⟩ (f , a) = (f ̂ 𝑨) a
+(Interp (𝑨 ╱ θ)) ⟨$⟩ (f , a) = (f ^ 𝑨) a
 cong (Interp (𝑨 ╱ θ)) {f , u} {.f , v} (refl , a) = is-compatible ∥ θ ∥ f a
 
 module _ (𝑨 : Algebra α ρ) where

--- a/src/Setoid/Homomorphisms/Basic.lagda.md
+++ b/src/Setoid/Homomorphisms/Basic.lagda.md
@@ -28,7 +28,7 @@ open import Relation.Binary   using ( Setoid )
 open import Overture          using ( ∣_∣ ; ∥_∥ )
 open import Setoid.Functions  using ( IsInjective ; IsSurjective )
 
-open import Setoid.Algebras {𝑆 = 𝑆} using ( Algebra ; _̂_ )
+open import Setoid.Algebras {𝑆 = 𝑆} using ( Algebra ; _^_ )
 
 private variable α β ρᵃ ρᵇ : Level
 
@@ -42,7 +42,7 @@ module _ (𝑨 : Algebra α ρᵃ)(𝑩 : Algebra β ρᵇ) where
 
  compatible-map-op : (A ⟶ B) → ∣ 𝑆 ∣ → Type (𝓥 ⊔ α ⊔ ρᵇ)
  compatible-map-op h f =  ∀ {a}
-  →                       h ⟨$⟩ (f ̂ 𝑨) a ≈₂ (f ̂ 𝑩) λ x → h ⟨$⟩ (a x)
+  →                       h ⟨$⟩ (f ^ 𝑨) a ≈₂ (f ^ 𝑩) λ x → h ⟨$⟩ (a x)
 
  compatible-map : (A ⟶ B) → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵇ)
  compatible-map h = ∀ {f} → compatible-map-op h f

--- a/src/Setoid/Homomorphisms/Factor.lagda.md
+++ b/src/Setoid/Homomorphisms/Factor.lagda.md
@@ -32,7 +32,7 @@ open import Overture         using ( ∣_∣ ; ∥_∥ ; kernelRel )
 open import Setoid.Functions using ( Image_∋_ ; IsSurjective ; SurjInv )
                              using ( SurjInvIsInverseʳ ; epic-factor )
 
-open import Setoid.Algebras {𝑆 = 𝑆}             using ( Algebra ; 𝕌[_] ; _̂_ )
+open import Setoid.Algebras {𝑆 = 𝑆}             using ( Algebra ; 𝕌[_] ; _^_ )
 open import Setoid.Homomorphisms.Basic {𝑆 = 𝑆}  using ( hom ; IsHom ; compatible-map ; epi ; IsEpi)
 
 private variable α ρᵃ β ρᵇ γ ρᶜ : Level
@@ -108,11 +108,11 @@ module _  {𝑨 : Algebra α ρᵃ} (𝑩 : Algebra β ρᵇ) {𝑪 : Algebra γ
          open _⟶_ φmap using () renaming (cong to φcong)
     in
     begin
-    g (h⁻¹ $ (f ̂ 𝑪) c)            ≈⟨ sym₂ $ φcong (cong Interp (≡.refl , λ _ → SurjInvIsInverseʳ hfunc hE)) ⟩
-    g (h⁻¹ $ f ̂ 𝑪 $ h ∘ h⁻¹ ∘ c)  ≈⟨ sym₂ $ φcong (compatible ∥ hh ∥) ⟩
-    g (h⁻¹ $ h $ f ̂ 𝑨 $ h⁻¹ ∘ c)  ≈⟨ sym₂ $ gφh $ (f ̂ 𝑨) (h⁻¹ ∘ c) ⟩
-    g (f ̂ 𝑨 $ h⁻¹ ∘ c)            ≈⟨ compatible ∥ gh ∥ ⟩
-    (f ̂ 𝑩)(g ∘ h⁻¹ ∘ c)           ∎
+    g (h⁻¹ $ (f ^ 𝑪) c)            ≈⟨ sym₂ $ φcong (cong Interp (≡.refl , λ _ → SurjInvIsInverseʳ hfunc hE)) ⟩
+    g (h⁻¹ $ f ^ 𝑪 $ h ∘ h⁻¹ ∘ c)  ≈⟨ sym₂ $ φcong (compatible ∥ hh ∥) ⟩
+    g (h⁻¹ $ h $ f ^ 𝑨 $ h⁻¹ ∘ c)  ≈⟨ sym₂ $ gφh $ (f ^ 𝑨) (h⁻¹ ∘ c) ⟩
+    g (f ^ 𝑨 $ h⁻¹ ∘ c)            ≈⟨ compatible ∥ gh ∥ ⟩
+    (f ^ 𝑩)(g ∘ h⁻¹ ∘ c)           ∎
 
   φhom : IsHom 𝑪 𝑩 φmap
   compatible φhom = φcomp

--- a/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
+++ b/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
@@ -35,7 +35,7 @@ open  import Setoid.Functions
       using ( _preimage≈image ; InvIsInverseʳ ; IsSurjective ; ⊙-IsSurjective )
 
 open  import Setoid.Algebras {𝑆 = 𝑆}
-      using ( Algebra ; ov ; _̂_ ; ⟨_⟩ ; Lift-Algˡ ; Lift-Alg ; 𝕌[_] )
+      using ( Algebra ; ov ; _^_ ; ⟨_⟩ ; Lift-Algˡ ; Lift-Alg ; 𝕌[_] )
 
 open import Setoid.Homomorphisms.Basic {𝑆 = 𝑆}         using ( hom ; IsHom )
 open import Setoid.Homomorphisms.Isomorphisms {𝑆 = 𝑆}  using ( _≅_ ; Lift-≅ )
@@ -97,20 +97,20 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
     using() renaming (Carrier to SRanh ; _≈_ to _≈₃_ ; refl to refl₃ )
 
    hhom :  ∀ {𝑓}(x : ∥ 𝑆 ∥ 𝑓 → ∣ h ∣ range )
-    →      (∣ h ∣ ⟨$⟩ (𝑓 ̂ 𝑨) ((∣ h ∣ preimage) ∘ x)) ≈₂ (𝑓 ̂ 𝑩) ((∣ h ∣ image) ∘ x)
+    →      (∣ h ∣ ⟨$⟩ (𝑓 ^ 𝑨) ((∣ h ∣ preimage) ∘ x)) ≈₂ (𝑓 ^ 𝑩) ((∣ h ∣ image) ∘ x)
 
    hhom {𝑓} x = trans₂ (compatible ∥ h ∥) (cong InterpB (≡.refl , (∣ h ∣ preimage≈image) ∘ x))
 
    f' : SRanh → ∣ h ∣ range
-   f' (𝑓 , x) =  (𝑓 ̂ 𝑩)((∣ h ∣ image)∘ x)        -- b : the image in ∣B∣
-                 , (𝑓 ̂ 𝑨)((∣ h ∣ preimage) ∘ x)  -- a : the preimage in ∣A∣
+   f' (𝑓 , x) =  (𝑓 ^ 𝑩)((∣ h ∣ image)∘ x)        -- b : the image in ∣B∣
+                 , (𝑓 ^ 𝑨)((∣ h ∣ preimage) ∘ x)  -- a : the preimage in ∣A∣
                  , hhom x                        -- p : proof that `(∣ h ∣ ⟨$⟩ a) ≈₂ b`
 
    cong' : ∀ {x y} → x ≈₃ y → ((∣ h ∣ image) (f' x)) ≈₂ ((∣ h ∣ image) (f' y))
    cong' {(𝑓 , u)} {(.𝑓 , v)} (≡.refl , EqA) = Goal
     where
     -- Alternative formulation of the goal:
-    goal : (𝑓 ̂ 𝑩)(λ i → ((∣ h ∣ image)(u i))) ≈₂ (𝑓 ̂ 𝑩)(λ i → ((∣ h ∣ image) (v i)))
+    goal : (𝑓 ^ 𝑩)(λ i → ((∣ h ∣ image)(u i))) ≈₂ (𝑓 ^ 𝑩)(λ i → ((∣ h ∣ image) (v i)))
     goal = cong InterpB (≡.refl , EqA )
 
     Goal : (∣ h ∣ image) (f' (𝑓 , u)) ≈₂ (∣ h ∣ image) (f' (𝑓 , v))

--- a/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
@@ -32,7 +32,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using ()
 open import Overture          using ( ∣_∣ ; ∥_∥ )
 open import Setoid.Functions  using ( _⊙_ ; eq ; IsInjective ; IsSurjective )
 
-open import Setoid.Algebras {𝑆 = 𝑆}  using ( Algebra ; Lift-Alg ; _̂_ )
+open import Setoid.Algebras {𝑆 = 𝑆}  using ( Algebra ; Lift-Alg ; _^_ )
                                      using ( Lift-Algˡ ; Lift-Algʳ ; ⨅ )
 
 open import Setoid.Homomorphisms.Basic       {𝑆 = 𝑆} using  ( hom ; IsHom )

--- a/src/Setoid/Homomorphisms/Kernels.lagda.md
+++ b/src/Setoid/Homomorphisms/Kernels.lagda.md
@@ -27,7 +27,7 @@ open  import Relation.Binary.PropositionalEquality as ≡ using ()
 -- Imports from the Agda Universal Algebra Library ------------------------------------------
 open  import Overture          using  ( ∣_∣ ; ∥_∥ ; kerRel ; kerRelOfEquiv )
 open  import Setoid.Functions  using  ( Image_∋_ )
-open  import Setoid.Algebras     {𝑆 = 𝑆}  using ( Algebra ; _̂_ ; ov )
+open  import Setoid.Algebras     {𝑆 = 𝑆}  using ( Algebra ; _^_ ; ov )
 open  import Setoid.Congruences  {𝑆 = 𝑆}  using ( _∣≈_ ; Con ; mkcon ; _╱_ ; IsCongruence )
 
 open  import Setoid.Homomorphisms.Basic {𝑆 = 𝑆}
@@ -51,23 +51,23 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} (hh : hom 𝑨 𝑩)
 
 
 `HomKerComp` asserts that the kernel of a homomorphism is compatible with the basic operations.
-That is, if each `(u i, v i)` belongs to the kernel, then so does the pair `((f ̂ 𝑨) u , (f ̂ 𝑨) v)`.
+That is, if each `(u i, v i)` belongs to the kernel, then so does the pair `((f ^ 𝑨) u , (f ^ 𝑨) v)`.
 
 
 ```agda
  HomKerComp : 𝑨 ∣≈ kerRel _≈₂_ h
  HomKerComp f {u}{v} kuv = Goal
   where
-  fhuv : (f ̂ 𝑩)(h ∘ u) ≈₂ (f ̂ 𝑩)(h ∘ v)
+  fhuv : (f ^ 𝑩)(h ∘ u) ≈₂ (f ^ 𝑩)(h ∘ v)
   fhuv = cong Interp (≡.refl , kuv)
 
-  lem1 : h ((f ̂ 𝑨) u) ≈₂ (f ̂ 𝑩)(h ∘ u)
+  lem1 : h ((f ^ 𝑨) u) ≈₂ (f ^ 𝑩)(h ∘ u)
   lem1 = IsHom.compatible ∥ hh ∥
 
-  lem2 : (f ̂ 𝑩) (h ∘ v) ≈₂ h ((f ̂ 𝑨) v)
+  lem2 : (f ^ 𝑩) (h ∘ v) ≈₂ h ((f ^ 𝑨) v)
   lem2 = sym (IsHom.compatible ∥ hh ∥)
 
-  Goal : h ((f ̂ 𝑨) u) ≈₂ h ((f ̂ 𝑨) v)
+  Goal : h ((f ^ 𝑨) u) ≈₂ h ((f ^ 𝑨) v)
   Goal = trans lem1 (trans fhuv lem2)
 ```
 

--- a/src/Setoid/Homomorphisms/Noether.lagda.md
+++ b/src/Setoid/Homomorphisms/Noether.lagda.md
@@ -31,7 +31,7 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 open import Overture          using ( ∣_∣ ; ∥_∥ )
 open import Setoid.Functions  using ( IsInjective )
 
-open import Setoid.Algebras {𝑆 = 𝑆}               using ( Algebra ; _̂_)
+open import Setoid.Algebras {𝑆 = 𝑆}               using ( Algebra ; _^_)
 open import Setoid.Homomorphisms.Basic {𝑆 = 𝑆}    using ( hom ; IsHom )
 open import Setoid.Homomorphisms.Kernels {𝑆 = 𝑆}  using ( kerquo ; πker )
 

--- a/src/Setoid/Homomorphisms/Products.lagda.md
+++ b/src/Setoid/Homomorphisms/Products.lagda.md
@@ -28,7 +28,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using ( _≡_ )
 -- Imports from the Agda Universal Algebras Library ----------------------
 open import Overture         using ( ∣_∣ ; ∥_∥)
 open import Setoid.Algebras {𝑆 = 𝑆}
-                             using ( Algebra ; _̂_ ; ⨅ )
+                             using ( Algebra ; _^_ ; ⨅ )
 open import Setoid.Homomorphisms.Basic {𝑆 = 𝑆}
                              using ( hom ; IsHom ; epi )
 

--- a/src/Setoid/Homomorphisms/Properties.lagda.md
+++ b/src/Setoid/Homomorphisms/Properties.lagda.md
@@ -30,7 +30,7 @@ open import Overture          using ( ∣_∣ ; ∥_∥ )
 open import Setoid.Functions  using ( _⊙_ ; 𝑖𝑑 ; Image_∋_ ; eq ; ⊙-IsSurjective )
 
 open  import Setoid.Algebras {𝑆 = 𝑆}
-      using ( Algebra ; _̂_; Lift-Algˡ; Lift-Algʳ; Lift-Alg; 𝕌[_])
+      using ( Algebra ; _^_; Lift-Algˡ; Lift-Algʳ; Lift-Alg; 𝕌[_])
 open  import Setoid.Homomorphisms.Basic {𝑆 = 𝑆}
       using ( hom ; IsHom ; epi ; IsEpi ; compatible-map )
 
@@ -64,10 +64,10 @@ module _  {𝑨 : Algebra α ρᵃ} {𝑩 : Algebra β ρᵇ} {𝑪 : Algebra γ
    c : compatible-map 𝑨 𝑪 (h ⊙ g)
    c {f}{a} = trans lemg lemh
     where
-    lemg : (h ⟨$⟩ (g ⟨$⟩ ((f ̂ 𝑨) a))) ≈₃ (h ⟨$⟩ ((f ̂ 𝑩) (λ x → g ⟨$⟩ (a x))))
+    lemg : (h ⟨$⟩ (g ⟨$⟩ ((f ^ 𝑨) a))) ≈₃ (h ⟨$⟩ ((f ^ 𝑩) (λ x → g ⟨$⟩ (a x))))
     lemg = cong h (compatible ghom)
 
-    lemh : (h ⟨$⟩ ((f ̂ 𝑩) (λ x → g ⟨$⟩ (a x)))) ≈₃ ((f ̂ 𝑪) (λ x → h ⟨$⟩ (g ⟨$⟩ (a x))))
+    lemh : (h ⟨$⟩ ((f ^ 𝑩) (λ x → g ⟨$⟩ (a x)))) ≈₃ ((f ^ 𝑪) (λ x → h ⟨$⟩ (g ⟨$⟩ (a x))))
     lemh = compatible hhom
 
   ⊙-hom : hom 𝑨 𝑩 → hom 𝑩 𝑪  → hom 𝑨 𝑪

--- a/src/Setoid/Subalgebras/Subuniverses.lagda.md
+++ b/src/Setoid/Subalgebras/Subuniverses.lagda.md
@@ -31,7 +31,7 @@ open import Relation.Binary.PropositionalEquality using ( refl )
 -- Imports from the Agda Universal Algebra Library ----------------------------------
 open import Overture                       using ( ∣_∣ ; ∥_∥ ; Im_⊆_ )
 open import Overture.Terms        {𝑆 = 𝑆}  using ( Term ; ℊ ; node )
-open import Setoid.Algebras       {𝑆 = 𝑆}  using ( Algebra ; 𝕌[_] ; _̂_ ; ov )
+open import Setoid.Algebras       {𝑆 = 𝑆}  using ( Algebra ; 𝕌[_] ; _^_ ; ov )
 open import Setoid.Terms          {𝑆 = 𝑆}  using ( module Environment )
 open import Setoid.Homomorphisms  {𝑆 = 𝑆}  using ( hom ; IsHom )
 
@@ -49,7 +49,7 @@ module _ (𝑨 : Algebra α ρᵃ) where
  private A = 𝕌[ 𝑨 ] -- the forgetful functor
 
  Subuniverses : Pred (Pred A ℓ) (𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ )
- Subuniverses B = ∀ f a → Im a ⊆ B → (f ̂ 𝑨) a ∈ B
+ Subuniverses B = ∀ f a → Im a ⊆ B → (f ^ 𝑨) a ∈ B
 
  -- Subuniverses as a record type
  record Subuniverse : Type(ov (α ⊔ ℓ)) where
@@ -61,7 +61,7 @@ module _ (𝑨 : Algebra α ρᵃ) where
  -- Subuniverse Generation
  data Sg (G : Pred A ℓ) : Pred A (𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ) where
   var : ∀ {v} → v ∈ G → v ∈ Sg G
-  app : ∀ f a → Im a ⊆ Sg G → (f ̂ 𝑨) a ∈ Sg G
+  app : ∀ f a → Im a ⊆ Sg G → (f ^ 𝑨) a ∈ Sg G
 ```
 
 
@@ -86,12 +86,12 @@ Next we prove by structural induction that `Sg X` is the smallest subuniverse of
   →              B ∈ Subuniverses  →  G ⊆ B  →  Sg G ⊆ B
 
  sgIsSmallest _ _ G⊆B (var Gx) = G⊆B Gx
- sgIsSmallest B B≤A G⊆B {.((f ̂ 𝑨) a)} (app f a SgGa) = Goal
+ sgIsSmallest B B≤A G⊆B {.((f ^ 𝑨) a)} (app f a SgGa) = Goal
   where
   IH : Im a ⊆ B
   IH i = sgIsSmallest B B≤A G⊆B (SgGa i)
 
-  Goal : (f ̂ 𝑨) a ∈ B
+  Goal : (f ^ 𝑨) a ∈ B
   Goal = B≤A f a IH
 ```
 
@@ -118,7 +118,7 @@ In the proof above, we assume the following typing judgments:
     f  : ∣ 𝑆 ∣
     σ  : (i : I) → 𝒜 i ∈ Subuniverses 𝑨
 
-and we must prove `(f ̂ 𝑨) a ∈ ⋂ I 𝒜`.  When we did this with the old
+and we must prove `(f ^ 𝑨) a ∈ ⋂ I 𝒜`.  When we did this with the old
 Algebra type, Agda could fill in the proof term `λ i → σ i f a (λ x → ν x i)`
 automatically using `C-c C-a`, but this doesn't work for Algebra
 as we've implemented it.  We get the error "Agsy does not support copatterns
@@ -164,7 +164,7 @@ Alternatively, we could express the preceeding fact using an inductive type repr
 ```agda
  data TermImage (B : Pred A ρᵃ) : Pred A (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵃ) where
   var : ∀ {b : A} → b ∈ B → b ∈ TermImage B
-  app : ∀ f ts →  ((i : ∥ 𝑆 ∥ f) → ts i ∈ TermImage B)  → (f ̂ 𝑨) ts ∈ TermImage B
+  app : ∀ f ts →  ((i : ∥ 𝑆 ∥ f) → ts i ∈ TermImage B)  → (f ^ 𝑨) ts ∈ TermImage B
 
  -- `TermImage B` is a subuniverse of 𝑨 that contains B.
  TermImageIsSub : {B : Pred A ρᵃ} → TermImage B ∈ Subuniverses 𝑨
@@ -202,17 +202,17 @@ we call `hom-unique`.
    →            (a : A) → (a ∈ Sg 𝑨 G → g a ≈ h a)
 
   hom-unique G σ a (var Ga) = σ a Ga
-  hom-unique G σ .((f ̂ 𝑨) a) (app f a SgGa) = Goal
+  hom-unique G σ .((f ^ 𝑨) a) (app f a SgGa) = Goal
    where
    IH : ∀ i → h (a i) ≈ g (a i)
    IH i = sym (hom-unique G σ (a i) (SgGa i))
 
-   Goal : g ((f ̂ 𝑨) a) ≈ h ((f ̂ 𝑨) a)
+   Goal : g ((f ^ 𝑨) a) ≈ h ((f ^ 𝑨) a)
    Goal =  begin
-           g ((f ̂ 𝑨) a)   ≈⟨ compatible ∥ gh ∥ ⟩
-           (f ̂ 𝑩)(g ∘ a ) ≈˘⟨ cong Interp (refl , IH) ⟩
-           (f ̂ 𝑩)(h ∘ a)  ≈˘⟨ compatible ∥ hh ∥ ⟩
-           h ((f ̂ 𝑨) a )  ∎
+           g ((f ^ 𝑨) a)   ≈⟨ compatible ∥ gh ∥ ⟩
+           (f ^ 𝑩)(g ∘ a ) ≈˘⟨ cong Interp (refl , IH) ⟩
+           (f ^ 𝑩)(h ∘ a)  ≈˘⟨ compatible ∥ hh ∥ ⟩
+           h ((f ^ 𝑨) a )  ∎
 ```
 
 
@@ -226,7 +226,7 @@ In the induction step, the following typing judgments are assumed:
     hh   : hom 𝑨 𝑩
     gh   : hom 𝑨 𝑩
 
-and, under these assumptions, we proved `g ((f ̂ 𝑨) a) ≈ h ((f ̂ 𝑨) a)`.
+and, under these assumptions, we proved `g ((f ^ 𝑨) a) ≈ h ((f ^ 𝑨) a)`.
 
 ---------------------------------
 

--- a/src/Setoid/Terms/Basic.lagda.md
+++ b/src/Setoid/Terms/Basic.lagda.md
@@ -32,7 +32,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using ( _≡_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
 open import Overture using ( ∥_∥ )
-open import Setoid.Algebras  {𝑆 = 𝑆}  using ( Algebra ; ov ; _̂_)
+open import Setoid.Algebras  {𝑆 = 𝑆}  using ( Algebra ; ov ; _^_)
 open import Overture.Terms  {𝑆 = 𝑆} using ( Term )
 
 open Func renaming ( to to _⟨$⟩_ )
@@ -133,7 +133,7 @@ module Environment (𝑨 : Algebra α ℓ) where
 
  EnvAlgebra : Type χ → Algebra (α ⊔ χ) (ℓ ⊔ χ)
  Domain (EnvAlgebra X) = Env X
- (Interp (EnvAlgebra X) ⟨$⟩ (f , aϕ)) x = (f ̂ 𝑨) (λ i → aϕ i x)
+ (Interp (EnvAlgebra X) ⟨$⟩ (f , aϕ)) x = (f ^ 𝑨) (λ i → aϕ i x)
  cong (Interp (EnvAlgebra X)) {f , a} {.f , b} (≡.refl , aibi) x = cong InterpA (≡.refl , (λ i → aibi i x))
 ```
 

--- a/src/Setoid/Terms/Operations.lagda.md
+++ b/src/Setoid/Terms/Operations.lagda.md
@@ -34,7 +34,7 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 -- Imports from Agda Universal Algebra Library -----------------------------------
 open  import Overture                         using ( ∣_∣ ; ∥_∥ )
 open  import Overture.Terms           {𝑆 = 𝑆} using ( Term )
-open  import Setoid.Algebras          {𝑆 = 𝑆} using ( Algebra ; _̂_ ; ov ; ⨅ )
+open  import Setoid.Algebras          {𝑆 = 𝑆} using ( Algebra ; _^_ ; ov ; ⨅ )
 open  import Setoid.Homomorphisms     {𝑆 = 𝑆} using ( hom ; IsHom )
 open  import Setoid.Terms.Properties  {𝑆 = 𝑆} using ( free-lift )
 open  import Setoid.Terms.Basic       {𝑆 = 𝑆}
@@ -72,7 +72,7 @@ module _ {X : Type χ} where
  open SetoidReasoning TX
 
  term-interp :  (f : ∣ 𝑆 ∣){s t : ∥ 𝑆 ∥ f → Term X} → (∀ i → s i ≐ t i)
-  →             ∀ η → ⟦ node f s ⟧ ⟨$⟩ η ≈ ⟦ node f t ⟧ ⟨$⟩ η -- (f ̂ 𝑻 X) t
+  →             ∀ η → ⟦ node f s ⟧ ⟨$⟩ η ≈ ⟦ node f t ⟧ ⟨$⟩ η -- (f ^ 𝑻 X) t
 
  term-interp f {s}{t} st η = cong Interp (≡.refl , λ i → ≐→Equal (s i) (t i) (st i) η )
 
@@ -129,8 +129,8 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}(hh : hom 𝑨 𝑩) 
   goal : h (⟦ node f t ⟧₁ ⟨$⟩ a) ≈ (⟦ node f t ⟧₂ ⟨$⟩ (h ∘ a))
   goal = begin
    h (⟦ node f t ⟧₁ ⟨$⟩ a)             ≈⟨ (compatible ∥ hh ∥) ⟩
-   (f ̂ 𝑩)(λ i → h (⟦ t i ⟧₁ ⟨$⟩ a))    ≈⟨ cong Interp₂ (≡.refl , λ i → comm-hom-term (t i) a) ⟩
-   (f ̂ 𝑩)(λ i → ⟦ t i ⟧₂ ⟨$⟩ (h ∘ a))  ≈⟨ refl ⟩
+   (f ^ 𝑩)(λ i → h (⟦ t i ⟧₁ ⟨$⟩ a))    ≈⟨ cong Interp₂ (≡.refl , λ i → comm-hom-term (t i) a) ⟩
+   (f ^ 𝑩)(λ i → ⟦ t i ⟧₂ ⟨$⟩ (h ∘ a))  ≈⟨ refl ⟩
    (⟦ node f t ⟧₂ ⟨$⟩ (h ∘ a))         ∎
 ```
 

--- a/src/Setoid/Terms/Properties.lagda.md
+++ b/src/Setoid/Terms/Properties.lagda.md
@@ -33,7 +33,7 @@ open import Setoid.Functions  using ( Img_∋_ ; eq ; isSurj ; IsSurjective )
                               using ( isSurj→IsSurjective )
 
 open import Overture.Terms        {𝑆 = 𝑆} using ( Term )
-open import Setoid.Algebras       {𝑆 = 𝑆} using ( Algebra ; 𝕌[_] ; _̂_ )
+open import Setoid.Algebras       {𝑆 = 𝑆} using ( Algebra ; 𝕌[_] ; _^_ )
 open import Setoid.Homomorphisms  {𝑆 = 𝑆} using ( hom ; compatible-map ; IsHom )
 open import Setoid.Terms.Basic    {𝑆 = 𝑆}  using ( 𝑻 ; _≐_  ; ≐-isRefl )
 
@@ -66,7 +66,7 @@ module _ {𝑨 : Algebra α ρ}(h : X → 𝕌[ 𝑨 ]) where
 
  free-lift : 𝕌[ 𝑻 X ] → 𝕌[ 𝑨 ]
  free-lift (ℊ x) = h x
- free-lift (node f t) = (f ̂ 𝑨) (λ i → free-lift (t i))
+ free-lift (node f t) = (f ^ 𝑨) (λ i → free-lift (t i))
 
  free-lift-of-surj-isSurj :  isSurj{𝑨 = ≡.setoid X}{𝑩 = A} h
   →                          isSurj{𝑨 = TX}{𝑩 = A} free-lift
@@ -92,7 +92,7 @@ Naturally, at the base step of the induction, when the term has the form `genera
 x, the free lift of `h` agrees with `h`.  For the inductive step, when the given term
 has the form `node f t`, the free lift is defined as follows: Assuming (the induction
 hypothesis) that we know the image of each subterm `t i` under the free lift of `h`,
-define the free lift at the full term by applying `f ̂ 𝑨` to the images of the subterms.
+define the free lift at the full term by applying `f ^ 𝑨` to the images of the subterms.
 
 The free lift so defined is a homomorphism by construction. Indeed, here is the trivial proof.
 
@@ -145,13 +145,13 @@ module _ {𝑨 : Algebra α ρ}{gh hh : hom (𝑻 X) 𝑨} where
   lem2 : ∀ i → (g (t i)) ≈ (h (t i))
   lem2 i = free-unique p (t i)
 
-  lem3 : (f ̂ 𝑨)(λ i → (g (t i))) ≈ (f ̂ 𝑨)(λ i → (h (t i)))
+  lem3 : (f ^ 𝑨)(λ i → (g (t i))) ≈ (f ^ 𝑨)(λ i → (h (t i)))
   lem3 = cong Interp (_≡_.refl , lem2)
 
-  geq : (g (node f t)) ≈ (f ̂ 𝑨)(λ i → (g (t i)))
+  geq : (g (node f t)) ≈ (f ^ 𝑨)(λ i → (g (t i)))
   geq = compatible ∥ gh ∥
 
-  heq : h (node f t) ≈ (f ̂ 𝑨)(λ i → h (t i))
+  heq : h (node f t) ≈ (f ^ 𝑨)(λ i → h (t i))
   heq = compatible ∥ hh ∥
 ```
 


### PR DESCRIPTION
Closes #368.  Part of the M4-1 umbrella (#267).

Rewrites every non-`Legacy/` callsite and import of the deprecated combining-caret `_̂_` to the definitionally identical ASCII `_^_` (both defined in `Setoid.Algebras.Basic`, where `_̂_` carries the v3.0 `WARNING_ON_USAGE`).

+  13 modules across `Setoid/Homomorphisms`, `Setoid/Terms`, `Setoid/Subalgebras/Subuniverses`, and `Setoid/Congruences/Basic` — broader than the issue's "only Congruences still uses it" estimate.
+  The `_̂_` definition and its pragma stay in `Setoid.Algebras.Basic` so `Legacy/` keeps compiling.
+  The self-contained `Demos/HSP.lagda.md` keeps its own local `_̂_` (maintainer scope decision); the acceptance grep is read as matching only `Setoid.Algebras.Basic` and `Demos/HSP`.
+  The STYLE_GUIDE Interpretation-table refresh is left to #369.

`make check` passes.

Note: the issue names `Setoid.Algebras.Congruences`, which does not exist; the live file is `Setoid/Congruences/Basic`.  Branched off `master`.

https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM)_