### PR TITLE
[M4-3] Settle 𝓞/𝓥 universe-variable scope: ADR-005 + cleanup (#269)

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -424,7 +424,7 @@ variable 𝓞 𝓥 : Level
 
 Every signature-parametrized module imports these by name from `Overture`.  Never re-declare them as `variable` in a downstream module.
 
-The design-discussion question of whether `𝓞` and `𝓥` should be `private variable` (forcing downstream modules to re-declare) or left as public `variable` is tracked in **M4-3**.  Until that issue is resolved, the rule is: leave `𝓞`/`𝓥` as public `variable`s in `Overture.Signatures` and import them by name.
+This convention is settled by [ADR-005](adr/005-universe-level-variable-scope.md): `𝓞` and `𝓥` remain public `variable`s in `Overture.Signatures`, co-located with the `Signature` type whose levels they name, and downstream modules import them by name.  Options 2 (`private` + re-declare downstream) and 3 (a dedicated `Overture.UniverseLevels` module) were weighed and rejected there.
 
 ### Other level variables
 

--- a/docs/adr/005-universe-level-variable-scope.md
+++ b/docs/adr/005-universe-level-variable-scope.md
@@ -1,0 +1,45 @@
+<!-- File: docs/adr/005-universe-level-variable-scope.md -->
+
+# ADR-005: Scope of the `𝓞` / `𝓥` universe-level variables
+
+## Status
+
+Proposed — 2026-06-06 (M4-3).
+
+## Context
+
+`𝓞` and `𝓥` are not generic level variables.  They are *semantically charged*: throughout the library `𝓞` denotes the universe level of a signature's *operation-symbol* type and `𝓥` the level of its *arity* type.  The convention is load-bearing — `Signature 𝓞 𝓥`, `Op`, `Term`, the `ov` shorthand, and every signature-parametrized module read against it — and the style guide already states that "using `𝓞` or `𝓥` for anything else is a bug."
+
+They are currently declared once, as a *public* (non-`private`) `variable 𝓞 𝓥 : Level` in `Overture.Signatures`, co-located with the `Signature` type whose two levels they name, and re-exported through the `Overture` umbrella.  Signature-parametrized modules pull them in by name (`open import Overture using ( 𝓞 ; 𝓥 ; Signature )`).  Being public, they are also in scope wherever `Overture` is opened without a `using` filter — which the style guide confines to umbrella aggregators.  The convenience is real, but a public `variable` can be shadowed by a careless local declaration, and a newcomer may not immediately know where an unqualified `𝓞` came from.
+
+A decision is forced now (M4-3) by a second, concrete problem: the handling is **not uniform**.  Although the style guide says "never re-declare them," `𝓥` is in fact re-declared as a `private variable` in `Overture.Operations` and `Setoid.Relations.Discrete` (and in several frozen `Legacy/Base/*` modules), drifting from the canonical declaration.  Issue #269 asks that `𝓞` / `𝓥` be handled uniformly and the rule recorded.  Three options were on the table:
+
+1.  Keep `𝓞` / `𝓥` as a single public `variable` in `Overture.Signatures`; document the rule and import them by name.
+2.  Make them `private` in `Overture.Signatures`; every downstream module re-declares its own `variable 𝓞 𝓥 : Level`.
+3.  Move them to a dedicated `Overture.UniverseLevels` module, imported explicitly.
+
+## Decision
+
+Adopt **Option 1**.  `𝓞` and `𝓥` remain a single public `variable 𝓞 𝓥 : Level` declared in `Overture.Signatures`, co-located with the `Signature` type whose levels they name; downstream modules import them by name from `Overture` (or `Overture.Signatures`) and never re-declare them.  Using either name for anything other than its charged meaning remains a bug.
+
+Applying this uniformly (issue #269's second acceptance criterion) means converting the live-tree drift sites — the `private variable … 𝓥 …` declarations in `Overture.Operations` and `Setoid.Relations.Discrete` — to import the canonical `𝓥` instead.  The frozen `Legacy/Base/*` tree is out of scope per ADR-001 and the M4 audit; its local re-declarations are left untouched.  The style-guide section "The `𝓞` / `𝓥` convention" is updated to drop the "tracked in M4-3 / interim" hedge and state the rule as settled.
+
+## Consequences
+
++  **One canonical declaration, co-located with its meaning**.  A reader who lands on `Signature 𝓞 𝓥` finds the two levels, their charged semantics, and the prose explaining them in the same module — the "one canonical form per concept" principle applied to a convention rather than a definition.
++  **Lowest churn of the three options, and it ratifies the de-facto rule**.  The style guide already mandates Option 1's behavior as an interim rule, so this decision only removes the "interim" hedge and fixes the two live drift sites; no `using ( 𝓞 ; 𝓥 ; Signature )` import is touched.
++  **The common case stays a one-line import**.  Signature-parametrized modules — the majority — need `Signature` together with its two levels, so a single `open import Overture using ( 𝓞 ; 𝓥 ; Signature )` is exactly right.
++  **The public `variable` is not leak-proof** (negative).  It stays in scope under a bare `open import Overture`, so a local declaration can shadow it.  This is mitigated, not eliminated: the `using`-list discipline confines bare opens to umbrella aggregators, and the "never re-declare / off-convention-use-is-a-bug" rules become settled policy instead of an open question.
++  **A levels-only consumer acquires a `Signatures` dependency** (negative).  A module that needs `𝓥` but not `Signature` — `Overture.Operations`, whose `Op` indexes by an arity level — must import the level from `Overture.Signatures`, coupling two small foundational modules (acyclically).  Option 3 would have avoided this edge.
+
+## Alternatives considered
+
++  **Option 2 — `private` in `Overture.Signatures`, re-declare downstream**.  Rejected.  It fragments a single charged convention across dozens of modules, contradicting "one canonical form per concept"; it reverses the existing "never re-declare" rule; it carries the widest blast radius (boilerplate in every signature-parametrized module, and every `using ( 𝓞 ; 𝓥 )` import removed); and it makes "off-convention use is a bug" harder to police once the names are declared locally everywhere.  Its one merit — matching stdlib's per-module `private variable` idiom — does not transfer, because stdlib's `a` / `ℓ` are generic whereas `𝓞` / `𝓥` carry fixed meaning.
++  **Option 3 — dedicated `Overture.UniverseLevels` module**.  Considered; the closest runner-up.  It keeps one source of truth, makes the import self-documenting (`open import Overture.UniverseLevels using ( 𝓞 ; 𝓥 )`), and lets a levels-only consumer avoid depending on `Overture.Signatures`.  Rejected as the primary choice because it decouples the `𝓞` / `𝓥` semantics from the `Signature` type they describe (where co-location most helps a reader); it makes the common signature-parametrized case a two-import affair rather than one; it does not actually remove the leak unless the `Overture` umbrella also stops re-exporting the new module — trading the leak for churn at every call site and a less convenient API; and a whole module for two `variable` declarations is marginal over-engineering.  It remains the natural fallback if the decoupling or full leak-elimination is later judged worth the cost.
+
+## References
+
++  Issue M4-3 — [Design discussion: scope of `𝓞` and `𝓥`](https://github.com/ualib/agda-algebras/issues/269).
++  `docs/STYLE_GUIDE.md` — sections "The `𝓞` / `𝓥` convention" (the interim rule this ADR settles) and "Other level variables".
++  `src/Overture/Signatures.lagda.md` — the declaration site and the co-located semantics prose.
++  ADR-001 — Setoid as canonical tree; the `Legacy/Base/` freeze that scopes Legacy out of the uniformity sweep.

--- a/docs/adr/005-universe-level-variable-scope.md
+++ b/docs/adr/005-universe-level-variable-scope.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-Proposed — 2026-06-06 (M4-3).
+Accepted — 2026-06-06 (M4-3).
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,7 +35,7 @@ ADRs are **append-only**.  Once accepted, the body text is not edited except to 
 +  [ADR-002 — Classical structures layer: Σ-typed core with record-typed bundle views](002-classical-layer-design.md)
 +  [ADR-003 — Cubical Agda as the canonical long-term target](003-cubical-canonical-target.md)
 +  [ADR-004 — Markdown-literate Agda as the canonical literate format](004-lagda-md-canonical.md)
-+  [ADR-005 — Scope of the `𝓞` / `𝓥` universe-level variables](005-universe-level-variable-scope.md) *(proposed)*
++  [ADR-005 — Scope of the `𝓞` / `𝓥` universe-level variables](005-universe-level-variable-scope.md)
 
 ## When to write an ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ ADRs are **append-only**.  Once accepted, the body text is not edited except to 
 +  [ADR-002 — Classical structures layer: Σ-typed core with record-typed bundle views](002-classical-layer-design.md)
 +  [ADR-003 — Cubical Agda as the canonical long-term target](003-cubical-canonical-target.md)
 +  [ADR-004 — Markdown-literate Agda as the canonical literate format](004-lagda-md-canonical.md)
++  [ADR-005 — Scope of the `𝓞` / `𝓥` universe-level variables](005-universe-level-variable-scope.md) *(proposed)*
 
 ## When to write an ADR
 

--- a/src/Overture/Operations.lagda.md
+++ b/src/Overture/Operations.lagda.md
@@ -31,7 +31,10 @@ module Overture.Operations where
 open import Agda.Primitive               using () renaming ( Set to Type )
 open import Level                        using ( Level ; _⊔_ )
 
-private variable a b ρ 𝓥 : Level
+-- Imports from the Agda Universal Algebra Library -----------------------------
+open import Overture.Signatures          using ( 𝓥 )
+
+private variable a b ρ : Level
 
 -- The type of I-ary operations on A.  Arity first, carrier second, so that
 -- `Op (Fin 2)` partially applies as "the type of binary operations on any A".

--- a/src/Overture/Operations.lagda.md
+++ b/src/Overture/Operations.lagda.md
@@ -15,12 +15,12 @@ purposes.
 The first of these is `𝓞` which we used in the [Overture.Signatures][]
 as the universe of the type of *operation symbols* of a signature.
 
-The second is `𝓥` which we reserve for types representing *arities* of relations or operations.
+The second is `𝓥` which we reserve for types representing *arities* of relations or
+operations.
 
 The type `Op` encodes the arity of an operation as an arbitrary type `I : Type 𝓥`,
 which gives us a very general way to represent an operation as a function type with
 domain `I → A` (the type of "tuples") and codomain `A`.
-
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
@@ -37,14 +37,13 @@ open import Overture.Signatures          using ( 𝓥 )
 private variable a b ρ : Level
 
 -- The type of I-ary operations on A.  Arity first, carrier second, so that
--- `Op (Fin 2)` partially applies as "the type of binary operations on any A".
+-- `Op (Fin 2)` partially applies as "the type of binary operations" on any given A.
 Op : Type 𝓥 → Type a → Type (a ⊔ 𝓥)
 Op I A = (I → A) → A
 ```
 
-
-For example, the `I`-*ary projection operations* on `A` are represented as inhabitants of the type `Op I A` as follows.
-
+For example, the `I`-*ary projection operations* on `A` are represented as
+inhabitants of the type `Op I A` as follows.
 
 ```agda
 -- Example (projections)
@@ -52,16 +51,13 @@ For example, the `I`-*ary projection operations* on `A` are represented as inhab
 π i = λ x → x i
 ```
 
-
 Occasionally we want to extract the arity of a given operation symbol.
-
 
 ```agda
 -- return the arity of a given operation symbol
 arity[_] : {I : Type 𝓥} {A : Type a } → Op I A → Type 𝓥
 arity[_] {I = I} f = I
 ```
-
 
 -----------
 

--- a/src/Setoid/Relations/Discrete.lagda.md
+++ b/src/Setoid/Relations/Discrete.lagda.md
@@ -31,7 +31,7 @@ open import Relation.Binary.PropositionalEquality
 -- Imports from agda-algebras -------------------------------------------------------------------
 open import Overture using ( Π-syntax )
 
-private variable α β ρᵃ ρᵇ ℓ 𝓥 : Level
+private variable α β ρᵃ ρᵇ ℓ : Level
 ```
 
 Here is a function that is useful for defining poitwise equality of functions wrt a given equality.

--- a/src/Setoid/Relations/Discrete.lagda.md
+++ b/src/Setoid/Relations/Discrete.lagda.md
@@ -32,7 +32,7 @@ open import Overture using ( Π-syntax )
 private variable α β ρᵃ ρᵇ ℓ : Level
 ```
 
-Here is a function that is useful for defining poitwise equality of functions wrt a
+Here is a function that is useful for defining pointwise equality of functions wrt a
 given equality.
 
 ```agda

--- a/src/Setoid/Relations/Discrete.lagda.md
+++ b/src/Setoid/Relations/Discrete.lagda.md
@@ -15,18 +15,16 @@ This is the [Setoid.Relations.Discrete][] module of the [Agda Universal Algebra 
 module Setoid.Relations.Discrete where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------------------------
-open import Agda.Primitive        using () renaming ( Set to Type )
-open import Data.Product          using ( _,_ ; _×_ )
-open import Function              using ( _∘_ ) renaming ( Func to _⟶_ )
-open import Level                 using ( Level ;  _⊔_ ; Lift )
-open import Relation.Binary       using ( IsEquivalence ; Setoid )
-open import Relation.Binary.Core  using ( _⇒_ ; _=[_]⇒_ )
-                                  renaming ( REL to BinREL ; Rel to BinRel )
-open import Relation.Binary.Definitions
-                                  using ( Reflexive ; Transitive )
-open import Relation.Unary        using ( _∈_; Pred )
-open import Relation.Binary.PropositionalEquality
-                                  using ( _≡_ )
+open import Agda.Primitive               using () renaming ( Set to Type )
+open import Data.Product                 using ( _,_ ; _×_ )
+open import Function                     using ( _∘_ ) renaming ( Func to _⟶_ )
+open import Level                        using ( Level ;  _⊔_ ; Lift )
+open import Relation.Binary              using ( IsEquivalence ; Setoid )
+open import Relation.Binary.Core         using ( _⇒_ ; _=[_]⇒_ )
+                                         renaming ( REL to BinREL ; Rel to BinRel )
+open import Relation.Binary.Definitions  using ( Reflexive ; Transitive )
+open import Relation.Unary               using ( _∈_; Pred )
+open import Relation.Binary.PropositionalEquality using ( _≡_ )
 
 -- Imports from agda-algebras -------------------------------------------------------------------
 open import Overture using ( Π-syntax )
@@ -34,47 +32,48 @@ open import Overture using ( Π-syntax )
 private variable α β ρᵃ ρᵇ ℓ : Level
 ```
 
-Here is a function that is useful for defining poitwise equality of functions wrt a given equality.
+Here is a function that is useful for defining poitwise equality of functions wrt a
+given equality.
 
 ```agda
 open _⟶_ renaming ( to to _⟨$⟩_ )
 module _ {𝐴 : Setoid α ρᵃ}{𝐵 : Setoid β ρᵇ} where
- open Setoid 𝐴  using () renaming ( Carrier to A ; _≈_ to _≈₁_ )
- open Setoid 𝐵  using () renaming ( Carrier to B ; _≈_ to _≈₂_ )
+  open Setoid 𝐴  using () renaming ( Carrier to A ; _≈_ to _≈₁_ )
+  open Setoid 𝐵  using () renaming ( Carrier to B ; _≈_ to _≈₂_ )
 
- function-equality : BinRel (𝐴 ⟶ 𝐵) (α ⊔ ρᵇ)
- function-equality f g = ∀ x → f ⟨$⟩ x ≈₂ g ⟨$⟩ x
+  function-equality : BinRel (𝐴 ⟶ 𝐵) (α ⊔ ρᵇ)
+  function-equality f g = ∀ x → f ⟨$⟩ x ≈₂ g ⟨$⟩ x
 ```
 
 Here is useful notation for asserting that the image of a function (the first argument)
 is contained in a predicate, the second argument (a "subset" of the codomain).
 
 ```agda
- Im_⊆_ : (𝐴 ⟶ 𝐵) → Pred B ℓ → Type (α ⊔ ℓ)
- Im f ⊆ S = ∀ x → f ⟨$⟩ x ∈ S
+  Im_⊆_ : (𝐴 ⟶ 𝐵) → Pred B ℓ → Type (α ⊔ ℓ)
+  Im f ⊆ S = ∀ x → f ⟨$⟩ x ∈ S
 ```
 
 
 #### Kernels on setoids
 
-Given setoids 𝐴 and 𝐵 (with carriers A and B, resp), the *kernel* of a function `f : 𝐴 ⟶ 𝐵` is defined
-informally by `{(x , y) ∈ A × A : f ⟨$⟩ x ≈₂ f ⟨$⟩ y}`.
+Given setoids 𝐴 and 𝐵 (with carriers A and B, resp), the *kernel* of a function `f :
+𝐴 ⟶ 𝐵` is defined informally by `{(x , y) ∈ A × A : f ⟨$⟩ x ≈₂ f ⟨$⟩ y}`.
 
 ```agda
- fker : (𝐴 ⟶ 𝐵) → BinRel A ρᵇ
- fker g x y = g ⟨$⟩ x ≈₂ g ⟨$⟩ y
+  fker : (𝐴 ⟶ 𝐵) → BinRel A ρᵇ
+  fker g x y = g ⟨$⟩ x ≈₂ g ⟨$⟩ y
 
- fkerPred : (𝐴 ⟶ 𝐵) → Pred (A × A) ρᵇ
- fkerPred g (x , y) = g ⟨$⟩ x ≈₂ g ⟨$⟩ y
+  fkerPred : (𝐴 ⟶ 𝐵) → Pred (A × A) ρᵇ
+  fkerPred g (x , y) = g ⟨$⟩ x ≈₂ g ⟨$⟩ y
 
- open IsEquivalence
+  open IsEquivalence
 
- fkerlift : (𝐴 ⟶ 𝐵) → (ℓ : Level) → BinRel A (ℓ ⊔ ρᵇ)
- fkerlift g ℓ x y = Lift ℓ (g ⟨$⟩ x ≈₂ g ⟨$⟩ y)
+  fkerlift : (𝐴 ⟶ 𝐵) → (ℓ : Level) → BinRel A (ℓ ⊔ ρᵇ)
+  fkerlift g ℓ x y = Lift ℓ (g ⟨$⟩ x ≈₂ g ⟨$⟩ y)
 
- -- The *identity relation* (equivalently, the kernel of a 1-to-1 function)
- 0rel : {ℓ : Level} → BinRel A (ρᵃ ⊔ ℓ)
- 0rel {ℓ} = λ x y → Lift ℓ (x ≈₁ y)
+  -- The *identity relation* (equivalently, the kernel of a 1-to-1 function)
+  0rel : {ℓ : Level} → BinRel A (ρᵃ ⊔ ℓ)
+  0rel {ℓ} = λ x y → Lift ℓ (x ≈₁ y)
 ```
 
 --------------------------------------


### PR DESCRIPTION
## Summary

Resolves the M4-3 design discussion (#269): how to handle the semantically-charged `𝓞` (operation-symbol level) and `𝓥` (arity level) universe variables, which were declared as a public `variable` in `Overture.Signatures` and leak through every downstream module.

The decision, recorded in **ADR-005** and ratified here, is **Option 1**: keep `𝓞` / `𝓥` as a single public `variable` in `Overture.Signatures`, co-located with the `Signature` type whose levels they name; downstream modules import them by name and never re-declare them.  Option 2 (`private` + re-declare downstream) and Option 3 (a dedicated `Overture.UniverseLevels` module) were weighed and rejected in the ADR.

## Why Option 1

+  `𝓞` / `𝓥` are *semantically charged*, not generic levels, so a single canonical declaration matters more than for stdlib's `a` / `ℓ` — this is "one canonical form per concept" applied to a convention.
+  Co-locating the declaration with `Signature` keeps the levels, their semantics, and the explanatory prose in one module.
+  It ratifies the de-facto rule the STYLE_GUIDE already mandated as the interim rule, so it is the lowest-churn option.
+  The leak is controlled by the `using`-list discipline, and the residual shadowing risk is mitigated by the now-settled "never re-declare" rule.

## Changes

+  **`docs/adr/005-universe-level-variable-scope.md`** — new ADR (status Accepted) writing up the three options, the decision, consequences, and the rejected alternatives.
+  **`docs/adr/README.md`** — index entry for ADR-005.
+  **`docs/STYLE_GUIDE.md`** — the "`𝓞` / `𝓥` convention" section drops the "tracked in M4-3 / interim" hedge and links the settled ADR.
+  **`src/Overture/Operations.lagda.md`** — import the canonical `𝓥` from `Overture.Signatures` instead of re-declaring it in a `private variable` block.
+  **`src/Setoid/Relations/Discrete.lagda.md`** — drop a dead `private … 𝓥` that was declared but never used.

`Legacy/Base/*` re-declarations are left untouched (frozen per ADR-001 and out of the M4 sweep).

## Acceptance criteria (#269)

+  [x] Decision recorded (ADR-005 + STYLE_GUIDE section).
+  [x] `𝓞` and `𝓥` handled uniformly across the live library; the two drift sites are converted and none remain outside frozen `Legacy/`.

## Verification

`make check` passes across the whole tree (176 live + 68 Legacy modules), with only the pre-existing `Legacy/` deprecation warnings.

Closes #269.

https://claude.ai/code/session_01Vj5HPxkgaiTt1jCLcipyRT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj5HPxkgaiTt1jCLcipyRT)_