### PR TITLE
[M4-2a] Remove HTML <a id> heading anchors across the live trees

### DIFF
--- a/scripts/python/remove_heading_anchors.py
+++ b/scripts/python/remove_heading_anchors.py
@@ -112,7 +112,9 @@ def main(argv: list[str]) -> int:
     referenced = collect_referenced_ids([Path('src'), Path('docs')])
     total = kept = unhandled = warnings = 0
     for target in targets:
-        for path in sorted(p for p in target.rglob('*.lagda.md') if 'Legacy/' not in str(p)):
+        for path in sorted(p for p in target.rglob('*.lagda.md')
+                           if 'Legacy/' not in str(p)
+                           and not str(p).replace('\\', '/').endswith('Demos/HSP.lagda.md')):
             for r in process_file(path, referenced, apply):
                 if 'unhandled' in r:
                     unhandled += 1

--- a/scripts/python/remove_heading_anchors.py
+++ b/scripts/python/remove_heading_anchors.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Remove HTML ``<a id="…">`` heading anchors, relying on kramdown's
+auto-generated heading slugs (M4-2a, issue #387).
+
+For every heading of the form
+
+    <level> <a id="TAG">TEXT</a>
+
+the HTML wrapper is removed.  *How* depends on whether kramdown's auto-slug of
+TEXT reproduces TAG, and on whether TAG is used as a cross-reference target:
+
+  * slug(TEXT) == TAG                       ->  ``<level> TEXT``
+  * slug(TEXT) != TAG and TAG unreferenced  ->  ``<level> TEXT``
+  * slug(TEXT) != TAG and TAG referenced     ->  ``<level> TEXT {#TAG}``
+
+The third case keeps the id explicitly (kramdown attribute-list syntax) so the
+existing ``#TAG`` cross-reference still resolves.  Cross-references are collected
+repo-wide (``src/`` + ``docs/``) so an anchor linked from another module or the
+paper is preserved.  Rewrites touch only the target paths passed on the command
+line; ``src/Legacy/**`` is never rewritten (but is still scanned for references).
+
+Usage::
+
+    python3 scripts/python/remove_heading_anchors.py src/Setoid           # dry-run report
+    python3 scripts/python/remove_heading_anchors.py --apply src/Setoid   # rewrite in place
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# A heading line that is exactly: hashes, the <a id="…"> wrapper, end of line.
+HEADING_ANCHOR = re.compile(r'^(#{1,6}) *<a id="([^"]+)"> *(.*?) *</a> *$')
+# Any line that mentions an <a id (used to flag forms the rewriter does not handle).
+ANY_ANCHOR = re.compile(r'<a id=')
+# Markdown inline-link target  ](…)  and reference-definition  [label]: …
+LINK_TARGET = re.compile(r'\]\(([^)]*)\)')
+REF_DEF = re.compile(r'^\s*\[[^\]]+\]:\s*(\S+)', re.MULTILINE)
+FRAGMENT = re.compile(r'#([A-Za-z0-9][A-Za-z0-9_-]*)')
+
+
+def kramdown_id(text: str) -> str:
+    """Reproduce kramdown's ``generate_id`` (auto_ids on, no transliteration):
+    strip leading non-letters, drop characters outside ``[A-Za-z0-9 -]``, turn
+    spaces into hyphens, downcase; an empty result becomes ``section``."""
+    s = re.sub(r'^[^A-Za-z]+', '', text)
+    s = re.sub(r'[^A-Za-z0-9 -]', '', s)
+    s = s.replace(' ', '-').lower()
+    return s or 'section'
+
+
+def collect_referenced_ids(roots: list[Path]) -> set[str]:
+    """Every fragment id that appears as a link or reference-definition target."""
+    refs: set[str] = set()
+    for root in roots:
+        for path in root.rglob('*.md'):
+            text = path.read_text(encoding='utf-8')
+            for target in LINK_TARGET.findall(text) + REF_DEF.findall(text):
+                m = FRAGMENT.search(target)
+                if m:
+                    refs.add(m.group(1))
+    return refs
+
+
+def process_file(path: Path, referenced: set[str], apply: bool) -> list[dict]:
+    """Rewrite (or report) the heading anchors in ``path``.  Returns one record
+    per anchor for the report."""
+    lines = path.read_text(encoding='utf-8').split('\n')
+    records: list[dict] = []
+    slugs_seen: dict[str, int] = {}
+    for idx, line in enumerate(lines):
+        m = HEADING_ANCHOR.match(line)
+        if not m:
+            if ANY_ANCHOR.search(line):
+                records.append({'line': idx + 1, 'unhandled': line.strip()})
+            continue
+        hashes, tag, text = m.group(1), m.group(2), m.group(3)
+        slug = kramdown_id(text)
+        if slug == tag:
+            action, new = 'strip (slug==tag)', f'{hashes} {text}'
+            final_id = slug
+        elif tag in referenced:
+            action, new = 'keep  (referenced)', f'{hashes} {text} {{#{tag}}}'
+            final_id = tag
+        else:
+            action, new = 'strip (unreferenced)', f'{hashes} {text}'
+            final_id = slug
+        slugs_seen[final_id] = slugs_seen.get(final_id, 0) + 1
+        records.append({
+            'line': idx + 1, 'tag': tag, 'slug': slug, 'action': action,
+            'new': new, 'final_id': final_id,
+            'both_referenced': slug != tag and slug in referenced,
+        })
+        if apply:
+            lines[idx] = new
+    # Flag any post-rewrite id collision within this file (kramdown would dedupe).
+    for record in records:
+        if 'final_id' in record:
+            record['collision'] = slugs_seen[record['final_id']] > 1
+    if apply and any('tag' in r for r in records):
+        path.write_text('\n'.join(lines), encoding='utf-8')
+    return records
+
+
+def main(argv: list[str]) -> int:
+    apply = '--apply' in argv
+    targets = [Path(a) for a in argv if not a.startswith('--')]
+    if not targets:
+        print('usage: remove_heading_anchors.py [--apply] <path>...', file=sys.stderr)
+        return 2
+    referenced = collect_referenced_ids([Path('src'), Path('docs')])
+    total = kept = unhandled = warnings = 0
+    for target in targets:
+        for path in sorted(p for p in target.rglob('*.lagda.md') if 'Legacy/' not in str(p)):
+            for r in process_file(path, referenced, apply):
+                if 'unhandled' in r:
+                    unhandled += 1
+                    print(f'!! {path}:{r["line"]}: UNHANDLED anchor form: {r["unhandled"]}')
+                    continue
+                total += 1
+                if r['action'].startswith('keep'):
+                    kept += 1
+                flags = ''
+                if r['both_referenced']:
+                    flags += '  [WARN: slug also referenced]'
+                    warnings += 1
+                if r['collision']:
+                    flags += '  [WARN: id collides within file]'
+                    warnings += 1
+                print(f'{path}:{r["line"]}: [{r["action"]}] id={r["tag"]!r} slug={r["slug"]!r}{flags}')
+                if r['slug'] != r['tag'] and r['action'].startswith('keep'):
+                    print(f'      -> {r["new"].strip()}')
+    mode = 'APPLIED' if apply else 'DRY-RUN'
+    print(f'\n{mode}: {total} anchors ({kept} kept as {{#id}}, {total - kept} stripped), '
+          f'{unhandled} unhandled, {warnings} warnings.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/Classical.lagda.md
+++ b/src/Classical.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-15"
 author: "the agda-algebras development team"
 ---
 
-## <a id="classical-algebraic-structures">Classical algebraic structures</a>
+## Classical algebraic structures
 
 This is the [Classical][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Bundles.lagda.md
+++ b/src/Classical/Bundles.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-15"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles">Stdlib-shaped record bundles for classical structures</a>
+### Stdlib-shaped record bundles for classical structures
 
 This is the [Classical.Bundles][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Bundles/AbelianGroup.lagda.md
+++ b/src/Classical/Bundles/AbelianGroup.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-abeliangroup">Bundle bridge for abelian groups</a>
+### Bundle bridge for abelian groups
 
 This is the [Classical.Bundles.AbelianGroup][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Bundles/CommutativeMonoid.lagda.md
+++ b/src/Classical/Bundles/CommutativeMonoid.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-24"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-commutativemonoid">Bundle bridge for commutative monoids</a>
+### Bundle bridge for commutative monoids
 
 This is the [Classical.Bundles.CommutativeMonoid][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Bundles/CommutativeRing.lagda.md
+++ b/src/Classical/Bundles/CommutativeRing.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-commutativering">Bundle bridge for commutative rings</a>
+### Bundle bridge for commutative rings
 
 This is the [Classical.Bundles.CommutativeRing][] module of the [Agda Universal Algebra Library][].
 
@@ -39,7 +39,7 @@ open import Setoid.Algebras.Basic {𝑆 = Sig-Ring}  using ( Algebra ; ⟨_⟩ ;
 private variable α ρ : Level
 ```
 
-#### <a id="core-to-bundle">Core to stdlib bundle</a>
+#### Core to stdlib bundle
 
 ```agda
 ⟨_⟩ᶜʳᵍ : CommutativeRing α ρ → stdlib-CommutativeRing α ρ
@@ -80,7 +80,7 @@ private variable α ρ : Level
   open Setoid 𝔻[ proj₁ 𝑪 ]
 ```
 
-#### <a id="bundle-to-core">Stdlib bundle to core</a>
+#### Stdlib bundle to core
 
 ```agda
 ⟪_⟫ᶜʳᵍ : stdlib-CommutativeRing α ρ → CommutativeRing α ρ
@@ -121,7 +121,7 @@ private variable α ρ : Level
     cong interp {1-Op , _} {.1-Op , _} (≡.refl , _)      = Setoid.refl setoid
 ```
 
-#### <a id="roundtrip">Pointwise round-trip</a>
+#### Pointwise round-trip
 
 ```agda
 module _ {𝑪 : CommutativeRing α ρ} where

--- a/src/Classical/Bundles/CommutativeSemigroup.lagda.md
+++ b/src/Classical/Bundles/CommutativeSemigroup.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-24"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-commutativesemigroup">Bundle bridge for commutative semigroups</a>
+### Bundle bridge for commutative semigroups
 
 This is the [Classical.Bundles.CommutativeSemigroup][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Bundles/Group.lagda.md
+++ b/src/Classical/Bundles/Group.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-group">Bundle bridge for groups</a>
+### Bundle bridge for groups
 
 This is the [Classical.Bundles.Group][] module of the [Agda Universal Algebra Library][].
 
@@ -43,7 +43,7 @@ open import Setoid.Algebras.Basic {𝑆 = Sig-Group} using ( Algebra ; ⟨_⟩ ;
 private variable α ρ : Level
 ```
 
-#### <a id="core-to-bundle">Core to stdlib bundle</a>
+#### Core to stdlib bundle
 
 ```agda
 ⟨_⟩ᵍᵖ : Group α ρ → stdlib-Group α ρ
@@ -71,7 +71,7 @@ private variable α ρ : Level
   open Setoid 𝔻[ 𝑨 ]
 ```
 
-#### <a id="bundle-to-core">Stdlib bundle to core</a>
+#### Stdlib bundle to core
 
 ```agda
 ⟪_⟫ᵍᵖ : stdlib-Group α ρ → Group α ρ
@@ -99,7 +99,7 @@ private variable α ρ : Level
     cong interp {⁻¹-Op , _} {.⁻¹-Op , _} (≡.refl , args≈) = ⁻¹-cong (args≈ 0F)
 ```
 
-#### <a id="roundtrip">Pointwise round-trip</a>
+#### Pointwise round-trip
 
 ```agda
 module _ {𝑮 : Group α ρ} where

--- a/src/Classical/Bundles/Lattice.lagda.md
+++ b/src/Classical/Bundles/Lattice.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-28"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-lattice">Bundle bridge for lattices</a>
+### Bundle bridge for lattices
 
 This is the [Classical.Bundles.Lattice][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Bundles/Magma.lagda.md
+++ b/src/Classical/Bundles/Magma.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-17"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-magma">Bundle bridge for magmas</a>
+### Bundle bridge for magmas
 
 This is the [Classical.Bundles.Magma][] module of the [Agda Universal Algebra Library][].
 
@@ -50,7 +50,7 @@ open Algebra using (Interp)
 private variable α ρ : Level
 ```
 
-#### <a id="core-to-bundle">Core to stdlib bundle</a>
+#### Core to stdlib bundle
 
 Going from the canonical Σ-typed core to the stdlib record reads off the
 domain's `Carrier` and `_≈_`, exposes the operation in curried form via
@@ -71,7 +71,7 @@ from the algebra's `Interp.cong` by unpacking the Fin 2 pattern.
   where open Magma-Op 𝑴; open Setoid 𝔻[ 𝑴 ]
 ```
 
-#### <a id="bundle-to-core">Stdlib bundle to core</a>
+#### Stdlib bundle to core
 
 The reverse direction reassembles the bundle's `Carrier`, `_≈_`, and `_∙_` into
 an `Algebra Sig-Magma`.  The interpretation of `∙-Op` uncurries the bundle's
@@ -95,7 +95,7 @@ equivalence proof.
   cong interp { ∙-Op , _ } { .∙-Op , _ } (≡.refl , args≈) = stdlib-Magma.∙-cong M (args≈ 0F) (args≈ 1F)
 ```
 
-#### <a id="roundtrip">Pointwise round-trip</a>
+#### Pointwise round-trip
 
 Going core → bundle → core preserves the curried operation pointwise.  The two
 sides reduce to the same `(∙-Op ^ 𝑴) (pair a b)` definitionally — `pair a b 0F`

--- a/src/Classical/Bundles/Monoid.lagda.md
+++ b/src/Classical/Bundles/Monoid.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-24"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-monoid">Bundle bridge for monoids</a>
+### Bundle bridge for monoids
 
 This is the [Classical.Bundles.Monoid][] module of the [Agda Universal Algebra Library][].
 
@@ -42,7 +42,7 @@ open import Setoid.Algebras.Basic {𝑆 = Sig-Monoid} using ( Algebra ; ⟨_⟩ 
 private variable α ρ : Level
 ```
 
-#### <a id="core-to-bundle">Core to stdlib bundle</a>
+#### Core to stdlib bundle
 
 ```agda
 ⟨_⟩ᵐᵒ : Monoid α ρ → stdlib-Monoid α ρ
@@ -65,7 +65,7 @@ private variable α ρ : Level
   open Setoid 𝔻[ 𝑨 ]
 ```
 
-#### <a id="bundle-to-core">Stdlib bundle to core</a>
+#### Stdlib bundle to core
 
 ```agda
 ⟪_⟫ᵐᵒ : stdlib-Monoid α ρ → Monoid α ρ
@@ -88,7 +88,7 @@ private variable α ρ : Level
     cong interp {ε-Op , _} {.ε-Op , _} (≡.refl , _)     = Setoid.refl setoid
 ```
 
-#### <a id="roundtrip">Pointwise round-trip</a>
+#### Pointwise round-trip
 
 ```agda
 module _ {𝑴 : Monoid α ρ} where

--- a/src/Classical/Bundles/Ring.lagda.md
+++ b/src/Classical/Bundles/Ring.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-ring">Bundle bridge for rings</a>
+### Bundle bridge for rings
 
 This is the [Classical.Bundles.Ring][] module of the [Agda Universal Algebra Library][].
 
@@ -42,7 +42,7 @@ open import Setoid.Algebras.Basic {𝑆 = Sig-Ring} using ( Algebra ; ⟨_⟩ ; 
 private variable α ρ : Level
 ```
 
-#### <a id="core-to-bundle">Core to stdlib bundle</a>
+#### Core to stdlib bundle
 
 ```agda
 ⟨_⟩ʳᵍ : Ring α ρ → stdlib-Ring α ρ
@@ -81,7 +81,7 @@ private variable α ρ : Level
   open Setoid 𝔻[ 𝑨 ]
 ```
 
-#### <a id="bundle-to-core">Stdlib bundle to core</a>
+#### Stdlib bundle to core
 
 ```agda
 ⟪_⟫ʳᵍ : stdlib-Ring α ρ → Ring α ρ
@@ -121,7 +121,7 @@ private variable α ρ : Level
     cong interp {1-Op , _} {.1-Op , _} (≡.refl , _)      = Setoid.refl setoid
 ```
 
-#### <a id="roundtrip">Pointwise round-trip</a>
+#### Pointwise round-trip
 
 ```agda
 module _ {𝑹 : Ring α ρ} where

--- a/src/Classical/Bundles/Semigroup.lagda.md
+++ b/src/Classical/Bundles/Semigroup.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-18"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-semigroup">Bundle bridge for semigroups</a>
+### Bundle bridge for semigroups
 
 This is the [Classical.Bundles.Semigroup][] module of the [Agda Universal Algebra Library][].
 
@@ -51,7 +51,7 @@ open import Setoid.Algebras.Basic {𝑆 = Sig-Magma} using ( Algebra ; ⟨_⟩ ;
 private variable α ρ : Level
 ```
 
-#### <a id="core-to-bundle">Core to stdlib bundle</a>
+#### Core to stdlib bundle
 
 Going from the canonical Σ-typed core to the stdlib record reads off the domain's
 `Carrier` and `_≈_` and exposes the operation and both law-fields through
@@ -79,7 +79,7 @@ once, upstream, inside `Semigroup-Op.interp-node` (see
   open Setoid 𝔻[ 𝑴 ]
 ```
 
-#### <a id="bundle-to-core">Stdlib bundle to core</a>
+#### Stdlib bundle to core
 
 The reverse direction reassembles the bundle's `Carrier`, `_≈_`, and `_∙_` into
 an `Sig-Magma`-algebra (exactly as in the M3-3 magma bridge) and pairs that
@@ -102,7 +102,7 @@ field by an environment-application of the same three-variable shape.
     cong interp { ∙-Op , _ } { .∙-Op , _ } (≡.refl , args≈) = ∙-cong (args≈ 0F) (args≈ 1F)
 ```
 
-#### <a id="roundtrip">Pointwise round-trip</a>
+#### Pointwise round-trip
 
 Going core → bundle → core preserves the curried operation pointwise.  Both
 sides reduce to `(∙-Op ^ 𝑺) (pair a b)` definitionally, so `Setoid.refl`

--- a/src/Classical/Bundles/Semilattice.lagda.md
+++ b/src/Classical/Bundles/Semilattice.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-27"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-bundles-semilattice">Bundle bridge for semilattices</a>
+### Bundle bridge for semilattices
 
 This is the [Classical.Bundles.Semilattice][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Equations.lagda.md
+++ b/src/Classical/Equations.lagda.md
@@ -131,7 +131,7 @@ module _ {𝑆 : Signature 𝓞 0ℓ} {X : Type χ} where
   Idempotent _ f-bin x = app₂ f-bin (ℊ x) (ℊ x) , ℊ x
 ```
 
-#### <a id="identity-laws">Identity laws</a>
+#### Identity laws
 
 These take a binary operation `f` together with a nullary "identity element" symbol
 `e`.  The arity-conformance evidence for `e` is `ArityOf e ≡ Fin 0`, consistent with
@@ -152,7 +152,7 @@ the `Op (Fin 0) A` representation of nullary operations in
   RightIdentity _ _ f-bin e-nul x = app₂ f-bin (ℊ x) (app₀ e-nul) , ℊ x
 ```
 
-#### <a id="inverse-laws">Inverse laws</a>
+#### Inverse laws
 
 These take a binary `f`, a nullary identity `e`, and a unary inverse `i`.  The arity
 evidence for `i` is `ArityOf i ≡ Fin 1`.
@@ -173,7 +173,7 @@ evidence for `i` is `ArityOf i ≡ Fin 1`.
     app₂ f-bin (ℊ x) (app₁ i-un (ℊ x)) , app₀ e-nul
 ```
 
-#### <a id="distributive-laws">Distributive laws</a>
+#### Distributive laws
 
 ```agda
   -- x · (y + z) ≈ (x · y) + (x · z)
@@ -194,7 +194,7 @@ evidence for `i` is `ArityOf i ≡ Fin 1`.
 
 ```
 
-#### <a id="absorption-laws">Absorption laws</a>
+#### Absorption laws
 
 These take two binary operations `f` and `g`; each builder expresses one
 direction of the absorption between them.  In a lattice, `f` and `g` are

--- a/src/Classical/Operations.lagda.md
+++ b/src/Classical/Operations.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-17"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-operations">Operations on classical structures — curry/uncurry between tuple-indexed and curried form</a>
+### Operations on classical structures — curry/uncurry between tuple-indexed and curried form
 
 This is the [Classical.Operations][] module of the [Agda Universal Algebra Library][].
 
@@ -34,7 +34,7 @@ private variable
   A : Type α
 ```
 
-#### <a id="op-types">Operation types</a>
+#### Operation types
 
 The type `Op I A` of `I`-ary operations on `A`, in tuple-indexed form.  Arity first, carrier second: this orders parameters from "less likely to vary" to "more likely to vary," which is the right convention for partial application — `Op (Fin 2)` partially applies as "binary operation," independent of any carrier.
 
@@ -43,7 +43,7 @@ Op : {𝓥 : Level} → Type 𝓥 → Type α → Type _
 Op I A = (I → A) → A
 ```
 
-#### <a id="pair-helper">Two-element argument tuple</a>
+#### Two-element argument tuple
 
 The canonical `Fin 2 → A` constructed from two elements.  Used internally by `Uncurry₂` and as the bridge target in bundle conversion functions.  Made public for the rare per-structure use case (e.g., expressing a tuple-indexed `(∙-Op ^ 𝑨) (pair a b)` directly when the curried form is inconvenient).
 
@@ -53,7 +53,7 @@ pair a b 0F = a
 pair a b 1F = b
 ```
 
-#### <a id="curry-uncurry">Curry and Uncurry, per arity</a>
+#### Curry and Uncurry, per arity
 
 The translation between tuple-indexed and curried operations.  Each pair is a two-line definition; the obligation that they form a definitional inverse on the curried side (`Curry₂ (Uncurry₂ f) ≡ f` as functions `A → A → A → A`) holds by `refl`.  The reverse direction (`Uncurry₂ (Curry₂ f) ≡ f` as `(Fin 2 → A) → A`) holds *pointwise* but not definitionally as functions, because the lack of η on `Fin 2`-pattern lambdas under `--cubical-compatible` prevents the lambda repackaging from collapsing.  This asymmetry is contained here and surfaced as the pointwise round-trip statement in per-structure bundle bridges (per [ADR-002 v2 §6](docs/adr/002-classical-layer-design.md)).
 

--- a/src/Classical/Properties.lagda.md
+++ b/src/Classical/Properties.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-28"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-properties">Derived properties of classical structures</a>
+### Derived properties of classical structures
 
 This is the [Classical.Properties][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Signatures.lagda.md
+++ b/src/Classical/Signatures.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-15"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-signatures">Signatures of classical structures</a>
+### Signatures of classical structures
 
 This is the [Classical.Signatures][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Signatures/Group.lagda.md
+++ b/src/Classical/Signatures/Group.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-signatures-group">The signature of groups</a>
+### The signature of groups
 
 This is the [Classical.Signatures.Group][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Signatures/Lattice.lagda.md
+++ b/src/Classical/Signatures/Lattice.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-27"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-signatures-lattice">The signature of lattices</a>
+### The signature of lattices
 
 This is the [Classical.Signatures.Lattice][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Signatures/Magma.lagda.md
+++ b/src/Classical/Signatures/Magma.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-17"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-signatures-magma">The signature of magmas</a>
+### The signature of magmas
 
 This is the [Classical.Signatures.Magma][] module of the [Agda Universal Algebra Library][].
 
@@ -58,7 +58,7 @@ open import Level          using ( 0ℓ )
 open import Overture.Signatures using ( Signature )
 ```
 
-#### <a id="operation-symbols">The operation-symbol type</a>
+#### The operation-symbol type
 
 A magma has a single binary operation symbol.  The constructor is named `∙-Op`
 following the `<symbol>-Op` convention; the bare `∙` is reserved for the curried
@@ -69,7 +69,7 @@ data Op-Magma : Type where
   ∙-Op : Op-Magma
 ```
 
-#### <a id="arity-function">The arity function</a>
+#### The arity function
 
 `∙-Op` is binary, so its arity is `Fin 2`.  Direct pattern matching on the single
 constructor lets `ArityOf Sig-Magma ∙-Op` reduce definitionally to `Fin 2` —
@@ -82,7 +82,7 @@ ar-Magma : Op-Magma → Type
 ar-Magma ∙-Op = Fin 2
 ```
 
-#### <a id="signature-value">The signature value</a>
+#### The signature value
 
 ```agda
 Sig-Magma : Signature 0ℓ 0ℓ

--- a/src/Classical/Signatures/Monoid.lagda.md
+++ b/src/Classical/Signatures/Monoid.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-22"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-signatures-monoid">The signature of monoids</a>
+### The signature of monoids
 
 This is the [Classical.Signatures.Monoid][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Signatures/Ring.lagda.md
+++ b/src/Classical/Signatures/Ring.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-signatures-ring">The signature of rings</a>
+### The signature of rings
 
 This is the [Classical.Signatures.Ring][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Small.lagda.md
+++ b/src/Classical/Small.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-15"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-small">Level-fixed veneers of classical structures</a>
+### Level-fixed veneers of classical structures
 
 This is the [Classical.Small][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Structures.lagda.md
+++ b/src/Classical/Structures.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-15"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-structures">Σ-typed cores of classical structures</a>
+### Σ-typed cores of classical structures
 
 This is the [Classical.Structures][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Structures/CommutativeSemigroup.lagda.md
+++ b/src/Classical/Structures/CommutativeSemigroup.lagda.md
@@ -48,7 +48,7 @@ open import Setoid.Varieties.EquationalLogic {𝑆 = Sig-Magma} using ( _⊧_≈
 private variable α ρ : Level
 ```
 
-#### <a id="satisfaction-alias">Satisfaction predicate and the type</a>
+#### Satisfaction predicate and the type
 
 ```agda
 infix 4 _⊨ᶜˢᵍ_
@@ -59,7 +59,7 @@ CommutativeSemigroup : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 CommutativeSemigroup α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ᶜˢᵍ Th-CommutativeSemigroup
 ```
 
-#### <a id="forgetful">The forgetful projection to semigroups (pure reindex)</a>
+#### The forgetful projection to semigroups (pure reindex)
 
 The pattern `assoc` is `Eq-Semigroup`'s sole constructor; the applied `assocᶜ` is
 `Eq-CommutativeSemigroup`'s (renamed on import).  Both theory entries are

--- a/src/Classical/Structures/Group.lagda.md
+++ b/src/Classical/Structures/Group.lagda.md
@@ -76,7 +76,7 @@ open import Setoid.Varieties.EquationalLogic {𝑆 = Sig-Group} using ( _⊧_≈
 private variable α ρ : Level
 ```
 
-#### <a id="satisfaction-alias">The local satisfaction predicate</a>
+#### The local satisfaction predicate
 
 ```agda
 infix 4 _⊨ᵍᵖ_
@@ -84,14 +84,14 @@ _⊨ᵍᵖ_ : (𝑨 : Algebra α ρ) (ℰ : Eq-Group → Term (Fin 3) × Term (F
 𝑨 ⊨ᵍᵖ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 ```
 
-#### <a id="the-type">The type of groups</a>
+#### The type of groups
 
 ```agda
 Group : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Group α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ᵍᵖ Th-Group
 ```
 
-#### <a id="forgetful-to-monoid">The reduct to monoids</a>
+#### The reduct to monoids
 
 The container morphism `Sig-Monoid ⟹ Sig-Group` sends the monoid's `∙-Opᵐᵒ` and
 `ε-Opᵐᵒ` to the group's `∙-Op` and `ε-Op`; the position maps are the identity.
@@ -111,7 +111,7 @@ group→monoidAlg : Group α ρ → Algebra {𝑆 = Sig-Monoid} α ρ
 group→monoidAlg 𝑮 = reduct mo-incl mo-κ (𝑮 .proj₁)
 ```
 
-#### <a id="curried-associativity">Curried associativity, standalone</a>
+#### Curried associativity, standalone
 
 `gp-assoc` proves `(x ∙ y) ∙ z ≈ x ∙ (y ∙ z)` for the group's own `∙`, a verbatim
 port of `Monoid-Op.mn-assoc` to `Sig-Group`.  It is standalone, above the forgetful,
@@ -148,7 +148,7 @@ module _ (𝑮 : Group α ρ) where
     rhsT = node ∙-Op (pair (ℊ 0F) (node ∙-Op (pair (ℊ 1F) (ℊ 2F))))
 ```
 
-#### <a id="group-op">The `Group-Op` module</a>
+#### The `Group-Op` module
 
 ```agda
 module Group-Op {α ρ : Level} (𝑮 : Group α ρ) where
@@ -211,7 +211,7 @@ module Group-Op {α ρ : Level} (𝑮 : Group α ρ) where
                             (trans (equations invʳ (λ _ → x)) (interp-node-ε {λ _ → x})))
 ```
 
-#### <a id="forgetful-to-monoid-proj">The forgetful projection to monoids</a>
+#### The forgetful projection to monoids
 
 `group→monoid` takes a group to the monoid on its `(∙, ε)`-reduct: the underlying
 algebra is `group→monoidAlg`, and the `Th-Monoid` satisfaction proof pivots through

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -99,7 +99,7 @@ open import Setoid.Varieties.EquationalLogic {𝑆 = Sig-Lattice} using ( _⊧_�
 private variable α ρ : Level
 ```
 
-#### <a id="satisfaction-alias">The local satisfaction predicate</a>
+#### The local satisfaction predicate
 
 ```agda
 infix 4 _⊨ˡᵃ_
@@ -107,14 +107,14 @@ _⊨ˡᵃ_ : (𝑨 : Algebra α ρ) (ℰ : Eq-Lattice → Term (Fin 3) × Term (
 𝑨 ⊨ˡᵃ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 ```
 
-#### <a id="the-type">The type of lattices</a>
+#### The type of lattices
 
 ```agda
 Lattice : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Lattice α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ˡᵃ Th-Lattice
 ```
 
-#### <a id="meet-magma-reduct">The meet and join magma reducts</a>
+#### The meet and join magma reducts
 
 The two container morphisms `Sig-Magma ⟹ Sig-Lattice` send the magma's
 `∙-Opᵐᵃ` to the lattice's `∧-Op` and `∨-Op` respectively; the position maps are
@@ -143,7 +143,7 @@ lattice→joinMagma : Lattice α ρ → Algebra {𝑆 = Sig-Magma} α ρ
 lattice→joinMagma 𝑳 = reduct ∨-incl ∨-κ (𝑳 .proj₁)
 ```
 
-#### <a id="curried-laws">Curried laws, standalone</a>
+#### Curried laws, standalone
 
 Each of the eight `Th-Lattice` equations is proved here in curried form once,
 above the semilattice forgetfuls, so that `Lattice-Op` and each
@@ -267,7 +267,7 @@ module _ (𝑳 : Lattice α ρ) where
     lhsT = node ∨-Op (pair x∧y (ℊ 0F))
 ```
 
-#### <a id="lattice-op">The `Lattice-Op` module</a>
+#### The `Lattice-Op` module
 
 `Lattice-Op` exposes `_∧_`, `_∨_`, their congruences, the term-to-curried node
 bridges `interp-node-∧` / `interp-node-∨`, the eight curried laws (matching the
@@ -331,7 +331,7 @@ module Lattice-Op {α ρ : Level} (𝑳 : Lattice α ρ) where
   absorbʳ-law = lt-absorbʳ 𝑳
 ```
 
-#### <a id="forgetfuls-to-semilattices">The forgetful projections to semilattices</a>
+#### The forgetful projections to semilattices
 
 `lattice→meetSemilattice` and `lattice→joinSemilattice` each take a lattice to
 the semilattice on its meet (resp. join) operation: the underlying algebra is
@@ -419,7 +419,7 @@ lattice→joinSemilattice ℒ@(𝑳 , _) = 𝑹 , thm
     x                                       ∎
 ```
 
-#### <a id="builders">Lattice builders</a>
+#### Lattice builders
 
 `opsToBareLattice` builds a "raw" `Sig-Lattice`-algebra from a carrier and two
 binary operations.  `eqsToLattice` adds the eight equation proofs and produces

--- a/src/Classical/Structures/Magma.lagda.md
+++ b/src/Classical/Structures/Magma.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-17"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-structures-magma">Magmas — the empty-theory base case</a>
+### Magmas — the empty-theory base case
 
 This is the [Classical.Structures.Magma][] module of the [Agda Universal Algebra Library][].
 
@@ -60,7 +60,7 @@ open import Setoid.Algebras.Basic {𝑆 = Sig-Magma}  using ( Algebra ; _^_ ; �
 private variable α ρ : Level
 ```
 
-#### <a id="the-type">The type of magmas</a>
+#### The type of magmas
 
 `Magma α ρ` is the type of `Sig-Magma`-algebras whose carrier sits at level `α`
 and whose underlying setoid equivalence sits at level `ρ`.  Empty theory means
@@ -77,7 +77,7 @@ Magma α ρ = Algebra α ρ
 `𝑆 = Sig-Magma`.)
 
 
-#### <a id="magma-op">The `Magma-Op` module: named accessors for a fixed magma</a>
+#### The `Magma-Op` module: named accessors for a fixed magma
 
 `Domain`, `Carrier`, and `_∙_` are exposed inside a named parametric module
 `Magma-Op`.  Users `open Magma-Op 𝑴` at a use site to bring all three into
@@ -138,7 +138,7 @@ opsToMagma A _·_ = record { Domain = ≡.setoid A ; Interp = interp }
   cong interp {∙-Op , _} {.∙-Op , _} (≡.refl , args≡) = ≡.cong₂ _·_ (args≡ 0F) (args≡ 1F)
 ```
 
-#### <a id="morphisms">A note on morphisms</a>
+#### A note on morphisms
 
 A magma morphism is, by [ADR-002][] §5, definitionally a homomorphism of the
 underlying `Sig-Magma`-algebras.  No per-structure morphism record is introduced; we

--- a/src/Classical/Structures/Monoid.lagda.md
+++ b/src/Classical/Structures/Monoid.lagda.md
@@ -85,7 +85,7 @@ open import Setoid.Varieties.EquationalLogic {𝑆 = Sig-Monoid} using ( _⊧_�
 private variable α ρ : Level
 ```
 
-#### <a id="satisfaction-alias">The local satisfaction predicate</a>
+#### The local satisfaction predicate
 
 ```agda
 infix 4 _⊨ᵐᵒ_
@@ -93,14 +93,14 @@ _⊨ᵐᵒ_ : (𝑨 : Algebra α ρ) (ℰ : Eq-Monoid → Term (Fin 3) × Term (
 𝑨 ⊨ᵐᵒ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 ```
 
-#### <a id="the-type">The type of monoids</a>
+#### The type of monoids
 
 ```agda
 Monoid : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Monoid α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ᵐᵒ Th-Monoid
 ```
 
-#### <a id="forgetful-to-magma">The reduct to magmas</a>
+#### The reduct to magmas
 
 The container morphism `Sig-Magma ⟹ Sig-Monoid` sends the magma's `∙-Opᵐᵃ` to the
 monoid's `∙-Op`; the position map is the identity (`Fin 2` to `Fin 2`).
@@ -123,7 +123,7 @@ monoid→magma : Monoid α ρ → Magma α ρ
 monoid→magma 𝑴 = reduct ∙-incl ∙-κ (𝑴 .proj₁)
 ```
 
-#### <a id="curried-associativity">Curried associativity, standalone</a>
+#### Curried associativity, standalone
 
 `mn-assoc` proves `(x ∙ y) ∙ z ≈ x ∙ (y ∙ z)` for the monoid's own `∙`, from
 `equations assoc`, via the local binary node-bridge `interp-node∙` built on
@@ -161,7 +161,7 @@ module _ (𝑴 : Monoid α ρ) where
     rhsT = node ∙-Op (pair (ℊ 0F) (node ∙-Op (pair (ℊ 1F) (ℊ 2F))))
 ```
 
-#### <a id="monoid-op">The `Monoid-Op` module</a>
+#### The `Monoid-Op` module
 
 ```agda
 module Monoid-Op {α ρ : Level} (𝑴 : Monoid α ρ) where
@@ -203,7 +203,7 @@ module Monoid-Op {α ρ : Level} (𝑴 : Monoid α ρ) where
                            (equations idʳ (λ _ → x)))
 ```
 
-#### <a id="forgetful-to-semigroup">The forgetful projection to semigroups</a>
+#### The forgetful projection to semigroups
 
 ```agda
 monoid→semigroup : Monoid α ρ → Semigroup α ρ

--- a/src/Classical/Structures/Reduct.lagda.md
+++ b/src/Classical/Structures/Reduct.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-23"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-structures-reduct">Signature reducts along a container morphism</a>
+### Signature reducts along a container morphism
 
 This is the [Classical.Structures.Reduct][] module of the [Agda Universal Algebra Library][].
 
@@ -54,7 +54,7 @@ private variable
   α ρ 𝓞₁ 𝓞₂ : Level
 ```
 
-#### <a id="the-reduct">The reduct of an algebra along a container morphism</a>
+#### The reduct of an algebra along a container morphism
 
 `reduct ι κ 𝑨` is the `𝑆₁`-algebra obtained from the `𝑆₂`-algebra `𝑨` by the
 container morphism `(ι , κ)`.  The domain is unchanged; the interpretation of a

--- a/src/Classical/Structures/Ring.lagda.md
+++ b/src/Classical/Structures/Ring.lagda.md
@@ -78,7 +78,7 @@ open import Setoid.Varieties.EquationalLogic {𝑆 = Sig-Ring} using ( _⊧_≈_
 private variable α ρ : Level
 ```
 
-#### <a id="satisfaction-alias">The local satisfaction predicate</a>
+#### The local satisfaction predicate
 
 ```agda
 infix 4 _⊨ʳᵍ_
@@ -86,14 +86,14 @@ _⊨ʳᵍ_ : (𝑨 : Algebra α ρ) (ℰ : Eq-Ring → Term (Fin 3) × Term (Fin
 𝑨 ⊨ʳᵍ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 ```
 
-#### <a id="the-type">The type of rings</a>
+#### The type of rings
 
 ```agda
 Ring : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Ring α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ʳᵍ Th-Ring
 ```
 
-#### <a id="reduct-algebras">The additive and multiplicative reduct algebras</a>
+#### The additive and multiplicative reduct algebras
 
 The container morphism `Sig-Group ⟹ Sig-Ring` sends `(∙-Opᵍ, ε-Opᵍ, ⁻¹-Opᵍ)` to the
 additive `(+-Op, 0-Op, -Op)`; the morphism `Sig-Monoid ⟹ Sig-Ring` sends
@@ -126,7 +126,7 @@ ring→monoidAlg : Ring α ρ → Algebra {𝑆 = Sig-Monoid} α ρ
 ring→monoidAlg 𝑹 = reduct ·-incl ·-κ (𝑹 .proj₁)
 ```
 
-#### <a id="curried-laws">The eleven curried laws, standalone</a>
+#### The eleven curried laws, standalone
 
 Each `Th-Ring` equation is proved here in curried form once, above the forgetfuls.
 The pattern is the same throughout: bridge each `node` to curried form via
@@ -353,7 +353,7 @@ module _ (ℛ : Ring α ρ) where
     rhsT = node +-Op (pair yx zx)
 ```
 
-#### <a id="ring-op">The `Ring-Op` module</a>
+#### The `Ring-Op` module
 
 `Ring-Op` exposes the additive `(_+_, 0R, -_)`, the multiplicative `(_·_, 1R)`, their
 congruences and node-bridges, the eleven curried laws, and the satisfaction-witness
@@ -435,7 +435,7 @@ module Ring-Op {α ρ : Level} (ℛ : Ring α ρ) where
   distribʳ-law = rg-distribʳ ℛ
 ```
 
-#### <a id="forgetful-additive">The forgetful projection to abelian groups</a>
+#### The forgetful projection to abelian groups
 
 `ring→abelianGroup` takes a ring to the abelian group on its additive reduct,
 discharging the six `Th-AbelianGroup` equations on `ring→abelianGroupAlg` via
@@ -510,7 +510,7 @@ ring→abelianGroup ℛ@(𝑹 , _) = 𝑹ᵍ , thm
     ⟦ Th-AbelianGroup commᵃ .proj₂ ⟧ ⟨$⟩ η   ∎
 ```
 
-#### <a id="forgetful-multiplicative">The forgetful projection to monoids</a>
+#### The forgetful projection to monoids
 
 `ring→monoid` takes a ring to the monoid on its multiplicative reduct, discharging the
 three `Th-Monoid` equations on `ring→monoidAlg` via `Ring-Op`'s multiplicative
@@ -559,7 +559,7 @@ ring→monoid ℛ@(𝑹 , _) = 𝑹-mon , thm
     _                                ∎
 ```
 
-#### <a id="builders">Ring builders</a>
+#### Ring builders
 
 `opsToBareRing` builds a "raw" `Sig-Ring`-algebra over `≡.setoid A` from a carrier and
 the five operations.  `eqsToRing` adds the eleven equation proofs.

--- a/src/Classical/Structures/Semigroup.lagda.md
+++ b/src/Classical/Structures/Semigroup.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-18"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-structures-semigroup">Semigroups — the first equation-bearing classical structure</a>
+### Semigroups — the first equation-bearing classical structure
 
 This is the [Classical.Structures.Semigroup][] module of the [Agda Universal Algebra Library][].
 
@@ -115,7 +115,7 @@ open Algebra using ( Interp )
 private variable α ρ : Level
 ```
 
-#### <a id="satisfaction-alias">The local satisfaction predicate</a>
+#### The local satisfaction predicate
 
 `𝑨 ⊨ ℰ` says that the algebra `𝑨` satisfies every equation in the theory `ℰ` — that
 is, for every equation `(p , q) = ℰ i`, the formulas `p` and `q` evaluate to setoid-equal
@@ -129,14 +129,14 @@ _⊨_ : (𝑨 : Algebra α ρ) (ℰ : Eq-Semigroup → Term (Fin 3) × Term (Fin
 𝑨 ⊨ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 ```
 
-#### <a id="the-type">The type of semigroups</a>
+#### The type of semigroups
 
 ```agda
 Semigroup : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Semigroup α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Semigroup
 ```
 
-#### <a id="forgetful">The forgetful projection to magmas</a>
+#### The forgetful projection to magmas
 
 A semigroup is a magma + a proof that its operation is associative; forgetting the
 proof recovers the magma.
@@ -146,7 +146,7 @@ semigroup→magma : Semigroup α ρ → Magma α ρ
 semigroup→magma = proj₁
 ```
 
-#### <a id="semigroup-op">The `Semigroup-Op` module: named accessors for a fixed semigroup</a>
+#### The `Semigroup-Op` module: named accessors for a fixed semigroup
 
 `Semigroup-Op 𝑺` exposes `_∙_` (re-exported from `Magma-Op (semigroup→magma 𝑺)`
 through the forgetful) and `equations` (the satisfaction-witness proof, projected

--- a/src/Classical/Structures/Semilattice.lagda.md
+++ b/src/Classical/Structures/Semilattice.lagda.md
@@ -52,7 +52,7 @@ open import Setoid.Varieties.EquationalLogic {𝑆 = Sig-Magma} using ( _⊧_≈
 private variable α ρ : Level
 ```
 
-#### <a id="satisfaction-alias">Satisfaction predicate and the type</a>
+#### Satisfaction predicate and the type
 
 ```agda
 infix 4 _⊨ˢˡ_
@@ -63,7 +63,7 @@ Semilattice : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Semilattice α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ˢˡ Th-Semilattice
 ```
 
-#### <a id="forgetful">The forgetful projection to commutative semigroups (pure reindex)</a>
+#### The forgetful projection to commutative semigroups (pure reindex)
 
 `Th-Semilattice` extends `Th-CommutativeSemigroup` by the single `idem` equation,
 over the same `Sig-Magma` signature; the forgetful is the identity on the underlying

--- a/src/Classical/Theories.lagda.md
+++ b/src/Classical/Theories.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-15"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories">Equational theories of classical structures</a>
+### Equational theories of classical structures
 
 This is the [Classical.Theories][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/AbelianGroup.lagda.md
+++ b/src/Classical/Theories/AbelianGroup.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-abeliangroup">The equational theory of abelian groups</a>
+### The equational theory of abelian groups
 
 This is the [Classical.Theories.AbelianGroup][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/CommutativeMonoid.lagda.md
+++ b/src/Classical/Theories/CommutativeMonoid.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-24"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-commutativemonoid">The equational theory of commutative monoids</a>
+### The equational theory of commutative monoids
 
 This is the [Classical.Theories.CommutativeMonoid][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/CommutativeRing.lagda.md
+++ b/src/Classical/Theories/CommutativeRing.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-commutativering">The equational theory of commutative rings</a>
+### The equational theory of commutative rings
 
 This is the [Classical.Theories.CommutativeRing][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/CommutativeSemigroup.lagda.md
+++ b/src/Classical/Theories/CommutativeSemigroup.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-24"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-commutativesemigroup">The equational theory of commutative semigroups</a>
+### The equational theory of commutative semigroups
 
 This is the [Classical.Theories.CommutativeSemigroup][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/Group.lagda.md
+++ b/src/Classical/Theories/Group.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-group">The equational theory of groups</a>
+### The equational theory of groups
 
 This is the [Classical.Theories.Group][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/Lattice.lagda.md
+++ b/src/Classical/Theories/Lattice.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-27"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-lattice">The equational theory of lattices</a>
+### The equational theory of lattices
 
 This is the [Classical.Theories.Lattice][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/Monoid.lagda.md
+++ b/src/Classical/Theories/Monoid.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-22"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-monoid">The equational theory of monoids</a>
+### The equational theory of monoids
 
 This is the [Classical.Theories.Monoid][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/Ring.lagda.md
+++ b/src/Classical/Theories/Ring.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-30"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-ring">The equational theory of rings</a>
+### The equational theory of rings
 
 This is the [Classical.Theories.Ring][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Classical/Theories/Semigroup.lagda.md
+++ b/src/Classical/Theories/Semigroup.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-18"
 author: "the agda-algebras development team"
 ---
 
-### <a id="classical-theories-semigroup">The equational theory of semigroups</a>
+### The equational theory of semigroups
 
 This is the [Classical.Theories.Semigroup][] module of the [Agda Universal Algebra Library][].
 
@@ -57,7 +57,7 @@ open import Classical.Equations                    using ( Associative )
 open import Overture.Terms {𝑆 = Sig-Magma}         using ( Term )
 ```
 
-#### <a id="eq-semigroup">The index of equations</a>
+#### The index of equations
 
 Semigroup's theory has exactly one equation, associativity.  The singleton enum
 `Eq-Semigroup` names it.
@@ -67,7 +67,7 @@ data Eq-Semigroup : Type where
   assoc : Eq-Semigroup
 ```
 
-#### <a id="th-semigroup">The theory map</a>
+#### The theory map
 
 `Th-Semigroup` sends the sole equation constructor `assoc` to the associativity
 term-pair built by the generic `Associative` builder from

--- a/src/Demos.lagda.md
+++ b/src/Demos.lagda.md
@@ -5,7 +5,7 @@ date : "2022-04-27"
 author: "the agda-algebras development team"
 ---
 
-## <a id="demos-of-the-agda-algebras-library">Demos of the Agda Algebras Library</a>
+## Demos of the Agda Algebras Library
 
 
 ```agda

--- a/src/Demos/ContraX.lagda.md
+++ b/src/Demos/ContraX.lagda.md
@@ -5,7 +5,7 @@ date : "2022-04-27"
 author: "the agda-algebras development team"
 ---
 
-### <a id="inconsistency-in-first-formalization-attempt">Inconsistency in first formalization attempt</a>
+### Inconsistency in first formalization attempt
 
 
 ```agda

--- a/src/Demos/GeneralOperationsAndRelations.lagda.md
+++ b/src/Demos/GeneralOperationsAndRelations.lagda.md
@@ -5,7 +5,7 @@ date : "2022-04-27"
 author: "the agda-algebras development team"
 ---
 
-### General Opereations and Relations
+### General Operations and Relations
 
 +  [Signatures][Overture.Signatures]
 

--- a/src/Demos/GeneralOperationsAndRelations.lagda.md
+++ b/src/Demos/GeneralOperationsAndRelations.lagda.md
@@ -5,7 +5,7 @@ date : "2022-04-27"
 author: "the agda-algebras development team"
 ---
 
-### <a id="general-operations-and-relations">General Opereations and Relations</a>
+### General Opereations and Relations
 
 +  [Signatures][Overture.Signatures]
 

--- a/src/Examples.lagda.md
+++ b/src/Examples.lagda.md
@@ -5,7 +5,7 @@ date : "2022-18-06"
 author: "the agda-algebras development team"
 ---
 
-### <a id="examples">Examples</a>
+### Examples
 
 This is the [Examples][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Examples/Classical/Magma.lagda.md
+++ b/src/Examples/Classical/Magma.lagda.md
@@ -43,7 +43,7 @@ import Classical.Structures.Magma as Polymorphic
 open Polymorphic.Magma-Op ℕ-magma using ( _∙_ )
 ```
 
-#### <a id="acceptance">Acceptance checks</a>
+#### Acceptance checks
 
 `∙-Op` interpreted in `ℕ-magma` reduces definitionally to `_+_`: no opacity from
 the `opsToMagma` construction, no opacity from the `Curry₂` wrapping in the named

--- a/src/Examples/Classical/Monoid.lagda.md
+++ b/src/Examples/Classical/Monoid.lagda.md
@@ -43,7 +43,7 @@ list-monoid = eqsToMonoid (List ℕ) _++_ [] ++-assoc ++-identityˡ ++-identity�
 open Polymorphic.Monoid-Op list-monoid using ( _∙_ ; ε )
 ```
 
-#### <a id="acceptance">Acceptance checks</a>
+#### Acceptance checks
 
 ```agda
 ∙-is-++-mn : ∀ (xs ys : List ℕ) → xs ∙ ys ≡ xs ++ ys

--- a/src/Examples/FunctionTypeBijections.lagda.md
+++ b/src/Examples/FunctionTypeBijections.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-10"
 author: "the agda-algebras development team"
 ---
 
-### <a id="nary-function-encodings">N-ary function encodings</a>
+### N-ary function encodings
 
 This is the [Examples.FunctionTypeBijections][] module of the [Agda Universal Algebra Library][].
 
@@ -36,7 +36,7 @@ open import Overture using ( _≈_ )
 private variable a b : Level
 ```
 
-#### <a id="bijections-of-nondependent-function-types">Bijections of nondependent function types</a>
+#### Bijections of nondependent function types
 
 The first piece of infrastructure is the type of bijections between two types, in two flavors: the definitional flavor (`Bijection`, where the round-trip composites are required to be `_≡_`-equal to `id`) and the pointwise flavor (`PointwiseBijection`, where pointwise equality `_≈_` suffices).  The investigation below turns on the gap between these two notions.
 
@@ -81,7 +81,7 @@ The product and curried forms enjoy a *definitional* bijection — the round-tri
                        ; to-from = refl ; from-to = refl }
 ```
 
-#### <a id="fin-indexed-encodings">Fin-indexed encodings</a>
+#### Fin-indexed encodings
 
 We now introduce the `Fin`-indexed encoding `Fin 2 → A` and transformations between it, the product form `A × A`, and the curried form `A → A`.  The asymmetric behavior of these transformations under definitional equality is the central pedagogical content of the module.
 
@@ -132,7 +132,7 @@ module _ {A : Type a} where
  Fin2A≡ u (s z) = refl
 ```
 
-#### <a id="failed-bijections">Failed bijections</a>
+#### Failed bijections
 
 We can establish that `CurryFin2 ∘ UncurryFin2 ≡ id` reduces to `refl`, but the reverse composition `UncurryFin2 ∘ CurryFin2` does *not*: it would require reducing `λ {z → u z; (s z) → u (s z)}` to `u`, which is η-expansion of a function out of `Fin 2`, and Agda's definitional equality does not include this reduction.  Hence no definitional bijection between `(Fin 2 → A) → B` and `A → A → B`; only a pointwise one.
 

--- a/src/Examples/Structures/Basic.lagda.md
+++ b/src/Examples/Structures/Basic.lagda.md
@@ -5,7 +5,7 @@ date : "2021-07-29"
 author: "agda-algebras development team"
 ---
 
-### <a id="examples-of-structures">Examples of Structures</a>
+### Examples of Structures
 
 
 ```agda

--- a/src/Exercises.lagda.md
+++ b/src/Exercises.lagda.md
@@ -5,7 +5,7 @@ date : "2022-18-06"
 author: "the agda-algebras development team"
 ---
 
-### <a id="exercises">Exercises</a>
+### Exercises
 
 This is the [Exercises][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Exercises/Complexity.lagda.md
+++ b/src/Exercises/Complexity.lagda.md
@@ -5,7 +5,7 @@ date : "2022-18-06"
 author: "the agda-algebras development team"
 ---
 
-### <a id="exercises-in-complexity-theory">Exercises in complexity theory</a>
+### Exercises in complexity theory
 
 This is the [Exercises.Complexity][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Exercises/Complexity/FiniteCSP.lagda.md
+++ b/src/Exercises/Complexity/FiniteCSP.lagda.md
@@ -6,7 +6,7 @@ date: "2026-05-11"
 author: "agda-algebras development team and Libor Barto"
 ---
 
-### <a id="csp-exercises">CSP Exercises</a>
+### CSP Exercises
 
 This is the [Exercises.Complexity.FiniteCSP][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Overture.lagda.md
+++ b/src/Overture.lagda.md
@@ -5,7 +5,7 @@ date : "2022-17-06"
 author: "the agda-algebras development team"
 ---
 
-## <a id="overture">Overture</a>
+## Overture
 
 This is the [Overture][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Overture/Adjunction.lagda.md
+++ b/src/Overture/Adjunction.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-09"
 author: "the agda-algebras development team"
 ---
 
-## <a id="adjunction">Adjunction</a>
+## Adjunction
 
 This is the [Overture.Adjunction][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Overture/Adjunction/Closure.lagda.md
+++ b/src/Overture/Adjunction/Closure.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-09"
 author: "the agda-algebras development team"
 ---
 
-### <a id="closure-systems">Closure Systems and Operators</a>
+### Closure Systems and Operators
 
 This is the [Overture.Adjunction.Closure][] module of the [Agda Universal Algebra Library][].
 
@@ -34,7 +34,7 @@ private variable
 ```
 
 
-#### <a id="closure-systems">Closure Systems</a>
+#### Closure Systems
 
 A *closure system* on a set `X` is a collection `𝒞` of subsets of `X` that is closed under arbitrary intersection (including the empty intersection, so `⋂ ∅ = X ∈ 𝒞`).  Thus a closure system is a complete meet semilattice with respect to the subset inclusion ordering.
 
@@ -63,7 +63,7 @@ module _ {χ ρ ℓ : Level}{X : Type χ} where
 ```
 
 
-#### <a id="closure-operators">Closure Operators</a>
+#### Closure Operators
 
 Let `𝑷 = (P, ≤)` be a poset.  A function `C : P → P` is called a *closure operator* on `𝑷` if it is
 
@@ -88,7 +88,7 @@ record ClOp {ℓ ℓ₁ ℓ₂ : Level}(𝑨 : Poset ℓ ℓ₁ ℓ₂) : Type  
 ```
 
 
-#### <a id="basic-properties-of-closure-operators">Basic properties of closure operators</a>
+#### Basic properties of closure operators
 
 
 ```agda

--- a/src/Overture/Adjunction/Galois.lagda.md
+++ b/src/Overture/Adjunction/Galois.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-09"
 author: "the agda-algebras development team"
 ---
 
-### <a id="galois-connections">Galois Connections</a>
+### Galois Connections
 
 This is the [Overture.Adjunction.Galois][] module of the [Agda Universal Algebra Library][].
 
@@ -87,7 +87,7 @@ module _ {𝒜 : Type α}{ℬ : Type β} where
 ```
 
 
-#### <a id="the-poset-of-subsets-of-a-set">The poset of subsets of a set</a>
+#### The poset of subsets of a set
 
 Here we define a type that represents the poset of subsets of a given set equipped with the usual set inclusion relation.  (It seems there is no definition in the standard library of this important example of a poset; we should propose adding it.)
 

--- a/src/Overture/Adjunction/Residuation.lagda.md
+++ b/src/Overture/Adjunction/Residuation.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-09"
 author: "the agda-algebras development team"
 ---
 
-### <a id="residuation">Residuation</a>
+### Residuation
 
 This is the [Overture.Adjunction.Residuation][] module of the [Agda Universal Algebra Library][].
 
@@ -45,7 +45,7 @@ module _ (A : Poset a ιᵃ α)(B : Poset b ιᵇ β) where
 ```
 
 
-#### <a id="basic-properties-of-residual-pairs">Basic properties of residual pairs</a>
+#### Basic properties of residual pairs
 
 
 ```agda

--- a/src/Overture/Basic.lagda.md
+++ b/src/Overture/Basic.lagda.md
@@ -5,11 +5,11 @@ date : "2021-01-13"
 author: "the agda-algebras development team"
 ---
 
-### <a id="preliminaries">Preliminaries</a>
+### Preliminaries
 
 This is the [Overture.Basic][] module of the [Agda Universal Algebra Library][].
 
-#### <a id="logical-foundations">Logical foundations</a>
+#### Logical foundations
 
 (See also the Equality module of the [agda-algebras][] library.)
 
@@ -42,7 +42,7 @@ Each module in the library begins with a pragma line of the form
 (Readers familiar with the standard library will notice occasional `-W[no]UnsupportedIndexedMatch` warnings on our pattern-matching definitions. These warnings come from `--cubical-compatible` and indicate that the flagged definition will not compute when applied to a `--cubical` transport. They are suppressed at the library level via the `flags:` field in `agda-algebras.agda-lib`. Every such site is a candidate for cleanup when we eventually port to Cubical; see the project's Milestone 5.)
 
 
-#### <a id="agda-modules">Agda modules</a>
+#### Agda modules
 
 The `OPTIONS` pragma is usually followed by the start of a module.  For example,
 the [Base.Functions.Basic][] module begins with the following line, and then a
@@ -79,7 +79,7 @@ data 𝟛 : Type 0ℓ where 𝟎 : 𝟛 ;  𝟏 : 𝟛 ;  𝟐 : 𝟛
 ```
 
 
-#### <a id="projection-notation">Projection notation</a>
+#### Projection notation
 
 The definition of `Σ` (and thus, of `×`) includes the fields `proj₁` and `proj₂`
 representing the first and second projections out of the product.  Sometimes we
@@ -141,7 +141,7 @@ infixl 30 _∙_
 ```
 
 
-#### <a id="sigma-types">Sigma types</a>
+#### Sigma types
 
 ```agda
 infix 2 ∃-syntax
@@ -153,7 +153,7 @@ syntax ∃-syntax (λ x → B) = ∃[ x ∈ A ] B
 ```
 
 
-#### <a id="pi-types">Pi types</a>
+#### Pi types
 
 The dependent function type is traditionally denoted with an uppercase pi symbol
 and typically expressed as `Π(x : A) B x`, or something similar.  In Agda syntax,
@@ -174,7 +174,7 @@ infix 6 Π-syntax
 In the modules that follow, we will see many examples of this syntax in action.
 
 
-#### <a id="agdas-universe-hierarchy">Agda's universe hierarchy</a>
+#### Agda's universe hierarchy
 
 The hierarchy of universes in Agda is structured as follows:
 
@@ -190,7 +190,7 @@ Specifically, in certain situations, the non-cumulativity makes it unduly
 difficult to convince Agda that a program or proof is correct.
 
 
-#### <a id="lifting-and-lowering">Lifting and lowering</a>
+#### Lifting and lowering
 
 Here we describe a general `Lift` type that help us overcome the technical issue
 described in the previous subsection.  In the [Lifts of algebras
@@ -236,7 +236,7 @@ lower∼lift = refl
 The proofs are trivial. Nonetheless, we'll come across some holes these lemmas can fill.
 
 
-#### <a id="pointwise-equality-of-dependent-functions">Pointwise equality of dependent functions</a>
+#### Pointwise equality of dependent functions
 
 We conclude this module with a definition that conveniently represents te assertion
 that two functions are (extensionally) the same in the sense that they produce

--- a/src/Overture/Functions.lagda.md
+++ b/src/Overture/Functions.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-07"
 author: "the agda-algebras development team"
 ---
 
-### <a id="functions">Foundational function infrastructure</a>
+### Foundational function infrastructure
 
 This is the [Overture.Functions][] module of the [Agda Universal Algebra Library][].
 
@@ -43,7 +43,7 @@ open import Overture.Basic  using ( _≈_ ; _∙_ ; transport )
 private variable a b c ι : Level
 ```
 
-#### <a id="image">The image of a raw function</a>
+#### The image of a raw function
 
 The *image* of a raw function `f : A → B` at a point `b : B` is the proposition that some `a : A` satisfies `f a ≡ b`.  We represent it as an inductive type with one constructor, `eq`, which packages the witness `a` together with the equality proof.  This inductive presentation matters: an inhabitant of `Image f ∋ b` carries an actual point of `A`, so we can extract that point computationally (the function `Inv` below).  The corresponding Σ-type formulation `Σ[ a ∈ A ] f a ≡ b` would be logically equivalent but syntactically less convenient at the call sites; the legacy module has used the inductive form throughout, and the canonical Setoid tree consumes it that way.
 
@@ -64,7 +64,7 @@ Given an inhabitant of `Image f ∋ b`, we recover the underlying preimage by pa
  InvIsInverseʳ (eq _ p) = sym p
 ```
 
-#### <a id="surjectivity">Surjectivity of raw functions</a>
+#### Surjectivity of raw functions
 
 A raw function `f : A → B` is *surjective* when every `b : B` is in the image of `f`.  The library distinguishes this from stdlib's `Function.Surjective`, which is a more general "respects two arbitrary equivalences" notion; the bare-types `IsSurjective` is the specialization to propositional equality on both sides.  Conversion in either direction is straightforward, as the two helper lemmas below show.
 
@@ -138,7 +138,7 @@ module _ {A : Type a}{B : Type b}{C : Type c} where
    goal = eq (g (finv y)) (sym η)
 ```
 
-#### <a id="projection">Coordinate projection out of a dependent product</a>
+#### Coordinate projection out of a dependent product
 
 Given an indexed family `B : I → Type b` and a "default" point `bs₀ : ∀ i → B i` of the dependent product, we define the coordinate projection `proj j` and prove it surjective.  The default point and the decidable equality on `I` are both essential: without a fallback value at indices `i ≠ j` we cannot construct a preimage of an arbitrary `b : B j`, and without decidable equality we cannot decide which coordinate to fill in with `b`.
 

--- a/src/Overture/Operations.lagda.md
+++ b/src/Overture/Operations.lagda.md
@@ -5,7 +5,7 @@ date : "2022-06-17"
 author: "the agda-algebras development team"
 ---
 
-### <a id="Operations">Operations</a>
+### Operations
 
 This is the [Overture.Operations][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Overture/Preface.lagda.md
+++ b/src/Overture/Preface.lagda.md
@@ -6,7 +6,7 @@ date : "2026-04-20"
 author: "the agda-algebras development team"
 ---
 
-### <a id="preface">Preface</a>
+### Preface
 
 This is the [Overture.Preface][] module of the [Agda Universal Algebra Library][].
 
@@ -23,13 +23,13 @@ The [Agda Universal Algebra Library][] ([agda-algebras][], for short) is a forma
 
 This Preface explains why a mathematician working in universal algebra or an adjacent area might care about this library, why it is written in Agda specifically, what the 3.0 reconstruction has changed, and where to go next.
 
-#### <a id="why-univ-alg-in-type-theory">Why formalize universal algebra in type theory?</a>
+#### Why formalize universal algebra in type theory?
 
 Universal algebra has a native affinity for type theory that is stronger than first appearances suggest.  Signatures are indexed families of operation symbols; algebras are sets together with a family of operations indexed by the signature; terms are the initial algebra over a set of variables; subalgebras, homomorphic images, and products are each captured by a small collection of definitions each a few lines long.  These are exactly the constructions Martin-Löf type theory was designed to support — inductive types for terms and trees, Π- and Σ-types for universal and existential parameters, dependent records for structured objects — and the transcription between informal mathematical practice and formal type-theoretic statement turns out to be short.
 
 The dividend is not only aesthetic.  A formalization in type theory is *computable by construction*: a closed proof that every variety is an equational class does not merely assert the theorem, it can be evaluated on inputs.  It is also *compositional*: the free algebra of a variety is not only named, it is built, and its universal property is a dependent function one can apply.  When the formalization is done constructively, as agda-algebras is, the resulting proof terms are objects one can inspect, slice, export, and share — a feature whose importance has grown sharply with the rise of machine learning on formal mathematics.
 
-#### <a id="why-agda">Why Agda?</a>
+#### Why Agda?
 
 The proof-assistant landscape of 2026 offers several mature choices — Lean 4, Coq / Rocq, Isabelle — each with excellent universal-algebra formalizations at various stages of development.  The case for Agda here rests on three pillars.
 
@@ -41,7 +41,7 @@ The proof-assistant landscape of 2026 offers several mature choices — Lean 4, 
 
 These three reasons are not independent: the constructive substrate makes the proof terms meaningful, and the cubical trajectory keeps the constructive substrate future-proof against the eventual migration of foundations to path-based equality.
 
-#### <a id="the-3-0-reconstruction">The 3.0 reconstruction</a>
+#### The 3.0 reconstruction
 
 The first public release, v2.0.1 ([archived on Zenodo](https://doi.org/10.5281/zenodo.5765793), December 2021), accompanied the TYPES 2021 proof of Birkhoff's HSP theorem.  It succeeded narrowly — the proof type-checks, as does everything it depends on — but bequeathed a codebase with two parallel developments (a standard-dependent-types `Base/` tree and a setoid-based `Setoid/` tree), uneven naming, a handful of synonyms for each central concept, and a documentation layer split across LaTeX-literate Agda, Markdown, and Jekyll templating in ways no one could reproduce from first principles.
 
@@ -54,7 +54,7 @@ The 3.0 reconstruction is a long-overdue consolidation, organized into nine mile
 
 The documentation conventions have also tightened: public definitions are paired with prose that explains what the definition means and when a mathematician would reach for it, rather than restating the type signature in English.  This is in service of the library's dual role as reference and training corpus, a role the 2021 version acknowledged in passing but did not systematically enforce.
 
-#### <a id="mathematical-horizon">Mathematical horizon</a>
+#### Mathematical horizon
 
 The library is a working substrate for active mathematical research, not only a reference for settled material.  The 3.0 roadmap sketches several tracks.
 
@@ -68,7 +68,7 @@ The library is a working substrate for active mathematical research, not only a 
 
 **Library as corpus**.  Milestone 8 (M8) treats the library itself as a deliverable: a published (theorem, proof) corpus, regenerated on each release, distributed on Hugging Face for retrieval and training.  The maintainers' parallel work on agda-native-air — an AI-assisted formal-proof workflow — is a natural downstream consumer, and the design of the corpus is informed by that use case.  The broader goal is to contribute a high-quality source of constructive, human-authored Agda proofs to the growing ecosystem of datasets for machine learning on formal mathematics.  This is not a side project relative to the pure mathematics: the library's design decisions — many small focused lemmas, named helper functions, rich prose comments paired with formal statements, explicit type signatures on every public definition — were tuned for this dual role from the start of the reconstruction.
 
-#### <a id="where-to-go-next">Where to go next</a>
+#### Where to go next
 
 Readers approaching the library for the first time will typically want one of a few entry points.
 
@@ -79,15 +79,15 @@ Readers approaching the library for the first time will typically want one of a 
 
 The remainder of the `Overture` chapter introduces the library's conventions and notation.  Readers familiar with both Agda and universal algebra can skim it; others may want to read it carefully before moving into the substantive material.
 
-#### <a id="attributions">Attributions</a>
+#### Attributions
 
 The [agda-algebras][] library is developed and maintained by the *agda-algebras development team*, led by [William DeMeo][] with senior-advisor contributions from [Jacques Carette][] (McMaster University).
 
-##### <a id="acknowledgements">Acknowledgements</a>
+##### Acknowledgements
 
 We thank [Andreas Abel][], [Jeremy Avigad][], [Andrej Bauer][], [Clifford Bergman][], [Venanzio Capretta][], [Martín Escardó][], [Ralph Freese][], [Hyeyoung Shin][], and [Siva Somayyajula][] for helpful discussions, corrections, advice, inspiration, and encouragement over the life of the project.  Most of the mathematical content formalized in agda-algebras is well known; the novelty lies in the formalization itself, which is due to the contributors and acknowledgees listed above.
 
-#### <a id="references">References</a>
+#### References
 
 The following Agda documentation and tutorials informed the development of agda-algebras, and we recommend them to readers new to the language.
 
@@ -99,11 +99,11 @@ The following Agda documentation and tutorials informed the development of agda-
 
 The official [Agda Wiki][], [Agda User's Manual][], [Agda Language Reference][], and the open-source [Agda Standard Library][] source code are also indispensable.
 
-#### <a id="citing">Citing</a>
+#### Citing
 
 Citation information — both the v2.0.1 Zenodo archival entry and the BibTeX for the Birkhoff formalization paper — is maintained in the [README's Citing section](https://github.com/ualib/agda-algebras#citing).  While the 3.0 reconstruction is in development, please cite the GitHub repository and pin a commit hash for reproducibility; a new Zenodo DOI will be minted at the v3.0 release.
 
-#### <a id="contributions-welcomed">Contributions welcomed</a>
+#### Contributions welcomed
 
 Improvements to `agda-algebras` — bug reports, design discussions, pull requests, documentation fixes — are welcome.  See [`CONTRIBUTING.md`](https://github.com/ualib/agda-algebras/blob/master/CONTRIBUTING.md) for the development workflow and the [GitHub issue tracker](https://github.com/ualib/agda-algebras/issues/new/choose) to report problems or propose changes.
 

--- a/src/Overture/Relations.lagda.md
+++ b/src/Overture/Relations.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-07"
 author: "the agda-algebras development team"
 ---
 
-## <a id="relations">Foundational relation infrastructure</a>
+## Foundational relation infrastructure
 
 This is the [Overture.Relations][] module of the [Agda Universal Algebra Library][].
 
@@ -46,7 +46,7 @@ private variable
  𝓦 : Level   -- arity-tuple level, conventional name elsewhere in the library
 ```
 
-### <a id="equivalence-bundle">The `Equivalence` Σ-bundle</a>
+### The `Equivalence` Σ-bundle
 
 `Equivalence A {ρ}` packages a binary relation on `A` with a proof that the relation is an equivalence.  Compared to stdlib's `Relation.Binary.Bundles.Setoid`, which bundles a `Carrier` *and* an `_≈_` *and* an `IsEquivalence`, `Equivalence` fixes the carrier as a parameter and bundles only the relation with its proof — useful when one wants to vary the equivalence relation over a fixed carrier (the situation in quotient and congruence constructions).
 
@@ -57,7 +57,7 @@ Equivalence A {ρ} = Σ[ r ∈ BinRel A ρ ] IsEquivalence r
 
 Given `R : Equivalence A`, we use `(proj₁ R)` for the underlying relation and `(proj₂ R)` for the equivalence-relation proof, following the library convention.
 
-### <a id="equivalence-blocks">Equivalence classes</a>
+### Equivalence classes
 
 If `R` is a binary relation on `A`, the *`R`-block containing* `u : A` is the predicate that holds at `v` precisely when `R u v`.  The notation `[ u ] R` is shorthand for that predicate.
 
@@ -68,7 +68,7 @@ If `R` is a binary relation on `A`, the *`R`-block containing* `u : A` is the pr
 infix 60 [_]
 ```
 
-### <a id="identity-relation">The identity relation</a>
+### The identity relation
 
 The *identity* (or *zero*) relation on `A` is `λ x y → Lift ρ (x ≡ y)`.  The `Lift` is there so that the relation's universe level can be parametrized independently of the carrier's level — useful when the relation has to live at a level dictated by surrounding context (e.g., congruence relations on an algebra at level `α ⊔ suc ρ`).
 
@@ -90,7 +90,7 @@ The identity relation is, of course, an equivalence relation; we package its `Is
 0[ A ]Equivalence {ρ} = 0[ A ] {ρ} , 0[ A ]IsEquivalence
 ```
 
-### <a id="kernels">Kernels of raw functions</a>
+### Kernels of raw functions
 
 The *kernel* of `f : A → B` is the equivalence relation on `A` whose blocks are the fibres of `f`.  We give three formulations corresponding to three idiomatic uses elsewhere in the library: `kerRel` parametrizes the codomain equivalence (used when `B` has its own equivalence relation that the kernel should reflect, e.g. the carrier of a setoid algebra); `kernelRel` repackages the same content as a predicate on pairs (more convenient for some `Pred`-based constructions); and `kerRelOfEquiv` lifts an `IsEquivalence` proof on the codomain to one on the kernel.
 
@@ -114,7 +114,7 @@ module _ {A : Type a}{B : Type b} where
                                }
 ```
 
-### <a id="image-containment">Image-containment of a tuple</a>
+### Image-containment of a tuple
 
 If `a : I → A` is a tuple of `A`-values indexed by `I`, and `B` is a subset of `A`, then `Im a ⊆ B` asserts that every component of the tuple lies in `B`.  This is the bare-types form of image-containment, in which `a` is a raw function rather than a setoid morphism.
 
@@ -127,7 +127,7 @@ Im a ⊆ B = ∀ i → a i ∈ B
 A setoid analogue of `Im_⊆_`, taking a setoid function rather than a raw function, is given separately in `Setoid.Relations.Discrete`.  The two coexist because they have genuinely different type signatures and serve genuinely different call sites.
 
 
-### <a id="pointwise-lifting">Pointwise lifting of a binary relation</a>
+### Pointwise lifting of a binary relation
 
 If `_≋_` is a binary relation on `B`, the *pointwise lift* of `_≋_` to the function space `A → B` holds at `f, g : A → B` precisely when `∀ x → f x ≋ g x`.  This construction is foundational across the library: it is the equality used in `Overture.Adjunction.Residuation` to express that the composite `g ∘ f ∘ g` agrees pointwise with `g`, and is the natural generalization of stdlib's `_≗_` (which fixes `_≋_ = _≡_`) to an arbitrary equivalence on the codomain.
 
@@ -150,7 +150,7 @@ Here `_≋_` is a *family* of relations; for each index `x : A`, an instance `_�
 ```
 
 
-### <a id="compatibility">Compatibility of operations with relations</a>
+### Compatibility of operations with relations
 
 If `f : Op A I` is an `I`-ary operation on `A` and `R` is a binary relation on `A`, we say that `f` and `R` are *compatible* (equivalently, that `f` *preserves* `R`) when, for all tuples `u v : I → A`, the pointwise hypothesis `∀ i → R (u i) (v i)` implies `R (f u) (f v)`.  We provide both a long-form name `_preserves_` and the customary infix shorthand `_|:_`.
 

--- a/src/Overture/Signatures.lagda.md
+++ b/src/Overture/Signatures.lagda.md
@@ -6,7 +6,7 @@ author: "agda-algebras development team"
 ---
 
 
-### <a id="signatures">Signatures</a>
+### Signatures
 
 This is the [Overture.Signatures][] module of the [Agda Universal Algebra Library][].
 
@@ -27,7 +27,7 @@ The variables `𝓞` and `𝓥` are not private since, throughout the [agda-alge
 `𝓞` denotes the universe level of *operation symbol* types, while `𝓥` denotes the universe
 level of *arity* types.
 
-#### <a id="theoretical-background">Theoretical background</a>
+#### Theoretical background
 
 In [model theory](https://en.wikipedia.org/wiki/Model_theory), the *signature*
 `𝑆 = (𝐶, 𝐹, 𝑅, ρ)` of a structure consists of three (possibly empty) sets `𝐶`, `𝐹`,
@@ -78,7 +78,7 @@ Then the following typing judgments obtain:
 `h ∘ a : ρ𝑓 → B` and `𝑓 (h ∘ a) : B`.
 
 
-#### <a id="the-signature-type">The signature type</a>
+#### The signature type
 
 In the [agda-algebras][] library we represent the *signature* of an algebraic
 structure using the following type.
@@ -107,7 +107,7 @@ Consequently, if `𝑆 : Signature 𝓞 𝓥` is a signature, then
 If `𝑓 : proj₁ 𝑆` is an operation symbol in the signature `𝑆`, then `proj₂ 𝑆 𝑓`
 is the arity of `𝑓`.
 
-#### <a id="self-documenting-projections">Self-documenting projections</a>
+#### Self-documenting projections
 
 Bare `proj₁` / `proj₂` read opaquely at signature use sites.  The following
 long-form aliases are definitionally identical to the projections and are the

--- a/src/Overture/Terms.lagda.md
+++ b/src/Overture/Terms.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-06"
 author: "agda-algebras development team"
 ---
 
-## <a id="terms">Terms over a signature</a>
+## Terms over a signature {#terms}
 
 A `Term X` is a finite tree whose leaves are drawn from a type `X` of variable symbols and whose internal nodes are labelled by operation symbols of the signature `𝑆`.  Equivalently, `Term` is the W-type for the polynomial functor associated to `𝑆`, freely adjoined a copy of `X` at the leaves.
 
@@ -26,7 +26,7 @@ open import Level           using ( Level ; suc ; _⊔_ )
 private variable χ : Level
 ```
 
-### <a id="ov">The level shorthand `ov`</a>
+### The level shorthand `ov`
 
 Throughout the library we package the universe levels of operation symbols (`𝓞`), arities (`𝓥`), and a separate "carrier-or-variable" level (`χ`) into a single shorthand `ov χ = 𝓞 ⊔ 𝓥 ⊔ suc χ`.  The `suc` is unavoidable because `Term X` mixes leaves of type `X : Type χ` with operation symbols of type `Type 𝓞`, so the resulting tree type sits one universe up.
 
@@ -37,7 +37,7 @@ ov : Level → Level
 ov χ = 𝓞 ⊔ 𝓥 ⊔ suc χ
 ```
 
-### <a id="the-type-of-terms">The type of terms</a>
+### The type of terms
 
 Fix a signature `𝑆` and let `X` denote an arbitrary collection of variable symbols, assumed disjoint from the operation symbols of `𝑆` (i.e. `X ∩ OperationSymbolsOf 𝑆 = ∅`).
 

--- a/src/Setoid.lagda.md
+++ b/src/Setoid.lagda.md
@@ -5,7 +5,7 @@ date : "2021-12-12"
 author: "the agda-algebras development team"
 ---
 
-## <a id="setoid-types-for-general-algebra">Setoid Types for General Algebra</a>
+## Setoid Types for General Algebra
 
 This module collects all submodule of that part of the library based on setoids,
 as opposed to "bare" types (see [Base.lagda][]).

--- a/src/Setoid/Algebras.lagda.md
+++ b/src/Setoid/Algebras.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-17"
 author: "agda-algebras development team"
 ---
 
-### <a id="setoid-representation-of-algebras">Setoid Representation of Algebras</a>
+### Setoid Representation of Algebras
 
 
 ```agda

--- a/src/Setoid/Algebras/Basic.lagda.md
+++ b/src/Setoid/Algebras/Basic.lagda.md
@@ -5,7 +5,7 @@ date : "2021-04-23"
 author: "agda-algebras development team"
 ---
 
-#### <a id="basic-definitions">Basic definitions</a>
+#### Basic definitions
 
 This is the [Setoid.Algebras.Basic][] module of the [Agda Universal Algebra Library][].
 
@@ -35,7 +35,7 @@ ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α
 ```
 
 
-#### <a id="setoid-algebras">Setoid Algebras</a>
+#### Setoid Algebras
 
 Here we define algebras over a setoid, instead of a mere type with no equivalence on it.
 
@@ -128,7 +128,7 @@ Level-of-Carrier {α = α} _ = α
 ```
 
 
-#### <a id="level-lifting-setoid-algebra-types">Level lifting setoid algebra types</a>
+#### Level lifting setoid algebra types
 
 ```agda
 module _ (𝑨 : Algebra α ρ)(ℓ : Level) where

--- a/src/Setoid/Algebras/Products.lagda.md
+++ b/src/Setoid/Algebras/Products.lagda.md
@@ -5,7 +5,7 @@ date : "2021-07-03"
 author: "agda-algebras development team"
 ---
 
-#### <a id="products-of-setoidalgebras">Products of Setoid Algebras</a>
+#### Products of Setoid Algebras
 
 This is the [Setoid.Algebras.Products][] module of the [Agda Universal Algebra Library][].
 
@@ -58,7 +58,7 @@ cong (Interp (⨅ {I} 𝒜)) (refl , f=g ) = λ i → cong  (Interp (𝒜 i)) (r
 ```
 
 
-#### <a id="products-of-classes-of-setoidalgebras">Products of classes of Algebras</a>
+#### Products of classes of Algebras
 
 
 ```agda

--- a/src/Setoid/Complexity.lagda.md
+++ b/src/Setoid/Complexity.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-09"
 author: "agda-algebras development team"
 ---
 
-## <a id="types-for-computational-complexity">Types for Computational Complexity</a>
+## Types for Computational Complexity
 
 This is the [Setoid.Complexity][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Complexity/Basic.lagda.md
+++ b/src/Setoid/Complexity/Basic.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-09"
 author: "agda-algebras development team"
 ---
 
-### <a id="complexity-theory">Complexity Theory</a>
+### Complexity Theory
 
 This is the [Setoid.Complexity.Basic][] module of the [Agda Universal Algebra Library][].
 
@@ -17,7 +17,7 @@ This module is the canonical home for the content previously developed in `Legac
 module Setoid.Complexity.Basic where
 ```
 
-#### <a id="words">Words</a>
+#### Words
 
 Let 𝑇ₙ be a totally ordered set of size 𝑛.  Let 𝐴 be a set (the alphabet).
 We can model the set 𝑊ₙ, of *words* (strings of letters from 𝐴) of length 𝑛

--- a/src/Setoid/Complexity/CSP.lagda.md
+++ b/src/Setoid/Complexity/CSP.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-09"
 author: "the agda-algebras development team"
 ---
 
-### <a id="constraint-satisfaction-problems">Constraint Satisfaction Problems</a>
+### Constraint Satisfaction Problems
 
 This is the [Setoid.Complexity.CSP][] module of the [Agda Universal Algebra Library][].
 
@@ -17,7 +17,7 @@ fixed finite domain, and a statement of the Bulatov–Zhuk algebraic dichotomy �
 scheduled under #274 (M7-1).  The infinite-template / ω-categorical extension is
 covered separately under #281 (M9-2), which depends on this canonical-path version.
 
-#### <a id="the-relational-formulation-of-csp">The relational formulation of CSP</a>
+#### The relational formulation of CSP
 
 Let 𝒜 = (𝐴 , 𝑅ᵃ) be a *relational structure* (or 𝑅-structure), that is, a pair
 consisting of a set 𝐴 along with a collection 𝑅ᵃ ⊆ ⋃ₙ 𝒫(𝐴ⁿ) of relations on 𝐴.
@@ -48,7 +48,7 @@ CSP(𝒜) of 𝑅 structures having homomorphisms into 𝒜.  That is, our algor
 as input an 𝑅-structure (a relational structure in the signature of 𝒜) and decide
 whether or not it belongs to the set CSP(𝒜).
 
-#### <a id="connection-to-algebraic-csp">Connection to algebraic CSP</a>
+#### Connection to algebraic CSP
 
 Let A be a set, let Op(A) denote the set of all operations, Rel(A) the set of all relations, on A.
 
@@ -97,7 +97,7 @@ open import Setoid.Relations.Continuous       using ( REL ; REL-syntax )
 open import Setoid.Algebras.Basic  {𝑆 = 𝑆}    using ( Algebra )
 ```
 
-#### <a id="constraints">Constraints</a>
+#### Constraints
 
 A constraint c consists of
 
@@ -153,7 +153,7 @@ infinitary CSP work under #281) needs to mix relation levels across constraints 
 a single instance.
 
 
-#### <a id="csp-templates-and-instances">CSP templates and instances</a>
+#### CSP templates and instances
 
 A CSP "template" restricts the relations that may occur in instances of the problem.
 A convenient way to specify a template is to give an indexed family 𝒜 : var → Algebra

--- a/src/Setoid/Functions.lagda.md
+++ b/src/Setoid/Functions.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-08"
 author: "the agda-algebras development team"
 ---
 
-## <a id="setoids-functions">Setoid Functions</a>
+## Setoid Functions
 
 This is the [Setoid.Functions][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Functions/Basic.lagda.md
+++ b/src/Setoid/Functions/Basic.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "the agda-algebras development team"
 ---
 
-### <a id="setoid-functions">Setoid functions</a>
+### Setoid functions
 
 This is the [Setoid.Functions.Basic][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Functions/Bijective.lagda.md
+++ b/src/Setoid/Functions/Bijective.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "the agda-algebras development team"
 ---
 
-### <a id="bijective-functions-on-setoids">Bijective functions on setoids</a>
+### Bijective functions on setoids
 
 This is the [Setoid.Functions.Bijective][] module of the [agda-algebras][] library.
 

--- a/src/Setoid/Functions/Injective.lagda.md
+++ b/src/Setoid/Functions/Injective.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "the agda-algebras development team"
 ---
 
-### <a id="injective-functions-on-setoids">Injective functions on setoids</a>
+### Injective functions on setoids
 
 This is the [Setoid.Functions.Injective][] module of the [agda-algebras][] library.
 

--- a/src/Setoid/Functions/Inverses.lagda.md
+++ b/src/Setoid/Functions/Inverses.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "the agda-algebras development team"
 ---
 
-### <a id="inverses-for-functions-with-structure">Inverses for functions with structure</a>
+### Inverses for functions with structure
 
 This is the [Setoid.Functions.Inverses][] module of the [agda-algebras][] library.
 

--- a/src/Setoid/Functions/Surjective.lagda.md
+++ b/src/Setoid/Functions/Surjective.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "the agda-algebras development team"
 ---
 
-### <a id="surjective-functions-on-setoids">Surjective functions on setoids</a>
+### Surjective functions on setoids
 
 This is the [Setoid.Functions.Surjective][] module of the [agda-algebras][] library.
 

--- a/src/Setoid/Homomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-17"
 author: "agda-algebras development team"
 ---
 
-### <a id="types-for-homomorphism-of-setoid-algebras">Types for Homomorphism of Setoid Algebras</a>
+### Types for Homomorphism of Setoid Algebras
 
 This is the [Setoid.Homomorphisms][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Homomorphisms/Basic.lagda.md
+++ b/src/Setoid/Homomorphisms/Basic.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "agda-algebras development team"
 ---
 
-#### <a id="homomorphisms-of-algebras-over-setoids">Homomorphisms of Algebras over Setoids</a>
+#### Homomorphisms of Algebras over Setoids
 
 This is the [Setoid.Homomorphisms.Basic][] module of the [Agda Universal Algebra Library][].
 
@@ -57,7 +57,7 @@ module _ (𝑨 : Algebra α ρᵃ)(𝑩 : Algebra β ρᵇ) where
 
 
 
-#### <a id="monomorphisms-and-epimorphisms">Monomorphisms and epimorphisms</a>
+#### Monomorphisms and epimorphisms
 
 
 ```agda

--- a/src/Setoid/Homomorphisms/Factor.lagda.md
+++ b/src/Setoid/Homomorphisms/Factor.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "agda-algebras development team"
 ---
 
-#### <a id="factoring-homomorphisms-of-setoidalgebra">Factoring Homomorphism of Algebras</a>
+#### Factoring Homomorphism of Algebras
 
 This is the [Setoid.Homomorphisms.Factor][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
+++ b/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-14"
 author: "agda-algebras development team"
 ---
 
-#### <a id="homomorphic-images-of-setoid-algebras">Homomorphic images of setoid algebras</a>
+#### Homomorphic images of setoid algebras
 
 This is the [Setoid.Homomorphisms.HomomorphicImages][] module of the [Agda Universal Algebra Library][].
 
@@ -73,7 +73,7 @@ Sigma type appearing in the second definition. Given an `𝑆`-algebra
 `𝑨 : Algebra α ρ`, the type `HomImages 𝑨` denotes the class `𝒦` of algebras such
 that `𝑩 ∈ 𝒦` provided there is a surjective homomorphism from `𝑨` to `𝑩`.
 
-#### <a id="constructing an algebra from the image of a hom">The image algebra of a hom</a>
+#### The image algebra of a hom
 
 Here we show how to construct a Algebra (called `ImageAlgebra` below) that is
 the image of given hom.
@@ -119,7 +119,7 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
 ```
 
 
-#### <a id="homomorphic-images-of-classes-of-setoid-algebras">Homomorphic images of classes of setoid algebras</a>
+#### Homomorphic images of classes of setoid algebras
 
 Given a class `𝒦` of `𝑆`-algebras, we need a type that expresses the assertion that a given algebra is a homomorphic image of some algebra in the class, as well as a type that represents all such homomorphic images.
 
@@ -133,7 +133,7 @@ HomImageOfClass 𝒦 = Σ[ 𝑩 ∈ Algebra _ _ ] IsHomImageOfClass {𝒦 = 𝒦
 ```
 
 
-#### <a id="lifting-tools">Lifting tools</a>
+#### Lifting tools
 
 Here are some tools that have been useful (e.g., in the road to the proof of Birkhoff's HSP theorem). The first states and proves the simple fact that the lift of an epimorphism is an epimorphism.
 

--- a/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-15"
 author: "agda-algebras development team"
 ---
 
-#### <a id="isomorphisms-of-setoid-algebras">Isomorphisms of setoid algebras</a>
+#### Isomorphisms of setoid algebras
 
 This is the [Setoid.Homomorphisms.Factor][] module of the [Agda Universal Algebra Library][].
 
@@ -98,7 +98,7 @@ module _ (𝑨 : Algebra α ρᵃ) (𝑩 : Algebra β ρᵇ) where
 That is, two structures are *isomorphic* provided there are homomorphisms going back and forth between them which compose to the identity map.
 
 
-#### <a id="properties-of-isomorphisms-of-setoid-algebras">Properties of isomorphism of setoid algebras</a>
+#### Properties of isomorphism of setoid algebras
 
 
 ```agda

--- a/src/Setoid/Homomorphisms/Kernels.lagda.md
+++ b/src/Setoid/Homomorphisms/Kernels.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "agda-algebras development team"
 ---
 
-#### <a id="kernels-of-homomorphisms-of-setoidalgebras">Kernels of Homomorphisms</a>
+#### Kernels of Homomorphisms
 
 This is the [Setoid.Homomorphisms.Kernels][] module of the [Agda Universal Algebra Library][].
 
@@ -95,7 +95,7 @@ ker[ 𝑨 ⇒ 𝑩 ] h = kerquo h
 
 
 
-#### <a id="the-canonical-projection">The canonical projection</a>
+#### The canonical projection
 
 Given an algebra `𝑨` and a congruence `θ`, the *canonical projection* is a map from `𝑨` onto `𝑨 ╱ θ` that is constructed, and proved epimorphic, as follows.
 

--- a/src/Setoid/Homomorphisms/Noether.lagda.md
+++ b/src/Setoid/Homomorphisms/Noether.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-15"
 author: "agda-algebras development team"
 ---
 
-### <a id="homomorphism-theorems">Homomorphism Theorems for Setoid Algebras</a>
+### Homomorphism Theorems for Setoid Algebras
 
 This is the [Setoid.Homomorphisms.Noether][] module of the [Agda Universal Algebra Library][].
 
@@ -39,7 +39,7 @@ private variable α ρᵃ β ρᵇ γ ρᶜ ι : Level
 ```
 
 
-#### <a id="the-first-homomorphism-theorem">The First Homomorphism Theorem for setoid algebras</a>
+#### The First Homomorphism Theorem for setoid algebras
 
 
 ```agda

--- a/src/Setoid/Homomorphisms/Products.lagda.md
+++ b/src/Setoid/Homomorphisms/Products.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-21"
 author: "agda-algebras development team"
 ---
 
-#### <a id="products-of-homomorphisms">Products of Homomorphisms of Algebras</a>
+#### Products of Homomorphisms of Algebras
 
 This is the [Setoid.Homomorphisms.Products][] module of the [Agda Universal Algebra Library][].
 
@@ -95,7 +95,7 @@ a homomorphism from `⨅ 𝒜` to `⨅ ℬ` in the following natural way.
 
 
 
-#### <a id="projections-out-of-products">Projection out of products</a>
+#### Projection out of products
 
 Later we will need a proof of the fact that projecting out of a product algebra
 onto one of its factors is a homomorphism.

--- a/src/Setoid/Homomorphisms/Properties.lagda.md
+++ b/src/Setoid/Homomorphisms/Properties.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-13"
 author: "agda-algebras development team"
 ---
 
-#### <a id="properties-of-homomorphisms-of-setoidalgebras">Properties of Homomorphisms of Algebras</a>
+#### Properties of Homomorphisms of Algebras
 
 This is the [Setoid.Homomorphisms.Properties][] module of the [Agda Universal Algebra Library][].
 
@@ -40,7 +40,7 @@ private variable α β γ ρᵃ ρᵇ ρᶜ ℓ : Level
 ```
 
 
-##### <a id="composition-of-homs">Composition of homs</a>
+##### Composition of homs
 
 
 ```agda
@@ -89,7 +89,7 @@ module _  {𝑨 : Algebra α ρᵃ} {𝑩 : Algebra β ρᵇ} {𝑪 : Algebra γ
 
 
 
-##### <a id="lifting-and-lowering">Lifting and lowering of homs</a>
+##### Lifting and lowering of homs
 
 First we define the identity homomorphism for setoid algebras and then we prove that the operations of lifting and lowering of a setoid algebra are homomorphisms.
 

--- a/src/Setoid/Relations.lagda.md
+++ b/src/Setoid/Relations.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-17"
 author: "the agda-algebras development team"
 ---
 
-## <a id="relations">Relations on setoids</a>
+## Relations on setoids
 
 This is the [Setoid.Relations][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Relations/Continuous.lagda.md
+++ b/src/Setoid/Relations/Continuous.lagda.md
@@ -38,7 +38,7 @@ open import Overture          using ( Op ; arity[_] )
 private variable α ρᵃ ρ ι : Level
 ```
 
-#### <a id="pi-setoid">The Π-setoid construction</a>
+#### The Π-setoid construction
 
 Given an indexing type `I : Type ι` and a family `𝒜 : I → Setoid α ρᵃ`, the indexed-product setoid `⨅ˢ 𝒜` has carrier the dependent function type `(i : I) → Carrier (𝒜 i)` and equivalence the pointwise equivalence `λ a b → ∀ i → _≈_ (𝒜 i) (a i) (b i)`, an equivalence relation by appeal to each `isEquivalence (𝒜 i)`.  The level signature matches `Setoid.Algebras.Products.⨅` exactly; lifting the construction to a named referent means downstream consumers can reference a single canonical Π-setoid rather than rolling it inline at each use site.
 
@@ -103,7 +103,7 @@ The predicates `Π-Respects-Rel` and `Π-Respects-REL` below name this property 
   ∀ {f g} → ((i : I) → _≈_ (𝒜 i) (f i) (g i)) → R f → R g
 ```
 
-#### <a id="compatibility-with-general-relations">Compatibility of operations with continuous relations</a>
+#### Compatibility of operations with continuous relations
 
 The operation `eval-Rel` lifts an `I`-ary relation to an `(I → J)`-ary relation: the lifted relation relates an `I`-tuple of `J`-tuples just in case each `J`-indexed *row* of the tuple-of-tuples (viewed as a `J`-indexed family of `I`-tuples) belongs to the original relation.
 
@@ -121,7 +121,7 @@ compatible-Rel :  {A : Type α}{I J : Type ι}
 compatible-Rel f R = ∀ t → eval-Rel R arity[ f ] t → R (λ i → f (t i))
 ```
 
-#### <a id="compatibility-of-operations-with-dependent-relations">Compatibility of operations with dependent relations</a>
+#### Compatibility of operations with dependent relations
 
 The multi-sorted analogues `eval-REL` and `compatible-REL` mirror the single-sorted versions exactly, with `Rel A I` replaced by `REL I 𝒜` and tuple types replaced by their dependent counterparts.  The definition of `compatible-REL` corrects the buggy form in the legacy module; see the module header.
 

--- a/src/Setoid/Relations/Discrete.lagda.md
+++ b/src/Setoid/Relations/Discrete.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-16"
 author: "the agda-algebras development team"
 ---
 
-### <a id="discrete-relations">Discrete Relations on Setoids</a>
+### Discrete Relations on Setoids
 
 This is the [Setoid.Relations.Discrete][] module of the [Agda Universal Algebra Library][].
 
@@ -55,7 +55,7 @@ is contained in a predicate, the second argument (a "subset" of the codomain).
 ```
 
 
-#### <a id="kernels">Kernels on setoids</a>
+#### Kernels on setoids
 
 Given setoids 𝐴 and 𝐵 (with carriers A and B, resp), the *kernel* of a function `f : 𝐴 ⟶ 𝐵` is defined
 informally by `{(x , y) ∈ A × A : f ⟨$⟩ x ≈₂ f ⟨$⟩ y}`.

--- a/src/Setoid/Relations/Properties.lagda.md
+++ b/src/Setoid/Relations/Properties.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-10"
 author: "the agda-algebras development team"
 ---
 
-### <a id="properties-of-binary-relations">Properties of binary relations</a>
+### Properties of binary relations
 
 This is the [Setoid.Relations.Properties][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Relations/Quotients.lagda.md
+++ b/src/Setoid/Relations/Quotients.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-16"
 author: "the agda-algebras development team"
 ---
 
-### <a id="quotients">Quotients of setoids</a>
+### Quotients of setoids
 
 This is the [Setoid.Relations.Quotients][] module of the [Agda Universal Algebra Library][].
 
@@ -32,7 +32,7 @@ open import Setoid.Relations.Discrete  using ( fker )
 private variable α β ρᵃ ρᵇ ℓ : Level
 ```
 
-#### <a id="kernels">Kernels</a>
+#### Kernels
 
 A prominent example of an equivalence relation is the kernel of any function.
 

--- a/src/Setoid/Subalgebras.lagda.md
+++ b/src/Setoid/Subalgebras.lagda.md
@@ -5,7 +5,7 @@ date : "2021-07-26"
 author: "agda-algebras development team"
 ---
 
-### <a id="subalgebra-setoid-types">Subalgebras over setoids</a>
+### Subalgebras over setoids
 
 This is the [Setoid.Subalgebras][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Subalgebras/Properties.lagda.md
+++ b/src/Setoid/Subalgebras/Properties.lagda.md
@@ -5,7 +5,7 @@ date : "2021-07-18"
 author: "agda-algebras development team"
 ---
 
-#### <a id="properties-of-the-subalgebra-relation">Properties of the subalgebra relation for setoid algebras</a>
+#### Properties of the subalgebra relation for setoid algebras
 
 This is the [Setoid.Subalgebras.Properties][] module of the [Agda Universal Algebra Library][].
 
@@ -142,7 +142,7 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
 
 
 
-#### <a id="lifts-of-subalgebras-of-setoid-algebras">Lifts of subalgebras of setoid algebras</a>
+#### Lifts of subalgebras of setoid algebras
 
 
 ```agda

--- a/src/Setoid/Subalgebras/Subalgebras.lagda.md
+++ b/src/Setoid/Subalgebras/Subalgebras.lagda.md
@@ -5,7 +5,7 @@ date : "2021-07-17"
 author: "agda-algebras development team"
 ---
 
-#### <a id="subalgebras-of-setoidalgebras">Subalgebras of setoid algebras</a>
+#### Subalgebras of setoid algebras
 
 This is the [Setoid.Subalgebras.Subalgebras][] module of the [Agda Universal Algebra Library][].
 
@@ -75,7 +75,7 @@ record SubalgebraREL(R : REL (Algebra β ρᵇ)(Algebra α ρᵃ) ℓ) : Type (o
 
 From now on we will use `𝑩 ≤ 𝑨` to express the assertion that `𝑩` is a subalgebra of `𝑨`.
 
-#### <a id="subalgebras-of-classes-of-algebras">Subalgebras of classes of setoid algebras</a>
+#### Subalgebras of classes of setoid algebras
 
 Suppose `𝒦 : Pred (Algebra α 𝑆) γ` denotes a class of `𝑆`-algebras and
 `𝑩 : Algebra β ρᵇ` denotes an arbitrary `𝑆`-algebra. Then we might wish to
@@ -112,7 +112,7 @@ SubalgebrasOfClass 𝒦 {β}{ρᵇ} = Σ[ 𝑩 ∈ Algebra β ρᵇ ] 𝑩 ≤c 
 
 
 
-#### <a id="consequences-of-first-homomorphism-theorem">Consequences of First Homomorphism Theorem</a>
+#### Consequences of First Homomorphism Theorem
 
 As an example use-case of the `IsSubalgebraOf` type defined above, we prove the
 following easy but useful corollary of the First Homomorphism Theorem (proved

--- a/src/Setoid/Subalgebras/Subuniverses.lagda.md
+++ b/src/Setoid/Subalgebras/Subuniverses.lagda.md
@@ -5,7 +5,7 @@ date : "2021-07-11"
 author: "agda-algebras development team"
 ---
 
-#### <a id="subuniverses-of-setoid-algebras">Subuniverses of setoid algebras</a>
+#### Subuniverses of setoid algebras
 
 This is the [Setoid.Subalgebras.Subuniverses][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Terms.lagda.md
+++ b/src/Setoid/Terms.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-18"
 author: "agda-algebras development team"
 ---
 
-### <a id="terms-on-setoids">Terms on setoids</a>
+### Terms on setoids
 
 This is the [Setoid.Terms][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Terms/Basic.lagda.md
+++ b/src/Setoid/Terms/Basic.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-18"
 author: "agda-algebras development team"
 ---
 
-#### <a id="basic-definitions">Basic definitions</a>
+#### Basic definitions
 
 This is the [Setoid.Terms.Basic][] module of the [Agda Universal Algebra Library][].
 
@@ -44,7 +44,7 @@ private variable
 ```
 
 
-##### <a id="equality-of-terms">Equality of terms</a>
+##### Equality of terms
 
 We take a different approach here, using Setoids instead of quotient types.
 That is, we will define the collection of terms in a signature as a setoid
@@ -92,7 +92,7 @@ cong (Interp (𝑻 X)) (≡.refl , ss≐ts) = gnl ss≐ts
 
 
 
-##### <a id="interpretation-of-terms-in-setoid-algebras">Interpretation of terms in setoid algebras</a>
+##### Interpretation of terms in setoid algebras
 
 The approach to terms and their interpretation in this module was inspired by
 [Andreas Abel's formal proof of Birkhoff's completeness theorem](http://www.cse.chalmers.se/~abela/agda/MultiSortedAlgebra.pdf).

--- a/src/Setoid/Terms/Operations.lagda.md
+++ b/src/Setoid/Terms/Operations.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-25"
 author: "agda-algebras development team"
 ---
 
-#### <a id="term-operations">Term Operations for Setoid Algebras</a>
+#### Term Operations for Setoid Algebras
 
 This section presents the [Setoid.Terms.Operations][] module of the [Agda Universal Algebra Library][].
 
@@ -82,7 +82,7 @@ module _ {X : Type χ} where
 ```
 
 
-#### <a id="interpretation-of-terms-in-product-algebras">Interpretation of terms in product algebras</a>
+#### Interpretation of terms in product algebras
 
 
 ```agda
@@ -100,7 +100,7 @@ module _ {X : Type χ }{I : Type ι}(𝒜 : I → Algebra α ρᵃ) where
 ```
 
 
-#### <a id="compatibility-of-terms">Compatibility of terms</a>
+#### Compatibility of terms
 
 We now prove two important facts about term operations.  The first of these, which is used very often in the sequel, asserts that every term commutes with every homomorphism.
 
@@ -136,7 +136,7 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}(hh : hom 𝑨 𝑩) 
 
 
 
-#### <a id="substitution">Substitution</a>
+#### Substitution
 
 A substitution from `Y` to `X` is simply a function from `Y` to `X`, and the application of a substitution is represented as follows.
 

--- a/src/Setoid/Terms/Properties.lagda.md
+++ b/src/Setoid/Terms/Properties.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-18"
 author: "agda-algebras development team"
 ---
 
-#### <a id="basic-properties">Basic properties of terms on setoids</a>
+#### Basic properties of terms on setoids
 
 This is the [Setoid.Terms.Properties][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Varieties.lagda.md
+++ b/src/Setoid/Varieties.lagda.md
@@ -5,7 +5,7 @@ date : "2021-07-26"
 author: "agda-algebras development team"
 ---
 
-### <a id="equations-and-varieties-for-setoids">Equations and Varieties for Setoids</a>
+### Equations and Varieties for Setoids
 
 This is the [Setoid.Varieties][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Varieties/Closure.lagda.md
+++ b/src/Setoid/Varieties/Closure.lagda.md
@@ -5,7 +5,7 @@ date : "2021-01-14"
 author: "agda-algebras development team"
 ---
 
-#### <a id="closure-operators-for-setoid-algebras">Closure Operators for Setoid Algebras</a>
+#### Closure Operators for Setoid Algebras
 
 Fix a signature 𝑆, let 𝒦 be a class of 𝑆-algebras, and define
 
@@ -97,7 +97,7 @@ module _ {α ρᵃ ℓ ι : Level} where
 ```
 
 
-#### <a id="closure-properties-of-S">Closure properties of S</a>
+#### Closure properties of S
 
 `S` is a closure operator.  The fact that S is expansive won't be needed, so we omit the proof, but we will make use of monotonicity and idempotence of `S`.
 
@@ -127,7 +127,7 @@ Of course, this is proved by establishing two inclusions, but one of them is tri
 
 
 
-#### <a id="closure-properties-of-P">Closure properties of P</a>
+#### Closure properties of P
 
 `P` is a closure operator.  This is proved by checking that `P` is *monotone*, *expansive*, and *idempotent*. The meaning of these terms will be clear from the definitions of the types that follow.
 

--- a/src/Setoid/Varieties/EquationalLogic.lagda.md
+++ b/src/Setoid/Varieties/EquationalLogic.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-24"
 author: "agda-algebras development team"
 ---
 
-### <a id="varieties-model-theory-and-equational-logic">Equational Logic and varieties of setoid algebras</a>
+### Equational Logic and varieties of setoid algebras
 
 This is the [Setoid.Varieties.EquationalLogic][] module of the [Agda Universal Algebra Library][] where the binary "models" relation ⊧, relating algebras (or classes of algebras) to the identities that they satisfy, is defined.
 
@@ -37,7 +37,7 @@ private variable χ α ρᵃ ℓ ι : Level
 ```
 
 
-#### <a id="the-models-relation">The models relation</a>
+#### The models relation
 
 We define the binary "models" relation `⊧` using infix syntax so that we may
 write, e.g., `𝑨 ⊧ p ≈ q` or `𝒦 ⊫ p ≈ q`, relating algebras (or classes of
@@ -71,7 +71,7 @@ this interpretation as `⟦ p ⟧ ρ ≈ ⟦ q ⟧ ρ`. (Recall, and environment
 assignment of values in the domain to variable symbols).
 
 
-#### <a id="equational-theories-and-models">Equational theories and models over setoids</a>
+#### Equational theories and models over setoids
 
 If 𝒦 denotes a class of structures, then `Th 𝒦` represents the set of identities
 modeled by the members of 𝒦.

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -5,7 +5,7 @@ date : "2021-06-29"
 author: "agda-algebras development team"
 ---
 
-#### <a id="free-setoid-algebras">Free setoid algebras</a>
+#### Free setoid algebras
 
 
 ```agda

--- a/src/Setoid/Varieties/HSP.lagda.md
+++ b/src/Setoid/Varieties/HSP.lagda.md
@@ -11,7 +11,7 @@ This is the [Setoid.Varieties.HSP][] module of the [Agda Universal Algebra Libra
 Two other presentations of Birkhoff's theorem live in the source tree, and both reference this module as their canonical source.  [Demos.HSP](https://ualib.org/Demos.HSP.html) is a single-file rendition extracted for the TYPES 2021 paper and retained as a self-contained teaching artifact; its theorem `Var⇒EqCl` plays the role of `Birkhoff` here.  [Legacy.Base.Varieties.FreeAlgebras](https://ualib.org/Legacy.Base.Varieties.FreeAlgebras.html) holds the original bare-types proof, frozen as part of the v3.0 `Base → Legacy.Base` consolidation; new work does not land there.
 
 
-#### <a id="the-hsp-theorem">The HSP Theorem</a>
+#### The HSP Theorem
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
@@ -185,7 +185,7 @@ that `𝔽[ X ]` is a subalgebra of the *lift* of `ℭ`, denoted `ℓℭ`.
 ```
 
 
-#### <a id="proof-of-the-hsp-theorem">Proof of the HSP theorem</a>
+#### Proof of the HSP theorem
 
 Finally, we are in a position to prove Birkhoff's celebrated variety theorem.
 

--- a/src/Setoid/Varieties/Invariants.lagda.md
+++ b/src/Setoid/Varieties/Invariants.lagda.md
@@ -5,7 +5,7 @@ date : "2026-05-10"
 author: "agda-algebras development team"
 ---
 
-### <a id="algebraic-invariants-for-setoid-algebras">Algebraic invariants for setoid algebras</a>
+### Algebraic invariants for setoid algebras
 
 This is the [Setoid.Varieties.Invariants][] module of the [Agda Universal Algebra Library][].
 

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-24"
 author: "agda-algebras development team"
 ---
 
-### <a id="Equation preservation">Equation preservation for setoid algebras</a>
+### Equation preservation for setoid algebras
 
 This is the [Setoid.Varieties.Preservation][] module of the [Agda Universal Algebra Library][] where we show
 that the classes \af H `𝒦`{.AgdaBound}, \af S `𝒦`{.AgdaBound}, \af P `𝒦`{.AgdaBound}, and \af V `𝒦`{.AgdaBound} all satisfy the
@@ -56,7 +56,7 @@ open Algebra  using ( Domain )
 
 
 
-#### <a id="closure-properties">Closure properties</a>
+#### Closure properties
 
 The types defined above represent operators with useful closure properties. We now
 prove a handful of such properties that we need later.
@@ -109,7 +109,7 @@ in a class 𝒦 is a subalgebra of a product of algebras in 𝒦.
 ```
 
 
-#### <a id="h-preserves-identities">H preserves identities</a>
+#### H preserves identities
 
 First we prove that the closure operator H is compatible with identities that hold in the given class.
 
@@ -136,7 +136,7 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 
-#### <a id="s-preserves-identities">S preserves identities</a>
+#### S preserves identities
 
 
 ```agda
@@ -150,7 +150,7 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 
-#### <a id="p-preserves-identities">P preserves identities</a>
+#### P preserves identities
 
 
 ```agda
@@ -168,7 +168,7 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 
-#### <a id="v-preserves-identities">V preserves identities</a>
+#### V preserves identities
 
 Finally, we prove the analogous preservation lemmas for the closure operator `V`.
 
@@ -204,7 +204,7 @@ module _  {α ρᵃ ℓ ι χ : Level}
 
 
 
-#### <a id="class-identities">Class identities</a>
+#### Class identities
 
 From `V-id1` it follows that if 𝒦 is a class of structures, then the set of identities
 modeled by all structures in `𝒦` is equivalent to the set of identities modeled by all

--- a/src/Setoid/Varieties/Properties.lagda.md
+++ b/src/Setoid/Varieties/Properties.lagda.md
@@ -5,7 +5,7 @@ date : "2021-09-24"
 author: "agda-algebras development team"
 ---
 
-### <a id="properties-of-the-models-relation">Properties of the models relation for setoid algebras</a>
+### Properties of the models relation for setoid algebras
 
 We prove some closure and invariance properties of the relation `⊧`.  In particular, we prove the following facts (which are needed, for example, in the proof the Birkhoff HSP Theorem).
 
@@ -56,7 +56,7 @@ open Algebra  using ( Domain )
 
 
 
-#### <a id="algebraic-invariance-of-models">Algebraic invariance of ⊧</a>
+#### Algebraic invariance of ⊧
 
 The binary relation ⊧ would be practically useless if it were not an *algebraic invariant* (i.e., invariant under isomorphism).
 
@@ -95,7 +95,7 @@ module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}(𝑩 : Algebra β ρᵇ)(p q : T
 As the proof makes clear, we show `𝑩 ⊧ p ≈ q` by showing that `𝑩 ⟦ p ⟧ ≡ 𝑩 ⟦ q ⟧`
 holds *extensionally*, that is, `∀ x, 𝑩 ⟦ p ⟧ x ≡ 𝑩 ⟦q ⟧ x`.
 
-#### <a id="lift-invariance">Lift-invariance of ⊧</a>
+#### Lift-invariance of ⊧ {#lift-invariance}
 The ⊧ relation is also invariant under the algebraic lift and lower operations.
 
 
@@ -110,7 +110,7 @@ module _ {X : Type χ}{𝑨 : Algebra α ρᵃ} where
 ```
 
 
-#### <a id="homomorphic-invariance">Homomorphic invariance of ⊧</a>
+#### Homomorphic invariance of ⊧
 Identities modeled by an algebra `𝑨` are also modeled by every homomorphic image
 of `𝑨`, which fact can be formalized as follows.
 
@@ -138,7 +138,7 @@ module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}{p q : T
 
 
 
-#### <a id="subalgebraic-invariance">Subalgebraic invariance of ⊧</a>
+#### Subalgebraic invariance of ⊧ {#subalgebraic-invariance}
 Identities modeled by an algebra `𝑨` are also modeled by every subalgebra of `𝑨`, which fact can be formalized as follows.
 
 
@@ -184,7 +184,7 @@ module _ {X : Type χ}{p q : Term X} where
 
 
 
-#### <a id="product-invariance">Product invariance of ⊧</a>
+#### Product invariance of ⊧ {#product-invariance}
 
 An identity satisfied by all algebras in an indexed collection is also satisfied
 by the product of algebras in that collection.
@@ -240,7 +240,7 @@ algebras models (p ≈̇ q) if the lift of each algebra in the collection models
 
 
 
-#### <a id="homomorphisc-invariance">Homomorphic invariance of ⊧</a>
+#### Homomorphic invariance of ⊧
 
 If an algebra 𝑨 models an identity (p ≈̇ q), then the pair (p , q) belongs to the
 kernel of every homomorphism φ : hom (𝑻 X) 𝑨 from the term algebra to 𝑨; that is,

--- a/src/Setoid/Varieties/Properties.lagda.md
+++ b/src/Setoid/Varieties/Properties.lagda.md
@@ -56,7 +56,7 @@ open Algebra  using ( Domain )
 
 
 
-#### Algebraic invariance of ⊧
+#### Algebraic invariance of ⊧ {#algebraic-invariance}
 
 The binary relation ⊧ would be practically useless if it were not an *algebraic invariant* (i.e., invariant under isomorphism).
 
@@ -240,7 +240,7 @@ algebras models (p ≈̇ q) if the lift of each algebra in the collection models
 
 
 
-#### Homomorphic invariance of ⊧
+#### Modeled identities and homomorphism kernels
 
 If an algebra 𝑨 models an identity (p ≈̇ q), then the pair (p , q) belongs to the
 kernel of every homomorphism φ : hom (𝑻 X) 𝑨 from the term algebra to 𝑨; that is,

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -5,7 +5,7 @@ date : "2021-01-14"
 author: "agda-algebras development team"
 ---
 
-#### <a id="entailment-derivation-rules-soundness-and-completeness">Entailment, derivation rules, soundness and completeness</a>
+#### Entailment, derivation rules, soundness and completeness
 
 This is the [Setoid.Varieties.SoundAndComplete][] module of the [Agda Universal Algebra Library][].
 
@@ -105,7 +105,7 @@ module _ {α}{ρᵃ}{ι}{I : Type ι} where
 
 
 
-##### <a id="derivations-in-a-context">Derivations in a context</a>
+##### Derivations in a context
 
 (Based on [Andreas Abel's Agda formalization of Birkhoff's completeness theorem](http://www.cse.chalmers.se/~abela/agda/MultiSortedAlgebra.pdf).)
 
@@ -126,7 +126,7 @@ module _ {χ ι : Level} where
 ```
 
 
-##### <a id="soundness-of-the-inference-rules">Soundness of the inference rules</a>
+##### Soundness of the inference rules
 
 (Based on [Andreas Abel's Agda formalization of Birkhoff's completeness theorem](see: http://www.cse.chalmers.se/~abela/agda/MultiSortedAlgebra.pdf).)
 
@@ -170,7 +170,7 @@ The converse is Birkhoff's completeness theorem: if Mod E ⊫ p ≈ q, then E �
 We will prove that result next.
 
 
-##### <a id="birkhoffs-completeness-theorem">Birkhoff's completeness theorem</a>
+##### Birkhoff's completeness theorem
 
 The proof proceeds by constructing a relatively free algebra consisting of term
 quotiented by derivable equality E ⊢ X ▹ _≈_.  It then suffices to prove


### PR DESCRIPTION
Closes #387.  Removes the HTML `<a id="…">` heading-anchor wrappers across the live trees, relying on kramdown's auto-generated heading slugs (per `docs/STYLE_GUIDE.md` § Section headings).  Doc-only (headings are outside `agda` fences); `make check` passes.  Rebased onto current master (post-#384).

## What changed

+  **263 anchors processed across the live trees**: 259 stripped to plain ATX headings; **4 preserved** as explicit kramdown attribute-list ids `{#id}` because the id is cross-referenced and its auto-slug would otherwise differ —
   +  `Setoid.Varieties.Properties`: `{#lift-invariance}`, `{#subalgebraic-invariance}`, `{#product-invariance}`;
   +  `Overture.Terms`: `{#terms}`.
+  **`Demos/HSP` is exempt** — a frozen artifact mirroring the published TYPES 2021 paper, whose section anchors may be linked externally (beyond this repo's detection); its 37 anchors are left intact.
+  Adds `scripts/python/remove_heading_anchors.py`, the re-runnable sweep tool (excludes `Legacy/` and `Demos/HSP`).
+  Folds in a fix for two pre-existing `Setoid.Varieties.Properties` issues the sweep surfaced (commit `2ed4239`): the dangling `#algebraic-invariance` TOC link (now pinned with `{#algebraic-invariance}`), and a duplicate "Homomorphic invariance of ⊧" heading — the second, which proves `⊧-H-ker`, is re-titled **"Modeled identities and homomorphism kernels"**.

## Algorithm (per `<level> <a id="TAG">TEXT</a>`)

+  `slug(TEXT) == TAG` → strip (the auto-slug reproduces the id, so `#TAG` links still resolve).
+  `slug ≠ TAG` and `TAG` not cross-referenced → strip.
+  `slug ≠ TAG` and `TAG` cross-referenced → keep `<level> TEXT {#TAG}`.

`slug` is kramdown's `generate_id`; cross-references are collected repo-wide (`src/` + `docs/`).

## Verified

+  No `<a id=` remains outside `src/Legacy/**` and the exempt `src/Demos/HSP.lagda.md`.
+  Cross-references resolve repo-wide: the only same-document TOC (`Setoid.Varieties.Properties`) and the `Overture.Preface` → `…HSP.html#proof-of-the-hsp-theorem` link; no `href`, `](#…)`, or `[label]: …#…` target points at a stripped anchor.
+  `make check` passes; `Legacy/` untouched.

https://claude.ai/code/session_01W8hSNrhEgagBfHMEotb9TM