### PR TITLE
[M4-5a] Strengthen reduct functoriality to strict (args-free) ≡; pointwise corollaries

### DIFF
--- a/src/Classical/Structures/Reduct.lagda.md
+++ b/src/Classical/Structures/Reduct.lagda.md
@@ -92,24 +92,36 @@ reductBy = reduct ∘₂ mkSigMorphism
 #### Functoriality
 
 `reduct` is functorial in the signature morphism, contravariantly: it preserves the identity
-and turns a composite into the *reversed* composite of reducts.  Under `--safe` these are
-stated *operation-wise* — the agreement the chosen hom-equality `_≡_` gives (ADR-006).  Each
-reduct keeps `𝑨`'s carrier definitionally, and the interpretation of every operation symbol
-agrees by `refl` (the position-map compositions reduce by η).  Full propositional equality of
-the *algebras* is not available under `--safe`: equating the setoid-congruence proof field
-would need funext — which is exactly the carrier-vs-operations split the M4-5a acceptance
-criteria anticipate.
+and turns a composite into the *reversed* composite of reducts.  Following the strict-first
+discipline, each law is stated at the level of an operation's *interpretation function*
+(`o ^ reduct … ≡ o ^ …`, with no argument tuple applied) and holds by `refl`; the conventional
+`args`-applied functoriality statement is the corollary directly below each (also `refl` — it
+is the strict law specialized to an argument tuple).  This is the strongest equality `--safe`
+affords short of equating the *algebras* themselves, which would need funext for the
+`Interp.cong` field.
 
 ```agda
 reduct-id : {𝑨 : Algebra {𝑆 = 𝑆} α ρ} {o : OperationSymbolsOf 𝑆}
-  {args : ArityOf 𝑆 o → 𝕌[ 𝑨 ]} → (o ^ reduct id-morphism 𝑨) args ≡ (o ^ 𝑨) args
+          → o ^ reduct id-morphism 𝑨 ≡ o ^ 𝑨
 reduct-id = refl
 
+reduct-id-ptw : {𝑨 : Algebra {𝑆 = 𝑆} α ρ} {o : OperationSymbolsOf 𝑆}
+                (args : ArityOf 𝑆 o → 𝕌[ 𝑨 ])
+              → (o ^ reduct id-morphism 𝑨) args ≡ (o ^ 𝑨) args
+reduct-id-ptw _ = refl
+
 reduct-∘ : {𝑆₁ 𝑆₂ 𝑆₃ : Signature 𝓞 𝓥}
-  {φ : SigMorphism 𝑆₁ 𝑆₂} {ψ : SigMorphism 𝑆₂ 𝑆₃}
-  {𝑨 : Algebra {𝑆 = 𝑆₃} α ρ} {o : OperationSymbolsOf 𝑆₁} {args : ArityOf 𝑆₁ o → 𝕌[ 𝑨 ]}
-  → (o ^ reduct (ψ ∘ₛ φ) 𝑨) args ≡ (o ^ reduct φ (reduct ψ 𝑨)) args
+           {φ : SigMorphism 𝑆₁ 𝑆₂} {ψ : SigMorphism 𝑆₂ 𝑆₃}
+           {𝑨 : Algebra {𝑆 = 𝑆₃} α ρ} {o : OperationSymbolsOf 𝑆₁}
+         → o ^ reduct (ψ ∘ₛ φ) 𝑨 ≡ o ^ reduct φ (reduct ψ 𝑨)
 reduct-∘ = refl
+
+reduct-∘-ptw : {𝑆₁ 𝑆₂ 𝑆₃ : Signature 𝓞 𝓥}
+               {φ : SigMorphism 𝑆₁ 𝑆₂} {ψ : SigMorphism 𝑆₂ 𝑆₃}
+               {𝑨 : Algebra {𝑆 = 𝑆₃} α ρ} {o : OperationSymbolsOf 𝑆₁}
+               (args : ArityOf 𝑆₁ o → 𝕌[ 𝑨 ])
+             → (o ^ reduct (ψ ∘ₛ φ) 𝑨) args ≡ (o ^ reduct φ (reduct ψ 𝑨)) args
+reduct-∘-ptw _ = refl
 ```
 
 --------------------------------------

--- a/src/Classical/Structures/Reduct.lagda.md
+++ b/src/Classical/Structures/Reduct.lagda.md
@@ -102,25 +102,24 @@ affords short of equating the *algebras* themselves, which would need funext for
 
 ```agda
 reduct-id : {𝑨 : Algebra {𝑆 = 𝑆} α ρ} {o : OperationSymbolsOf 𝑆}
-          → o ^ reduct id-morphism 𝑨 ≡ o ^ 𝑨
+  → o ^ reduct id-morphism 𝑨 ≡ o ^ 𝑨
 reduct-id = refl
 
 reduct-id-ptw : {𝑨 : Algebra {𝑆 = 𝑆} α ρ} {o : OperationSymbolsOf 𝑆}
-                (args : ArityOf 𝑆 o → 𝕌[ 𝑨 ])
-              → (o ^ reduct id-morphism 𝑨) args ≡ (o ^ 𝑨) args
+  (args : ArityOf 𝑆 o → 𝕌[ 𝑨 ]) → (o ^ reduct id-morphism 𝑨) args ≡ (o ^ 𝑨) args
 reduct-id-ptw _ = refl
 
 reduct-∘ : {𝑆₁ 𝑆₂ 𝑆₃ : Signature 𝓞 𝓥}
-           {φ : SigMorphism 𝑆₁ 𝑆₂} {ψ : SigMorphism 𝑆₂ 𝑆₃}
-           {𝑨 : Algebra {𝑆 = 𝑆₃} α ρ} {o : OperationSymbolsOf 𝑆₁}
-         → o ^ reduct (ψ ∘ₛ φ) 𝑨 ≡ o ^ reduct φ (reduct ψ 𝑨)
+  {φ : SigMorphism 𝑆₁ 𝑆₂} {ψ : SigMorphism 𝑆₂ 𝑆₃}
+  {𝑨 : Algebra {𝑆 = 𝑆₃} α ρ} {o : OperationSymbolsOf 𝑆₁}
+  → o ^ reduct (ψ ∘ₛ φ) 𝑨 ≡ o ^ reduct φ (reduct ψ 𝑨)
 reduct-∘ = refl
 
 reduct-∘-ptw : {𝑆₁ 𝑆₂ 𝑆₃ : Signature 𝓞 𝓥}
-               {φ : SigMorphism 𝑆₁ 𝑆₂} {ψ : SigMorphism 𝑆₂ 𝑆₃}
-               {𝑨 : Algebra {𝑆 = 𝑆₃} α ρ} {o : OperationSymbolsOf 𝑆₁}
-               (args : ArityOf 𝑆₁ o → 𝕌[ 𝑨 ])
-             → (o ^ reduct (ψ ∘ₛ φ) 𝑨) args ≡ (o ^ reduct φ (reduct ψ 𝑨)) args
+  {φ : SigMorphism 𝑆₁ 𝑆₂} {ψ : SigMorphism 𝑆₂ 𝑆₃}
+  {𝑨 : Algebra {𝑆 = 𝑆₃} α ρ} {o : OperationSymbolsOf 𝑆₁}
+  (args : ArityOf 𝑆₁ o → 𝕌[ 𝑨 ])
+  → (o ^ reduct (ψ ∘ₛ φ) 𝑨) args ≡ (o ^ reduct φ (reduct ψ 𝑨)) args
 reduct-∘-ptw _ = refl
 ```
 


### PR DESCRIPTION
## Summary

Applies the strict-first / derive-the-weaker discipline (established in M4-5b) retroactively to `Classical.Structures.Reduct`'s functoriality results.

`reduct-id` and `reduct-∘` now state equality of the **operation-interpretation functions** — `o ^ reduct … ≡ o ^ …`, with *no* argument tuple applied — and still hold by `refl`.  This is strictly stronger than the previous `args`-applied statements (which are recovered by `cong-app`), and is the strongest form `--safe` affords short of equating the *algebras* themselves, which would need funext for the `Interp.cong` field.

## Changes

+  **`reduct-id`** : `o ^ reduct id-morphism 𝑨 ≡ o ^ 𝑨` (`refl`).
+  **`reduct-∘`** : `o ^ reduct (ψ ∘ₛ φ) 𝑨 ≡ o ^ reduct φ (reduct ψ 𝑨)` (`refl`).
+  **`reduct-id-ptw` / `reduct-∘-ptw`** : the conventional `args`-applied functoriality statements, retained as corollaries.

## Note on the corollary proofs

The `-ptw` corollaries are proved by `refl` (the strict law specialized to an argument tuple) rather than `cong-app` of the strict law.  Deriving them via `cong-app` would require pinning the strict law's implicits explicitly (up to seven on `reduct-∘-ptw`), because `_^_` unfolds through the non-injective `Interp` / `Carrier` and inference can't recover the signature/algebra/symbol from the result type.  `refl` keeps the corpus clean; the prose records the strict-law-implies-pointwise relationship.

## Verification

`make check` passes across the full library (178 canonical + 68 Legacy modules).

https://claude.ai/code/session_01Vj5HPxkgaiTt1jCLcipyRT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj5HPxkgaiTt1jCLcipyRT)_