### PR TITLE
[M4-1f] Unify fst / snd → proj₁ / proj₂

### DIFF
--- a/src/Overture/Adjunction/Galois.lagda.md
+++ b/src/Overture/Adjunction/Galois.lagda.md
@@ -17,7 +17,7 @@ module Overture.Adjunction.Galois where
 
 -- Imports from Agda and the Agda Standard Library --------------------------------------
 open import Agda.Primitive           using () renaming ( Set to Type )
-open import Data.Product             using ( _,_ ; _×_ ; swap ) renaming ( proj₁ to fst )
+open import Data.Product             using ( _,_ ; _×_ ; swap ; proj₁ )
 open import Function.Base            using ( _∘_ ; id )
 open import Level                    using ( _⊔_ ;  Level ; suc )
 open import Relation.Binary.Bundles  using ( Poset )
@@ -116,7 +116,7 @@ module _ {α : Level} (ρ : Level) (𝒜 : Type α) where
  _≤_ PosetOfSubsets = _⊆_
  isPartialOrder PosetOfSubsets =
   record  { isPreorder = record  { isEquivalence = ≐-iseqv
-                                 ; reflexive = fst
+                                 ; reflexive = proj₁
                                  ; trans = λ u v → v ∘ u
                                  }
           ; antisym = _,_

--- a/src/Overture/Functions.lagda.md
+++ b/src/Overture/Functions.lagda.md
@@ -27,8 +27,7 @@ module Overture.Functions where
 -- Imports from Agda primitives and the standard library.
 open import Agda.Primitive    using ()           renaming ( Set to Type )
 open import Data.Empty        using ( ⊥-elim )
-open import Data.Product      using ( Σ ; Σ-syntax ; _,_ )
-                              renaming ( proj₁ to fst ; proj₂ to snd )
+open import Data.Product      using ( Σ ; Σ-syntax ; _,_ ; proj₁ ; proj₂ )
 open import Function          using ( _∘_ ; _$_ ; Surjective )
 open import Level             using ( Level ; _⊔_ )
 open import Relation.Binary   using ( Decidable )
@@ -82,12 +81,12 @@ module _ {A : Type a}{B : Type b} where
   imgfy→A : Image f ∋ y → Σ[ x ∈ A ] f x ≡ y
   imgfy→A (eq x p) = x , sym p
   goal : Σ[ x ∈ A ] ({z : A} → z ≡ x → f z ≡ y)
-  goal = fst (imgfy→A $ fE y)
-       , λ z≡fst → trans (cong f z≡fst) $ snd (imgfy→A $ fE y)
+  goal = proj₁ (imgfy→A $ fE y)
+       , λ z≡fst → trans (cong f z≡fst) $ proj₂ (imgfy→A $ fE y)
 
  Surjective→IsSurjective :  (f : A → B) → Surjective {A = A} _≡_ _≡_ f
   →                         IsSurjective f
- Surjective→IsSurjective f fE y = eq (fst $ fE y) (sym $ snd (fE y) refl)
+ Surjective→IsSurjective f fE y = eq (proj₁ $ fE y) (sym $ proj₂ (fE y) refl)
 ```
 
 A right-inverse of a surjective `f` is obtained by composing `Inv` with the surjectivity proof.  The right-inverse property is then immediate from `InvIsInverseʳ` above.

--- a/src/Overture/Relations.lagda.md
+++ b/src/Overture/Relations.lagda.md
@@ -29,7 +29,6 @@ module Overture.Relations where
 -- Imports from Agda primitives and the standard library.
 open import Agda.Primitive   using ()           renaming ( Set to Type )
 open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax )
-                             renaming ( proj₁ to fst ; proj₂ to snd )
 open import Function         using ( _∘_ )
 open import Level            using ( Level ; Lift ; lift ; lower ; suc ; _⊔_ )
 open import Relation.Binary  using ( IsEquivalence ; _=[_]⇒_ )

--- a/src/Setoid/Functions/Inverses.lagda.md
+++ b/src/Setoid/Functions/Inverses.lagda.md
@@ -19,7 +19,7 @@ module Setoid.Functions.Inverses where
 open import Agda.Primitive    using ( _⊔_ ; Level ) renaming ( Set to Type )
 open import Function          using ( id ; _$_ )   renaming ( Func to _⟶_ )
 open import Data.Product      using ( _,_ ; Σ-syntax )
-                              renaming ( proj₁ to fst ; proj₂ to snd ; _×_ to _∧_)
+                              renaming ( _×_ to _∧_)
 open import Relation.Unary    using ( Pred ; _∈_ )
 open import Relation.Binary   using ( Setoid ; _Preserves_⟶_ )
 

--- a/src/Setoid/Functions/Surjective.lagda.md
+++ b/src/Setoid/Functions/Surjective.lagda.md
@@ -19,7 +19,7 @@ module Setoid.Functions.Surjective where
 
 -- Imports from Agda and the Agda Standard Library --------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
-open import Data.Product     using ( _,_ ; Σ-syntax ) renaming (proj₁ to fst ; proj₂ to snd)
+open import Data.Product     using ( _,_ ; Σ-syntax )
 open import Function         using ( Surjection ; IsSurjection ; _$_ ; _∘_ )
                              renaming ( Func to _⟶_ )
 open import Level            using ( _⊔_ ; Level )
@@ -71,7 +71,7 @@ module _ {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ} where
   g : 𝑨 ⟶ 𝑩
   g = (record { to = _⟨$⟩_ s ; cong = cong s })
   gE : IsSurjective g
-  gE {y} = eq (proj₁ ((surjective s) y)) (sym (snd (surjective s y) (IsEquivalence.refl isEqA)))
+  gE {y} = eq (proj₁ ((surjective s) y)) (sym (proj₂ (surjective s y) (IsEquivalence.refl isEqA)))
 
  SurjectionIsSurjection : (Surjection 𝑨 𝑩) → Σ[ g ∈ (𝑨 ⟶ 𝑩) ] (IsSurjection _≈₁_ _≈₂_ (_⟨$⟩_ g))
  SurjectionIsSurjection s = g , gE

--- a/src/Setoid/Homomorphisms/Factor.lagda.md
+++ b/src/Setoid/Homomorphisms/Factor.lagda.md
@@ -18,7 +18,7 @@ open import Overture using (𝓞 ; 𝓥 ; Signature)
 module Setoid.Homomorphisms.Factor {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------------------------
-open import Data.Product     using ( _,_ ; Σ-syntax )  renaming ( proj₁ to fst ; proj₂ to snd )
+open import Data.Product     using ( _,_ ; Σ-syntax )
 open import Function         using ( _∘_ ; _$_ )       renaming ( Func to _⟶_ )
 open import Level            using ( Level )
 open import Relation.Binary  using ( Setoid )
@@ -134,13 +134,13 @@ If, in addition, `g` is surjective, then so will be the factor `φ`.
   homfactor = HomFactor Khg hE
 
   φmap : C ⟶ B
-  φmap = fst (proj₁ homfactor)
+  φmap = proj₁ (proj₁ homfactor)
 
   gφh : (a : 𝕌[ 𝑨 ]) → g a ≈₂ φmap ⟨$⟩ (h a)
-  gφh = snd homfactor -- Khg ξ
+  gφh = proj₂ homfactor -- Khg ξ
 
   φhom : IsHom 𝑪 𝑩 φmap
-  φhom = snd (proj₁ homfactor)
+  φhom = proj₂ (proj₁ homfactor)
 
   φepi : IsEpi 𝑪 𝑩 φmap
   φepi = record  { isHom = φhom

--- a/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
+++ b/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
@@ -20,7 +20,7 @@ module Setoid.Homomorphisms.HomomorphicImages {𝑆 : Signature 𝓞 𝓥} where
 -- Imports from Agda and the Agda Standard Library ------------------------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
 open import Data.Product     using ( _,_ ; Σ-syntax )
-                             renaming ( _×_ to _∧_ ; proj₁ to fst ; proj₂ to snd )
+                             renaming ( _×_ to _∧_ )
 open import Function         using ( Func ; _on_ ; _∘_ ; id )
 open import Level            using ( Level ; _⊔_ ; suc )
 open import Relation.Binary  using ( Setoid ; _Preserves_⟶_ )

--- a/src/Setoid/Homomorphisms/Noether.lagda.md
+++ b/src/Setoid/Homomorphisms/Noether.lagda.md
@@ -18,7 +18,7 @@ open import Overture using (𝓞 ; 𝓥 ; Signature)
 module Setoid.Homomorphisms.Noether {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library ---------------------------
-open import Data.Product     using (Σ-syntax ; _,_ )  renaming ( _×_ to _∧_ ; proj₁ to fst)
+open import Data.Product     using (Σ-syntax ; _,_ )  renaming ( _×_ to _∧_)
 open import Function         using ( id )             renaming ( Func to _⟶_ )
 open import Level            using ( Level )
 open import Relation.Binary  using ( Setoid )

--- a/src/Setoid/Homomorphisms/Properties.lagda.md
+++ b/src/Setoid/Homomorphisms/Properties.lagda.md
@@ -18,7 +18,7 @@ open import Overture using (𝓞 ; 𝓥 ; Signature)
 module Setoid.Homomorphisms.Properties {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library ------------------------------------------
-open import Data.Product     using ( _,_ ) renaming ( proj₁ to fst ; proj₂ to snd )
+open import Data.Product     using ( _,_ )
 open import Function         using ( id ; _$_ ) renaming ( Func to _⟶_ )
 open import Level            using ( Level )
 open import Relation.Binary  using ( Setoid )
@@ -172,7 +172,7 @@ module _ {𝑨 : Algebra α ρᵃ} {𝑩 : Algebra β ρᵇ} where
  open Level
 
  Lift-homˡ : hom 𝑨 𝑩  → (ℓᵃ ℓᵇ : Level) →  hom (Lift-Algˡ 𝑨 ℓᵃ) (Lift-Algˡ 𝑩 ℓᵇ)
- Lift-homˡ (f , fhom) ℓᵃ ℓᵇ = ϕ , ⊙-is-hom lABh (snd ToLiftˡ)
+ Lift-homˡ (f , fhom) ℓᵃ ℓᵇ = ϕ , ⊙-is-hom lABh (proj₂ ToLiftˡ)
   where
   lA lB : Algebra _ _
   lA = Lift-Algˡ 𝑨 ℓᵃ
@@ -183,7 +183,7 @@ module _ {𝑨 : Algebra α ρᵃ} {𝑩 : Algebra β ρᵇ} where
   cong ψ = cong f
 
   lABh : IsHom lA 𝑩 ψ
-  lABh = ⊙-is-hom (snd FromLiftˡ) fhom
+  lABh = ⊙-is-hom (proj₂ FromLiftˡ) fhom
 
   ϕ : Domain lA ⟶ Domain lB
   ϕ ⟨$⟩ x = lift (f ⟨$⟩ (lower x))
@@ -200,14 +200,14 @@ module _ {𝑨 : Algebra α ρᵃ} {𝑩 : Algebra β ρᵇ} where
   cong ψ xy = cong f (lower xy)
 
   lABh : IsHom lA 𝑩 ψ
-  lABh = ⊙-is-hom (snd FromLiftʳ) fhom
+  lABh = ⊙-is-hom (proj₂ FromLiftʳ) fhom
 
   ϕ : Domain lA ⟶ Domain lB
   ϕ ⟨$⟩ x = f ⟨$⟩ x
   lower (cong ϕ xy) = cong f $ lower xy
 
   Goal : IsHom lA lB ϕ
-  Goal = ⊙-is-hom lABh (snd ToLiftʳ)
+  Goal = ⊙-is-hom lABh (proj₂ ToLiftʳ)
 
  open Setoid using ( _≈_ )
 

--- a/src/Setoid/Subalgebras/Properties.lagda.md
+++ b/src/Setoid/Subalgebras/Properties.lagda.md
@@ -20,7 +20,7 @@ module Setoid.Subalgebras.Properties {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library ------------------------------------
 open import Agda.Primitive   using ()       renaming ( Set to Type )
-open import Data.Product     using ( _,_ )  renaming ( proj₁ to fst ; proj₂ to snd )
+open import Data.Product     using ( _,_ )
 open import Function         using ( _∘_ )  renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_ )
 open import Relation.Binary  using ( Setoid )
@@ -91,7 +91,7 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}{𝑪 : Algebra γ ρ
 ≤→≤c→≤c :  {𝑨 : Algebra α α}{𝑩 : Algebra α α}{𝒦 : Pred(Algebra α α) (ov α)}
  →         𝑨 ≤ 𝑩 → 𝑩 ≤c 𝒦 → 𝑨 ≤c 𝒦
 
-≤→≤c→≤c {𝑨 = 𝑨} A≤B sB = (proj₁ sB) , (fst (proj₂ sB) , ≤-trans A≤B (snd (proj₂ sB)))
+≤→≤c→≤c {𝑨 = 𝑨} A≤B sB = (proj₁ sB) , (proj₁ (proj₂ sB) , ≤-trans A≤B (proj₂ (proj₂ sB)))
 
 module _ {α ρᵃ ρ : Level} where
 

--- a/src/Setoid/Subalgebras/Subalgebras.lagda.md
+++ b/src/Setoid/Subalgebras/Subalgebras.lagda.md
@@ -20,7 +20,7 @@ module Setoid.Subalgebras.Subalgebras {𝑆 : Signature 𝓞 𝓥} where
 -- imports from Agda and the Agda Standard Library ------------------------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
 open import Data.Product     using ( _,_ ; Σ-syntax )
-                             renaming ( _×_ to _∧_ ; proj₂ to snd )
+                             renaming ( _×_ to _∧_ )
 open import Level            using ( Level ; _⊔_ )
 open import Relation.Binary  using ( REL )
 open import Relation.Unary   using ( Pred ; _∈_ )
@@ -125,7 +125,7 @@ is (isomorphic to) a subalgebra of `𝑩`.
 FirstHomCorollary :  {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}
                      (hh : hom 𝑨 𝑩) → (kerquo hh) IsSubalgebraOf 𝑩
 
-FirstHomCorollary hh = (proj₁ (FirstHomTheorem hh)) , snd (proj₂ (FirstHomTheorem hh))
+FirstHomCorollary hh = (proj₁ (FirstHomTheorem hh)) , proj₂ (proj₂ (FirstHomTheorem hh))
 ```
 
 

--- a/src/Setoid/Varieties/EquationalLogic.lagda.md
+++ b/src/Setoid/Varieties/EquationalLogic.lagda.md
@@ -22,8 +22,7 @@ module Setoid.Varieties.EquationalLogic {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
-open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax)
-                             renaming ( proj₁ to fst ; proj₂ to snd )
+open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax ; proj₁ ; proj₂ )
 open import Function         using () renaming ( Func to _⟶_ )
 open import Level            using ( _⊔_ ; Level )
 open import Relation.Binary  using ( Setoid )
@@ -110,7 +109,7 @@ It is sometimes more convenient to have a "tupled" version of the previous defin
 
 ```agda
  Modᵗ : {I : Type ι} → (I → Term X × Term X) → {α : Level} → Pred(Algebra α ρᵃ) (χ ⊔ ρᵃ ⊔ ι ⊔ α)
- Modᵗ ℰ = λ 𝑨 → ∀ i → 𝑨 ⊧ fst (ℰ i) ≈ snd (ℰ i)
+ Modᵗ ℰ = λ 𝑨 → ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 ```
 
 

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -18,7 +18,6 @@ module Setoid.Varieties.FreeAlgebras {𝑆 : Signature 𝓞 𝓥} where
 -- Imports from Agda and the Agda Standard Library -------------------------------
 open import Agda.Primitive   using ()                  renaming ( Set to Type )
 open import Data.Product     using ( Σ-syntax ; _,_ )
-                             renaming ( proj₁ to fst ; proj₂ to snd )
 open import Function         using ( _∘_ ; id )        renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_)
 open import Relation.Binary  using ( Setoid )
@@ -124,7 +123,7 @@ Finally, we define an epimorphism from `𝑻 X` onto the relatively free algebra
  hom𝔽[ X ] = epi→hom (𝑻 X) 𝔽[ X ] epi𝔽[ X ]
 
  hom𝔽[_]-is-epic : (X : Type χ) → IsSurjective (proj₁ (hom𝔽[ X ]))
- hom𝔽[ X ]-is-epic = IsEpi.isSurjective (snd (epi𝔽[ X ]))
+ hom𝔽[ X ]-is-epic = IsEpi.isSurjective (proj₂ (epi𝔽[ X ]))
 
 
  class-models-kernel : ∀{X p q} → (p , q) ∈ fkerPred (proj₁ (hom𝔽[ X ])) → 𝒦 ⊫ (p ≈̇ q)

--- a/src/Setoid/Varieties/HSP.lagda.md
+++ b/src/Setoid/Varieties/HSP.lagda.md
@@ -23,7 +23,6 @@ module Setoid.Varieties.HSP {𝑆 : Signature 𝓞 𝓥} where
 -- Imports from Agda and the Agda Standard Library -------------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
 open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ )
-                             renaming ( proj₁ to fst ; proj₂ to snd )
 open import Function         using () renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_ )
 open import Relation.Binary  using ( Setoid )
@@ -95,7 +94,7 @@ so belongs to `S (P 𝒦)`.
 
 ```agda
  skEqual : (i : ℑ⁺) → ∀{p q} → Type ρᵃ
- skEqual i {p}{q} = ⟦ p ⟧ ⟨$⟩ snd (proj₂ i) ≈ ⟦ q ⟧ ⟨$⟩ snd (proj₂ i)
+ skEqual i {p}{q} = ⟦ p ⟧ ⟨$⟩ proj₂ (proj₂ i) ≈ ⟦ q ⟧ ⟨$⟩ proj₂ (proj₂ i)
   where
   open Setoid (Domain (𝔄⁺ i)) using ( _≈_ )
   open Environment (𝔄⁺ i) using ( ⟦_⟧ )
@@ -116,7 +115,7 @@ so belongs to `S (P 𝒦)`.
  homℭ = ⨅-hom-co 𝔄⁺ h
   where
   h : ∀ i → hom (𝑻 X) (𝔄⁺ i)
-  h i = lift-hom (snd (proj₂ i))
+  h i = lift-hom (proj₂ (proj₂ i))
 
  open Algebra 𝔽[ X ]  using () renaming ( Domain to F ; Interp to InterpF )
  open Setoid F        using () renaming (refl to reflF ; _≈_ to _≈F≈_ ; Carrier to ∣F∣)
@@ -147,9 +146,9 @@ so belongs to `S (P 𝒦)`.
    where
    open Environment (𝔄⁺ i)      using () renaming ( ⟦_⟧ to ⟦_⟧ᵢ )
    open Setoid (Domain (𝔄⁺ i))  using ( _≈_ ; sym ; trans )
-   goal : ⟦ p ⟧ᵢ ⟨$⟩ snd (proj₂ i) ≈ ⟦ q ⟧ᵢ ⟨$⟩ snd (proj₂ i)
-   goal = trans  (free-lift-interp{𝑨 = (proj₁ i)}(snd (proj₂ i)) p)
-                 (trans (pKq i)(sym (free-lift-interp{𝑨 = (proj₁ i)} (snd (proj₂ i)) q)))
+   goal : ⟦ p ⟧ᵢ ⟨$⟩ proj₂ (proj₂ i) ≈ ⟦ q ⟧ᵢ ⟨$⟩ proj₂ (proj₂ i)
+   goal = trans  (free-lift-interp{𝑨 = (proj₁ i)}(proj₂ (proj₂ i)) p)
+                 (trans (pKq i)(sym (free-lift-interp{𝑨 = (proj₁ i)} (proj₂ (proj₂ i)) q)))
   E⊢pq : ℰ ⊢ X ▹ p ≈ q
   E⊢pq = AllEqual⊆ker𝔽 pqEqual
 
@@ -176,7 +175,7 @@ that `𝔽[ X ]` is a subalgebra of the *lift* of `ℭ`, denoted `ℓℭ`.
  SP𝔽 = S-idem SSP𝔽
   where
   PSℭ : ℭ ∈ P (α ⊔ ρᵃ ⊔ ℓ) ι (S ℓ 𝒦)
-  PSℭ = ℑ⁺ , (𝔄⁺ , ((λ i → fst (proj₂ i)) , ≅-refl))
+  PSℭ = ℑ⁺ , (𝔄⁺ , ((λ i → proj₁ (proj₂ i)) , ≅-refl))
 
   SPℭ : ℭ ∈ S ι (P ℓ ι 𝒦)
   SPℭ = PS⊆SP {ℓ = ℓ} PSℭ

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -22,7 +22,6 @@ module Setoid.Varieties.Preservation {𝑆 : Signature 𝓞 𝓥} where
 -- Imports from Agda and the Agda Standard Library -------------------------------
 open import Agda.Primitive         using ()       renaming ( Set to Type )
 open import Data.Product           using ( _,_ )
-                                   renaming ( proj₁ to fst ; proj₂ to snd )
 open import Data.Unit.Polymorphic  using ( ⊤ )
 open import Function               using ( _∘_ )  renaming ( Func to _⟶_ )
 open import Level                  using ( Level ; _⊔_ )
@@ -102,9 +101,9 @@ in a class 𝒦 is a subalgebra of a product of algebras in 𝒦.
   ℬ : I → Algebra α ρᵃ
   ℬ i = (proj₁ (sA i))
   kB : (i : I) → ℬ i ∈ 𝒦
-  kB i =  fst (proj₂ (sA i))
+  kB i =  proj₁ (proj₂ (sA i))
   ⨅A≤⨅B : ⨅ 𝒜 ≤ ⨅ ℬ
-  ⨅A≤⨅B = ⨅-≤ λ i → snd (proj₂ (sA i))
+  ⨅A≤⨅B = ⨅-≤ λ i → proj₂ (proj₂ (sA i))
   Goal : 𝑩 ∈ S{β = oaℓ}{oaℓ}oaℓ (P {β = oaℓ}{oaℓ} ℓ oaℓ 𝒦)
   Goal = ⨅ ℬ , (I , (ℬ , (kB , ≅-refl))) , (≅-trans-≤ B≅⨅A ⨅A≤⨅B)
 ```

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -22,7 +22,6 @@ module Setoid.Varieties.SoundAndComplete {𝑆 : Signature 𝓞 𝓥} where
 -- imports from Agda and the Agda Standard Library -------------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
 open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ )
-                             renaming ( proj₁ to fst ; proj₂ to snd )
 open import Function         using ( _∘_ ; flip ; id ) renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_ )
 open import Relation.Binary  using ( Setoid ; IsEquivalence )
@@ -33,7 +32,7 @@ open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl )
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                  using ( proj₁ ; OperationSymbolsOf )
+open import Overture                  using ( proj₁ ; proj₂ ; OperationSymbolsOf )
 open import Overture.Terms   {𝑆 = 𝑆}  using ( Term )
 open import Setoid.Algebras  {𝑆 = 𝑆}  using ( Algebra ; ov ; ⟨_⟩ )
 open import Setoid.Terms     {𝑆 = 𝑆}  using ( module Environment ; Sub ; _[_] )
@@ -96,7 +95,7 @@ module _ {α ρᵃ ℓ : Level} where
  module _ {χ : Level}{X : Type χ} where
 
   ThTuple : (𝒦 : Pred (Algebra α ρᵃ) ℓ) → ℑTh{χ = χ} (Th{X = X} 𝒦) → Eq{χ}
-  ThTuple 𝒦 = λ i → fst (proj₁ i) ≈̇ snd (proj₁ i)
+  ThTuple 𝒦 = λ i → proj₁ (proj₁ i) ≈̇ proj₂ (proj₁ i)
 
 module _ {α}{ρᵃ}{ι}{I : Type ι} where
  -- An entailment E ⊃ eq holds iff it holds in all models of E.


### PR DESCRIPTION
Closes #384.  Part of the M4-1 umbrella (#267) — the final child.

Collapses the `renaming ( proj₁ to fst ; proj₂ to snd )` shorthand (and one-sided variants) across the live trees, unifying on the canonical `proj₁` / `proj₂` per the STYLE_GUIDE "one canonical form per concept" rule.  This is the follow-up to #367 task 4, which mischaracterized the rename as "dead" — it is in fact a deliberate convention across 16 modules.

## Per-file strategy

+  **12 Setoid modules** that already import proj from the `Overture` umbrella (via #367) simply **drop** the Data.Product projection rename.
+  **4 modules without an Overture-proj import** — `Setoid.Varieties.EquationalLogic` and the three Overture-internal modules (`Relations`, `Functions`, `Adjunction/Galois`) — import `proj₁` / `proj₂` **plainly** from `Data.Product`.
+  `SoundAndComplete` gains `proj₂` in its Overture import (it had only `proj₁`).
+  `_×_ to _∧_` renames sharing the same import clauses are preserved.

## The gotcha

`fst` → `proj₁` and `snd` → `proj₂` at every call site, but the definition names `Lift-hom-fst` / `Lift-hom-snd` (`Setoid.Homomorphisms.Properties`) and the variable `z≡fst` (`Overture.Functions`) are **left alone**.  A naive `\bfst\b` would corrupt them, since `\b` matches inside `Lift-hom-fst` and after `≡`.  The conversion instead matches `fst` / `snd` only when delimited by whitespace or `(`.

`Demos/HSP` keeps its self-contained `fst` / `snd` (maintainer decision, consistent with #367 / #368).

`make check` passes (canonical + Legacy); the acceptance grep `grep -rn 'proj₁ to fst\|proj₂ to snd' src` matches only `Legacy/` and the exempt `Demos/HSP`.

With this, the M4-1 umbrella (#267) has all six children addressed.  Branched off `master` (post-#367/#368).

https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM)_