### PR TITLE
[M4-1c] Reconcile docs/STYLE_GUIDE.md self-contradictions

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -297,14 +297,14 @@ Don't decorate names to indicate implementation/type choices; avoid suffixes lik
 | `proj₂` | Second projection of a Σ-type | stdlib `Data.Product` (re-exported by `Overture`) | **canonical** |
 | `OperationSymbolsOf` | A signature's operation symbols (`proj₁ 𝑆`) | `Overture.Signatures` | **canonical** for signature components |
 | `ArityOf` | A signature's arity function (`proj₂ 𝑆`) | `Overture.Signatures` | **canonical** for signature components |
-| `∣_∣` | First projection of a Σ-type | `Overture.Basic` | **deprecated** (v3.0, `WARNING_ON_USAGE`); migrated out of the live trees by #367, retained for `Legacy/` |
-| `∥_∥` | Second projection of a Σ-type | `Overture.Basic` | **deprecated** (v3.0, `WARNING_ON_USAGE`); migrated out of the live trees by #367, retained for `Legacy/` |
+| `∣_∣` | First projection of a Σ-type | `Overture.Basic` | **deprecated** (v3.0); the live-tree sweep to `proj₁` and the `WARNING_ON_USAGE` land with #367, after which it is retained for `Legacy/` |
+| `∥_∥` | Second projection of a Σ-type | `Overture.Basic` | **deprecated** (v3.0); the live-tree sweep to `proj₂` and the `WARNING_ON_USAGE` land with #367, after which it is retained for `Legacy/` |
 | `_,_` | Σ-type constructor | stdlib `Data.Product` | **standard** |
 | `Σ[_∈_]_` | Σ-type binder syntax | stdlib `Data.Product` | **standard** |
 
-The mechanical sweep replacing `∣_∣` / `∥_∥` with the standard `proj₁` / `proj₂` was carried out in M4-1 (#367).  The vertical-bars convention was an `agda-algebras` idiom carried over from earlier `TypeTopology`-style developments; the bars read *less* clearly for mathematicians who reserve them for absolute value and norm, and the stdlib names bridge more cleanly to `Data.Product`.  Signature components use the self-documenting `OperationSymbolsOf` / `ArityOf` (definitionally `proj₁` / `proj₂` of the signature); see [ADR-002][] §1.
+The mechanical sweep replacing `∣_∣` / `∥_∥` with the standard `proj₁` / `proj₂` across the live trees is M4-1 (#367).  The vertical-bars convention was an `agda-algebras` idiom carried over from earlier `TypeTopology`-style developments; the bars read *less* clearly for mathematicians who reserve them for absolute value and norm, and the stdlib names bridge more cleanly to `Data.Product`.  Signature components use the self-documenting `OperationSymbolsOf` / `ArityOf` (definitionally `proj₁` / `proj₂` of the signature); see [ADR-002][] §1.
 
-**Scope note**.  The live trees (`Overture/`, `Setoid/`, `Classical/`, `Demos/ContraX`, `Examples/`) are on `proj₁` / `proj₂`; the bracket definitions remain in `Overture.Basic` under a `WARNING_ON_USAGE` so `Legacy/` keeps compiling.  The `∣` glyph legitimately survives outside `Legacy/` in the `_∣≈_` / `_∥≈_` operators, the `∣_∣=∣_∣` / `∣_∣≈∣_∣` bijection operators (`Examples.FunctionTypeBijections`), the `∣A∣`-style Carrier-alias identifiers, and CSP math prose; and the self-contained `Demos/HSP` keeps its own bracket notation.
+**Scope note**.  Once #367 lands, the live trees (`Overture/`, `Setoid/`, `Classical/`, `Demos/ContraX`, `Examples/`) are on `proj₁` / `proj₂`, and the bracket definitions remain in `Overture.Basic` under a `WARNING_ON_USAGE` so `Legacy/` keeps compiling.  The `∣` glyph legitimately survives outside `Legacy/` in the `_∣≈_` / `_∥≈_` operators, the `∣_∣=∣_∣` / `∣_∣≈∣_∣` bijection operators (`Examples.FunctionTypeBijections`), the `∣A∣`-style Carrier-alias identifiers, and CSP math prose; and the self-contained `Demos/HSP` keeps its own bracket notation.
 
 
 ### Universe levels
@@ -375,7 +375,7 @@ Plain-text `A`, `B` denote carrier types; mathematical bold italic `𝑨`, `𝑩
 | Symbol | Meaning |
 |---|---|
 | `_^_` | interpretation of an operation symbol in an algebra or other structure (`𝑓 ^ 𝑨`) |
-| `_̂_` | deprecated (v3.0, `WARNING_ON_USAGE`) combining-caret alias of `_^_`; migrated out of the live trees by #368, retained for `Legacy/` |
+| `_̂_` | deprecated (v3.0) combining-caret alias of `_^_`; the live-tree sweep to `_^_` lands with #368, after which it is retained for `Legacy/` |
 | `Domain` | underlying setoid of an algebra or other structure |
 | `Interp` | `Func`-typed interpretation of operations |
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -186,7 +186,13 @@ This pattern is to be ratified in ADR-002 (to land with [M3-1][`docs/GITHUB_PROJ
 
 ### Module headers have comment blocks
 
-Every non-trivial module should have a prose comment block near the top — after the pragma and any module-header imports, but before the main body; e.g.,
+Every non-trivial module should have a prose comment block near the top.  In a literate `.lagda.md` module that block is Markdown — the section heading and an introductory paragraph or two — and it *precedes* the opening code fence, rather than sitting in a `-- |` block inside it.  For example, `Setoid.Algebras.Basic` would open with prose like
+
+> ### Basic definitions
+>
+> An `Algebra` over signature `𝑆` is a setoid (the domain) equipped with an interpretation of each operation symbol in `𝑆` as a function on the carrier that respects the setoid's equivalence relation.  This module is the canonical entry point for the Setoid tree; see `Setoid.Algebras.Products` for indexed products, `Setoid.Algebras.Congruences` for the congruence relations used to build quotients, and `Setoid.Homomorphisms.Basic` for homomorphisms between algebras.
+
+and only then the opening fence:
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
@@ -194,17 +200,6 @@ Every non-trivial module should have a prose comment block near the top — afte
 open import Overture using ( 𝓞 ; 𝓥 ; Signature )
 
 module Setoid.Algebras.Basic {𝑆 : Signature 𝓞 𝓥} where
-
--- | Basic definitions for Setoid-based universal algebras.
--- |
--- | An `Algebra` over signature `𝑆` is a setoid (the domain) equipped with an
--- | interpretation of each operation symbol in `𝑆` as a function on the
--- | carrier that respects the setoid's equivalence relation.
--- |
--- | This module is the canonical entry point for the Setoid tree.  Related modules:
--- | `Setoid.Algebras.Products` for indexed products; `Setoid.Algebras.Congruences`
--- | for the congruence relations used to build quotients.  See also
--- | `Setoid.Homomorphisms.Basic` for homomorphisms between algebras.
 ```
 
 The content of these blocks matters — see [Comments and documentation](#comments-and-documentation) below.
@@ -246,7 +241,7 @@ open import Relation.Binary  using ( IsEquivalence ) renaming ( Rel to BinRel )
 open import Relation.Unary   using ( _∈_ ; Pred )
 
 -- Imports from the agda-algebras library.
-open import Overture         using ( ∣_∣ ; ∥_∥ ; Op )
+open import Overture         using ( proj₁ ; proj₂ ; Op )
 open import Base.Relations   using ( _|:_ ; _|:pred_ ; Rel ; compatible-Rel )
                              using ( REL ; compatible-REL )
 ```
@@ -298,14 +293,18 @@ Don't decorate names to indicate implementation/type choices; avoid suffixes lik
 
 | Symbol | Meaning | Source | Status/Plan |
 |---|---|---|---|
-| `∣_∣` | First projection of a Σ-type | `Overture.Basic` | **deprecated** : replace with `proj₁` in v3.0 |
-| `∥_∥` | Second projection of a Σ-type | `Overture.Basic` | **deprecated** : replace with `proj₂` in v3.0 |
-| `_,_` | Σ-type constructor | stdlib `Data.Product` | **standard** : retain in v3.0 |
-| `Σ[_∈_]_` | Σ-type binder syntax | stdlib `Data.Product` | **standard** : retain in v3.0 |
+| `proj₁` | First projection of a Σ-type | stdlib `Data.Product` (re-exported by `Overture`) | **canonical** |
+| `proj₂` | Second projection of a Σ-type | stdlib `Data.Product` (re-exported by `Overture`) | **canonical** |
+| `OperationSymbolsOf` | A signature's operation symbols (`proj₁ 𝑆`) | `Overture.Signatures` | **canonical** for signature components |
+| `ArityOf` | A signature's arity function (`proj₂ 𝑆`) | `Overture.Signatures` | **canonical** for signature components |
+| `∣_∣` | First projection of a Σ-type | `Overture.Basic` | **deprecated** (v3.0, `WARNING_ON_USAGE`); migrated out of the live trees by #367, retained for `Legacy/` |
+| `∥_∥` | Second projection of a Σ-type | `Overture.Basic` | **deprecated** (v3.0, `WARNING_ON_USAGE`); migrated out of the live trees by #367, retained for `Legacy/` |
+| `_,_` | Σ-type constructor | stdlib `Data.Product` | **standard** |
+| `Σ[_∈_]_` | Σ-type binder syntax | stdlib `Data.Product` | **standard** |
 
-In the upcoming release cycle we will replace `∣_∣` and `∥_∥` with the more standard `proj₁` and `proj₂` throughout.  The vertical-bars convention was an `agda-algebras` idiom carried over from earlier `TypeTopology`-style developments; they make the code *less* readable for mathematicians who typically reserve those symbols for absolute value and norm, and the stdlib names bridge more cleanly to `Data.Product`.
+The mechanical sweep replacing `∣_∣` / `∥_∥` with the standard `proj₁` / `proj₂` was carried out in M4-1 (#367).  The vertical-bars convention was an `agda-algebras` idiom carried over from earlier `TypeTopology`-style developments; the bars read *less* clearly for mathematicians who reserve them for absolute value and norm, and the stdlib names bridge more cleanly to `Data.Product`.  Signature components use the self-documenting `OperationSymbolsOf` / `ArityOf` (definitionally `proj₁` / `proj₂` of the signature); see [ADR-002][] §1.
 
-**Scope note**.  These projections are used pervasively throughout `src/` and `docs/lagda/` — this is the largest syntactic change in the 3.0 cycle.  The rationale and migration plan will be captured in a dedicated ADR (see M1-6), and the mechanical sweep is scheduled as part of M4-1.  Until then, existing `∣_∣` / `∥_∥` callsites remain valid; new code may use either notation, but `proj₁` / `proj₂` is preferred.
+**Scope note**.  The live trees (`Overture/`, `Setoid/`, `Classical/`, `Demos/ContraX`, `Examples/`) are on `proj₁` / `proj₂`; the bracket definitions remain in `Overture.Basic` under a `WARNING_ON_USAGE` so `Legacy/` keeps compiling.  The `∣` glyph legitimately survives outside `Legacy/` in the `_∣≈_` / `_∥≈_` operators, the `∣_∣=∣_∣` / `∣_∣≈∣_∣` bijection operators (`Examples.FunctionTypeBijections`), the `∣A∣`-style Carrier-alias identifiers, and CSP math prose; and the self-contained `Demos/HSP` keeps its own bracket notation.
 
 
 ### Universe levels
@@ -375,7 +374,8 @@ Plain-text `A`, `B` denote carrier types; mathematical bold italic `𝑨`, `𝑩
 
 | Symbol | Meaning |
 |---|---|
-| `_̂_` | interpretation of an operation symbol in an algebra or other structure (`𝑓 ̂ 𝑨`) |
+| `_^_` | interpretation of an operation symbol in an algebra or other structure (`𝑓 ^ 𝑨`) |
+| `_̂_` | deprecated (v3.0, `WARNING_ON_USAGE`) combining-caret alias of `_^_`; migrated out of the live trees by #368, retained for `Legacy/` |
 | `Domain` | underlying setoid of an algebra or other structure |
 | `Interp` | `Func`-typed interpretation of operations |
 
@@ -533,18 +533,13 @@ proof = begin
 
 ### Every public definition has a prose comment block
 
-This is non-negotiable for public API.  A public definition — anything re-exported from a barrel module, anything documented in the user-facing literate-Agda files — has a comment block immediately above it; e.g.,
+This is non-negotiable for public API.  A public definition — anything re-exported from a barrel module, anything documented in the user-facing literate-Agda files — has a prose comment block immediately above it.  In a literate `.lagda.md` module that prose is Markdown preceding the code fence (not `-- |` comments inside it); e.g.,
+
+`hom 𝑨 𝑩` is the type of homomorphisms from `𝑨` to `𝑩`.  A homomorphism is a setoid function on carriers that respects every operation of the signature: for every operation symbol `𝑓`, the map commutes with `𝑓 ^ 𝑨` and `𝑓 ^ 𝑩`.  See also `IsHom` for the predicate form, `∘-hom` for composition, and `Setoid.Homomorphisms.Isomorphisms` for the isomorphism variant.
 
 ```agda
--- | `Hom 𝑨 𝑩` is the type of homomorphisms from `𝑨` to `𝑩`.  A
--- | homomorphism is a setoid function on carriers that respects every
--- | operation of the signature: for every operation symbol `𝑓`, the
--- | map commutes with `𝑓 ̂ 𝑨` and `𝑓 ̂ 𝑩`.
--- |
--- | See also: `IsHom` for the predicate form, `∘-hom` for composition,
--- | and `Setoid.Homomorphisms.Isomorphisms` for the isomorphism variant.
-Hom : (𝑨 : Algebra α ρᵃ) (𝑩 : Algebra β ρᵇ) → Type _
-Hom 𝑨 𝑩 = Σ (Domain 𝑨 ⟶ Domain 𝑩) (IsHom 𝑨 𝑩)
+hom : (𝑨 : Algebra α ρᵃ) (𝑩 : Algebra β ρᵇ) → Type _
+hom 𝑨 𝑩 = Σ (Domain 𝑨 ⟶ Domain 𝑩) (IsHom 𝑨 𝑩)
 ```
 
 ### What a good comment block contains

--- a/docs/adr/002-classical-layer-design.md
+++ b/docs/adr/002-classical-layer-design.md
@@ -7,6 +7,7 @@
 Accepted — 2026-04-24.
 Revised v2 — 2026-05-17, following the M3-2 (Semigroup) load test.
 Amended v2.1 — 2026-05-28, adds §10 on `Classical/Properties/` following the M3-7 (Lattice) order-theoretic equivalence work.
+Amended v2.2 — 2026-06-04, records the M4-1 Σ-projection migration (#267 / #367): the bracket projections `∣_∣` / `∥_∥` are replaced by `proj₁` / `proj₂` across the live trees, revising the "no mass rename of Σ-projections" stance in §1, §7, and *Alternatives considered*.  The long-form `OperationSymbolsOf` / `ArityOf` remain canonical for signature components and are now defined via `proj₁` / `proj₂`.  The caret (§7) and long-form-naming policies are unaffected.
 
 ---
 
@@ -45,13 +46,13 @@ The arity-first ordering `Op : Type 𝓥 → Type α → Type (𝓥 ⊔ α)` wit
 
 ```agda
 OperationSymbolsOf : Signature 𝓞 𝓥 → Type 𝓞
-OperationSymbolsOf 𝑆 = ∣ 𝑆 ∣
+OperationSymbolsOf 𝑆 = proj₁ 𝑆
 
-ArityOf : {𝑆 : Signature 𝓞 𝓥} → OperationSymbolsOf 𝑆 → Type 𝓥
-ArityOf {𝑆 = 𝑆} f = ∥ 𝑆 ∥ f
+ArityOf : (𝑆 : Signature 𝓞 𝓥) → OperationSymbolsOf 𝑆 → Type 𝓥
+ArityOf 𝑆 f = proj₂ 𝑆 f
 ```
 
-These are definitionally identical to the bracket notation.  New `Classical/` code uses the long forms by default; the bracket notation is retained indefinitely for the existing `Setoid/`-tree code and remains available everywhere.
+These are definitionally identical to `proj₁` / `proj₂`.  As of M4-1 (#267 / #367) the long forms are the canonical names for signature components throughout the library, and the live trees use `proj₁` / `proj₂` for generic Σ-projections; the bracket definitions `∣_∣` / `∥_∥` remain in `Overture.Basic` under a `WARNING_ON_USAGE`, retained only so `Legacy/` keeps compiling.
 
 ### 2.  Variable carrier for equations: `Fin n`, not per-structure named enums
 
@@ -119,9 +120,9 @@ Pointwise agreement is the mathematically correct notion of "same semigroup" und
 
 +  *Subscripted Latin used to name structure-specific entities* — `𝑆ₓ`, `Thₓ`, `Eqₓ` in the original draft.  Replaced by hyphen-separated long forms: `Sig-X`, `Th-X`, `Eq-X`.  Hyphen-separated forms grep cleanly, display in any monospaced font, read aloud sensibly, and don't require an Agda-input-mode dance per occurrence.  New `Classical/` code uses the long forms exclusively.
 
-+  *Bracket notation for Σ-projections* — `∣ 𝑆 ∣`, `∥ 𝑆 ∥ f`, `𝔻[ 𝑨 ]`, `𝕌[ 𝑨 ]`.  Kept available everywhere; supplemented by self-documenting long-form aliases (`OperationSymbolsOf`, `ArityOf`, `Domain`, `Carrier`) that new `Classical/` code uses by default.  No retroactive rename of existing `Setoid/` / `Overture/` code.
++  *Bracket notation for Σ-projections* — `∣ 𝑆 ∣`, `∥ 𝑆 ∥ f`.  **Migrated** to `proj₁` / `proj₂` (and the `OperationSymbolsOf` / `ArityOf` long-forms for signature components) across the live trees in M4-1 (#267 / #367); the definitions remain in `Overture.Basic` under a `WARNING_ON_USAGE` for `Legacy/`.  The blackboard accessor notation `𝔻[ 𝑨 ]` (Domain) and `𝕌[ 𝑨 ]` (Carrier) is category-1 standard notation and is **kept** everywhere.
 
-No mass rename is performed.  The policy is: new `Classical/` code adopts the cleaner long-form conventions; the existing universal-algebra meta-theory in `Setoid/` retains its existing bracket-and-subscript notation, which is well-established reference material.
+The original v2 policy performed no mass rename; M4-1 (amendment v2.2) revised this for the `∣_∣` / `∥_∥` Σ-projections specifically, which are now `proj₁` / `proj₂` library-wide.  The remaining policy stands: new `Classical/` code adopts the long-form conventions, and the subscript / blackboard notation in `Setoid/` is retained as well-established reference material.
 
 ### 8.  First concrete structure: Magma
 
@@ -212,7 +213,7 @@ The revisions above are the response to these findings.  No part of the original
 
 +  **Distinguished elements as algebra-level distinguished carrier elements rather than nullary operation symbols**.  Considered for the apparent simplicity of "a pointed group is a group with a chosen basepoint."  Rejected because the equational-logic substrate (`Modᵗ`, the variety machinery) characterizes a variety as algebras satisfying identities *over the signature*: if a distinguished element does not appear as a signature symbol, no identity can mention it, and the structure's theory cannot constrain it.  Nullary-symbol encoding (revised §9) is what makes the variety of monoids a proper variety and what makes pointed-group expansions a meaningful distinct variety.
 
-+  **Mass rename of unicode in the existing `Setoid/` tree**.  Considered for consistency with the long-form-name convention adopted for new `Classical/` code.  Rejected as churn for no architectural benefit: `Setoid/` is well-established reference material, the unicode there is mostly category-1 (standard mathematical notation) anyway, and a rename would invalidate existing tutorials, papers, and external references to specific identifiers.  Policy is per-tree: new `Classical/` long-form, existing `Setoid/` retained.
++  **Mass rename of unicode in the existing `Setoid/` tree**.  Considered for consistency with the long-form-name convention adopted for new `Classical/` code.  Rejected as churn for no architectural benefit: `Setoid/` is well-established reference material, the unicode there is mostly category-1 (standard mathematical notation) anyway, and a rename would invalidate existing tutorials, papers, and external references to specific identifiers.  Policy is per-tree: new `Classical/` long-form, existing `Setoid/` retained.  (Amended v2.2: the one narrow exception is the `∣_∣` / `∥_∥` Σ-projections, migrated to `proj₁` / `proj₂` in M4-1 (#267 / #367) — there the readability and grep-tooling arguments outweighed the churn; the category-1 mathematical notation, subscripts, and blackboard accessors are still retained.)
 
 +  **Per-structure `Classical/<X>/Properties.lagda.md` subdirectories** (e.g. `Classical/Lattice/Properties.lagda.md`).  Considered as a layout option for derived results when M3-7's lattice order-theoretic equivalence motivated the first Properties module.  Rejected for organizational uniformity: the existing tree organizes strictly by concern (one axis = concern as directory, leaf = structure), and per-structure subdirectories for properties alone would mix two organizing axes (concern-as-directory for everything else, structure-as-directory only for properties).  By-concern (§10) keeps the existing pattern uniform and mirrors stdlib's layout.
 

--- a/docs/adr/002-classical-layer-design.md
+++ b/docs/adr/002-classical-layer-design.md
@@ -7,7 +7,7 @@
 Accepted — 2026-04-24.
 Revised v2 — 2026-05-17, following the M3-2 (Semigroup) load test.
 Amended v2.1 — 2026-05-28, adds §10 on `Classical/Properties/` following the M3-7 (Lattice) order-theoretic equivalence work.
-Amended v2.2 — 2026-06-04, records the M4-1 Σ-projection migration (#267 / #367): the bracket projections `∣_∣` / `∥_∥` are replaced by `proj₁` / `proj₂` across the live trees, revising the "no mass rename of Σ-projections" stance in §1, §7, and *Alternatives considered*.  The long-form `OperationSymbolsOf` / `ArityOf` remain canonical for signature components and are now defined via `proj₁` / `proj₂`.  The caret (§7) and long-form-naming policies are unaffected.
+Amended v2.2 — 2026-06-04, records the M4-1 Σ-projection migration (#267 / #367): the bracket projections `∣_∣` / `∥_∥` are replaced by `proj₁` / `proj₂` across the live trees, revising the "no mass rename of Σ-projections" stance in §1, §7, and *Alternatives considered*.  The long-form `OperationSymbolsOf` / `ArityOf` remain canonical for signature components and are defined via `proj₁` / `proj₂` once #367 lands.  The caret (§7) and long-form-naming policies are unaffected.
 
 ---
 
@@ -52,7 +52,7 @@ ArityOf : (𝑆 : Signature 𝓞 𝓥) → OperationSymbolsOf 𝑆 → Type 𝓥
 ArityOf 𝑆 f = proj₂ 𝑆 f
 ```
 
-These are definitionally identical to `proj₁` / `proj₂`.  As of M4-1 (#267 / #367) the long forms are the canonical names for signature components throughout the library, and the live trees use `proj₁` / `proj₂` for generic Σ-projections; the bracket definitions `∣_∣` / `∥_∥` remain in `Overture.Basic` under a `WARNING_ON_USAGE`, retained only so `Legacy/` keeps compiling.
+These are definitionally identical to `proj₁` / `proj₂`.  M4-1 makes the long forms the canonical names for signature components throughout the library and migrates generic Σ-projections in the live trees to `proj₁` / `proj₂` (#367); that change also adds a `WARNING_ON_USAGE` to the bracket definitions `∣_∣` / `∥_∥` in `Overture.Basic` and retains them only so `Legacy/` keeps compiling.
 
 ### 2.  Variable carrier for equations: `Fin n`, not per-structure named enums
 
@@ -120,7 +120,7 @@ Pointwise agreement is the mathematically correct notion of "same semigroup" und
 
 +  *Subscripted Latin used to name structure-specific entities* — `𝑆ₓ`, `Thₓ`, `Eqₓ` in the original draft.  Replaced by hyphen-separated long forms: `Sig-X`, `Th-X`, `Eq-X`.  Hyphen-separated forms grep cleanly, display in any monospaced font, read aloud sensibly, and don't require an Agda-input-mode dance per occurrence.  New `Classical/` code uses the long forms exclusively.
 
-+  *Bracket notation for Σ-projections* — `∣ 𝑆 ∣`, `∥ 𝑆 ∥ f`.  **Migrated** to `proj₁` / `proj₂` (and the `OperationSymbolsOf` / `ArityOf` long-forms for signature components) across the live trees in M4-1 (#267 / #367); the definitions remain in `Overture.Basic` under a `WARNING_ON_USAGE` for `Legacy/`.  The blackboard accessor notation `𝔻[ 𝑨 ]` (Domain) and `𝕌[ 𝑨 ]` (Carrier) is category-1 standard notation and is **kept** everywhere.
++  *Bracket notation for Σ-projections* — `∣ 𝑆 ∣`, `∥ 𝑆 ∥ f`.  **Migrated** to `proj₁` / `proj₂` (and the `OperationSymbolsOf` / `ArityOf` long-forms for signature components) across the live trees by M4-1 (#367), which adds a `WARNING_ON_USAGE` to the definitions in `Overture.Basic` and retains them for `Legacy/`.  The blackboard accessor notation `𝔻[ 𝑨 ]` (Domain) and `𝕌[ 𝑨 ]` (Carrier) is category-1 standard notation and is **kept** everywhere.
 
 The original v2 policy performed no mass rename; M4-1 (amendment v2.2) revised this for the `∣_∣` / `∥_∥` Σ-projections specifically, which are now `proj₁` / `proj₂` library-wide.  The remaining policy stands: new `Classical/` code adopts the long-form conventions, and the subscript / blackboard notation in `Setoid/` is retained as well-established reference material.
 


### PR DESCRIPTION
Closes #369.  Part of the M4-1 umbrella (#267).  Doc-only — no Agda changes.

Reconciles the STYLE_GUIDE's self-contradictions and brings ADR-002's projection policy into line with the M4-1 migration.

## STYLE_GUIDE.md

+  **Docstring form**: both `-- |`-inside-a-fence examples (the "Module headers have comment blocks" example and the "Every public definition has a prose comment block" example — the issue cited one; I found the second in passing) are rewritten to Markdown-prose-before-the-fence, per the guide's own "Prose belongs in Markdown" rule.  A grep confirms no `-- |` docstring blocks remain.
+  **`Hom` → `hom`**: the public-definition example defined a capital `Hom`, the synonym the Naming section deprecates; it now defines lowercase `hom` and uses `𝑓 ^ 𝑨` rather than the deprecated caret.
+  **Tables**: the Projections table now makes `proj₁` / `proj₂` and the `OperationSymbolsOf` / `ArityOf` long-forms canonical and marks `∣_∣` / `∥_∥` deprecated (#367); the Interpretation table makes `_^_` canonical and marks `_̂_` deprecated (#368).  The "Group imports by origin" example is updated to `proj₁` / `proj₂`.

## ADR-002

+  §1's `OperationSymbolsOf` / `ArityOf` definitions now read `proj₁` / `proj₂` (matching the live `Overture.Signatures`).
+  §7 and *Alternatives considered* are updated: the original "no mass rename" stance is revised for the `∣_∣` / `∥_∥` Σ-projections specifically (migrated in M4-1), recorded as an **Amended v2.2** note.  The caret and long-form-naming policies are unaffected.

The remaining #369 tasks — the `Overture.Signatures` prose and the stale `Base.Functions` cross-reference — were handled in #367 (PR #383).

With this, the M4-1 umbrella (#267) has all five original children addressed; #384 [M4-1f] is filed as the follow-up for the `fst` / `snd` unification.

https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM)_