### PR TITLE
[M4-10] Substitution kit: derivable-equality bridge + compound-term instantiation

### DIFF
--- a/src/Examples/Setoid/FreeSemigroup.lagda.md
+++ b/src/Examples/Setoid/FreeSemigroup.lagda.md
@@ -89,7 +89,7 @@ free-semigroup-models-assoc = FreeAlgebra.satisfies E
 
 The carrier equality of `𝔽[ X ]` *is* derivable equality, so the
 associativity rule `hyp`{.AgdaInductiveConstructor} `0F` witnesses, on the nose,
-that the two parenthesisations of `g₀ · g₁ · g₂` are equal elements of the free
+that the two parenthesisations of `x · y · z` are equal elements of the free
 semigroup — exactly the identification that the free magma withholds.
 
 ```agda

--- a/src/Examples/Setoid/FreeSemigroup.lagda.md
+++ b/src/Examples/Setoid/FreeSemigroup.lagda.md
@@ -32,18 +32,22 @@ module Examples.Setoid.FreeSemigroup where
 -- Imports from Agda and the Agda Standard Library -----------------------------
 open import Agda.Primitive                   using () renaming ( Set to Type )
 open import Data.Fin.Base                    using ( Fin )
-open import Data.Fin.Patterns                using ( 0F ; 1F ; 2F )
+open import Data.Fin.Patterns                using ( 0F ; 1F ; 2F ; 3F )
 
 -- Imports from the Agda Universal Algebra Library -----------------------------
 open import Classical.Signatures.Magma       using ( Sig-Magma ; ∙-Op )
 open import Overture.Terms {𝑆 = Sig-Magma}   using ( Term ; ℊ ; node )
 open import Setoid.Algebras {𝑆 = Sig-Magma}  using ( 𝔻[_] )
+open import Setoid.Terms.Basic {𝑆 = Sig-Magma}
+  using ( _≐_ ; ≐-isRefl ; Sub ; _[_] )
 open import Setoid.Varieties.SoundAndComplete {𝑆 = Sig-Magma}
   using ( Eq ; _≈̇_ ; _⊨_ ; _⊢_▹_≈_ ; module FreeAlgebra )
+open import Setoid.Varieties.FreeSubstitution {𝑆 = Sig-Magma}  using ( sub▹ )
 
 open import Relation.Binary using ( Setoid )
 
-open _⊢_▹_≈_ using ( hyp ; app ; refl ; sym ; trans )
+open _≐_     using ( gnl )
+open _⊢_▹_≈_ using ( hyp ; app ; sub ; refl ; sym ; trans )
 ```
 
 #### The Associativity Theory
@@ -128,6 +132,50 @@ rewrite² = trans left right
   right = app λ { 0F → refl ; 1F → hyp 0F }
 ```
 
+#### Instantiating associativity at arbitrary terms
+
+`assoc≈` above is associativity for the three *generators* `g₀ , g₁ , g₂`.  To rewrite an
+associativity redex whose factors are *arbitrary* terms `p , q , r`, we instantiate the
+rule with the substitution `σ` sending the generators to `p , q , r` and use
+`sub`{.AgdaInductiveConstructor}.  The catch (issue [M4-10][]) is that `sub` lands in
+`_[ σ ]`-form, which is only *pointwise* equal to the readable rebuilt terms `(p · q) · r`
+and `p · (q · r)`; `sub▹`{.AgdaFunction} ([Setoid.Varieties.FreeSubstitution][]) bridges
+that gap, taking the two rebuild equalities — mechanical `gnl` / `≐-isRefl` matches, since
+`(ℊ k) [ σ ]` reduces to the chosen term — and returning the readable derivation.
+
+```agda
+assoc▹ : {Γ : Type} (p q r : Term Γ) → E ⊢ Γ ▹ ((p · q) · r) ≈ (p · (q · r))
+assoc▹ {Γ} p q r = sub▹ (hyp 0F) σ blhs brhs
+  where
+  σ : Sub Γ (Fin 3)
+  σ = λ { 0F → p ; 1F → q ; 2F → r }
+
+  blhs : ((p · q) · r) ≐ (((g₀ · g₁) · g₂) [ σ ])
+  blhs = gnl λ { 0F → gnl (λ { 0F → ≐-isRefl ; 1F → ≐-isRefl }) ; 1F → ≐-isRefl }
+
+  brhs : ((g₀ · (g₁ · g₂)) [ σ ]) ≐ (p · (q · r))
+  brhs = gnl λ { 0F → ≐-isRefl ; 1F → gnl (λ { 0F → ≐-isRefl ; 1F → ≐-isRefl }) }
+```
+
+#### A multi-step reassociation
+
+With `assoc▹`{.AgdaFunction} in hand, a full reassociation chains cleanly.  Over four
+generators, the left-combed `(((a · b) · c) · d)` rewrites to the right-combed
+`a · (b · (c · d))` in two associativity steps — first at the top with first factor
+`a · b`, then at the top of the result — composed with `trans`{.AgdaInductiveConstructor}.
+This is the readable, `sub`-driven rewrite the issue asks for; no factor needs to match
+the rule literally.
+
+```agda
+a b c d : Term (Fin 4)
+a = ℊ 0F ; b = ℊ 1F ; c = ℊ 2F ; d = ℊ 3F
+
+reassoc⁴ : E ⊢ Fin 4 ▹ ((((a · b) · c) · d)) ≈ (a · (b · (c · d)))
+reassoc⁴ = trans (assoc▹ (a · b) c d) (assoc▹ a b (c · d))
+```
+
 --------------------------------------
+
+[M4-10]: https://github.com/ualib/agda-algebras/issues/362
 
 {% include UALib.Links.md %}

--- a/src/Examples/Setoid/FreeSemigroup.lagda.md
+++ b/src/Examples/Setoid/FreeSemigroup.lagda.md
@@ -30,24 +30,22 @@ inside a larger term via congruence.
 module Examples.Setoid.FreeSemigroup where
 
 -- Imports from Agda and the Agda Standard Library -----------------------------
-open import Agda.Primitive                   using () renaming ( Set to Type )
-open import Data.Fin.Base                    using ( Fin )
-open import Data.Fin.Patterns                using ( 0F ; 1F ; 2F ; 3F )
+open import Agda.Primitive                      using () renaming ( Set to Type )
+open import Data.Fin.Base                       using ( Fin )
+open import Data.Fin.Patterns                   using ( 0F ; 1F ; 2F ; 3F )
+open import Relation.Binary                     using ( Setoid )
 
 -- Imports from the Agda Universal Algebra Library -----------------------------
-open import Classical.Signatures.Magma       using ( Sig-Magma ; ∙-Op )
-open import Overture.Terms {𝑆 = Sig-Magma}   using ( Term ; ℊ ; node )
-open import Setoid.Algebras {𝑆 = Sig-Magma}  using ( 𝔻[_] )
-open import Setoid.Terms.Basic {𝑆 = Sig-Magma}
-  using ( _≐_ ; ≐-isRefl ; Sub ; _[_] )
+open import Classical.Signatures.Magma          using ( Sig-Magma ; ∙-Op )
+open import Overture.Terms {𝑆 = Sig-Magma}      using ( Term ; ℊ ; node )
+open import Setoid.Algebras {𝑆 = Sig-Magma}     using ( 𝔻[_] )
+open import Setoid.Terms.Basic {𝑆 = Sig-Magma}  using ( _≐_ ; ≐-isRefl ; Sub ; _[_] )
 open import Setoid.Varieties.SoundAndComplete {𝑆 = Sig-Magma}
   using ( Eq ; _≈̇_ ; _⊨_ ; _⊢_▹_≈_ ; module FreeAlgebra )
-open import Setoid.Varieties.FreeSubstitution {𝑆 = Sig-Magma}  using ( sub▹ )
-
-open import Relation.Binary using ( Setoid )
-
-open _≐_     using ( gnl )
-open _⊢_▹_≈_ using ( hyp ; app ; sub ; refl ; sym ; trans )
+open import Setoid.Varieties.FreeSubstitution {𝑆 = Sig-Magma}
+  using ( sub▹ )
+open _≐_      using ( gnl )
+open _⊢_▹_≈_  using ( hyp ; app ; sub ; refl ; sym ; trans )
 ```
 
 #### The Associativity Theory
@@ -61,14 +59,14 @@ _·_ : {X : Type} → Term X → Term X → Term X
 s · t = node ∙-Op λ { 0F → s ; 1F → t }
 
 -- the three generators of the free semigroup on Fin 3
-g₀ g₁ g₂ : Term (Fin 3)
-g₀ = ℊ 0F
-g₁ = ℊ 1F
-g₂ = ℊ 2F
+private
+  x y z : Term (Fin 3)
+  x = ℊ 0F
+  y = ℊ 1F
+  z = ℊ 2F
 
--- (g₀ · g₁) · g₂  ≈̇  g₀ · (g₁ · g₂)
 assoc-eq : Eq
-assoc-eq = ((g₀ · g₁) · g₂) ≈̇ (g₀ · (g₁ · g₂))
+assoc-eq = (x · y) · z ≈̇  x · (y · z)
 
 -- a one-equation theory indexed by Fin 1
 E : Fin 1 → Eq
@@ -97,11 +95,11 @@ semigroup — exactly the identification that the free magma withholds.
 ```agda
 open Setoid 𝔻[ 𝔽[ Fin 3 ] ] using ( _≈_ )
 
-assoc≈ : ((g₀ · g₁) · g₂) ≈ (g₀ · (g₁ · g₂))
+assoc≈ : (x · y) · z ≈ x · (y · z)
 assoc≈ = hyp 0F
 
 -- and the symmetric reading, since derivable equality is symmetric
-assoc≈˘ : (g₀ · (g₁ · g₂)) ≈ ((g₀ · g₁) · g₂)
+assoc≈˘ : x · (y · z) ≈ (x · y) · z
 assoc≈˘ = sym (hyp 0F)
 ```
 
@@ -109,32 +107,32 @@ assoc≈˘ = sym (hyp 0F)
 
 Congruence (`app`{.AgdaInductiveConstructor}) lets us rewrite an associativity
 *redex* wherever it occurs as a subterm.  Starting from a product whose *both*
-factors are the redex `(g₀ · g₁) · g₂`{.AgdaFunction}, we normalise the left factor,
+factors are the redex `(x · y) · z`{.AgdaFunction}, we normalise the left factor,
 then the right, and chain the two steps with `trans`{.AgdaInductiveConstructor}.
 
 ```agda
--- the doubled redex  ((g₀·g₁)·g₂) · ((g₀·g₁)·g₂)
+-- the doubled redex  ((x·y)·z) · ((x·y)·z)
 redex² : Term (Fin 3)
-redex² = ((g₀ · g₁) · g₂) · ((g₀ · g₁) · g₂)
+redex² = ((x · y) · z) · ((x · y) · z)
 
 -- its fully right-nested normal form
 nf² : Term (Fin 3)
-nf² = (g₀ · (g₁ · g₂)) · (g₀ · (g₁ · g₂))
+nf² = (x · (y · z)) · (x · (y · z))
 
 rewrite² : redex² ≈ nf²
 rewrite² = trans left right
   where
   -- rewrite the left factor, leave the right untouched
-  left : redex² ≈ ((g₀ · (g₁ · g₂)) · ((g₀ · g₁) · g₂))
+  left : redex² ≈ ((x · (y · z)) · ((x · y) · z))
   left = app λ { 0F → hyp 0F ; 1F → refl }
   -- rewrite the right factor
-  right : ((g₀ · (g₁ · g₂)) · ((g₀ · g₁) · g₂)) ≈ nf²
+  right : (x · (y · z)) · ((x · y) · z) ≈ nf²
   right = app λ { 0F → refl ; 1F → hyp 0F }
 ```
 
 #### Instantiating associativity at arbitrary terms
 
-`assoc≈` above is associativity for the three *generators* `g₀ , g₁ , g₂`.  To rewrite an
+`assoc≈` above is associativity for the three *generators* `x , y , z`.  To rewrite an
 associativity redex whose factors are *arbitrary* terms `p , q , r`, we instantiate the
 rule with the substitution `σ` sending the generators to `p , q , r` and use
 `sub`{.AgdaInductiveConstructor}.  The catch (issue [M4-10][]) is that `sub` lands in
@@ -144,33 +142,34 @@ that gap, taking the two rebuild equalities — mechanical `gnl` / `≐-isRefl` 
 `(ℊ k) [ σ ]` reduces to the chosen term — and returning the readable derivation.
 
 ```agda
-assoc▹ : {Γ : Type} (p q r : Term Γ) → E ⊢ Γ ▹ ((p · q) · r) ≈ (p · (q · r))
+assoc▹ : {Γ : Type} (p q r : Term Γ) → E ⊢ Γ ▹ (p · q) · r ≈ p · (q · r)
 assoc▹ {Γ} p q r = sub▹ (hyp 0F) σ blhs brhs
   where
   σ : Sub Γ (Fin 3)
   σ = λ { 0F → p ; 1F → q ; 2F → r }
 
-  blhs : ((p · q) · r) ≐ (((g₀ · g₁) · g₂) [ σ ])
+  blhs : (p · q) · r ≐ ((x · y) · z) [ σ ]
   blhs = gnl λ { 0F → gnl (λ { 0F → ≐-isRefl ; 1F → ≐-isRefl }) ; 1F → ≐-isRefl }
 
-  brhs : ((g₀ · (g₁ · g₂)) [ σ ]) ≐ (p · (q · r))
+  brhs : (x · (y · z)) [ σ ] ≐ p · (q · r)
   brhs = gnl λ { 0F → ≐-isRefl ; 1F → gnl (λ { 0F → ≐-isRefl ; 1F → ≐-isRefl }) }
 ```
 
 #### A multi-step reassociation
 
 With `assoc▹`{.AgdaFunction} in hand, a full reassociation chains cleanly.  Over four
-generators, the left-combed `(((a · b) · c) · d)` rewrites to the right-combed
+generators, the left-combed `((a · b) · c) · d` rewrites to the right-combed
 `a · (b · (c · d))` in two associativity steps — first at the top with first factor
 `a · b`, then at the top of the result — composed with `trans`{.AgdaInductiveConstructor}.
 This is the readable, `sub`-driven rewrite the issue asks for; no factor needs to match
 the rule literally.
 
 ```agda
-a b c d : Term (Fin 4)
-a = ℊ 0F ; b = ℊ 1F ; c = ℊ 2F ; d = ℊ 3F
+private
+  a b c d : Term (Fin 4)
+  a = ℊ 0F ; b = ℊ 1F ; c = ℊ 2F ; d = ℊ 3F
 
-reassoc⁴ : E ⊢ Fin 4 ▹ ((((a · b) · c) · d)) ≈ (a · (b · (c · d)))
+reassoc⁴ : E ⊢ Fin 4 ▹ ((a · b) · c) · d ≈ a · (b · (c · d))
 reassoc⁴ = trans (assoc▹ (a · b) c d) (assoc▹ a b (c · d))
 ```
 

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -134,8 +134,8 @@ Finally, we define an epimorphism from `𝑻 X` onto the relatively free algebra
     ker𝔽⊆Equal : ∀{p q} → (p , q) ∈ fkerPred (proj₁ (hom𝔽[ X ])) → Equal p q
     ker𝔽⊆Equal{p = p}{q} x = S-id1{ℓ = ℓ}{p = p}{q} (ℰ⊢[ X ]▹Th𝒦 x) 𝑨 sA
 
-  𝒦⊫→ℰ⊢ : {X : Type χ} → ∀{p q} → 𝒦 ⊫ (p ≈̇ q) → ℰ ⊢ X ▹ p ≈ q
-  𝒦⊫→ℰ⊢ {p = p} {q} pKq = hyp ((p ≈̇ q) , pKq) where open _⊢_▹_≈_ using (hyp)
+  𝒦⊫→ℰ⊢ : {X : Type χ} → ∀{p q} → 𝒦 ⊫ p ≈̇ q → ℰ ⊢ X ▹ p ≈ q
+  𝒦⊫→ℰ⊢ {p = p} {q} pKq = hyp (p ≈̇ q , pKq) where open _⊢_▹_≈_ using (hyp)
 
 ------------------------------------------------------------------------------
 
@@ -182,21 +182,19 @@ module _ {α ρᵃ ℓ : Level} {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔
       where
       φ : 𝔻[ 𝔽[ ∣A∣ ] ] ⟶ A
       φ ⟨$⟩ x = free-lift id x
-      φ .cong {p} {q} pq = Goal
-        where
-        Goal : free-lift id p ≈ free-lift id q
-        Goal = begin
-          free-lift id p ≈˘⟨ free-lift-interp{𝑨 = 𝑨} id p ⟩
-          ⟦ p ⟧ ⟨$⟩ id ≈⟨ A∈ModThK{p = p}{q} (kernel-in-theory pq) id ⟩
-          ⟦ q ⟧ ⟨$⟩ id ≈⟨ free-lift-interp{𝑨 = 𝑨} id q ⟩
-          free-lift id q ∎
+      φ .cong {p} {q} pq = begin
+          free-lift id p  ≈˘⟨ free-lift-interp{𝑨 = 𝑨} id p ⟩
+          ⟦ p ⟧ ⟨$⟩ id    ≈⟨ A∈ModThK{p = p}{q} (kernel-in-theory pq) id ⟩
+          ⟦ q ⟧ ⟨$⟩ id    ≈⟨ free-lift-interp{𝑨 = 𝑨} id q ⟩
+          free-lift id q  ∎
 
       isEpi : IsEpi 𝔽[ ∣A∣ ] 𝑨 φ
       isEpi .isHom .compatible = cong Interp (≡.refl , λ _ → refl)
       isEpi .isSurjective = eq (ℊ _) refl
 
     𝔽-ModTh-epi-lift : 𝑨 ∈ Mod (Th (V ℓ ι 𝒦)) → epi 𝔽[ ∣A∣ ] (Lift-Alg 𝑨 ι ι)
-    𝔽-ModTh-epi-lift A∈ModThK = ⊙-epi (𝔽-ModTh-epi (λ {p q} → A∈ModThK{p = p}{q})) ToLift-epi
+    𝔽-ModTh-epi-lift A∈ModThK =
+      ⊙-epi (𝔽-ModTh-epi (λ {p q} → A∈ModThK{p = p}{q})) ToLift-epi
 ```
 
 --------------------------------

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -135,7 +135,7 @@ Finally, we define an epimorphism from `𝑻 X` onto the relatively free algebra
     ker𝔽⊆Equal{p = p}{q} x = S-id1{ℓ = ℓ}{p = p}{q} (ℰ⊢[ X ]▹Th𝒦 x) 𝑨 sA
 
   𝒦⊫→ℰ⊢ : {X : Type χ} → ∀{p q} → 𝒦 ⊫ (p ≈̇ q) → ℰ ⊢ X ▹ p ≈ q
-  𝒦⊫→ℰ⊢ {p = p} {q} pKq = hyp (p ≈̇ q , pKq) where open _⊢_▹_≈_ using (hyp)
+  𝒦⊫→ℰ⊢ {p = p} {q} pKq = hyp ((p ≈̇ q) , pKq) where open _⊢_▹_≈_ using (hyp)
 
 ------------------------------------------------------------------------------
 

--- a/src/Setoid/Varieties/FreeSubstitution.lagda.md
+++ b/src/Setoid/Varieties/FreeSubstitution.lagda.md
@@ -12,42 +12,44 @@ This is the [Setoid.Varieties.FreeSubstitution][] module of the [Agda Universal 
 
 Substitution `_[_]` ([Setoid.Terms.Basic][]) pushes into a node *pointwise*,
 
-```text
-   (node f ts) [ σ ]  =  node f (λ i → ts i [ σ ]).
-```
+    (node f ts) [ σ ] = node f (λ i → ts i [ σ ]).
 
-When `ts` is a finite tuple written as a pattern-matching lambda — the natural way to
-write a binary term, `s · t = node ∙-Op (λ { 0F → s ; 1F → t })` — the result
-`node f (λ i → ts i [ σ ])` is **not** definitionally equal to a freshly *rebuilt* term
-`(s [ σ ]) · (t [ σ ]) = node ∙-Op (λ { 0F → s [ σ ] ; 1F → t [ σ ] })`: a
-pattern-matching lambda does not reduce under a variable index `i`, and bridging the two
-position functions needs function extensionality, which is unavailable under
-`--safe` / `--cubical-compatible`.  (This is the same `Fin n` η-gap that the M4-5
-development meets repeatedly; see ADR-002 §6.)
+When `ts` is a finite tuple written as a pattern-matching lambda, say,
+`λ { 0F → s ; 1F → t }`, the natural way to write a binary term is, e.g.,
+`s · t = node ∙-Op (λ { 0F → s ; 1F → t })`.
 
-The practical bite (issue [M4-10][]) is that the obvious way to instantiate an equation
-at *compound* terms fails: `sub (hyp i) σ` produces a goal in `_[ σ ]`-form that will not
-match a readable, rebuilt term, so a multi-step rewrite like a four-fold reassociation
-cannot be written directly.
+Unfortunately, the result `node f (λ i → ts i [ σ ])` is not definitionally equal to
+a freshly *rebuilt* term
+
+    s [ σ ] · t [ σ ] = node ∙-Op (λ { 0F → s [ σ ] ; 1F → t [ σ ] }),
+
+since a pattern-matching lambda does not reduce under a variable index `i`, and
+bridging the two position functions needs function extensionality, which is
+unavailable under `--safe` / `--cubical-compatible`.[^1]
+
+The practical bite is that the obvious way to instantiate an equation at *compound*
+terms fails: `sub (hyp i) σ` produces a goal in `_[ σ ]`-form that will not match a
+readable, rebuilt term, so a multi-step rewrite like a four-fold reassociation cannot
+be written directly.
 
 The fix is small, because the bookkeeping half of the kit is already proved: the
-`_≐_`-level laws `[]-unitˡ` (left unit, the issue's `[]-ℊ`), `[]-unitʳ`, `[]-assoc` (the
-issue's `[]-∘`), and `[]-cong` live in [Setoid.Terms.Monad][] and are re-exported here so
-the kit reads from one place.  What is added here is the bridge between the two equalities
-on terms — the inductive equality `_≐_` of [Setoid.Terms.Basic][] and the *derivable*
+`_≐_`-level laws `[]-unitˡ` (left unit, the issue's `[]-ℊ`), `[]-unitʳ`, `[]-assoc`,
+and `[]-cong` live in [Setoid.Terms.Monad][] and are re-exported here so the kit
+reads from one place.  What is added here is the bridge between the two equalities on
+terms — the inductive equality `_≐_` of [Setoid.Terms.Basic][] and the *derivable*
 equality `_⊢_▹_≈_` of [Setoid.Varieties.SoundAndComplete][]:
 
-+  `≐→⊢`{.AgdaFunction} — every `_≐_`-equality is derivable.  Two terms that are `_≐_`
-   (same shape, equal variables at the leaves) are equal in *every* equational theory, by
-   `refl` at the leaves and the congruence rule `app` at the nodes.  This is exactly the
-   tool for rewriting a `_[ σ ]`-form into the rebuilt term it agrees with pointwise:
-   the rebuild is a `_≐_`-fact (a finite, mechanical `gnl` / `≐-isRefl` match), and `≐→⊢`
-   turns it into a derivation step.
++  `≐→⊢`{.AgdaFunction} — every `_≐_`-equality is derivable.  Two terms that are
+   `_≐_` (same shape, equal variables at the leaves) are equal in *every* equational
+   theory, by `refl` at the leaves and the congruence rule `app` at the nodes.  This
+   is exactly the tool for rewriting a `_[ σ ]`-form into the rebuilt term it agrees
+   with pointwise: the rebuild is a `_≐_`-fact (a finite, mechanical `gnl` /
+   `≐-isRefl` match), and `≐→⊢` turns it into a derivation step.
 +  `sub▹`{.AgdaFunction} — instantiate a derivation at a substitution and land on
    *readable* end terms.  It packages `sub` between two `≐→⊢` bridges, so a consumer
    writes `sub▹ d σ l≐pσ qσ≐r` and gets `E ⊢ Γ ▹ l ≈ r` directly.
 
-The worked four-fold reassociation that motivated the issue is in
+The worked four-fold reassociation that motivated the substitution kit is in
 [Examples.Setoid.FreeSemigroup][], built from one application of `sub▹` (a generic
 `assoc▹` that instantiates associativity at arbitrary subterms) plus the congruence rule.
 
@@ -92,8 +94,8 @@ inspects the equation set `E`, so this holds uniformly.
 
 ```agda
 ≐→⊢ : {E : I → Eq} {s t : Term Γ} → s ≐ t → E ⊢ Γ ▹ s ≈ t
-≐→⊢ (rfl ≡.refl) = refl
-≐→⊢ (gnl ps)     = app (λ i → ≐→⊢ (ps i))
+≐→⊢ (rfl ≡.refl)  = refl
+≐→⊢ (gnl ps)      = app (λ i → ≐→⊢ (ps i))
 ```
 
 #### Instantiating a derivation at compound terms
@@ -106,11 +108,14 @@ the `_≐_` arguments are the mechanical "rebuild" bridges, and `sub▹` hides t
 
 ```agda
 sub▹ : {E : I → Eq} {p q : Term Δ} (d : E ⊢ Δ ▹ p ≈ q) (σ : Sub Γ Δ)
-       {l r : Term Γ} → l ≐ (p [ σ ]) → (q [ σ ]) ≐ r → E ⊢ Γ ▹ l ≈ r
+       {l r : Term Γ} → l ≐ p [ σ ] → q [ σ ] ≐ r → E ⊢ Γ ▹ l ≈ r
 sub▹ d σ l≐pσ qσ≐r = trans (≐→⊢ l≐pσ) (trans (sub d σ) (≐→⊢ qσ≐r))
 ```
 
 --------------------------------------
+
+[^1]: This is the same `Fin n` η-gap that the M4-5 development meets repeatedly; see [ADR-002][] §6.
+
 
 [M4-10]: https://github.com/ualib/agda-algebras/issues/362
 

--- a/src/Setoid/Varieties/FreeSubstitution.lagda.md
+++ b/src/Setoid/Varieties/FreeSubstitution.lagda.md
@@ -1,0 +1,117 @@
+---
+layout: default
+file: "src/Setoid/Varieties/FreeSubstitution.lagda.md"
+title: "Setoid.Varieties.FreeSubstitution module"
+date: "2026-06-19"
+author: "the agda-algebras development team"
+---
+
+### A substitution kit for derivable equality
+
+This is the [Setoid.Varieties.FreeSubstitution][] module of the [Agda Universal Algebra Library][].
+
+Substitution `_[_]` ([Setoid.Terms.Basic][]) pushes into a node *pointwise*,
+
+```text
+   (node f ts) [ σ ]  =  node f (λ i → ts i [ σ ]).
+```
+
+When `ts` is a finite tuple written as a pattern-matching lambda — the natural way to
+write a binary term, `s · t = node ∙-Op (λ { 0F → s ; 1F → t })` — the result
+`node f (λ i → ts i [ σ ])` is **not** definitionally equal to a freshly *rebuilt* term
+`(s [ σ ]) · (t [ σ ]) = node ∙-Op (λ { 0F → s [ σ ] ; 1F → t [ σ ] })`: a
+pattern-matching lambda does not reduce under a variable index `i`, and bridging the two
+position functions needs function extensionality, which is unavailable under
+`--safe` / `--cubical-compatible`.  (This is the same `Fin n` η-gap that the M4-5
+development meets repeatedly; see ADR-002 §6.)
+
+The practical bite (issue [M4-10][]) is that the obvious way to instantiate an equation
+at *compound* terms fails: `sub (hyp i) σ` produces a goal in `_[ σ ]`-form that will not
+match a readable, rebuilt term, so a multi-step rewrite like a four-fold reassociation
+cannot be written directly.
+
+The fix is small, because the bookkeeping half of the kit is already proved: the
+`_≐_`-level laws `[]-unitˡ` (left unit, the issue's `[]-ℊ`), `[]-unitʳ`, `[]-assoc` (the
+issue's `[]-∘`), and `[]-cong` live in [Setoid.Terms.Monad][] and are re-exported here so
+the kit reads from one place.  What is added here is the bridge between the two equalities
+on terms — the inductive equality `_≐_` of [Setoid.Terms.Basic][] and the *derivable*
+equality `_⊢_▹_≈_` of [Setoid.Varieties.SoundAndComplete][]:
+
++  `≐→⊢`{.AgdaFunction} — every `_≐_`-equality is derivable.  Two terms that are `_≐_`
+   (same shape, equal variables at the leaves) are equal in *every* equational theory, by
+   `refl` at the leaves and the congruence rule `app` at the nodes.  This is exactly the
+   tool for rewriting a `_[ σ ]`-form into the rebuilt term it agrees with pointwise:
+   the rebuild is a `_≐_`-fact (a finite, mechanical `gnl` / `≐-isRefl` match), and `≐→⊢`
+   turns it into a derivation step.
++  `sub▹`{.AgdaFunction} — instantiate a derivation at a substitution and land on
+   *readable* end terms.  It packages `sub` between two `≐→⊢` bridges, so a consumer
+   writes `sub▹ d σ l≐pσ qσ≐r` and gets `E ⊢ Γ ▹ l ≈ r` directly.
+
+The worked four-fold reassociation that motivated the issue is in
+[Examples.Setoid.FreeSemigroup][], built from one application of `sub▹` (a generic
+`assoc▹` that instantiates associativity at arbitrary subterms) plus the congruence rule.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+
+module Setoid.Varieties.FreeSubstitution {𝑆 : Signature 𝓞 𝓥} where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Agda.Primitive  using () renaming ( Set to Type )
+open import Level           using ( Level )
+
+import Relation.Binary.PropositionalEquality as ≡
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture.Terms                      {𝑆 = 𝑆} using ( Term ; ℊ ; node )
+open import Setoid.Terms.Basic                  {𝑆 = 𝑆} using ( _≐_ ; Sub ; _[_] )
+open import Setoid.Varieties.SoundAndComplete   {𝑆 = 𝑆} using ( Eq ; _⊢_▹_≈_ )
+
+-- The bookkeeping laws (proved in Setoid.Terms.Monad) re-exported for one-stop access.
+-- The issue's `[]-ℊ` is `[]-unitˡ`; its `[]-∘` is `[]-assoc`.
+open import Setoid.Terms.Monad {𝑆 = 𝑆}
+  using ( _⊙ˢ_ ; []-unitˡ ; []-unitˡ-ptw ; []-unitʳ ; []-assoc ; []-cong ) public
+
+open _≐_         using ( rfl ; gnl )
+open _⊢_▹_≈_     using ( app ; sub ; refl ; trans )
+
+private variable
+  χ ι : Level
+  Γ Δ : Type χ
+  I   : Type ι
+```
+
+#### Derivable equality refines term equality
+
+Every `_≐_`-equality is derivable in any theory `E`.  The leaf case is the reflexivity
+rule (the variables are equal, so the terms are literally equal); the node case is the
+congruence rule `app` applied to the inductive hypotheses at the positions.  No clause
+inspects the equation set `E`, so this holds uniformly.
+
+```agda
+≐→⊢ : {E : I → Eq} {s t : Term Γ} → s ≐ t → E ⊢ Γ ▹ s ≈ t
+≐→⊢ (rfl ≡.refl) = refl
+≐→⊢ (gnl ps)     = app (λ i → ≐→⊢ (ps i))
+```
+
+#### Instantiating a derivation at compound terms
+
+`sub▹ d σ` substitutes `σ` into a derivation `d : E ⊢ Δ ▹ p ≈ q` and rewrites both ends
+to readable terms supplied by the caller: given `l ≐ p [ σ ]` and `q [ σ ] ≐ r`, it
+returns `E ⊢ Γ ▹ l ≈ r`.  This is the clean way to use an equation at compound terms —
+the `_≐_` arguments are the mechanical "rebuild" bridges, and `sub▹` hides the
+`_[ σ ]`-form behind them.
+
+```agda
+sub▹ : {E : I → Eq} {p q : Term Δ} (d : E ⊢ Δ ▹ p ≈ q) (σ : Sub Γ Δ)
+       {l r : Term Γ} → l ≐ (p [ σ ]) → (q [ σ ]) ≐ r → E ⊢ Γ ▹ l ≈ r
+sub▹ d σ l≐pσ qσ≐r = trans (≐→⊢ l≐pσ) (trans (sub d σ) (≐→⊢ qσ≐r))
+```
+
+--------------------------------------
+
+[M4-10]: https://github.com/ualib/agda-algebras/issues/362
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Varieties/FreeSubstitution.lagda.md
+++ b/src/Setoid/Varieties/FreeSubstitution.lagda.md
@@ -67,7 +67,7 @@ open import Level           using ( Level )
 import Relation.Binary.PropositionalEquality as ≡
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture.Terms                      {𝑆 = 𝑆} using ( Term ; ℊ ; node )
+open import Overture.Terms                      {𝑆 = 𝑆} using ( Term )
 open import Setoid.Terms.Basic                  {𝑆 = 𝑆} using ( _≐_ ; Sub ; _[_] )
 open import Setoid.Varieties.SoundAndComplete   {𝑆 = 𝑆} using ( Eq ; _⊢_▹_≈_ )
 

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -11,7 +11,6 @@ This is the [Setoid.Varieties.SoundAndComplete][] module of the [Agda Universal 
 
 This module is based on [Andreas Abel's Agda formalization of Birkhoff's completeness theorem](http://www.cse.chalmers.se/~abela/agda/MultiSortedAlgebra.pdf).
 
-
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
@@ -19,8 +18,9 @@ open import Overture using (𝓞 ; 𝓥 ; Signature)
 
 module Setoid.Varieties.SoundAndComplete {𝑆 : Signature 𝓞 𝓥} where
 
--- imports from Agda and the Agda Standard Library -------------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
+
+-- imports from the Agda Standard Library ---------------------------------------
 open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ )
 open import Function         using ( _∘_ ; flip ; id ) renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_ )
@@ -44,7 +44,7 @@ open Term
 private variable
  χ α ρᵃ ι ℓ : Level
  X Γ Δ : Type χ
- f     : OperationSymbolsOf 𝑆
+ f : OperationSymbolsOf 𝑆
  I : Type ι
 
 -- Equations
@@ -55,7 +55,7 @@ record Eq : Type (ov χ) where
   {cxt}  : Type χ
   lhs    : Term cxt
   rhs    : Term cxt
-
+infix 4 _≈̇_
 open Eq public
 
 -- Equation p ≈̇ q holding in algebra M. (type \~~\^. to get ≈̇; type \models to get ⊧)
@@ -104,28 +104,23 @@ module _ {α}{ρᵃ}{ι}{I : Type ι} where
 
 ##### Derivations in a context
 
-(Based on [Andreas Abel's Agda formalization of Birkhoff's completeness
-theorem](http://www.cse.chalmers.se/~abela/agda/MultiSortedAlgebra.pdf).)
-
 ```agda
 module _ {χ ι : Level} where
 
   data _⊢_▹_≈_ {I : Type ι}(E : I → Eq) : (X : Type χ)(p q : Term X) → Type (ι ⊔ ov χ) where
-    hyp    : ∀ i → let p ≈̇ q = E i in E ⊢ _ ▹ p ≈ q
-    app    : ∀ {ps qs} → (∀ i → E ⊢ Γ ▹ ps i ≈ qs i) → E ⊢ Γ ▹ (node f ps) ≈ (node f qs)
-    sub    : ∀ {p q} → E ⊢ Δ ▹ p ≈ q → ∀ (σ : Sub Γ Δ) → E ⊢ Γ ▹ (p [ σ ]) ≈ (q [ σ ])
-    refl   : ∀ {p}              → E ⊢ Γ ▹ p ≈ p
-    sym    : ∀ {p q : Term Γ}   → E ⊢ Γ ▹ p ≈ q → E ⊢ Γ ▹ q ≈ p
-    trans  : ∀ {p q r : Term Γ} → E ⊢ Γ ▹ p ≈ q → E ⊢ Γ ▹ q ≈ r → E ⊢ Γ ▹ p ≈ r
+    hyp    : ∀ (i : I)           → let p ≈̇ q = E i in E ⊢ _ ▹ p ≈ q
+    app    : ∀ {ps qs}           → (∀ i → E ⊢ Γ ▹ ps i ≈ qs i) → E ⊢ Γ ▹ node f ps ≈ node f qs
+    sub    : ∀ {p q : Term Δ}    → E ⊢ Δ ▹ p ≈ q → ∀ (σ : Sub Γ Δ) → E ⊢ Γ ▹ p [ σ ] ≈ q [ σ ]
+    refl   : ∀ {p : Term Γ}      → E ⊢ Γ ▹ p ≈ p
+    sym    : ∀ {p q : Term Γ}    → E ⊢ Γ ▹ p ≈ q → E ⊢ Γ ▹ q ≈ p
+    trans  : ∀ {p q r : Term Γ}  → E ⊢ Γ ▹ p ≈ q → E ⊢ Γ ▹ q ≈ r → E ⊢ Γ ▹ p ≈ r
+  infix 4 _⊢_▹_≈_
 
   ⊢▹≈IsEquiv : {I : Type ι}{E : I → Eq} → IsEquivalence (E ⊢ Γ ▹_≈_)
   ⊢▹≈IsEquiv = record { refl = refl ; sym = sym ; trans = trans }
 ```
 
 ##### Soundness of the inference rules
-
-(Based on [Andreas Abel's Agda formalization of Birkhoff's completeness theorem](see:
-http://www.cse.chalmers.se/~abela/agda/MultiSortedAlgebra.pdf).)
 
 ```agda
 module Soundness
@@ -174,9 +169,6 @@ We will prove that result next.
 The proof proceeds by constructing a relatively free algebra consisting of term
 quotiented by derivable equality `E ⊢ X ▹ _≈_`.  It then suffices to prove that this
 model satisfies all equations in `E`.
-
-(Based on [Andreas Abel's Agda formalization of Birkhoff's completeness
-theorem](http://www.cse.chalmers.se/~abela/agda/MultiSortedAlgebra.pdf).)
 
 We denote by `𝔽[ X ]` the *relatively free algebra* over `X` (relative to `E`), which
 is defined as `Term X` modulo `E ⊢ X ▹ _≈_`.  This algebra `𝔽[ X ]` is "free" or
@@ -243,7 +235,8 @@ type `X` (or `Δ`, or `Γ`), which is an arbitrary inhabitant of `Type χ`.)
       open SetoidReasoning (Domain 𝔽[ Δ ]) ; p = lhs (E i) ; q = rhs (E i)
 ```
 
-We are finally ready to formally state and prove Birkhoff's Completeness Theorem, which asserts that every valid consequence is derivable.
+We are finally ready to formally state and prove Birkhoff's Completeness Theorem,
+which asserts that every valid consequence is derivable.
 
 ```agda
   module _ {Γ : Type χ} where

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -55,7 +55,7 @@ record Eq : Type (ov χ) where
   {cxt}  : Type χ
   lhs    : Term cxt
   rhs    : Term cxt
-infix 4 _≈̇_
+infix 6 _≈̇_
 open Eq public
 
 -- Equation p ≈̇ q holding in algebra M. (type \~~\^. to get ≈̇; type \models to get ⊧)
@@ -64,6 +64,7 @@ _⊧_ : (𝑨 : Algebra α ρᵃ)(term-identity : Eq{χ}) → Type _
 
 _⊫_ : Pred (Algebra α ρᵃ) ℓ → Eq{χ} → Type (ℓ ⊔ χ ⊔ ov(α ⊔ ρᵃ))
 𝒦 ⊫ eq = ∀ 𝑨 → 𝒦 𝑨 → 𝑨 ⊧ eq                    -- (type \||= to get ⊫)
+infix 5 _⊫_
 
 -- An I-indexed set of equations inhabits the type I → Eq.
 


### PR DESCRIPTION
Closes #362.

## Problem

Substitution `_[_]` pushes into a node pointwise, `(node f ts) [ σ ] = node f (λ i → ts i [ σ ])`.  When `ts` is a pattern-matching lambda (the natural binary term `s · t = node ∙-Op (λ { 0F → s ; 1F → t })`), the result is **not** definitionally the rebuilt `(s [ σ ]) · (t [ σ ])` — the `Fin n` η-gap, with no funext under `--safe`/`--cubical-compatible`.  That blocked instantiating an equation at *compound* terms via `sub` and writing a clean multi-step reassociation (as the issue's `Examples.Setoid.FreeSemigroup` demo had to avoid).

## What this adds

The *bookkeeping* half of the kit the issue lists already existed in `Setoid.Terms.Monad` — `[]-unitˡ` (the issue's `[]-ℊ`), `[]-unitʳ`, `[]-assoc` (the issue's `[]-∘`), `[]-cong`.  The missing piece is the bridge between term equality `_≐_` and *derivable* equality `_⊢_▹_≈_`:

+ **`Setoid.Varieties.FreeSubstitution`** (new):
  + `≐→⊢` — every `_≐_`-equality is derivable in any theory (`refl` at the leaves, the congruence rule `app` at the nodes).  This turns a "rebuild" `_≐_`-fact into a derivation step.
  + `sub▹` — instantiate a derivation at a substitution and land on *readable* end terms: `sub▹ d σ l≐pσ qσ≐r : E ⊢ Γ ▹ l ≈ r`, hiding the `_[ σ ]`-form behind two `≐` bridges.
  + Re-exports the Monad `[]`-laws for one-stop access, and documents the funext obstruction.
+ **`Examples.Setoid.FreeSemigroup`** (upgraded): adds `assoc▹` (instantiate associativity at *arbitrary* subterms via `sub▹`) and `reassoc⁴` — the four-fold reassociation `(((a · b) · c) · d) ≈ a · (b · (c · d))` in two clean steps, the exact demo the issue could not previously write.

## Acceptance criteria

+ ✅ An equation is instantiated at compound terms via `sub` and matches a readable rebuilt term (`assoc▹`, via `sub▹` + one-line `≐` bridges).
+ ✅ A multi-step reassociation example type-checks cleanly (`reassoc⁴`).
+ ✅ `nix develop --command make check` passes (only the pre-existing `Legacy/` deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S29vQFyb8K4m28vVHaLtXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01S29vQFyb8K4m28vVHaLtXS)_