### PR TITLE
M6-2 (#272): subdirect products, subdirectly irreducible algebras, and Birkhoff's subdirect representation theorem

### DIFF
--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -3000,16 +3000,25 @@ Subdirect products and subdirect irreducibility are foundational for both the FL
 
 ## Tasks
 
-- [ ] `SubdirectProduct : (𝒜 : I → Algebra α ρ) → Algebra _ _` — embeds into `⨅ 𝒜` with each projection surjective.
-- [ ] `IsSubdirectlyIrreducible : Algebra α ρ → Type _`.
-- [ ] Birkhoff's subdirect product theorem: every algebra is a subdirect product of SI algebras.
-- [ ] SI characterization via monolithic congruences.
+- [x] `SubdirectProduct` / subdirect embedding — landed as `IsSubdirectEmbedding` / `SubdirectEmbedding` (`Setoid.Subalgebras.Subdirect`): an injective hom into `⨅ 𝒜` whose every coordinate projection is surjective (the standard relational presentation of "a subalgebra of `⨅ 𝒜` meeting every factor", rather than a separately-constructed algebra).
+- [x] `IsSubdirectlyIrreducible : Algebra α ρ → Type _` — landed (`Setoid.Congruences.Monolith`), defined as `Nontrivial × HasMonolith`.
+- [x] Birkhoff's subdirect representation theorem: the choice-free core is proved (`SIRep→Representable` — a separating SI-family of congruences yields a subdirect embedding into a product of SI algebras); `Birkhoff-subdirect` proves the full statement relative to an explicit choice principle (`SubdirectSIRep` existence), the Zorn step isolated as a module parameter rather than postulated.
+- [x] SI characterization via monolithic congruences — `monolith⇒cmi` (a monolith makes `0ᴬ` completely meet-irreducible) and `monolith⇒∧-irreducible` (`0ᴬ` is meet-irreducible); `monolith-unique`.
 
 ## Acceptance criteria
 
-- [ ] Subdirect product construction type-checks.
-- [ ] Birkhoff's subdirect product theorem is proved.
-- [ ] SI characterization is proved.
+- [x] Subdirect product construction type-checks — `Setoid.Subalgebras.Subdirect` type-checks under `make check`.
+- [x] Birkhoff's subdirect representation theorem is proved — constructive core in full; the choice-dependent existence is an explicit module parameter (mirrors M6-3's handling of choice-dependent theorems).  See the design note.
+- [x] SI characterization is proved — the forward direction (monolith ⟹ completely meet-irreducible) is proved constructively; the converse is predicativity-blocked and recorded as a follow-up.
+
+## Status — first pass (M6-2)
+
+The constructive core of subdirect representation theory landed in two modules:
+
++  `Setoid.Congruences.Monolith` — `Nontrivial` / `Trivial`, `Nonzero` congruences, the infinitary meet `⋂`, `IsMonolith` / `HasMonolith` / `monolith-unique`, `IsSubdirectlyIrreducible`, and the characterization `monolith⇒cmi` / `monolith⇒∧-irreducible`.
++  `Setoid.Subalgebras.Subdirect` — `⨅-proj`, `coord`, `IsSubdirectEmbedding` / `SubdirectEmbedding` / `subdirect→≤`; the bridge `separating→SubdirectEmbedding` (with `⟪⟫-injective` / `⟪⟫-separates` showing injectivity is *definitionally* the separation hypothesis "the meet is the diagonal"); and `Birkhoff-subdirect`, the subdirect representation theorem relative to the choice principle `SubdirectSIRep`.
+
+The choice/Zorn decision (option (a): explicit module parameter), the constructive-`¬¬` reason the parameter is a separating SI-*family* rather than per-pair maximal congruences, the predicativity wall blocking the cmi-⟹-monolith converse, and the level conventions are recorded in `docs/notes/m6-2-subdirect.md`.  Follow-ups: the constructive finite case (option (b), discharging the parameter by search when `≈` is decidable); the impredicative converse; and linking SI to the absence of a nontrivial subdirect decomposition.
 
 ---
 

--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -3000,25 +3000,16 @@ Subdirect products and subdirect irreducibility are foundational for both the FL
 
 ## Tasks
 
-- [x] `SubdirectProduct` / subdirect embedding — landed as `IsSubdirectEmbedding` / `SubdirectEmbedding` (`Setoid.Subalgebras.Subdirect`): an injective hom into `⨅ 𝒜` whose every coordinate projection is surjective (the standard relational presentation of "a subalgebra of `⨅ 𝒜` meeting every factor", rather than a separately-constructed algebra).
-- [x] `IsSubdirectlyIrreducible : Algebra α ρ → Type _` — landed (`Setoid.Congruences.Monolith`), defined as `Nontrivial × HasMonolith`.
-- [x] Birkhoff's subdirect representation theorem: the choice-free core is proved (`SIRep→Representable` — a separating SI-family of congruences yields a subdirect embedding into a product of SI algebras); `Birkhoff-subdirect` proves the full statement relative to an explicit choice principle (`SubdirectSIRep` existence), the Zorn step isolated as a module parameter rather than postulated.
-- [x] SI characterization via monolithic congruences — `monolith⇒cmi` (a monolith makes `0ᴬ` completely meet-irreducible) and `monolith⇒∧-irreducible` (`0ᴬ` is meet-irreducible); `monolith-unique`.
+- [ ] `SubdirectProduct : (𝒜 : I → Algebra α ρ) → Algebra _ _` — embeds into `⨅ 𝒜` with each projection surjective.
+- [ ] `IsSubdirectlyIrreducible : Algebra α ρ → Type _`.
+- [ ] Birkhoff's subdirect product theorem: every algebra is a subdirect product of SI algebras.
+- [ ] SI characterization via monolithic congruences.
 
 ## Acceptance criteria
 
-- [x] Subdirect product construction type-checks — `Setoid.Subalgebras.Subdirect` type-checks under `make check`.
-- [x] Birkhoff's subdirect representation theorem is proved — constructive core in full; the choice-dependent existence is an explicit module parameter (mirrors M6-3's handling of choice-dependent theorems).  See the design note.
-- [x] SI characterization is proved — the forward direction (monolith ⟹ completely meet-irreducible) is proved constructively; the converse is predicativity-blocked and recorded as a follow-up.
-
-## Status — first pass (M6-2)
-
-The constructive core of subdirect representation theory landed in two modules:
-
-+  `Setoid.Congruences.Monolith` — `Nontrivial` / `Trivial`, `Nonzero` congruences, the infinitary meet `⋂`, `IsMonolith` / `HasMonolith` / `monolith-unique`, `IsSubdirectlyIrreducible`, and the characterization `monolith⇒cmi` / `monolith⇒∧-irreducible`.
-+  `Setoid.Subalgebras.Subdirect` — `⨅-proj`, `coord`, `IsSubdirectEmbedding` / `SubdirectEmbedding` / `subdirect→≤`; the bridge `separating→SubdirectEmbedding` (with `⟪⟫-injective` / `⟪⟫-separates` showing injectivity is *definitionally* the separation hypothesis "the meet is the diagonal"); and `Birkhoff-subdirect`, the subdirect representation theorem relative to the choice principle `SubdirectSIRep`.
-
-The choice/Zorn decision (option (a): explicit module parameter), the constructive-`¬¬` reason the parameter is a separating SI-*family* rather than per-pair maximal congruences, the predicativity wall blocking the cmi-⟹-monolith converse, and the level conventions are recorded in `docs/notes/m6-2-subdirect.md`.  Follow-ups: the constructive finite case (option (b), discharging the parameter by search when `≈` is decidable); the impredicative converse; and linking SI to the absence of a nontrivial subdirect decomposition.
+- [ ] Subdirect product construction type-checks.
+- [ ] Birkhoff's subdirect product theorem is proved.
+- [ ] SI characterization is proved.
 
 ---
 

--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -2996,20 +2996,29 @@ The current `Setoid.Algebras.Congruences` defines congruences but does not organ
 
 ## Description
 
-Subdirect products and subdirect irreducibility are foundational for both the FLRP and for general universal-algebraic theorems (e.g. Birkhoff's subdirect product theorem).
+Subdirect products and subdirect irreducibility are foundational for both the FLRP and for general universal-algebraic theorems (e.g. Birkhoff's subdirect representation theorem).
 
 ## Tasks
 
-- [ ] `SubdirectProduct : (𝒜 : I → Algebra α ρ) → Algebra _ _` — embeds into `⨅ 𝒜` with each projection surjective.
-- [ ] `IsSubdirectlyIrreducible : Algebra α ρ → Type _`.
-- [ ] Birkhoff's subdirect product theorem: every algebra is a subdirect product of SI algebras.
-- [ ] SI characterization via monolithic congruences.
+- [x] `SubdirectProduct` / subdirect embedding — landed as `IsSubdirectEmbedding` / `SubdirectEmbedding` (`Setoid.Subalgebras.Subdirect`): an injective hom into `⨅ 𝒜` whose every coordinate projection is surjective (the standard relational presentation of "a subalgebra of `⨅ 𝒜` meeting every factor", rather than a separately-constructed algebra).
+- [x] `IsSubdirectlyIrreducible : Algebra α ρ → Type _` — landed (`Setoid.Congruences.Monolith`), defined as `Nontrivial × HasMonolith`.
+- [x] Birkhoff's subdirect representation theorem — the choice-free core is proved (`SIRep→Representable`: a separating SI-family of congruences yields a subdirect embedding into a product of SI algebras); `Birkhoff-subdirect` proves the full statement relative to an explicit choice principle (`SubdirectSIRep` existence), the Zorn step isolated as a module parameter rather than postulated.
+- [x] SI characterization via monolithic congruences — `monolith⇒cmi` (a monolith makes `0ᴬ` completely meet-irreducible) and the binary instance `monolith⇒∧-irreducible` (`0ᴬ` is meet-irreducible); plus `monolith-unique`.
 
 ## Acceptance criteria
 
-- [ ] Subdirect product construction type-checks.
-- [ ] Birkhoff's subdirect product theorem is proved.
-- [ ] SI characterization is proved.
+- [x] Subdirect product construction type-checks — `Setoid.Subalgebras.Subdirect` type-checks under `make check`.
+- [x] Birkhoff's subdirect representation theorem is proved — constructive core in full; the choice-dependent existence is an explicit module parameter (mirrors M6-3's handling of choice-dependent theorems).  See the design note.
+- [x] SI characterization is proved — the forward direction (monolith ⟹ completely meet-irreducible) is proved constructively; the converse is predicativity-blocked and recorded as a follow-up.
+
+## Status — first pass (PR #418)
+
+The constructive core of subdirect representation theory landed in two modules:
+
++  `Setoid.Congruences.Monolith` — `Nontrivial` / `Trivial`, `Nonzero` congruences, the infinitary meet `⋂`, `IsMonolith` / `HasMonolith` / `monolith-unique`, `IsSubdirectlyIrreducible`, and the characterization `monolith⇒cmi` / `monolith⇒∧-irreducible`.
++  `Setoid.Subalgebras.Subdirect` — `⨅-proj`, `coord`, `IsSubdirectEmbedding` / `SubdirectEmbedding` / `subdirect→≤`; the bridge `separating→SubdirectEmbedding` (with `natmap-injective` / `natmap-separates`, and a `refl`-checked `IsInjective (proj₁ natmap) ≡ Separates`, showing injectivity is *definitionally* the separation hypothesis "the meet is the diagonal"); and `Birkhoff-subdirect`, the subdirect representation theorem relative to the choice principle `SubdirectSIRep`.
+
+The choice/Zorn decision (option (a): explicit module parameter), the constructive-`¬¬` reason the parameter is a separating SI-family rather than per-pair maximal congruences, the predicativity wall blocking the cmi-⟹-monolith converse, and the level conventions are recorded in `docs/notes/m6-2-subdirect.md`.  Follow-ups: the constructive finite case (option (b), discharging the parameter by search when `≈` is decidable); the impredicative converse; and linking SI to the absence of a nontrivial subdirect decomposition.
 
 ---
 
@@ -3051,7 +3060,7 @@ Deferred proofs are tracked in successor issues: #410 ([M6-4] free-algebra `Cg`�
 
 ---
 
-### Issue M6-4: Free-algebra congruence/derivability bridge (infrastructure for the Maltsev-condition converses) (#410)
+### Issue M6-4: Free-algebra congruence/derivability bridge (infrastructure for the Maltsev-condition converses) (#410, closed)
 
 **Labels**: `milestone-6-flrp`
 
@@ -3137,7 +3146,7 @@ So assembling the lattice is a "step-3"-style task, closely parallel to the cong
 
 ---
 
-### Issue M6-5: Converse of Maltsev's theorem: congruence-permutable ⟹ Maltsev term (#411)
+### Issue M6-5: Converse of Maltsev's theorem: congruence-permutable ⟹ Maltsev term (#411, closed)
 
 **Labels**: `milestone-6-flrp`
 
@@ -3213,7 +3222,7 @@ This is separated from #373 because it is a sizeable undertaking on its own:
 
 ### Issue M6-6: Forward Jónsson/Day: Jónsson terms ⟹ CD and Day terms ⟹ CM (#412)
 
-**Labels**: `milestone-6-flrp`
+**Labels**: `enhancement`, `milestone-6-flrp`
 
 ## Description
 
@@ -3254,7 +3263,7 @@ https://claude.ai/code/session_01MvPrLTCxKjFgsnTMK8j2qZ
 
 ### Issue M6-7: Converse Jónsson/Day: CD ⟹ Jónsson terms and CM ⟹ Day terms (#413)
 
-**Labels**: `milestone-6-flrp`
+**Labels**: `enhancement`, `milestone-6-flrp`, `research-exploratory`
 
 ## Description
 
@@ -3297,6 +3306,112 @@ Construction (Burris–Sankappanavar, Thms. 12.6 and 12.4), sketched in `docs/no
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 https://claude.ai/code/session_01MvPrLTCxKjFgsnTMK8j2qZ
+
+---
+
+### Issue M6-8: Finite Birkhoff: discharge SubdirectSIRep constructively for finite algebras with decidable equality (#419)
+
+**Labels**: `enhancement`, `milestone-6-flrp`
+
+## Description
+
+[M6-2] (#272, PR #418) proved the choice-free core of Birkhoff's subdirect representation theorem: the bridge `separating→SubdirectEmbedding` (a family of congruences whose meet is the diagonal embeds `𝑨` subdirectly into the product of its quotients) and the reduction `SIRep→Representable`.  The full theorem `Birkhoff-subdirect` is stated *relative to* a module parameter `SubdirectSIRep 𝑨` — the existence of a separating family of SI-quotient congruences — because producing it in general is a Zorn's-lemma step (a congruence maximal among those excluding a given pair), incompatible with postulate-free `--safe`.
+
+For **finite algebras with decidable setoid equality** that parameter can be *discharged constructively*: the congruence lattice is finite and searchable, so for each pair `a ≢ b` one finds a congruence maximal among those not relating `a , b` by search.  Such a congruence is completely meet-irreducible, hence its quotient is subdirectly irreducible (via the monolith characterization in `Setoid.Congruences.Monolith`), and the family over all distinct pairs separates points.  This turns `Birkhoff-subdirect` into an *unconditional* theorem on finite algebras — and finiteness is exactly the FLRP setting, so this is the payoff direction.
+
+This is option (b) of the M6-2 design note (`docs/notes/m6-2-subdirect.md`).
+
+## Tasks
+
++  Fix the finiteness/decidability interface: a decidable setoid equality on `𝕌[ 𝑨 ]` and a finiteness/enumerability witness for the relevant congruences at the working level.  Decide the cleanest encoding (reuse any existing `Fin`/`Setoid`-based finiteness already in the tree).
++  For a distinct pair `a , b`, search the (finite) set of congruences not relating `a , b` for a maximal one, and prove its maximality.
++  Show a maximal-separating congruence is completely meet-irreducible and that its quotient is `IsSubdirectlyIrreducible`.  Note the subtlety the design note flags: with decidable `≈` the `¬¬`-gap that blocks the general construction disappears, so the family's meet is *exactly* the diagonal.
++  Assemble `SubdirectSIRep 𝑨` (index = distinct pairs) and instantiate `Birkhoff-subdirect` to obtain the unconditional finite statement.
+
+## Dependencies
+
++  [M6-2] (#272, PR #418) — `Setoid.Subalgebras.Subdirect` (the bridge, `SubdirectSIRep`, `Birkhoff-subdirect`) and `Setoid.Congruences.Monolith` (SI via monolith, `monolith⇒cmi`).
+
+## Acceptance criteria
+
++  A constructive `SubdirectSIRep 𝑨` for finite algebras with decidable equality, and `Birkhoff-subdirect` instantiated to an unconditional subdirect-representation theorem on that class, type-checking under `--cubical-compatible --exact-split --safe`.
+
+## References
+
++  Burris and Sankappanavar, *A Course in Universal Algebra*, Thm. II.8.6 (Birkhoff's subdirect representation theorem).
++  Design note: `docs/notes/m6-2-subdirect.md` (option (b)).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01B9q9aP34sakGdPgZVaXU2s
+
+---
+
+### Issue M6-9: The completely-meet-irreducible ⟹ monolith converse (needs an impredicative/resized congruence meet) (#420)
+
+**Labels**: `enhancement`, `milestone-6-flrp`, `design-discussion`
+
+## Description
+
+`Setoid.Congruences.Monolith` (from [M6-2] (#272, PR #418)) proves the useful direction of the subdirect-irreducibility characterization: a monolith makes `0ᴬ` completely meet-irreducible (`monolith⇒cmi`, in the constructive contrapositive form "every member of a family nonzero ⟹ the meet is nonzero").
+
+The **converse** — `0ᴬ` completely meet-irreducible ⟹ a monolith exists — is not proved, for a predicativity reason.  The natural construction takes the monolith to be `μ = ⋀ { θ : Nonzero θ }`, the meet of *all* nonzero congruences; but that family is indexed by `Σ[ θ ∈ Con 𝑨 ℓ ] Nonzero θ`, which lives one universe up, so the meet lands at a level `ℓ′ > ℓ` and is not a monolith *at level `ℓ`*.  This is the same predicativity wall the complete-lattice construction meets (completeness only for `ℓ₀`-small families).
+
+## Tasks
+
++  Decide the resolution: (i) a level-polymorphic monolith / `IsSubdirectlyIrreducible` allowing the monolith one level up; (ii) an impredicative or resized congruence meet, taken as an explicit parameter (mirroring the M6-2 choice-principle discipline, so nothing is postulated under `--safe`); or (iii) restrict to a setting where the nonzero congruences are `ℓ`-small (e.g. finite, dovetailing with [M6-8]).
++  Prove the converse under the chosen resolution: from completely-meet-irreducible `0ᴬ` (and nontriviality) construct the least nonzero congruence and show `IsMonolith`.
++  Record the assumption / level cost explicitly.
+
+## Dependencies
+
++  [M6-2] (#272, PR #418) — `Setoid.Congruences.Monolith` (`IsMonolith`, `Nonzero`, `⋂`, `monolith⇒cmi`).
+
+## Acceptance criteria
+
++  `cmi ⟹ HasMonolith` proved (at the appropriate level / under the stated resizing assumption), completing the SI ⟺ completely-meet-irreducible characterization, type-checking under `--safe`.
+
+## References
+
++  Design note: `docs/notes/m6-2-subdirect.md` (§ "The monolith characterization and its converse").
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01B9q9aP34sakGdPgZVaXU2s
+
+---
+
+### Issue M6-10: Subdirectly irreducible ⟺ no nontrivial subdirect decomposition (the structural characterization) (#421)
+
+**Labels**: `enhancement`, `milestone-6-flrp`
+
+## Description
+
+`Setoid.Congruences.Monolith` (from [M6-2] (#272, PR #418)) *defines* subdirect irreducibility order-theoretically: `IsSubdirectlyIrreducible 𝑨 = Nontrivial 𝑨 × HasMonolith 𝑨`.  What makes the name apt is the **structural** characterization: `𝑨` is subdirectly irreducible iff it has no nontrivial subdirect decomposition — i.e. in every subdirect embedding `𝑨 ↪ ⨅ 𝒜`, some coordinate projection `projᵢ ∘ h` is an isomorphism.  This issue proves that equivalence, tying `Setoid.Congruences.Monolith` to `Setoid.Subalgebras.Subdirect`.
+
+## Tasks
+
++  State "no nontrivial subdirect decomposition": in every subdirect embedding `h : 𝑨 ↪ ⨅ 𝒜`, some coordinate map is an isomorphism.  Pick the cleanest constructive phrasing — via the kernels, a subdirect embedding corresponds to a separating family `θ` (`⋂ θ` the diagonal), and "some projection is iso" ⟺ "some `θ i ≑ 0ᴬ`".
++  Prove monolith ⟹ structural irreducibility: if `⋂ θ` is the diagonal and `𝑨` has a monolith `μ`, then some `θ i ≑ 0ᴬ` (else `μ ⊆ θ i` for all `i`, so `μ ⊆ ⋂ θ ≑ 0ᴬ`, contradicting `Nonzero μ`) — `monolith⇒cmi` transported across the kernel/subdirect correspondence.  Extracting the specific `i` constructively may need the index decidable/finite (coordinate with [M6-8]); otherwise state the contrapositive.
++  Prove the converse (structural ⟹ monolith), or document its level/choice cost if it mirrors [M6-9].
+
+## Dependencies
+
++  [M6-2] (#272, PR #418) — `Setoid.Subalgebras.Subdirect` and `Setoid.Congruences.Monolith`.
++  Likely interacts with [M6-8] (finite/decidable extraction) and [M6-9] (the converse's predicativity).
+
+## Acceptance criteria
+
++  The equivalence (at least the constructive direction, with the converse proved or its cost documented) type-checks under `--safe`, connecting `IsSubdirectlyIrreducible` to subdirect decompositions.
+
+## References
+
++  Burris and Sankappanavar, *A Course in Universal Algebra*, Def. II.8.3 and Thm. II.8.4.
++  Design note: `docs/notes/m6-2-subdirect.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01B9q9aP34sakGdPgZVaXU2s
 
 <!-- END GENERATED: milestone-6 -->
 

--- a/docs/notes/m6-2-subdirect.md
+++ b/docs/notes/m6-2-subdirect.md
@@ -22,14 +22,14 @@ Two modules, both `--cubical-compatible --exact-split --safe`.
    of subdirect irreducibility.
    +  `Nontrivial 𝑨` / `Trivial 𝑨` — the carrier has two `≈`-distinct elements / all
       elements are `≈`-equal (the degenerate one-element case); `trivial⇒¬nontrivial`.
-   +  `BelowDiagonal θ` (`θ` relates only `≈`-equal elements, i.e. `θ ≡ 0ᴬ`) and its
+   +  `BelowDiagonal θ` (`θ` relates only `≈`-equal elements, i.e. `θ ≑ 0ᴬ`) and its
       negation `Nonzero θ` (the right "strictly above `0ᴬ`" notion).
    +  `⋂` — the meet (intersection) of an `ℓ`-small family of `ℓ`-level congruences, at
       the algebra's own relation level (the natural-level instance of the `⋀` that
       `Setoid.Congruences.CompleteLattice` packages at the absorbing level `L`).
    +  `IsMonolith μ` — `μ` is nonzero and is contained in every nonzero congruence (the
       least nonzero congruence); `HasMonolith`; `monolith-unique` (the monolith is
-      unique up to `≡`, the mutual-containment equivalence on congruences).
+      unique up to `≑`, the mutual-containment equivalence on congruences).
    +  `IsSubdirectlyIrreducible 𝑨 = Nontrivial 𝑨 × HasMonolith 𝑨`, with `si⇒nontrivial`
       and `trivial⇒¬si`.
    +  `monolith⇒cmi` — the characterization: a monolith makes `0ᴬ` *completely
@@ -45,10 +45,10 @@ Two modules, both `--cubical-compatible --exact-split --safe`.
       whose every coordinate map is surjective); `SubdirectEmbedding`; `subdirect→≤`
       (a subdirect embedding is in particular a subalgebra inclusion `𝑩 ≤ ⨅ 𝒜`).
    +  **The bridge.**  For a family `θ : I → Con 𝑨`, the natural map
-      `⟪ θ ⟫hom = ⨅-hom-co (πhom ∘ θ) : 𝑨 → ⨅ (λ i → 𝑨 ╱ θ i)`.  `Separates θ` says the
-      meet `⋂ θ` is the diagonal (`∀ i, θ i a b ⟹ a ≈ b`).  Then `⟪⟫-injective` /
-      `⟪⟫-separates` show injectivity of the natural map is **definitionally** the
-      separation property, and `⟪⟫-proj-onto` shows each coordinate map *is* the
+      `natmap = ⨅-hom-co (πhom ∘ θ) : 𝑨 → ⨅ (λ i → 𝑨 ╱ θ i)`.  `Separates θ` says the
+      meet `⋂ θ` is the diagonal (`∀ i, θ i a b ⟹ a ≈ b`).  Then `natmap-injective` /
+      `natmap-separates` show injectivity of the natural map is **definitionally** the
+      separation property, and `natmap-proj-onto` shows each coordinate map *is* the
       canonical quotient epimorphism, hence surjective — with no decidability or choice
       on the index.  `separating→SubdirectEmbedding` assembles them.
    +  **Birkhoff, reduced to existence.**  `SubdirectlyRepresentable 𝑨` (a family of SI
@@ -61,11 +61,12 @@ Two modules, both `--cubical-compatible --exact-split --safe`.
 ## The injectivity-is-separation identity
 
 The technical pleasantness of the bridge is that the two halves are *definitional*, not
-just provable.  The image of `a : 𝕌[ 𝑨 ]` under `⟪ θ ⟫hom` is its tuple of congruence
+just provable.  The image of `a : 𝕌[ 𝑨 ]` under `natmap` is its tuple of congruence
 classes `λ i → a`, and equality in `⨅ (λ i → 𝑨 ╱ θ i)` at that tuple unfolds to
 `∀ i → proj₁ (θ i) a b` — exactly the hypothesis of `Separates`.  So
-`IsInjective (proj₁ ⟪ θ ⟫hom)` and `Separates θ` are the *same type*, and
-`⟪⟫-injective = λ sep → sep`.  Likewise `coord 𝑨╱ ⟪ θ ⟫hom i` reduces to the canonical
+`IsInjective (proj₁ natmap)` and `Separates θ` are the *same type* — a fact we record
+with a `refl`-checked `IsInjective (proj₁ natmap) ≡ Separates` (propositional `≡`) — and
+`natmap-injective = id`.  Likewise `coord 𝑨╱ natmap i` reduces to the canonical
 projection `πepi 𝒾𝒹 (θ i)`, so its surjectivity is `IsEpi.isSurjective` of that epi
 verbatim.  This is the formal content of the brief's "injectivity is exactly *the meet is
 the diagonal*".
@@ -104,7 +105,7 @@ as a checked `Type`), since (a) both states the assumption and proves the theore
 
 `monolith⇒cmi` is stated in **contrapositive** form: *if every member of a family is
 nonzero, the meet is nonzero*.  This is the constructively honest reading of "`0ᴬ` is
-completely meet-irreducible" — the textbook form "`⋀ θ ≡ 0ᴬ ⟹ ∃ i, θ i ≡ 0ᴬ`" would
+completely meet-irreducible" — the textbook form "`⋀ θ ≑ 0ᴬ ⟹ ∃ i, θ i ≑ 0ᴬ`" would
 require extracting a witnessing index from a negated statement.  The proof is immediate
 from the monolith: `μ ⊆ θ i` for every `i`, so `μ ⊆ ⋀ θ`, and `μ` nonzero forces `⋀ θ`
 nonzero.

--- a/docs/notes/m6-2-subdirect.md
+++ b/docs/notes/m6-2-subdirect.md
@@ -22,14 +22,14 @@ Two modules, both `--cubical-compatible --exact-split --safe`.
    of subdirect irreducibility.
    +  `Nontrivial 𝑨` / `Trivial 𝑨` — the carrier has two `≈`-distinct elements / all
       elements are `≈`-equal (the degenerate one-element case); `trivial⇒¬nontrivial`.
-   +  `BelowDiagonal θ` (`θ` relates only `≈`-equal elements, i.e. `θ ≅ 0ᴬ`) and its
+   +  `BelowDiagonal θ` (`θ` relates only `≈`-equal elements, i.e. `θ ≡ 0ᴬ`) and its
       negation `Nonzero θ` (the right "strictly above `0ᴬ`" notion).
    +  `⋂` — the meet (intersection) of an `ℓ`-small family of `ℓ`-level congruences, at
       the algebra's own relation level (the natural-level instance of the `⋀` that
       `Setoid.Congruences.CompleteLattice` packages at the absorbing level `L`).
    +  `IsMonolith μ` — `μ` is nonzero and is contained in every nonzero congruence (the
       least nonzero congruence); `HasMonolith`; `monolith-unique` (the monolith is
-      unique up to `≅`).
+      unique up to `≡`, the mutual-containment equivalence on congruences).
    +  `IsSubdirectlyIrreducible 𝑨 = Nontrivial 𝑨 × HasMonolith 𝑨`, with `si⇒nontrivial`
       and `trivial⇒¬si`.
    +  `monolith⇒cmi` — the characterization: a monolith makes `0ᴬ` *completely
@@ -104,9 +104,9 @@ as a checked `Type`), since (a) both states the assumption and proves the theore
 
 `monolith⇒cmi` is stated in **contrapositive** form: *if every member of a family is
 nonzero, the meet is nonzero*.  This is the constructively honest reading of "`0ᴬ` is
-completely meet-irreducible" — the textbook form "`⋀ θ ≅ 0ᴬ ⟹ ∃ i, θ i ≅ 0ᴬ`" would
+completely meet-irreducible" — the textbook form "`⋀ θ ≡ 0ᴬ ⟹ ∃ i, θ i ≡ 0ᴬ`" would
 require extracting a witnessing index from a negated statement.  The proof is immediate
-from the monolith: `μ ≤ θ i` for every `i`, so `μ ≤ ⋀ θ`, and `μ` nonzero forces `⋀ θ`
+from the monolith: `μ ⊆ θ i` for every `i`, so `μ ⊆ ⋀ θ`, and `μ` nonzero forces `⋀ θ`
 nonzero.
 
 The **converse** (`0ᴬ` completely meet-irreducible ⟹ a monolith exists) is *not* added.

--- a/docs/notes/m6-2-subdirect.md
+++ b/docs/notes/m6-2-subdirect.md
@@ -1,0 +1,158 @@
+<!-- File: docs/notes/m6-2-subdirect.md -->
+
+# M6-2 design note: subdirect products, subdirectly irreducible algebras, and Birkhoff's subdirect representation theorem
+
+This note records the first pass of [M6-2][] (#272) — *subdirect products and
+subdirectly irreducible algebras* — the foundational FLRP-prerequisite that the M6
+track skipped over when it did congruence permutability (M6-3/#273) and the CP converse
+(M6-4/M6-5, #410/#411) first.  Read it alongside the M6 milestone description in
+[`GITHUB_PROJECT.md`][] and the merged congruence-lattice work
+(`Setoid.Congruences.{Lattice,Generation,CompleteLattice}`).
+
+The deliverable mirrors M6-3's discipline: the **constructive core is proved in full**,
+and the one genuinely choice-dependent statement (the *existence* half of Birkhoff's
+theorem) is isolated as an explicit module parameter rather than postulated, so the
+library stays postulate-free under `--safe`.
+
+## What landed
+
+Two modules, both `--cubical-compatible --exact-split --safe`.
+
++  `Setoid.Congruences.Monolith` — pure congruence theory; the order-theoretic content
+   of subdirect irreducibility.
+   +  `Nontrivial 𝑨` / `Trivial 𝑨` — the carrier has two `≈`-distinct elements / all
+      elements are `≈`-equal (the degenerate one-element case); `trivial⇒¬nontrivial`.
+   +  `BelowDiagonal θ` (`θ` relates only `≈`-equal elements, i.e. `θ ≅ 0ᴬ`) and its
+      negation `Nonzero θ` (the right "strictly above `0ᴬ`" notion).
+   +  `⋂` — the meet (intersection) of an `ℓ`-small family of `ℓ`-level congruences, at
+      the algebra's own relation level (the natural-level instance of the `⋀` that
+      `Setoid.Congruences.CompleteLattice` packages at the absorbing level `L`).
+   +  `IsMonolith μ` — `μ` is nonzero and is contained in every nonzero congruence (the
+      least nonzero congruence); `HasMonolith`; `monolith-unique` (the monolith is
+      unique up to `≅`).
+   +  `IsSubdirectlyIrreducible 𝑨 = Nontrivial 𝑨 × HasMonolith 𝑨`, with `si⇒nontrivial`
+      and `trivial⇒¬si`.
+   +  `monolith⇒cmi` — the characterization: a monolith makes `0ᴬ` *completely
+      meet-irreducible*; and `monolith⇒∧-irreducible` — its binary instance, the meet of
+      two nonzero congruences is nonzero ("`0ᴬ` is meet-irreducible", the
+      directly-indecomposable-adjacent fact).
+
++  `Setoid.Subalgebras.Subdirect` — the subdirect structures and the bridge.
+   +  `⨅-proj` — the coordinate projection `⨅ 𝒜 → 𝒜 i` as a homomorphism (the
+      `⨅-projection-hom` of `Setoid.Homomorphisms.Products` re-derived so the factor
+      family alone determines it, without that version's vestigial domain parameter).
+   +  `coord h i = projᵢ ∘ h` and `IsSubdirectEmbedding` (a hom that is injective and
+      whose every coordinate map is surjective); `SubdirectEmbedding`; `subdirect→≤`
+      (a subdirect embedding is in particular a subalgebra inclusion `𝑩 ≤ ⨅ 𝒜`).
+   +  **The bridge.**  For a family `θ : I → Con 𝑨`, the natural map
+      `⟪ θ ⟫hom = ⨅-hom-co (πhom ∘ θ) : 𝑨 → ⨅ (λ i → 𝑨 ╱ θ i)`.  `Separates θ` says the
+      meet `⋂ θ` is the diagonal (`∀ i, θ i a b ⟹ a ≈ b`).  Then `⟪⟫-injective` /
+      `⟪⟫-separates` show injectivity of the natural map is **definitionally** the
+      separation property, and `⟪⟫-proj-onto` shows each coordinate map *is* the
+      canonical quotient epimorphism, hence surjective — with no decidability or choice
+      on the index.  `separating→SubdirectEmbedding` assembles them.
+   +  **Birkhoff, reduced to existence.**  `SubdirectlyRepresentable 𝑨` (a family of SI
+      algebras with a subdirect embedding of `𝑨` into their product) is the theorem's
+      conclusion.  `SubdirectSIRep 𝑨` packages the bridge's input: a separating family
+      whose quotients are all subdirectly irreducible.  `SIRep→Representable` is the
+      fully-constructive reduction, and `Birkhoff-subdirect` is the theorem relative to
+      the choice principle `(∀ 𝑨 → SubdirectSIRep 𝑨)`.
+
+## The injectivity-is-separation identity
+
+The technical pleasantness of the bridge is that the two halves are *definitional*, not
+just provable.  The image of `a : 𝕌[ 𝑨 ]` under `⟪ θ ⟫hom` is its tuple of congruence
+classes `λ i → a`, and equality in `⨅ (λ i → 𝑨 ╱ θ i)` at that tuple unfolds to
+`∀ i → proj₁ (θ i) a b` — exactly the hypothesis of `Separates`.  So
+`IsInjective (proj₁ ⟪ θ ⟫hom)` and `Separates θ` are the *same type*, and
+`⟪⟫-injective = λ sep → sep`.  Likewise `coord 𝑨╱ ⟪ θ ⟫hom i` reduces to the canonical
+projection `πepi 𝒾𝒹 (θ i)`, so its surjectivity is `IsEpi.isSurjective` of that epi
+verbatim.  This is the formal content of the brief's "injectivity is exactly *the meet is
+the diagonal*".
+
+## The choice decision for Birkhoff (option (a))
+
+Birkhoff's subdirect representation theorem needs, for each pair `a ≢ b`, a congruence
+**maximal** among those not relating `a , b`.  Such a congruence is completely
+meet-irreducible, so its quotient is subdirectly irreducible, and the family of these
+(over all distinct pairs) meets to the diagonal.  Producing the maximal congruence is a
+Zorn's-lemma step: incompatible with postulate-free `--safe`.
+
+The brief offered three ways to handle this; we took **(a)**: state the theorem relative
+to an explicit choice principle taken as a module parameter.  Concretely
+`Birkhoff-subdirect` abstracts over `sirep : (𝑨 : Algebra α ρ) → SubdirectSIRep 𝑨 ℓ ι`
+and derives `SubdirectlyRepresentable 𝑨` for every `𝑨`.  The choice-free half — *given
+the SI quotients with meet `0ᴬ`, you get the subdirect embedding* — is `SIRep→Representable`
+and is proved unconditionally, so the theorem reduces to *exactly* the choice-dependent
+existence claim `∀ 𝑨 → SubdirectSIRep 𝑨`, as the brief asks.
+
+Why `SubdirectSIRep` (a separating SI-family) rather than the more atomic "for each
+`a ≢ b`, a separating cmi congruence" as the parameter?  Because turning the per-pair
+congruences into a family with meet *exactly* the diagonal is itself non-constructive.
+Indexing by distinct pairs, the separation proof for a fixed `a , b` must inspect whether
+`a ≈ b` to form the index `(a , b , _)`, which yields only `¬ ¬ (a ≈ b)`; recovering
+`a ≈ b` needs `≈` to be stable (decidable equality, or a double-negation elimination).
+That stability is precisely the classical input, so we fold it into the parameter and
+take the directly-usable `SubdirectSIRep` — a separating family in the constructively
+strong sense — as the assumption.  Option (b) (the finite/decidable case, where `≈` *is*
+decidable and the maximal separating congruence is found by search over a finite
+congruence lattice) is the natural way to *discharge* this parameter constructively for
+finite algebras; it is left as a follow-up.  We did not take option (c) (state-and-defer
+as a checked `Type`), since (a) both states the assumption and proves the theorem from it.
+
+## The monolith characterization and its converse
+
+`monolith⇒cmi` is stated in **contrapositive** form: *if every member of a family is
+nonzero, the meet is nonzero*.  This is the constructively honest reading of "`0ᴬ` is
+completely meet-irreducible" — the textbook form "`⋀ θ ≅ 0ᴬ ⟹ ∃ i, θ i ≅ 0ᴬ`" would
+require extracting a witnessing index from a negated statement.  The proof is immediate
+from the monolith: `μ ≤ θ i` for every `i`, so `μ ≤ ⋀ θ`, and `μ` nonzero forces `⋀ θ`
+nonzero.
+
+The **converse** (`0ᴬ` completely meet-irreducible ⟹ a monolith exists) is *not* added.
+The natural construction takes `μ = ⋀ {θ : θ nonzero}`, the meet of all nonzero
+congruences; but that family is indexed by `Σ[ θ ∈ Con 𝑨 ℓ ] Nonzero θ`, which lives one
+universe up, so the resulting meet is a `Con 𝑨 ℓ′` with `ℓ′ > ℓ` — it is not a monolith
+*at level `ℓ`*.  This is the same predicativity wall that the complete-lattice
+construction meets (its completeness is only for `ℓ₀`-small families).  Stating the
+converse cleanly would need an impredicative meet; we record it here as a known limitation
+rather than forcing a level-bumped statement.  The forward direction is the one consumed
+downstream.
+
+## Levels
+
+The congruence level of an SI algebra is fixed to the algebra's **own relation level**
+`ρ`: for `𝑨 : Algebra α ρ` the diagonal `0ᴬ` is the setoid equality `_≈_ : Con 𝑨 ρ` and
+the monolith (when present) is a `Con 𝑨 ρ`, so `IsSubdirectlyIrreducible` carries no
+extra level parameter.  This is the natural predicative choice; a level-generic variant
+is possible but unnecessary for the present clients.  The bridge keeps the family level
+`ℓ` and index level `ι` generic (the product `⨅` lands at `Algebra (α ⊔ ι)(ℓ ⊔ ι)`, per
+the standard product level arithmetic), so the Birkhoff index can be the
+`(α ⊔ ρ)`-level type of distinct pairs without forcing `ℓ = ρ`.
+
+## Homes and naming
+
++  Monolith/SI live under `Setoid.Congruences.` because they are congruence-lattice
+   notions and depend only on `Setoid.Congruences.{Basic,Lattice}`; putting them under
+   `Setoid.Algebras.` would invert the layering (Algebras is below Congruences).
++  Subdirect products/embeddings and Birkhoff live under `Setoid.Subalgebras.` (a
+   subdirect product *is* a subalgebra of a product); `Subdirect` imports `Monolith` for
+   the SI predicate, a clean one-way dependency.
++  The theorem is `Birkhoff-subdirect`, distinct from the HSP variety theorem's
+   `Birkhoff` (`Setoid.Varieties.HSP`), so both can be re-exported through the top-level
+   `Setoid` barrel without an ambiguous-name clash.
+
+## What remains (follow-ups)
+
++  The constructive finite case (option (b)): for an algebra with decidable `≈` and a
+   finite congruence lattice, *discharge* `SubdirectSIRep` by searching for maximal
+   separating congruences — turning `Birkhoff-subdirect` into an unconditional theorem on
+   finite algebras.
++  The impredicative converse `cmi ⟹ monolith`, if/when the library adopts an
+   impredicative or resized meet.
++  Connecting `IsSubdirectlyIrreducible` to the *absence of a nontrivial subdirect
+   decomposition* (an SI algebra's every subdirect embedding has an isomorphism
+   coordinate) — the equivalence that makes "subdirectly irreducible" name what it does.
+
+[M6-2]: https://github.com/ualib/agda-algebras/issues/272
+[`GITHUB_PROJECT.md`]: ../GITHUB_PROJECT.md

--- a/mkdocs/_includes/UALib.Links.md
+++ b/mkdocs/_includes/UALib.Links.md
@@ -128,6 +128,7 @@
 [Setoid.Congruences.CompleteLattice]: https://ualib.org/Setoid.Congruences.CompleteLattice.html
 [Setoid.Congruences.Permutability]: https://ualib.org/Setoid.Congruences.Permutability.html
 [Setoid.Congruences.Properties]: https://ualib.org/Setoid.Congruences.Properties.html
+[Setoid.Congruences.Monolith]: https://ualib.org/Setoid.Congruences.Monolith.html
 
 [Setoid.Homomorphisms]: https://ualib.org/Setoid.Homomorphisms.html
 [Setoid.Homomorphisms.Basic]: https://ualib.org/Setoid.Homomorphisms.Basic.html
@@ -151,6 +152,7 @@
 [Setoid.Subalgebras.Subalgebras]: https://ualib.org/Setoid.Subalgebras.Subalgebras.html
 [Setoid.Subalgebras.Subuniverses]: https://ualib.org/Setoid.Subalgebras.Subuniverses.html
 [Setoid.Subalgebras.CompleteLattice]: https://ualib.org/Setoid.Subalgebras.CompleteLattice.html
+[Setoid.Subalgebras.Subdirect]: https://ualib.org/Setoid.Subalgebras.Subdirect.html
 
 [Setoid.Varieties]: https://ualib.org/Setoid.Varieties.html
 [Setoid.Varieties.Closure]: https://ualib.org/Setoid.Varieties.Closure.html

--- a/src/Examples/Setoid/CongruenceLattice.lagda.md
+++ b/src/Examples/Setoid/CongruenceLattice.lagda.md
@@ -81,7 +81,7 @@ With the base level `ℓ₀ = 0ℓ` the absorbing level `L` is `0ℓ`, so the co
 lattice of `𝟚` is the chain on `Con 𝟚 {0ℓ}`.  All three bundles type-check.
 
 ```agda
-open import Setoid.Congruences.Lattice {𝑆 = 𝑆₀} using ( _≤_ )
+open import Setoid.Congruences.Lattice {𝑆 = 𝑆₀} using ( _⊆_ )
 open import Setoid.Congruences.CompleteLattice {𝑆 = 𝑆₀}
   using ( Con-Lattice ; Con-BoundedLattice ; Con-CompleteLattice ; 1ᴬ ; 0ᴬ ; 0ᴬ-minimum )
 
@@ -98,7 +98,7 @@ but `⊤` relates `true` and `false` while `Δ` (namely `_≡_`) does not, so `t
 — a contradiction.
 
 ```agda
-Con𝟚-nontrivial : ¬ ( (1ᴬ 𝟚 0ℓ) ≤ (0ᴬ 𝟚 0ℓ) )
+Con𝟚-nontrivial : ¬ ( (1ᴬ 𝟚 0ℓ) ⊆ (0ᴬ 𝟚 0ℓ) )
 Con𝟚-nontrivial ⊤≤⊥ with 0ᴬ-minimum 𝟚 0ℓ Δ (⊤≤⊥ {true} {false} (lift _))
 ... | ()
 ```

--- a/src/Setoid/Congruences.lagda.md
+++ b/src/Setoid/Congruences.lagda.md
@@ -18,7 +18,7 @@ module Setoid.Congruences {𝑆 : Signature 𝓞 𝓥} where
 open import Setoid.Congruences.Basic {𝑆 = 𝑆} public
 open import Setoid.Congruences.CompleteLattice {𝑆 = 𝑆} public
 open import Setoid.Congruences.Generation {𝑆 = 𝑆} public
-open import Setoid.Congruences.Lattice {𝑆 = 𝑆} public renaming (_≡_ to _↔_)
+open import Setoid.Congruences.Lattice {𝑆 = 𝑆} public
 open import Setoid.Congruences.Monolith {𝑆 = 𝑆} public
 open import Setoid.Congruences.Properties {𝑆 = 𝑆} public
 open import Setoid.Congruences.Permutability {𝑆 = 𝑆} public

--- a/src/Setoid/Congruences.lagda.md
+++ b/src/Setoid/Congruences.lagda.md
@@ -21,6 +21,7 @@ open import Setoid.Congruences.Generation {𝑆 = 𝑆} public
 open import Setoid.Congruences.Lattice {𝑆 = 𝑆}
 open import Setoid.Congruences.Properties {𝑆 = 𝑆} public
 open import Setoid.Congruences.Permutability {𝑆 = 𝑆} public
+open import Setoid.Congruences.Monolith {𝑆 = 𝑆} public
 ```
 
 --------------------------------

--- a/src/Setoid/Congruences.lagda.md
+++ b/src/Setoid/Congruences.lagda.md
@@ -18,10 +18,10 @@ module Setoid.Congruences {𝑆 : Signature 𝓞 𝓥} where
 open import Setoid.Congruences.Basic {𝑆 = 𝑆} public
 open import Setoid.Congruences.CompleteLattice {𝑆 = 𝑆} public
 open import Setoid.Congruences.Generation {𝑆 = 𝑆} public
-open import Setoid.Congruences.Lattice {𝑆 = 𝑆}
+open import Setoid.Congruences.Lattice {𝑆 = 𝑆} public renaming (_≡_ to _↔_)
+open import Setoid.Congruences.Monolith {𝑆 = 𝑆} public
 open import Setoid.Congruences.Properties {𝑆 = 𝑆} public
 open import Setoid.Congruences.Permutability {𝑆 = 𝑆} public
-open import Setoid.Congruences.Monolith {𝑆 = 𝑆} public
 ```
 
 --------------------------------

--- a/src/Setoid/Congruences/Basic.lagda.md
+++ b/src/Setoid/Congruences/Basic.lagda.md
@@ -30,7 +30,7 @@ open import Relation.Binary.PropositionalEquality using ( refl )
 -- Imports from the Agda Universal Algebras Library ------------------------------
 open import Overture          using ( proj₁  ; proj₂ ; 0[_] ; _|:_ ; Equivalence )
 open import Setoid.Relations  using ( ⟪_⟫ ; _/_ ; ⟪_∼_⟫-elim )
-open import Setoid.Algebras.Basic {𝑆 = 𝑆} using ( ov ; Algebra ; 𝕌[_] ; _^_ )
+open import Setoid.Algebras.Basic {𝑆 = 𝑆} using ( ov ; Algebra ; 𝔻[_] ; 𝕌[_] ; _^_ )
 
 private variable α ρ ℓ : Level
 ```
@@ -109,20 +109,19 @@ open Func     using ( cong ) renaming ( to to _⟨$⟩_ )
 
 _╱_ : (𝑨 : Algebra α ρ) → Con 𝑨 ℓ → Algebra α ℓ
 Domain (𝑨 ╱ θ) = 𝕌[ 𝑨 ] / (Eqv (proj₂ θ))
-(Interp (𝑨 ╱ θ)) ⟨$⟩ (f , a) = (f ^ 𝑨) a
-cong (Interp (𝑨 ╱ θ)) {f , u} {.f , v} (refl , a) = is-compatible (proj₂ θ) f a
+Interp (𝑨 ╱ θ) ⟨$⟩ (f , a) = (f ^ 𝑨) a
+Interp (𝑨 ╱ θ) .cong {f , u} {.f , v} (refl , a) = is-compatible (proj₂ θ) f a
 
 module _ (𝑨 : Algebra α ρ) where
- open Algebra 𝑨  using ( )      renaming (Domain to A )
- open Setoid A   using ( _≈_ )  renaming (refl to refl₁)
+  open Setoid 𝔻[ 𝑨 ]   using ( _≈_ )
 
- _/∙_ : 𝕌[ 𝑨 ] → (θ : Con 𝑨 ℓ) → Carrier (Domain (𝑨 ╱ θ))
- a /∙ θ = a
+  _/∙_ : 𝕌[ 𝑨 ] → (θ : Con 𝑨 ℓ) → 𝕌[ 𝑨 ╱ θ ]
+  a /∙ θ = a
 
- /-≡ :  (θ : Con 𝑨 ℓ){u v : 𝕌[ 𝑨 ]}
-  →     ⟪ u ⟫{Eqv (proj₂ θ)} ≈ ⟪ v ⟫{Eqv (proj₂ θ)} → (proj₁ θ) u v
+  /-≡ : (θ : Con 𝑨 ℓ){u v : 𝕌[ 𝑨 ]}
+    → ⟪ u ⟫{Eqv (proj₂ θ)} ≈ ⟪ v ⟫{Eqv (proj₂ θ)} → (proj₁ θ) u v
 
- /-≡ θ {u}{v} uv = reflexive (proj₂ θ) uv
+  /-≡ θ uv = reflexive (Con→IsCongruence θ) uv
 ```
 
 --------------------------------------

--- a/src/Setoid/Congruences/CompleteLattice.lagda.md
+++ b/src/Setoid/Congruences/CompleteLattice.lagda.md
@@ -55,15 +55,17 @@ open import Relation.Binary.Lattice      using ( Supremum ; Infimum ; IsLattice
                                                ; BoundedLattice )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
-open import Setoid.Algebras.Basic {𝑆 = 𝑆}             using  ( ov ; Algebra ; 𝕌[_] )
-open import Order.CompleteLattice  using  ( CompleteLattice )
-open import Setoid.Congruences.Basic {𝑆 = 𝑆}
-  using  ( Con ; mkcon ; _∣≈_ ; reflexive ; is-equivalence ; is-compatible )
-open import Setoid.Congruences.Lattice {𝑆 = 𝑆}
-  using  ( _≅_ ; _≤_ ; _∧_ ; ≤-isPartialOrder ; ∧-infimum )
-open import Setoid.Congruences.Generation  {𝑆 = 𝑆}
-  using  ( Cg ; Cg-least ; base ; _∨_ ; ∨-upperˡ ; ∨-upperʳ ; ∨-least )
-
+open import Setoid.Algebras.Basic            {𝑆 = 𝑆}  using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Order.CompleteLattice                     using  ( CompleteLattice )
+open import Setoid.Congruences.Basic         {𝑆 = 𝑆}  using  ( Con ; mkcon ; _∣≈_
+                                                             ; reflexive ; is-equivalence
+                                                             ; is-compatible )
+open import Setoid.Congruences.Lattice       {𝑆 = 𝑆}  using  ( _≡_ ; _⊆_ ; _∧_
+                                                             ; ⊆-isPartialOrder
+                                                             ; ∧-infimum )
+open import Setoid.Congruences.Generation    {𝑆 = 𝑆}  using  ( Cg ; Cg-least ; base
+                                                             ; _∨_ ; ∨-upperˡ
+                                                             ; ∨-upperʳ ; ∨-least )
 private variable α ρ ℓ₀ : Level
 ```
 
@@ -76,8 +78,7 @@ relation level is `L = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ ⊔ ℓ₀`.  Because level j
 
 ```agda
 module _ (𝑨 : Algebra α ρ) (ℓ₀ : Level) where
-  open Algebra 𝑨 using () renaming ( Domain to 𝐀 )
-  open Setoid 𝐀 using ( _≈_ ) renaming ( refl to reflA )
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ) renaming ( refl to reflA )
 
   L : Level
   L = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ ⊔ ℓ₀
@@ -91,25 +92,25 @@ The join is the least upper bound: the two upper-bound facts come from `Generati
 and the universality is `∨-least`.
 
 ```agda
-  Con-supremum : Supremum (_≤_ {𝑨 = 𝑨} {L}) _∨_
+  Con-supremum : Supremum (_⊆_ {𝑨 = 𝑨} {L}) _∨_
   Con-supremum θ φ  = ∨-upperˡ θ φ
                     , ∨-upperʳ θ φ
-                    , λ ψ θ≤ψ φ≤ψ → ∨-least θ φ ψ θ≤ψ φ≤ψ
+                    , λ ψ θ⊆ψ φ⊆ψ → ∨-least θ φ ψ θ⊆ψ φ⊆ψ
 ```
 
 Assembling the partial order, the supremum, and the meet's infimum gives the lattice.
 
 ```agda
-  Con-isLattice : IsLattice (_≅_ {𝑨 = 𝑨} {L}) _≤_ _∨_ _∧_
-  Con-isLattice = record  { isPartialOrder  = ≤-isPartialOrder
+  Con-isLattice : IsLattice (_≡_ {𝑨 = 𝑨} {L}) _⊆_ _∨_ _∧_
+  Con-isLattice = record  { isPartialOrder  = ⊆-isPartialOrder
                           ; supremum        = Con-supremum
                           ; infimum         = ∧-infimum
                           }
 
   Con-Lattice : Lattice (α ⊔ ρ ⊔ ov L) (α ⊔ L) (α ⊔ L)
   Con-Lattice = record  { Carrier    = Conᴸ
-                        ; _≈_        = _≅_
-                        ; _≤_        = _≤_
+                        ; _≈_        = _≡_
+                        ; _≤_        = _⊆_
                         ; _∨_        = _∨_
                         ; _∧_        = _∧_
                         ; isLattice  = Con-isLattice
@@ -144,10 +145,10 @@ the greatest.
                             })
                    (λ _ _ → lift tt)
 
-  0ᴬ-minimum : Minimum _≤_ 0ᴬ
+  0ᴬ-minimum : Minimum _⊆_ 0ᴬ
   0ᴬ-minimum θ = Cg-least θ (λ { (lift ()) })
 
-  1ᴬ-maximum : Maximum _≤_ 1ᴬ
+  1ᴬ-maximum : Maximum _⊆_ 1ᴬ
   1ᴬ-maximum _ _ = lift tt
 ```
 
@@ -155,7 +156,7 @@ With the bounds the lattice becomes a bounded lattice (`1ᴬ` is the maximum, `0
 minimum).
 
 ```agda
-  Con-isBoundedLattice : IsBoundedLattice (_≅_ {𝑨 = 𝑨} {L}) _≤_ _∨_ _∧_ 1ᴬ 0ᴬ
+  Con-isBoundedLattice : IsBoundedLattice (_≡_ {𝑨 = 𝑨} {L}) _⊆_ _∨_ _∧_ 1ᴬ 0ᴬ
   Con-isBoundedLattice = record  { isLattice  = Con-isLattice
                                  ; maximum    = 1ᴬ-maximum
                                  ; minimum    = 0ᴬ-minimum
@@ -163,8 +164,8 @@ minimum).
 
   Con-BoundedLattice : BoundedLattice (α ⊔ ρ ⊔ ov L) (α ⊔ L) (α ⊔ L)
   Con-BoundedLattice = record  { Carrier           = Conᴸ
-                               ; _≈_               = _≅_
-                               ; _≤_               = _≤_
+                               ; _≈_               = _≡_
+                               ; _≤_               = _⊆_
                                ; _∨_               = _∨_
                                ; _∧_               = _∧_
                                ; ⊤                 = 1ᴬ
@@ -205,17 +206,17 @@ join the least upper bound of the family.
     ⋁ : Conᴸ
     ⋁ = Cg (λ x y → Σ[ i ∈ I ] proj₁ (f i) x y)
 
-    ⋀-lower : (i : I) → ⋀ ≤ f i
+    ⋀-lower : (i : I) → ⋀ ⊆ f i
     ⋀-lower i p = p i
 
-    ⋀-greatest : (ψ : Conᴸ) → (∀ i → ψ ≤ f i) → ψ ≤ ⋀
-    ⋀-greatest ψ ψ≤f p i = ψ≤f i p
+    ⋀-greatest : (ψ : Conᴸ) → (∀ i → ψ ⊆ f i) → ψ ⊆ ⋀
+    ⋀-greatest ψ ψ⊆f p i = ψ⊆f i p
 
-    ⋁-upper : (i : I) → f i ≤ ⋁
+    ⋁-upper : (i : I) → f i ⊆ ⋁
     ⋁-upper i p = base (i , p)
 
-    ⋁-least : (ψ : Conᴸ) → (∀ i → f i ≤ ψ) → ⋁ ≤ ψ
-    ⋁-least ψ f≤ψ = Cg-least {𝑨 = 𝑨} ψ (λ (i , p) → f≤ψ i p)
+    ⋁-least : (ψ : Conᴸ) → (∀ i → f i ⊆ ψ) → ⋁ ⊆ ψ
+    ⋁-least ψ f⊆ψ = Cg-least {𝑨 = 𝑨} ψ (λ (i , p) → f⊆ψ i p)
 ```
 
 #### The complete lattice
@@ -227,9 +228,9 @@ yields the complete lattice of congruences.
   Con-CompleteLattice : CompleteLattice (α ⊔ ρ ⊔ ov L) (α ⊔ L) (α ⊔ L) ℓ₀
   Con-CompleteLattice = record
     { Carrier          = Conᴸ
-    ; _≈_              = _≅_
-    ; _≤_              = _≤_
-    ; isPartialOrder   = ≤-isPartialOrder
+    ; _≈_              = _≡_
+    ; _≤_              = _⊆_
+    ; isPartialOrder   = ⊆-isPartialOrder
     ; ⨆                = ⋁
     ; ⨅                = ⋀
     ; ⨆-upper          = λ f i → ⋁-upper f i

--- a/src/Setoid/Congruences/CompleteLattice.lagda.md
+++ b/src/Setoid/Congruences/CompleteLattice.lagda.md
@@ -60,7 +60,7 @@ open import Order.CompleteLattice                     using  ( CompleteLattice )
 open import Setoid.Congruences.Basic         {𝑆 = 𝑆}  using  ( Con ; mkcon ; _∣≈_
                                                              ; reflexive ; is-equivalence
                                                              ; is-compatible )
-open import Setoid.Congruences.Lattice       {𝑆 = 𝑆}  using  ( _≡_ ; _⊆_ ; _∧_
+open import Setoid.Congruences.Lattice       {𝑆 = 𝑆}  using  ( _≑_ ; _⊆_ ; _∧_
                                                              ; ⊆-isPartialOrder
                                                              ; ∧-infimum )
 open import Setoid.Congruences.Generation    {𝑆 = 𝑆}  using  ( Cg ; Cg-least ; base
@@ -101,7 +101,7 @@ and the universality is `∨-least`.
 Assembling the partial order, the supremum, and the meet's infimum gives the lattice.
 
 ```agda
-  Con-isLattice : IsLattice (_≡_ {𝑨 = 𝑨} {L}) _⊆_ _∨_ _∧_
+  Con-isLattice : IsLattice (_≑_ {𝑨 = 𝑨} {L}) _⊆_ _∨_ _∧_
   Con-isLattice = record  { isPartialOrder  = ⊆-isPartialOrder
                           ; supremum        = Con-supremum
                           ; infimum         = ∧-infimum
@@ -109,7 +109,7 @@ Assembling the partial order, the supremum, and the meet's infimum gives the lat
 
   Con-Lattice : Lattice (α ⊔ ρ ⊔ ov L) (α ⊔ L) (α ⊔ L)
   Con-Lattice = record  { Carrier    = Conᴸ
-                        ; _≈_        = _≡_
+                        ; _≈_        = _≑_
                         ; _≤_        = _⊆_
                         ; _∨_        = _∨_
                         ; _∧_        = _∧_
@@ -156,7 +156,7 @@ With the bounds the lattice becomes a bounded lattice (`1ᴬ` is the maximum, `0
 minimum).
 
 ```agda
-  Con-isBoundedLattice : IsBoundedLattice (_≡_ {𝑨 = 𝑨} {L}) _⊆_ _∨_ _∧_ 1ᴬ 0ᴬ
+  Con-isBoundedLattice : IsBoundedLattice (_≑_ {𝑨 = 𝑨} {L}) _⊆_ _∨_ _∧_ 1ᴬ 0ᴬ
   Con-isBoundedLattice = record  { isLattice  = Con-isLattice
                                  ; maximum    = 1ᴬ-maximum
                                  ; minimum    = 0ᴬ-minimum
@@ -164,7 +164,7 @@ minimum).
 
   Con-BoundedLattice : BoundedLattice (α ⊔ ρ ⊔ ov L) (α ⊔ L) (α ⊔ L)
   Con-BoundedLattice = record  { Carrier           = Conᴸ
-                               ; _≈_               = _≡_
+                               ; _≈_               = _≑_
                                ; _≤_               = _⊆_
                                ; _∨_               = _∨_
                                ; _∧_               = _∧_
@@ -228,7 +228,7 @@ yields the complete lattice of congruences.
   Con-CompleteLattice : CompleteLattice (α ⊔ ρ ⊔ ov L) (α ⊔ L) (α ⊔ L) ℓ₀
   Con-CompleteLattice = record
     { Carrier          = Conᴸ
-    ; _≈_              = _≡_
+    ; _≈_              = _≑_
     ; _≤_              = _⊆_
     ; isPartialOrder   = ⊆-isPartialOrder
     ; ⨆                = ⋁

--- a/src/Setoid/Congruences/Lattice.lagda.md
+++ b/src/Setoid/Congruences/Lattice.lagda.md
@@ -12,7 +12,7 @@ This is the [Setoid.Congruences.Lattice][] module of the [Agda Universal Algebra
 The congruences of an algebra `𝑨`, ordered by containment, form a complete lattice.
 This module begins the formalization of that fact by promoting `Con 𝑨` to a
 first-class ordered object: it defines the containment order `_≤_`, the induced
-equivalence `_≅_` of mutual containment, and the **meet** `θ ∧ φ`, which is the
+equivalence `_≡_` of mutual containment, and the **meet** `θ ∧ φ`, which is the
 relational intersection `θ ∩ φ`.  The intersection of two congruences is again a
 congruence, and it is the greatest lower bound of the two arguments.  Thus we have a
 partially ordered set which, with the meet operation, forms a semilattice.
@@ -32,25 +32,25 @@ module Setoid.Congruences.Lattice {𝑆 : Signature 𝓞 𝓥} where
 open import Agda.Primitive           using () renaming ( Set to Type )
 open import Data.Product             using ( _×_ ; _,_ ; proj₁ ; proj₂ ; swap )
 open import Level                    using ( Level ; _⊔_ )
-open import Relation.Binary          using ( Setoid ; IsEquivalence ; IsPartialOrder )
-                                     renaming ( Rel to BinRel ; _⇒_ to _⊆_ )
+open import Relation.Binary          using ( Setoid ; IsEquivalence ; IsPartialOrder ; _⇒_ )
+                                     renaming ( Rel to BinRel )
 open import Relation.Binary.Bundles  using ( Poset )
 open import Relation.Binary.Lattice  using ( Infimum ; IsMeetSemilattice ; MeetSemilattice )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
-open import Setoid.Algebras.Basic {𝑆 = 𝑆}     using  ( ov ; Algebra ; 𝕌[_] )
-open import Setoid.Congruences.Basic {𝑆 = 𝑆}  using  ( Con ; mkcon ; _∣≈_ ; reflexive
-                                                     ; is-equivalence ; is-compatible )
+open import Setoid.Algebras.Basic     {𝑆 = 𝑆}  using  ( ov ; Algebra ; 𝕌[_] )
+open import Setoid.Congruences.Basic  {𝑆 = 𝑆}  using  ( Con ; mkcon ; _∣≈_ ; reflexive
+                                                      ; is-equivalence ; is-compatible )
 private variable α ρ ℓ : Level
 ```
 
 #### The containment order on congruences
 
-For congruences `θ φ : Con 𝑨` we write `θ ≤ φ` when the underlying relation of `θ`
+For congruences `θ φ : Con 𝑨` we write `θ ⊆ φ` when the underlying relation of `θ`
 is **contained** in that of `φ` ("contained" is with respect to subset inclusion on
 `ℙ(A × A)`).  Classically this is the familiar (lattice) partial order on equivalence
-relations, and it remains a partial order here — `_≤_` is antisymmetric
-**with respect to `_≅_`**, the equivalence of *mutual* containment.  The only
+relations, and it remains a partial order here — `_⊆_` is antisymmetric
+**with respect to `_≡_`**, the equivalence of *mutual set containment*.  The only
 subtlety is which equality counts as **equal congruences**.
 
 The underlying relation of a congruence inhabits the `BinRel` type
@@ -58,75 +58,76 @@ The underlying relation of a congruence inhabits the `BinRel` type
 between the proof-types `proj₁ θ x y` and `proj₁ φ x y` rather than a proof that the
 packaged congruences are *propositionally* equal.
 
-Upgrading `_≅_` to `≡` would need function extensionality with propositional
-extensionality/univalence (and proof-irrelevance for the `IsCongruence` witness),
-and that's simply not available under  `--safe --cubical-compatible`; so we
-take `_≅_` as the equality of congruences, exactly as the `Setoid/` discipline
-dictates.  Classically `_≅_` collapses to `_≡_` via propositional extensionality.
+Upgrading `_≡_` to propositional equality would need function extensionality with
+propositional extensionality/univalence (and proof-irrelevance for the `IsCongruence`
+witness), and that's simply not available under   `--safe --cubical-compatible`; so we
+take `_≡_` as the equality of congruences, exactly as the `Setoid/` discipline
+dictates.  Classically `_≡_` collapses to propositional equality via propositional
+extensionality.
 
 ```agda
 module _ {𝑨 : Algebra α ρ} where
   open Algebra 𝑨 using () renaming ( Domain to A )
-  open Setoid A using ( _≈_ )
+  open Setoid A using () renaming ( _≈_ to _≈ᴬ_ )
 
-  -- θ ≤ φ : the relation of θ is contained in the relation of φ.
-  _≤_ : Con 𝑨 ℓ → Con 𝑨 ℓ → Type (α ⊔ ℓ)
-  θ ≤ φ = proj₁ θ ⊆ proj₁ φ
-  infix 4 _≤_
+  -- θ ⊆ φ : the relation of θ is contained in the relation of φ.
+  _⊆_ : Con 𝑨 ℓ → Con 𝑨 ℓ → Type (α ⊔ ℓ)
+  θ ⊆ φ = proj₁ θ ⇒ proj₁ φ
+  infix 4 _⊆_
 
-  -- θ ≅ φ : mutual containment (the equivalence the partial order is taken over).
-  _≅_ : Con 𝑨 ℓ → Con 𝑨 ℓ → Type (α ⊔ ℓ)
-  θ ≅ φ = θ ≤ φ × φ ≤ θ
-  infix 4 _≅_
+  -- θ ≡ φ : mutual containment (the equivalence the partial order is taken over).
+  _≡_ : Con 𝑨 ℓ → Con 𝑨 ℓ → Type (α ⊔ ℓ)
+  θ ≡ φ = θ ⊆ φ × φ ⊆ θ
+  infix 4 _≡_
 ```
 
-The order is reflexive and transitive, and `_≅_` collapses it to a partial order.
+The order is reflexive and transitive, and `_≡_` collapses it to a partial order.
 
 ```agda
-  ≤-refl : {θ : Con 𝑨 ℓ} → θ ≤ θ
-  ≤-refl p = p
+  ⊆-refl : {θ : Con 𝑨 ℓ} → θ ⊆ θ
+  ⊆-refl p = p
 
-  ≤-trans : {θ φ ψ : Con 𝑨 ℓ} → θ ≤ φ → φ ≤ ψ → θ ≤ ψ
-  ≤-trans θ≤φ φ≤ψ p = φ≤ψ (θ≤φ p)
+  ⊆-trans : {θ φ ψ : Con 𝑨 ℓ} → θ ⊆ φ → φ ⊆ ψ → θ ⊆ ψ
+  ⊆-trans θ⊆φ φ⊆ψ p = φ⊆ψ (θ⊆φ p)
 
-  -- A ≅-step entails a ≤-step (the `reflexive` field of a preorder).
-  ≤-reflexive : {θ φ : Con 𝑨 ℓ} → θ ≅ φ → θ ≤ φ
-  ≤-reflexive = proj₁
+  -- A ≡-step entails a ⊆-step (the `reflexive` field of a preorder).
+  ⊆-reflexive : {θ φ : Con 𝑨 ℓ} → θ ≡ φ → θ ⊆ φ
+  ⊆-reflexive = proj₁
 
-  -- Antisymmetry holds up to mutual containment, by definition of _≅_.
-  ≤-antisym : {θ φ : Con 𝑨 ℓ} → θ ≤ φ → φ ≤ θ → θ ≅ φ
-  ≤-antisym θ≤φ φ≤θ = θ≤φ , φ≤θ
+  -- Antisymmetry holds up to mutual containment, by definition of _≡_.
+  ⊆-antisym : {θ φ : Con 𝑨 ℓ} → θ ⊆ φ → φ ⊆ θ → θ ≡ φ
+  ⊆-antisym θ⊆φ φ⊆θ = θ⊆φ , φ⊆θ
 
-  -- The components are written out directly rather than via ≤-refl/≤-trans:
-  -- because _≤_ is a defined relation (not an injective type former), Agda
+  -- The components are written out directly rather than via ⊆-refl/⊆-trans:
+  -- because _⊆_ is a defined relation (not an injective type former), Agda
   -- cannot recover the implicit congruence arguments of those lemmas from the
   -- expected component types, so we inline the (trivial) proofs here.
-  ≅-refl : {θ : Con 𝑨 ℓ} → θ ≅ θ
-  ≅-refl = (λ z → z) , (λ z → z)
+  ≡-refl : {θ : Con 𝑨 ℓ} → θ ≡ θ
+  ≡-refl = (λ z → z) , (λ z → z)
 
-  ≅-sym : {θ φ : Con 𝑨 ℓ} → θ ≅ φ → φ ≅ θ
-  ≅-sym = swap
+  ≡-sym : {θ φ : Con 𝑨 ℓ} → θ ≡ φ → φ ≡ θ
+  ≡-sym = swap
 
-  ≅-trans : {θ φ ψ : Con 𝑨 ℓ} → θ ≅ φ → φ ≅ ψ → θ ≅ ψ
-  ≅-trans (θ≤φ , φ≤θ) (φ≤ψ , ψ≤φ) = (λ p → φ≤ψ (θ≤φ p)) , (λ p → φ≤θ (ψ≤φ p))
+  ≡-trans : {θ φ ψ : Con 𝑨 ℓ} → θ ≡ φ → φ ≡ ψ → θ ≡ ψ
+  ≡-trans (θ⊆φ , φ⊆θ) (φ⊆ψ , ψ⊆φ) = (λ p → φ⊆ψ (θ⊆φ p)) , (λ p → φ⊆θ (ψ⊆φ p))
 
   -- The implicit congruence (and level) arguments of the helper lemmas are bound
   -- by lambdas and forwarded explicitly: they cannot be inferred through the
   -- (non-injective) `Con 𝑨 ℓ` carrier type at these function-typed fields.
-  ≅-isEquivalence : IsEquivalence (_≅_ {ℓ})
-  ≅-isEquivalence {ℓ} = record
-    { refl = λ {θ} → ≅-refl {ℓ} {θ}
-    ; sym = λ {θ} {φ} → ≅-sym {ℓ} {θ} {φ}
-    ; trans = λ {θ} {φ} {ψ} → ≅-trans  {ℓ} {θ} {φ} {ψ}
+  ≡-isEquivalence : IsEquivalence (_≡_ {ℓ})
+  ≡-isEquivalence {ℓ} = record
+    { refl = λ {θ} → ≡-refl {ℓ} {θ}
+    ; sym = λ {θ} {φ} → ≡-sym {ℓ} {θ} {φ}
+    ; trans = λ {θ} {φ} {ψ} → ≡-trans  {ℓ} {θ} {φ} {ψ}
     }
 
-  ≤-isPartialOrder : IsPartialOrder (_≅_ {ℓ}) _≤_
-  ≤-isPartialOrder {ℓ} = record
-    { isPreorder = record  { isEquivalence = ≅-isEquivalence {ℓ}
-                           ; reflexive = λ {θ} {φ} → ≤-reflexive {ℓ} {θ} {φ}
-                           ; trans = λ {θ} {φ} {ψ} → ≤-trans {ℓ} {θ} {φ} {ψ}
+  ⊆-isPartialOrder : IsPartialOrder (_≡_ {ℓ}) _⊆_
+  ⊆-isPartialOrder {ℓ} = record
+    { isPreorder = record  { isEquivalence = ≡-isEquivalence {ℓ}
+                           ; reflexive = λ {θ} {φ} → ⊆-reflexive {ℓ} {θ} {φ}
+                           ; trans = λ {θ} {φ} {ψ} → ⊆-trans {ℓ} {θ} {φ} {ψ}
                            }
-    ; antisym = λ {θ} {φ} → ≤-antisym {ℓ} {θ} {φ}
+    ; antisym = λ {θ} {φ} → ⊆-antisym {ℓ} {θ} {φ}
     }
 ```
 
@@ -152,7 +153,7 @@ the underlying relation first, then bundle the `IsCongruence` proof.
     φe = is-equivalence φc
 
     -- The meet contains the setoid equality because θ and φ both do.
-    m-reflexive : ∀ {a₀ a₁} → a₀ ≈ a₁ → meetRel θ φ a₀ a₁
+    m-reflexive : ∀ {a₀ a₁} → a₀ ≈ᴬ a₁ → meetRel θ φ a₀ a₁
     m-reflexive e = reflexive θc e , reflexive φc e
 
     -- The meet is an equivalence relation, proved componentwise.
@@ -172,44 +173,44 @@ the underlying relation first, then bundle the `IsCongruence` proof.
 
 The meet is the *greatest lower bound* of its two arguments: it is below each of
 them, and it is above any common lower bound.  These three facts are exactly the
-`Infimum` of `_≤_` at `_∧_`.
+`Infimum` of `_⊆_` at `_∧_`.
 
 ```agda
-  ∧-lowerˡ : {θ φ : Con 𝑨 ℓ} → θ ∧ φ ≤ θ
+  ∧-lowerˡ : {θ φ : Con 𝑨 ℓ} → θ ∧ φ ⊆ θ
   ∧-lowerˡ = proj₁
 
-  ∧-lowerʳ : {θ φ : Con 𝑨 ℓ} → θ ∧ φ ≤ φ
+  ∧-lowerʳ : {θ φ : Con 𝑨 ℓ} → θ ∧ φ ⊆ φ
   ∧-lowerʳ = proj₂
 
-  ∧-greatest : {θ φ ψ : Con 𝑨 ℓ} → ψ ≤ θ → ψ ≤ φ → ψ ≤ θ ∧ φ
-  ∧-greatest ψ≤θ ψ≤φ p = ψ≤θ p , ψ≤φ p
+  ∧-greatest : {θ φ ψ : Con 𝑨 ℓ} → ψ ⊆ θ → ψ ⊆ φ → ψ ⊆ θ ∧ φ
+  ∧-greatest ψ⊆θ ψ⊆φ p = ψ⊆θ p , ψ⊆φ p
 
   -- As above, the implicit congruence arguments of ∧-lowerˡ/ʳ and ∧-greatest
   -- are not inferable from the expected component types, so we inline them.
-  ∧-infimum : Infimum (_≤_ {ℓ}) _∧_
-  ∧-infimum θ φ = proj₁ , proj₂ , λ ψ ψ≤θ ψ≤φ p → ψ≤θ p , ψ≤φ p
+  ∧-infimum : Infimum (_⊆_ {ℓ}) _∧_
+  ∧-infimum θ φ = proj₁ , proj₂ , λ ψ ψ⊆θ ψ⊆φ p → ψ⊆θ p , ψ⊆φ p
 
-  ∧-isMeetSemilattice : IsMeetSemilattice (_≅_ {ℓ}) _≤_ _∧_
-  ∧-isMeetSemilattice {ℓ} = record { isPartialOrder = ≤-isPartialOrder {ℓ} ; infimum = ∧-infimum {ℓ} }
+  ∧-isMeetSemilattice : IsMeetSemilattice (_≡_ {ℓ}) _⊆_ _∧_
+  ∧-isMeetSemilattice {ℓ} = record { isPartialOrder = ⊆-isPartialOrder {ℓ} ; infimum = ∧-infimum {ℓ} }
 ```
 
 #### The poset and meet-semilattice of congruences
 
 Finally we assemble the standard-library bundles.  At a fixed relation level `ℓ`,
-`Con-Poset 𝑨` is the poset `(Con 𝑨, ≅, ≤)` and `Con-MeetSemilattice 𝑨` equips it
+`Con-Poset 𝑨` is the poset `(Con 𝑨, ≡, ⊆)` and `Con-MeetSemilattice 𝑨` equips it
 with the meet `_∧_`.  (The full lattice and complete lattice, with the join and
 the bounds `⊥`/`⊤`, are built in the subsequent steps of #271.)
 
 ```agda
 module _ (𝑨 : Algebra α ρ) {ℓ : Level} where
  Con-Poset : Poset (α ⊔ ρ ⊔ ov ℓ) (α ⊔ ℓ) (α ⊔ ℓ)
- Con-Poset = record  { Carrier = Con 𝑨 ℓ ; _≈_ = _≅_ ; _≤_ = _≤_
-                     ; isPartialOrder  = ≤-isPartialOrder }
+ Con-Poset = record  { Carrier = Con 𝑨 ℓ ; _≈_ = _≡_ ; _≤_ = _⊆_
+                     ; isPartialOrder  = ⊆-isPartialOrder }
 
  Con-MeetSemilattice : MeetSemilattice (α ⊔ ρ ⊔ ov ℓ) (α ⊔ ℓ) (α ⊔ ℓ)
  Con-MeetSemilattice = record  { Carrier = Con 𝑨 ℓ
-                               ; _≈_ = _≅_
-                               ; _≤_ = _≤_
+                               ; _≈_ = _≡_
+                               ; _≤_ = _⊆_
                                ; _∧_ = _∧_
                                ; isMeetSemilattice  = ∧-isMeetSemilattice
                                }

--- a/src/Setoid/Congruences/Lattice.lagda.md
+++ b/src/Setoid/Congruences/Lattice.lagda.md
@@ -12,7 +12,7 @@ This is the [Setoid.Congruences.Lattice][] module of the [Agda Universal Algebra
 The congruences of an algebra `𝑨`, ordered by containment, form a complete lattice.
 This module begins the formalization of that fact by promoting `Con 𝑨` to a
 first-class ordered object: it defines the containment order `_≤_`, the induced
-equivalence `_≡_` of mutual containment, and the **meet** `θ ∧ φ`, which is the
+equivalence `_≑_` of mutual containment, and the **meet** `θ ∧ φ`, which is the
 relational intersection `θ ∩ φ`.  The intersection of two congruences is again a
 congruence, and it is the greatest lower bound of the two arguments.  Thus we have a
 partially ordered set which, with the meet operation, forms a semilattice.
@@ -50,7 +50,7 @@ For congruences `θ φ : Con 𝑨` we write `θ ⊆ φ` when the underlying rela
 is **contained** in that of `φ` ("contained" is with respect to subset inclusion on
 `ℙ(A × A)`).  Classically this is the familiar (lattice) partial order on equivalence
 relations, and it remains a partial order here — `_⊆_` is antisymmetric
-**with respect to `_≡_`**, the equivalence of *mutual set containment*.  The only
+**with respect to `_≑_`**, the equivalence of *mutual set containment*.  The only
 subtlety is which equality counts as **equal congruences**.
 
 The underlying relation of a congruence inhabits the `BinRel` type
@@ -58,11 +58,11 @@ The underlying relation of a congruence inhabits the `BinRel` type
 between the proof-types `proj₁ θ x y` and `proj₁ φ x y` rather than a proof that the
 packaged congruences are *propositionally* equal.
 
-Upgrading `_≡_` to propositional equality would need function extensionality with
+Upgrading `_≑_` to propositional equality would need function extensionality with
 propositional extensionality/univalence (and proof-irrelevance for the `IsCongruence`
 witness), and that's simply not available under   `--safe --cubical-compatible`; so we
-take `_≡_` as the equality of congruences, exactly as the `Setoid/` discipline
-dictates.  Classically `_≡_` collapses to propositional equality via propositional
+take `_≑_` as the equality of congruences, exactly as the `Setoid/` discipline
+dictates.  Classically `_≑_` collapses to propositional equality via propositional
 extensionality.
 
 ```agda
@@ -75,13 +75,14 @@ module _ {𝑨 : Algebra α ρ} where
   θ ⊆ φ = proj₁ θ ⇒ proj₁ φ
   infix 4 _⊆_
 
-  -- θ ≡ φ : mutual containment (the equivalence the partial order is taken over).
-  _≡_ : Con 𝑨 ℓ → Con 𝑨 ℓ → Type (α ⊔ ℓ)
-  θ ≡ φ = θ ⊆ φ × φ ⊆ θ
-  infix 4 _≡_
+  -- θ ≑ φ : mutual containment (the equivalence the partial order is taken over).
+  -- (the symbol ≑ is input as \doteqdot)
+  _≑_ : Con 𝑨 ℓ → Con 𝑨 ℓ → Type (α ⊔ ℓ)
+  θ ≑ φ = θ ⊆ φ × φ ⊆ θ
+  infix 4 _≑_
 ```
 
-The order is reflexive and transitive, and `_≡_` collapses it to a partial order.
+The order is reflexive and transitive, and `_≑_` collapses it to a partial order.
 
 ```agda
   ⊆-refl : {θ : Con 𝑨 ℓ} → θ ⊆ θ
@@ -90,40 +91,40 @@ The order is reflexive and transitive, and `_≡_` collapses it to a partial ord
   ⊆-trans : {θ φ ψ : Con 𝑨 ℓ} → θ ⊆ φ → φ ⊆ ψ → θ ⊆ ψ
   ⊆-trans θ⊆φ φ⊆ψ p = φ⊆ψ (θ⊆φ p)
 
-  -- A ≡-step entails a ⊆-step (the `reflexive` field of a preorder).
-  ⊆-reflexive : {θ φ : Con 𝑨 ℓ} → θ ≡ φ → θ ⊆ φ
+  -- A ≑-step entails a ⊆-step (the `reflexive` field of a preorder).
+  ⊆-reflexive : {θ φ : Con 𝑨 ℓ} → θ ≑ φ → θ ⊆ φ
   ⊆-reflexive = proj₁
 
-  -- Antisymmetry holds up to mutual containment, by definition of _≡_.
-  ⊆-antisym : {θ φ : Con 𝑨 ℓ} → θ ⊆ φ → φ ⊆ θ → θ ≡ φ
+  -- Antisymmetry holds up to mutual containment, by definition of _≑_.
+  ⊆-antisym : {θ φ : Con 𝑨 ℓ} → θ ⊆ φ → φ ⊆ θ → θ ≑ φ
   ⊆-antisym θ⊆φ φ⊆θ = θ⊆φ , φ⊆θ
 
   -- The components are written out directly rather than via ⊆-refl/⊆-trans:
   -- because _⊆_ is a defined relation (not an injective type former), Agda
   -- cannot recover the implicit congruence arguments of those lemmas from the
   -- expected component types, so we inline the (trivial) proofs here.
-  ≡-refl : {θ : Con 𝑨 ℓ} → θ ≡ θ
-  ≡-refl = (λ z → z) , (λ z → z)
+  ≑-refl : {θ : Con 𝑨 ℓ} → θ ≑ θ
+  ≑-refl = (λ z → z) , (λ z → z)
 
-  ≡-sym : {θ φ : Con 𝑨 ℓ} → θ ≡ φ → φ ≡ θ
-  ≡-sym = swap
+  ≑-sym : {θ φ : Con 𝑨 ℓ} → θ ≑ φ → φ ≑ θ
+  ≑-sym = swap
 
-  ≡-trans : {θ φ ψ : Con 𝑨 ℓ} → θ ≡ φ → φ ≡ ψ → θ ≡ ψ
-  ≡-trans (θ⊆φ , φ⊆θ) (φ⊆ψ , ψ⊆φ) = (λ p → φ⊆ψ (θ⊆φ p)) , (λ p → φ⊆θ (ψ⊆φ p))
+  ≑-trans : {θ φ ψ : Con 𝑨 ℓ} → θ ≑ φ → φ ≑ ψ → θ ≑ ψ
+  ≑-trans (θ⊆φ , φ⊆θ) (φ⊆ψ , ψ⊆φ) = (λ p → φ⊆ψ (θ⊆φ p)) , (λ p → φ⊆θ (ψ⊆φ p))
 
   -- The implicit congruence (and level) arguments of the helper lemmas are bound
   -- by lambdas and forwarded explicitly: they cannot be inferred through the
   -- (non-injective) `Con 𝑨 ℓ` carrier type at these function-typed fields.
-  ≡-isEquivalence : IsEquivalence (_≡_ {ℓ})
-  ≡-isEquivalence {ℓ} = record
-    { refl = λ {θ} → ≡-refl {ℓ} {θ}
-    ; sym = λ {θ} {φ} → ≡-sym {ℓ} {θ} {φ}
-    ; trans = λ {θ} {φ} {ψ} → ≡-trans  {ℓ} {θ} {φ} {ψ}
+  ≑-isEquivalence : IsEquivalence (_≑_ {ℓ})
+  ≑-isEquivalence {ℓ} = record
+    { refl = λ {θ} → ≑-refl {ℓ} {θ}
+    ; sym = λ {θ} {φ} → ≑-sym {ℓ} {θ} {φ}
+    ; trans = λ {θ} {φ} {ψ} → ≑-trans  {ℓ} {θ} {φ} {ψ}
     }
 
-  ⊆-isPartialOrder : IsPartialOrder (_≡_ {ℓ}) _⊆_
+  ⊆-isPartialOrder : IsPartialOrder (_≑_ {ℓ}) _⊆_
   ⊆-isPartialOrder {ℓ} = record
-    { isPreorder = record  { isEquivalence = ≡-isEquivalence {ℓ}
+    { isPreorder = record  { isEquivalence = ≑-isEquivalence {ℓ}
                            ; reflexive = λ {θ} {φ} → ⊆-reflexive {ℓ} {θ} {φ}
                            ; trans = λ {θ} {φ} {ψ} → ⊆-trans {ℓ} {θ} {φ} {ψ}
                            }
@@ -190,26 +191,26 @@ them, and it is above any common lower bound.  These three facts are exactly the
   ∧-infimum : Infimum (_⊆_ {ℓ}) _∧_
   ∧-infimum θ φ = proj₁ , proj₂ , λ ψ ψ⊆θ ψ⊆φ p → ψ⊆θ p , ψ⊆φ p
 
-  ∧-isMeetSemilattice : IsMeetSemilattice (_≡_ {ℓ}) _⊆_ _∧_
+  ∧-isMeetSemilattice : IsMeetSemilattice (_≑_ {ℓ}) _⊆_ _∧_
   ∧-isMeetSemilattice {ℓ} = record { isPartialOrder = ⊆-isPartialOrder {ℓ} ; infimum = ∧-infimum {ℓ} }
 ```
 
 #### The poset and meet-semilattice of congruences
 
 Finally we assemble the standard-library bundles.  At a fixed relation level `ℓ`,
-`Con-Poset 𝑨` is the poset `(Con 𝑨, ≡, ⊆)` and `Con-MeetSemilattice 𝑨` equips it
+`Con-Poset 𝑨` is the poset `(Con 𝑨, ≑, ⊆)` and `Con-MeetSemilattice 𝑨` equips it
 with the meet `_∧_`.  (The full lattice and complete lattice, with the join and
 the bounds `⊥`/`⊤`, are built in the subsequent steps of #271.)
 
 ```agda
 module _ (𝑨 : Algebra α ρ) {ℓ : Level} where
  Con-Poset : Poset (α ⊔ ρ ⊔ ov ℓ) (α ⊔ ℓ) (α ⊔ ℓ)
- Con-Poset = record  { Carrier = Con 𝑨 ℓ ; _≈_ = _≡_ ; _≤_ = _⊆_
+ Con-Poset = record  { Carrier = Con 𝑨 ℓ ; _≈_ = _≑_ ; _≤_ = _⊆_
                      ; isPartialOrder  = ⊆-isPartialOrder }
 
  Con-MeetSemilattice : MeetSemilattice (α ⊔ ρ ⊔ ov ℓ) (α ⊔ ℓ) (α ⊔ ℓ)
  Con-MeetSemilattice = record  { Carrier = Con 𝑨 ℓ
-                               ; _≈_ = _≡_
+                               ; _≈_ = _≑_
                                ; _≤_ = _⊆_
                                ; _∧_ = _∧_
                                ; isMeetSemilattice  = ∧-isMeetSemilattice

--- a/src/Setoid/Congruences/Lattice.lagda.md
+++ b/src/Setoid/Congruences/Lattice.lagda.md
@@ -11,7 +11,7 @@ This is the [Setoid.Congruences.Lattice][] module of the [Agda Universal Algebra
 
 The congruences of an algebra `𝑨`, ordered by containment, form a complete lattice.
 This module begins the formalization of that fact by promoting `Con 𝑨` to a
-first-class ordered object: it defines the containment order `_≤_`, the induced
+first-class ordered object: it defines the containment order `_⊆_`, the induced
 equivalence `_≑_` of mutual containment, and the **meet** `θ ∧ φ`, which is the
 relational intersection `θ ∩ φ`.  The intersection of two congruences is again a
 congruence, and it is the greatest lower bound of the two arguments.  Thus we have a

--- a/src/Setoid/Congruences/Monolith.lagda.md
+++ b/src/Setoid/Congruences/Monolith.lagda.md
@@ -21,8 +21,8 @@ congruences.
 The development here is pure congruence theory and is fully constructive.  We work
 throughout with congruences at the algebra's own relation level `ρ`, so the diagonal
 `0ᴬ` is the setoid equality `_≈_ : Con 𝑨 ρ` and the monolith (when it exists) is a
-`Con 𝑨 ρ`.  The choice-dependent *existence* of subdirect SI-representations — Birkhoff's
-subdirect representation theorem — is built on top of this in
+`Con 𝑨 ρ`.  The choice-dependent *existence* of subdirect SI-representations —
+Birkhoff's subdirect representation theorem — is built on top of this in
 [Setoid.Subalgebras.Subdirect][]; nothing here assumes it.
 
 ```agda
@@ -34,16 +34,16 @@ module Setoid.Congruences.Monolith {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
-open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax ; proj₁ ; proj₂ )
+open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax ; ∃-syntax ; proj₁ ; proj₂ )
 open import Level            using ( Level ; _⊔_ )
 open import Relation.Binary  using ( Setoid ; IsEquivalence )
 open import Relation.Nullary using ( ¬_ )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Setoid.Algebras.Basic     {𝑆 = 𝑆}  using ( ov ; Algebra ; 𝕌[_] )
-open import Setoid.Congruences.Basic   {𝑆 = 𝑆}
-  using ( Con ; mkcon ; _∣≈_ ; reflexive ; is-equivalence ; is-compatible )
-open import Setoid.Congruences.Lattice {𝑆 = 𝑆}  using ( _≤_ ; _≅_ ; _∧_ )
+open import Setoid.Algebras.Basic       {𝑆 = 𝑆}  using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Congruences.Basic    {𝑆 = 𝑆}  using  ( Con ; mkcon ; _∣≈_ ; reflexive
+                                                        ; is-equivalence ; is-compatible )
+open import Setoid.Congruences.Lattice  {𝑆 = 𝑆}  using  ( _⊆_ ; _≡_ ; _∧_ )
 
 private variable α ρ ℓ : Level
 ```
@@ -56,16 +56,16 @@ setoid equality keeps apart; the degenerate (one-element) algebras are exactly t
 
 ```agda
 module _ (𝑨 : Algebra α ρ) where
-  open Algebra 𝑨 using () renaming ( Domain to A )
-  open Setoid A  using ( _≈_ )
+  open Setoid 𝔻[ 𝑨 ]  using ( _≈_ )
 
   -- 𝑨 has two ≈-distinct elements.
   Nontrivial : Type (α ⊔ ρ)
-  Nontrivial = Σ[ a ∈ 𝕌[ 𝑨 ] ] Σ[ b ∈ 𝕌[ 𝑨 ] ] ¬ (a ≈ b)
+  Nontrivial = ∃[ a ] ∃[ b ] ¬ (a ≈ b)
+  -- `∃[ a ] P a`  is shorthand for `Σ[ a ∈ 𝕌[ 𝑨 ] ] P a`
 
   -- Every two elements of 𝑨 are equal (the one-element, degenerate case).
   Trivial : Type (α ⊔ ρ)
-  Trivial = (a b : 𝕌[ 𝑨 ]) → a ≈ b
+  Trivial = ∀ a b → a ≈ b
 
   -- A trivial algebra is not nontrivial.
   trivial⇒¬nontrivial : Trivial → ¬ Nontrivial
@@ -73,13 +73,13 @@ module _ (𝑨 : Algebra α ρ) where
 ```
 
 A congruence is **below the diagonal** when it relates only `≈`-equal elements; this is
-exactly the assertion `θ ≅ 0ᴬ` (since `0ᴬ ≤ θ` always holds), so its negation is the
+exactly the assertion `θ ≡ 0ᴬ` (since `0ᴬ ⊆ θ` always holds), so its negation is the
 right notion of a **nonzero** (strictly-above-`0ᴬ`) congruence.
 
 ```agda
-  -- θ relates only equal elements, i.e. θ ≅ 0ᴬ.
+  -- θ relates only equal elements, i.e. θ ≡ 0ᴬ.
   BelowDiagonal : Con 𝑨 ℓ → Type (α ⊔ ρ ⊔ ℓ)
-  BelowDiagonal θ = ∀ {a b} → proj₁ θ a b → a ≈ b
+  BelowDiagonal (_θ_ , _) = ∀ {a b} → a θ b → a ≈ b
 
   -- θ is nonzero: it is *not* below the diagonal (it relates some distinct pair).
   Nonzero : Con 𝑨 ℓ → Type (α ⊔ ρ ⊔ ℓ)
@@ -88,8 +88,8 @@ right notion of a **nonzero** (strictly-above-`0ᴬ`) congruence.
 
 #### The infinitary meet of a family of congruences
 
-For the completely-meet-irreducible characterization we need the meet (intersection) of
-a family of congruences.  This is the same intersection that
+For the completely-meet-irreducible characterization we need the meet (intersection)
+of a family of congruences.  This is the same intersection that
 [Setoid.Congruences.CompleteLattice][] packages (there as `⋀`, at the absorbing level
 `L`); here we take it at the algebra's own relation level `ℓ` for an `ℓ`-small index
 `I`, where it stays a `Con 𝑨 ℓ`.
@@ -101,18 +101,19 @@ a family of congruences.  This is the same intersection that
     m-refl : ∀ {a₀ a₁} → a₀ ≈ a₁ → (i : I) → proj₁ (θ i) a₀ a₁
     m-refl e i = reflexive (proj₂ (θ i)) e
 
+    open IsEquivalence
     m-equiv : IsEquivalence (λ x y → (i : I) → proj₁ (θ i) x y)
     m-equiv = record
-      { refl   = λ i → IsEquivalence.refl (is-equivalence (proj₂ (θ i)))
-      ; sym    = λ p i → IsEquivalence.sym (is-equivalence (proj₂ (θ i))) (p i)
-      ; trans  = λ p q i → IsEquivalence.trans (is-equivalence (proj₂ (θ i))) (p i) (q i)
+      { refl   = λ i      → is-equivalence (proj₂ (θ i)) .refl
+      ; sym    = λ p i    → is-equivalence (proj₂ (θ i)) .sym    (p i)
+      ; trans  = λ p q i  → is-equivalence (proj₂ (θ i)) .trans  (p i) (q i)
       }
 
     m-comp : 𝑨 ∣≈ (λ x y → (i : I) → proj₁ (θ i) x y)
     m-comp f h i = is-compatible (proj₂ (θ i)) f (λ k → h k i)
 
   -- The meet is a lower bound of each family member.
-  ⋂-lower : {I : Type ℓ}(θ : I → Con 𝑨 ℓ)(i : I) → ⋂ θ ≤ θ i
+  ⋂-lower : {I : Type ℓ}(θ : I → Con 𝑨 ℓ)(i : I) → ⋂ θ ⊆ θ i
   ⋂-lower θ i p = p i
 ```
 
@@ -126,7 +127,7 @@ so the diagonal and the monolith are `Con 𝑨 ρ`.)
   record IsMonolith (μ : Con 𝑨 ρ) : Type (α ⊔ ov ρ) where
     field
       mono-nonzero : Nonzero μ
-      mono-least   : (θ : Con 𝑨 ρ) → Nonzero θ → μ ≤ θ
+      mono-least   : (θ : Con 𝑨 ρ) → Nonzero θ → μ ⊆ θ
 
   open IsMonolith public
 
@@ -134,14 +135,13 @@ so the diagonal and the monolith are `Con 𝑨 ρ`.)
   HasMonolith = Σ[ μ ∈ Con 𝑨 ρ ] IsMonolith μ
 ```
 
-The monolith, when it exists, is unique up to mutual containment `≅`: two least nonzero
+The monolith, when it exists, is unique up to mutual containment `≡`: two least nonzero
 congruences are each below the other.
 
 ```agda
-  monolith-unique : (m m′ : HasMonolith) → proj₁ m ≅ proj₁ m′
+  monolith-unique : (m m′ : HasMonolith) → proj₁ m ≡ proj₁ m′
   monolith-unique (μ , mono) (μ′ , mono′) =
-      mono-least mono  μ′ (mono-nonzero mono′)
-    , mono-least mono′ μ  (mono-nonzero mono)
+    mono-least mono  μ′ (mono-nonzero mono′) , mono-least mono′ μ  (mono-nonzero mono)
 ```
 
 #### Subdirect irreducibility
@@ -184,14 +184,14 @@ meet were below the diagonal, so would `μ` be, contradicting `Nonzero μ`.
 
 ```agda
   monolith⇒cmi : HasMonolith → CompletelyMeetIrreducible
-  monolith⇒cmi (μ , mono) θ all-nonzero ⋂θ≤Δ = mono-nonzero mono μ≤Δ
+  monolith⇒cmi (μ , mono) θ all-nonzero ⋂θ⊆Δ = mono-nonzero mono μ⊆Δ
     where
-    μ≤θ : ∀ i → μ ≤ θ i
-    μ≤θ i = mono-least mono (θ i) (all-nonzero i)
-    μ≤⋂ : μ ≤ ⋂ θ
-    μ≤⋂ p i = μ≤θ i p
-    μ≤Δ : BelowDiagonal μ
-    μ≤Δ p = ⋂θ≤Δ (μ≤⋂ p)
+    μ⊆θ : ∀ i → μ ⊆ θ i
+    μ⊆θ i = mono-least mono (θ i) (all-nonzero i)
+    μ⊆⋂ : μ ⊆ ⋂ θ
+    μ⊆⋂ p i = μ⊆θ i p
+    μ⊆Δ : BelowDiagonal μ
+    μ⊆Δ p = ⋂θ⊆Δ (μ⊆⋂ p)
 ```
 
 ```agda
@@ -199,15 +199,15 @@ meet were below the diagonal, so would `μ` be, contradicting `Nonzero μ`.
   -- is meet-irreducible.  This is the "directly-indecomposable-adjacent" fact: a
   -- monolithic algebra cannot have two nonzero congruences with diagonal meet.
   monolith⇒∧-irreducible :
-      HasMonolith → (θ φ : Con 𝑨 ρ) → Nonzero θ → Nonzero φ → Nonzero (θ ∧ φ)
-  monolith⇒∧-irreducible (μ , mono) θ φ nzθ nzφ θ∧φ≤Δ = mono-nonzero mono μ≤Δ
+    HasMonolith → (θ φ : Con 𝑨 ρ) → Nonzero θ → Nonzero φ → Nonzero (θ ∧ φ)
+  monolith⇒∧-irreducible (μ , mono) θ φ nzθ nzφ θ∧φ⊆Δ = mono-nonzero mono μ⊆Δ
     where
-    μ≤θ : μ ≤ θ
-    μ≤θ = mono-least mono θ nzθ
-    μ≤φ : μ ≤ φ
-    μ≤φ = mono-least mono φ nzφ
-    μ≤Δ : BelowDiagonal μ
-    μ≤Δ p = θ∧φ≤Δ (μ≤θ p , μ≤φ p)
+    μ⊆θ : μ ⊆ θ
+    μ⊆θ = mono-least mono θ nzθ
+    μ⊆φ : μ ⊆ φ
+    μ⊆φ = mono-least mono φ nzφ
+    μ⊆Δ : BelowDiagonal μ
+    μ⊆Δ p = θ∧φ⊆Δ (μ⊆θ p , μ⊆φ p)
 ```
 
 --------------------------------------

--- a/src/Setoid/Congruences/Monolith.lagda.md
+++ b/src/Setoid/Congruences/Monolith.lagda.md
@@ -1,0 +1,218 @@
+---
+layout: default
+file: "src/Setoid/Congruences/Monolith.lagda.md"
+title: "Setoid.Congruences.Monolith module (The Agda Universal Algebra Library)"
+date: "2026-06-20"
+author: "the agda-algebras development team"
+---
+
+### Monoliths and subdirectly irreducible algebras
+
+This is the [Setoid.Congruences.Monolith][] module of the [Agda Universal Algebra Library][].
+
+[Setoid.Congruences.CompleteLattice][] organized the congruences of an algebra into a
+complete lattice with bottom `0ᴬ` (the diagonal) and top `1ᴬ`.  This module isolates
+the order-theoretic property at the heart of *subdirect irreducibility*: an algebra is
+**subdirectly irreducible** (SI) when it is nontrivial and `0ᴬ` has a unique cover — a
+**monolith**, the least congruence strictly above the diagonal.  Equivalently, `0ᴬ` is
+*completely meet-irreducible*: it is not the meet of any family of strictly larger
+congruences.
+
+The development here is pure congruence theory and is fully constructive.  We work
+throughout with congruences at the algebra's own relation level `ρ`, so the diagonal
+`0ᴬ` is the setoid equality `_≈_ : Con 𝑨 ρ` and the monolith (when it exists) is a
+`Con 𝑨 ρ`.  The choice-dependent *existence* of subdirect SI-representations — Birkhoff's
+subdirect representation theorem — is built on top of this in
+[Setoid.Subalgebras.Subdirect][]; nothing here assumes it.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+
+module Setoid.Congruences.Monolith {𝑆 : Signature 𝓞 𝓥} where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Agda.Primitive   using () renaming ( Set to Type )
+open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax ; proj₁ ; proj₂ )
+open import Level            using ( Level ; _⊔_ )
+open import Relation.Binary  using ( Setoid ; IsEquivalence )
+open import Relation.Nullary using ( ¬_ )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Setoid.Algebras.Basic     {𝑆 = 𝑆}  using ( ov ; Algebra ; 𝕌[_] )
+open import Setoid.Congruences.Basic   {𝑆 = 𝑆}
+  using ( Con ; mkcon ; _∣≈_ ; reflexive ; is-equivalence ; is-compatible )
+open import Setoid.Congruences.Lattice {𝑆 = 𝑆}  using ( _≤_ ; _≅_ ; _∧_ )
+
+private variable α ρ ℓ : Level
+```
+
+#### Nontriviality and the diagonal
+
+Fix an algebra `𝑨`.  It is **nontrivial** when its carrier has two elements that the
+setoid equality keeps apart; the degenerate (one-element) algebras are exactly the
+**trivial** ones, on which every two elements are equal.
+
+```agda
+module _ (𝑨 : Algebra α ρ) where
+  open Algebra 𝑨 using () renaming ( Domain to A )
+  open Setoid A  using ( _≈_ )
+
+  -- 𝑨 has two ≈-distinct elements.
+  Nontrivial : Type (α ⊔ ρ)
+  Nontrivial = Σ[ a ∈ 𝕌[ 𝑨 ] ] Σ[ b ∈ 𝕌[ 𝑨 ] ] ¬ (a ≈ b)
+
+  -- Every two elements of 𝑨 are equal (the one-element, degenerate case).
+  Trivial : Type (α ⊔ ρ)
+  Trivial = (a b : 𝕌[ 𝑨 ]) → a ≈ b
+
+  -- A trivial algebra is not nontrivial.
+  trivial⇒¬nontrivial : Trivial → ¬ Nontrivial
+  trivial⇒¬nontrivial triv (a , b , a≢b) = a≢b (triv a b)
+```
+
+A congruence is **below the diagonal** when it relates only `≈`-equal elements; this is
+exactly the assertion `θ ≅ 0ᴬ` (since `0ᴬ ≤ θ` always holds), so its negation is the
+right notion of a **nonzero** (strictly-above-`0ᴬ`) congruence.
+
+```agda
+  -- θ relates only equal elements, i.e. θ ≅ 0ᴬ.
+  BelowDiagonal : Con 𝑨 ℓ → Type (α ⊔ ρ ⊔ ℓ)
+  BelowDiagonal θ = ∀ {a b} → proj₁ θ a b → a ≈ b
+
+  -- θ is nonzero: it is *not* below the diagonal (it relates some distinct pair).
+  Nonzero : Con 𝑨 ℓ → Type (α ⊔ ρ ⊔ ℓ)
+  Nonzero θ = ¬ BelowDiagonal θ
+```
+
+#### The infinitary meet of a family of congruences
+
+For the completely-meet-irreducible characterization we need the meet (intersection) of
+a family of congruences.  This is the same intersection that
+[Setoid.Congruences.CompleteLattice][] packages (there as `⋀`, at the absorbing level
+`L`); here we take it at the algebra's own relation level `ℓ` for an `ℓ`-small index
+`I`, where it stays a `Con 𝑨 ℓ`.
+
+```agda
+  ⋂ : {I : Type ℓ} → (I → Con 𝑨 ℓ) → Con 𝑨 ℓ
+  ⋂ {I = I} θ = (λ x y → (i : I) → proj₁ (θ i) x y) , mkcon m-refl m-equiv m-comp
+    where
+    m-refl : ∀ {a₀ a₁} → a₀ ≈ a₁ → (i : I) → proj₁ (θ i) a₀ a₁
+    m-refl e i = reflexive (proj₂ (θ i)) e
+
+    m-equiv : IsEquivalence (λ x y → (i : I) → proj₁ (θ i) x y)
+    m-equiv = record
+      { refl   = λ i → IsEquivalence.refl (is-equivalence (proj₂ (θ i)))
+      ; sym    = λ p i → IsEquivalence.sym (is-equivalence (proj₂ (θ i))) (p i)
+      ; trans  = λ p q i → IsEquivalence.trans (is-equivalence (proj₂ (θ i))) (p i) (q i)
+      }
+
+    m-comp : 𝑨 ∣≈ (λ x y → (i : I) → proj₁ (θ i) x y)
+    m-comp f h i = is-compatible (proj₂ (θ i)) f (λ k → h k i)
+
+  -- The meet is a lower bound of each family member.
+  ⋂-lower : {I : Type ℓ}(θ : I → Con 𝑨 ℓ)(i : I) → ⋂ θ ≤ θ i
+  ⋂-lower θ i p = p i
+```
+
+#### Monoliths
+
+A **monolith** of `𝑨` is a least nonzero congruence: it is itself nonzero, and it is
+contained in every nonzero congruence.  (Working at the algebra's relation level `ρ`,
+so the diagonal and the monolith are `Con 𝑨 ρ`.)
+
+```agda
+  record IsMonolith (μ : Con 𝑨 ρ) : Type (α ⊔ ov ρ) where
+    field
+      mono-nonzero : Nonzero μ
+      mono-least   : (θ : Con 𝑨 ρ) → Nonzero θ → μ ≤ θ
+
+  open IsMonolith public
+
+  HasMonolith : Type (α ⊔ ov ρ)
+  HasMonolith = Σ[ μ ∈ Con 𝑨 ρ ] IsMonolith μ
+```
+
+The monolith, when it exists, is unique up to mutual containment `≅`: two least nonzero
+congruences are each below the other.
+
+```agda
+  monolith-unique : (m m′ : HasMonolith) → proj₁ m ≅ proj₁ m′
+  monolith-unique (μ , mono) (μ′ , mono′) =
+      mono-least mono  μ′ (mono-nonzero mono′)
+    , mono-least mono′ μ  (mono-nonzero mono)
+```
+
+#### Subdirect irreducibility
+
+An algebra is **subdirectly irreducible** when it is nontrivial and has a monolith.
+(The role of SI algebras in subdirect *representations* — Birkhoff's theorem that every
+algebra is a subdirect product of SI algebras — is developed in
+[Setoid.Subalgebras.Subdirect][].)
+
+```agda
+  IsSubdirectlyIrreducible : Type (α ⊔ ov ρ)
+  IsSubdirectlyIrreducible = Nontrivial × HasMonolith
+
+  -- An SI algebra is nontrivial; a trivial algebra is not SI.
+  si⇒nontrivial : IsSubdirectlyIrreducible → Nontrivial
+  si⇒nontrivial = proj₁
+
+  trivial⇒¬si : Trivial → ¬ IsSubdirectlyIrreducible
+  trivial⇒¬si triv si = trivial⇒¬nontrivial triv (si⇒nontrivial si)
+```
+
+#### The monolith characterization
+
+The substantive fact is that having a monolith makes `0ᴬ` **completely meet-irreducible**:
+whenever a family of congruences meets to the diagonal, some member is already the
+diagonal.  Constructively we state and prove the contrapositive — *if every member of a
+family is nonzero, then so is the meet* — which is the form actually used downstream and
+avoids extracting a witnessing index from a negated existential.  As with the monolith,
+the family ranges over congruences at the algebra's relation level `ρ`.
+
+```agda
+  -- 0ᴬ is completely meet-irreducible (contrapositive form).
+  CompletelyMeetIrreducible : Type (α ⊔ ov ρ)
+  CompletelyMeetIrreducible =
+    {I : Type ρ}(θ : I → Con 𝑨 ρ) → (∀ i → Nonzero (θ i)) → Nonzero (⋂ θ)
+```
+
+The proof: the monolith `μ` is below every nonzero `θ i`, hence below the meet; if the
+meet were below the diagonal, so would `μ` be, contradicting `Nonzero μ`.
+
+```agda
+  monolith⇒cmi : HasMonolith → CompletelyMeetIrreducible
+  monolith⇒cmi (μ , mono) θ all-nonzero ⋂θ≤Δ = mono-nonzero mono μ≤Δ
+    where
+    μ≤θ : ∀ i → μ ≤ θ i
+    μ≤θ i = mono-least mono (θ i) (all-nonzero i)
+    μ≤⋂ : μ ≤ ⋂ θ
+    μ≤⋂ p i = μ≤θ i p
+    μ≤Δ : BelowDiagonal μ
+    μ≤Δ p = ⋂θ≤Δ (μ≤⋂ p)
+```
+
+```agda
+  -- The binary instance: the meet of two nonzero congruences is nonzero, i.e. `0ᴬ`
+  -- is meet-irreducible.  This is the "directly-indecomposable-adjacent" fact: a
+  -- monolithic algebra cannot have two nonzero congruences with diagonal meet.
+  monolith⇒∧-irreducible :
+      HasMonolith → (θ φ : Con 𝑨 ρ) → Nonzero θ → Nonzero φ → Nonzero (θ ∧ φ)
+  monolith⇒∧-irreducible (μ , mono) θ φ nzθ nzφ θ∧φ≤Δ = mono-nonzero mono μ≤Δ
+    where
+    μ≤θ : μ ≤ θ
+    μ≤θ = mono-least mono θ nzθ
+    μ≤φ : μ ≤ φ
+    μ≤φ = mono-least mono φ nzφ
+    μ≤Δ : BelowDiagonal μ
+    μ≤Δ p = θ∧φ≤Δ (μ≤θ p , μ≤φ p)
+```
+
+--------------------------------------
+
+<span style="float:left;">[← Setoid.Congruences.CompleteLattice](Setoid.Congruences.CompleteLattice.html)</span>
+<span style="float:right;">[Setoid.Homomorphisms →](Setoid.Homomorphisms.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Congruences/Monolith.lagda.md
+++ b/src/Setoid/Congruences/Monolith.lagda.md
@@ -43,7 +43,7 @@ open import Relation.Nullary using ( ¬_ )
 open import Setoid.Algebras.Basic       {𝑆 = 𝑆}  using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Congruences.Basic    {𝑆 = 𝑆}  using  ( Con ; mkcon ; _∣≈_ ; reflexive
                                                         ; is-equivalence ; is-compatible )
-open import Setoid.Congruences.Lattice  {𝑆 = 𝑆}  using  ( _⊆_ ; _≡_ ; _∧_ )
+open import Setoid.Congruences.Lattice  {𝑆 = 𝑆}  using  ( _⊆_ ; _≑_ ; _∧_ )
 
 private variable α ρ ℓ : Level
 ```
@@ -73,11 +73,11 @@ module _ (𝑨 : Algebra α ρ) where
 ```
 
 A congruence is **below the diagonal** when it relates only `≈`-equal elements; this is
-exactly the assertion `θ ≡ 0ᴬ` (since `0ᴬ ⊆ θ` always holds), so its negation is the
+exactly the assertion `θ ≑ 0ᴬ` (since `0ᴬ ⊆ θ` always holds), so its negation is the
 right notion of a **nonzero** (strictly-above-`0ᴬ`) congruence.
 
 ```agda
-  -- θ relates only equal elements, i.e. θ ≡ 0ᴬ.
+  -- θ relates only equal elements, i.e. θ ≑ 0ᴬ.
   BelowDiagonal : Con 𝑨 ℓ → Type (α ⊔ ρ ⊔ ℓ)
   BelowDiagonal (_θ_ , _) = ∀ {a b} → a θ b → a ≈ b
 
@@ -135,11 +135,11 @@ so the diagonal and the monolith are `Con 𝑨 ρ`.)
   HasMonolith = Σ[ μ ∈ Con 𝑨 ρ ] IsMonolith μ
 ```
 
-The monolith, when it exists, is unique up to mutual containment `≡`: two least nonzero
+The monolith, when it exists, is unique up to mutual containment `≑`: two least nonzero
 congruences are each below the other.
 
 ```agda
-  monolith-unique : (m m′ : HasMonolith) → proj₁ m ≡ proj₁ m′
+  monolith-unique : (m m′ : HasMonolith) → proj₁ m ≑ proj₁ m′
   monolith-unique (μ , mono) (μ′ , mono′) =
     mono-least mono  μ′ (mono-nonzero mono′) , mono-least mono′ μ  (mono-nonzero mono)
 ```

--- a/src/Setoid/Congruences/Properties.lagda.md
+++ b/src/Setoid/Congruences/Properties.lagda.md
@@ -64,7 +64,7 @@ module _ {α ρ : Level} (𝑨 : Algebra α ρ)(ℓ₀ : Level) where
 #### Congruence modularity
 
 An algebra `𝑨` is **congruence-modular** (CM) when its congruence lattice satisfies
-the modular law: whenever `θ ≤ ψ`, `θ ∨ (φ ∧ ψ) ≑ (θ ∨ φ) ∧ ψ`.  Distributivity
+the modular law: whenever `θ ⊆ ψ`, `θ ∨ (φ ∧ ψ) ≑ (θ ∨ φ) ∧ ψ`.  Distributivity
 implies modularity, so the congruence-distributive algebras form a subclass of the
 congruence-modular ones.
 

--- a/src/Setoid/Congruences/Properties.lagda.md
+++ b/src/Setoid/Congruences/Properties.lagda.md
@@ -35,7 +35,7 @@ open import Level           using ( Level ; _⊔_ ) renaming (suc to lsuc)
 -- Imports from the Agda Universal Algebra Library ----------------------------
 open import Setoid.Algebras.Basic          {𝑆 = 𝑆} using ( ov ; Algebra )
 open import Setoid.Congruences.Basic       {𝑆 = 𝑆} using ( Con )
-open import Setoid.Congruences.Lattice     {𝑆 = 𝑆} using ( _⊆_ ; _≡_ ; _∧_ )
+open import Setoid.Congruences.Lattice     {𝑆 = 𝑆} using ( _⊆_ ; _≑_ ; _∧_ )
 open import Setoid.Congruences.Generation  {𝑆 = 𝑆} using ( _∨_ )
 ```
 
@@ -50,27 +50,27 @@ open import Setoid.Congruences.Generation  {𝑆 = 𝑆} using ( _∨_ )
 #### Congruence distributivity
 
 An algebra `𝑨` is **congruence-distributive** (CD) when its congruence lattice
-satisfies the distributive law `θ ∧ (φ ∨ ψ) ≡ (θ ∧ φ) ∨ (θ ∧ ψ)`.  (The reverse
-containment half of this `≡` is automatic in any lattice; the distributive law is the
+satisfies the distributive law `θ ∧ (φ ∨ ψ) ≑ (θ ∧ φ) ∨ (θ ∧ ψ)`.  (The reverse
+containment half of this `≑` is automatic in any lattice; the distributive law is the
 forward containment `θ ∧ (φ ∨ ψ) ⊆ (θ ∧ φ) ∨ (θ ∧ ψ)`, but we state the full
-symmetric `≡` result for uniformity.)
+symmetric `≑` result for uniformity.)
 
 ```agda
 module _ {α ρ : Level} (𝑨 : Algebra α ρ)(ℓ₀ : Level) where
   CongruenceDistributive : Type (lsuc (Ł α ρ ℓ₀))
-  CongruenceDistributive = (θ φ ψ : Con 𝑨 (Ł α ρ ℓ₀)) → θ ∧ (φ ∨ ψ) ≡ (θ ∧ φ) ∨ (θ ∧ ψ)
+  CongruenceDistributive = (θ φ ψ : Con 𝑨 (Ł α ρ ℓ₀)) → θ ∧ (φ ∨ ψ) ≑ (θ ∧ φ) ∨ (θ ∧ ψ)
 ```
 
 #### Congruence modularity
 
 An algebra `𝑨` is **congruence-modular** (CM) when its congruence lattice satisfies
-the modular law: whenever `θ ≤ ψ`, `θ ∨ (φ ∧ ψ) ≡ (θ ∨ φ) ∧ ψ`.  Distributivity
+the modular law: whenever `θ ≤ ψ`, `θ ∨ (φ ∧ ψ) ≑ (θ ∨ φ) ∧ ψ`.  Distributivity
 implies modularity, so the congruence-distributive algebras form a subclass of the
 congruence-modular ones.
 
 ```agda
   CongruenceModular : Type (lsuc (Ł α ρ ℓ₀))
-  CongruenceModular = (θ φ ψ : Con 𝑨 (Ł α ρ ℓ₀)) → θ ⊆ ψ → θ ∨ (φ ∧ ψ) ≡ (θ ∨ φ) ∧ ψ
+  CongruenceModular = (θ φ ψ : Con 𝑨 (Ł α ρ ℓ₀)) → θ ⊆ ψ → θ ∨ (φ ∧ ψ) ≑ (θ ∨ φ) ∧ ψ
 ```
 
 --------------------------------------

--- a/src/Setoid/Congruences/Properties.lagda.md
+++ b/src/Setoid/Congruences/Properties.lagda.md
@@ -35,7 +35,7 @@ open import Level           using ( Level ; _⊔_ ) renaming (suc to lsuc)
 -- Imports from the Agda Universal Algebra Library ----------------------------
 open import Setoid.Algebras.Basic          {𝑆 = 𝑆} using ( ov ; Algebra )
 open import Setoid.Congruences.Basic       {𝑆 = 𝑆} using ( Con )
-open import Setoid.Congruences.Lattice     {𝑆 = 𝑆} using ( _≤_ ; _≅_ ; _∧_ )
+open import Setoid.Congruences.Lattice     {𝑆 = 𝑆} using ( _⊆_ ; _≡_ ; _∧_ )
 open import Setoid.Congruences.Generation  {𝑆 = 𝑆} using ( _∨_ )
 ```
 
@@ -50,27 +50,27 @@ open import Setoid.Congruences.Generation  {𝑆 = 𝑆} using ( _∨_ )
 #### Congruence distributivity
 
 An algebra `𝑨` is **congruence-distributive** (CD) when its congruence lattice
-satisfies the distributive law `θ ∧ (φ ∨ ψ) ≅ (θ ∧ φ) ∨ (θ ∧ ψ)`.  (The reverse
-containment half of this `≅` is automatic in any lattice; the distributive law is the
+satisfies the distributive law `θ ∧ (φ ∨ ψ) ≡ (θ ∧ φ) ∨ (θ ∧ ψ)`.  (The reverse
+containment half of this `≡` is automatic in any lattice; the distributive law is the
 forward containment `θ ∧ (φ ∨ ψ) ⊆ (θ ∧ φ) ∨ (θ ∧ ψ)`, but we state the full
-symmetric `≅` result for uniformity.)
+symmetric `≡` result for uniformity.)
 
 ```agda
 module _ {α ρ : Level} (𝑨 : Algebra α ρ)(ℓ₀ : Level) where
   CongruenceDistributive : Type (lsuc (Ł α ρ ℓ₀))
-  CongruenceDistributive = (θ φ ψ : Con 𝑨 (Ł α ρ ℓ₀)) → θ ∧ (φ ∨ ψ) ≅ (θ ∧ φ) ∨ (θ ∧ ψ)
+  CongruenceDistributive = (θ φ ψ : Con 𝑨 (Ł α ρ ℓ₀)) → θ ∧ (φ ∨ ψ) ≡ (θ ∧ φ) ∨ (θ ∧ ψ)
 ```
 
 #### Congruence modularity
 
 An algebra `𝑨` is **congruence-modular** (CM) when its congruence lattice satisfies
-the modular law: whenever `θ ≤ ψ`, `θ ∨ (φ ∧ ψ) ≅ (θ ∨ φ) ∧ ψ`.  Distributivity
+the modular law: whenever `θ ≤ ψ`, `θ ∨ (φ ∧ ψ) ≡ (θ ∨ φ) ∧ ψ`.  Distributivity
 implies modularity, so the congruence-distributive algebras form a subclass of the
 congruence-modular ones.
 
 ```agda
   CongruenceModular : Type (lsuc (Ł α ρ ℓ₀))
-  CongruenceModular = (θ φ ψ : Con 𝑨 (Ł α ρ ℓ₀)) → θ ≤ ψ → θ ∨ (φ ∧ ψ) ≅ (θ ∨ φ) ∧ ψ
+  CongruenceModular = (θ φ ψ : Con 𝑨 (Ł α ρ ℓ₀)) → θ ⊆ ψ → θ ∨ (φ ∧ ψ) ≡ (θ ∨ φ) ∧ ψ
 ```
 
 --------------------------------------

--- a/src/Setoid/Subalgebras.lagda.md
+++ b/src/Setoid/Subalgebras.lagda.md
@@ -21,6 +21,7 @@ open import Setoid.Subalgebras.CompleteLattice {𝑆 = 𝑆}
 open import Setoid.Subalgebras.Properties {𝑆 = 𝑆} public
 open import Setoid.Subalgebras.Subalgebras {𝑆 = 𝑆} public
 open import Setoid.Subalgebras.Subuniverses {𝑆 = 𝑆} public
+open import Setoid.Subalgebras.Subdirect {𝑆 = 𝑆} public
 ```
 
 

--- a/src/Setoid/Subalgebras/Subdirect.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect.lagda.md
@@ -1,0 +1,228 @@
+---
+layout: default
+file: "src/Setoid/Subalgebras/Subdirect.lagda.md"
+title: "Setoid.Subalgebras.Subdirect module (The Agda Universal Algebra Library)"
+date: "2026-06-20"
+author: "the agda-algebras development team"
+---
+
+### Subdirect products and Birkhoff's subdirect representation theorem
+
+This is the [Setoid.Subalgebras.Subdirect][] module of the [Agda Universal Algebra Library][].
+
+A **subdirect product** of a family `𝒜 : I → Algebra` is a subalgebra of the product
+`⨅ 𝒜` whose every coordinate projection is *surjective* — the subalgebra meets every
+factor.  A **subdirect embedding** of `𝑨` is a monomorphism `𝑨 ↪ ⨅ 𝒜` exhibiting `𝑨`
+as such a subdirect product.  These are the structures underlying Birkhoff's *subdirect
+representation theorem*: every algebra is a subdirect product of subdirectly irreducible
+algebras.
+
+This module proves the **choice-free core** in full:
+
++  *the bridge* — a family of congruences `θ : I → Con 𝑨` whose meet is the diagonal
+   (`θ` *separates points*) induces a subdirect embedding `𝑨 ↪ ⨅ (λ i → 𝑨 ╱ θ i)`, with
+   injectivity *exactly* the separation hypothesis and the coordinate projections
+   surjective because they are the canonical quotient maps; and
++  *the reduction of Birkhoff to existence* — given a subdirect SI-representation of `𝑨`
+   (a separating family whose quotients are all subdirectly irreducible), `𝑨` is a
+   subdirect product of subdirectly irreducible algebras.
+
+What is **not** choice-free is the *existence* of a subdirect SI-representation for an
+arbitrary algebra: for each pair `a ≢ b` one needs a congruence maximal among those not
+relating `a , b` (it is completely meet-irreducible, so its quotient is subdirectly
+irreducible), and selecting it is a Zorn's-lemma step incompatible with postulate-free
+`--safe`.  Following option (a) of the design brief, we take that existence as an
+explicit module parameter (`SubdirectSIRep`), so the theorem is proved *relative to* a
+precisely-stated assumption and nothing is postulated.  See the design note
+`docs/notes/m6-2-subdirect.md` for the alternatives (finite/decidable search; deferral)
+and the rationale.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+
+module Setoid.Subalgebras.Subdirect {𝑆 : Signature 𝓞 𝓥} where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Agda.Primitive   using () renaming ( Set to Type )
+open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax ; proj₁ ; proj₂ )
+open import Function         using () renaming ( Func to _⟶_ )
+open import Level            using ( Level ; _⊔_ )
+open import Relation.Binary  using ( Setoid )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Setoid.Functions  using ( IsInjective ; IsSurjective )
+
+open import Setoid.Algebras       {𝑆 = 𝑆}  using ( Algebra ; ov ; _^_ ; ⨅ ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Congruences    {𝑆 = 𝑆}  using ( Con ; _╱_ )
+open import Setoid.Homomorphisms  {𝑆 = 𝑆}
+  using ( hom ; IsHom ; epi ; IsEpi ; 𝒾𝒹 ; ⊙-hom ; ⨅-hom-co ; πhom ; πepi )
+open import Setoid.Subalgebras.Subalgebras {𝑆 = 𝑆}  using ( _≤_ )
+open import Setoid.Congruences.Monolith     {𝑆 = 𝑆}  using ( IsSubdirectlyIrreducible )
+
+open _⟶_  using ( cong ) renaming ( to to _⟨$⟩_ )
+open Algebra  using ( Domain )
+
+private variable α ρ β ρᵇ ℓ ι : Level
+```
+
+#### Coordinate projections out of a product
+
+The projection of a product algebra onto its `i`-th factor is a homomorphism.  (This is
+the `⨅-projection-hom` of [Setoid.Homomorphisms.Products][], re-derived here without that
+version's vestigial domain parameter so that the factor family `𝒜` determines it.)
+
+```agda
+module _ {I : Type ι}(𝒜 : I → Algebra α ρ) where
+  open Algebra (⨅ 𝒜) using () renaming ( Domain to ⨅A )
+
+  ⨅-proj : (i : I) → hom (⨅ 𝒜) (𝒜 i)
+  ⨅-proj i = F , isHom
+    where
+    open Algebra (𝒜 i) using () renaming ( Domain to Aᵢ )
+    open Setoid Aᵢ     using () renaming ( refl to reflᵢ )
+    F : ⨅A ⟶ Aᵢ
+    F = record { to = λ x → x i ; cong = λ xy → xy i }
+    isHom : IsHom (⨅ 𝒜) (𝒜 i) F
+    isHom = record { compatible = reflᵢ }
+```
+
+#### Subdirect products and subdirect embeddings
+
+Fix a candidate algebra `𝑩` and a factor family `𝒜`.  The `i`-th **coordinate map** of a
+homomorphism `h : 𝑩 → ⨅ 𝒜` is the composite `projᵢ ∘ h : 𝑩 → 𝒜 i`.  A homomorphism is a
+**subdirect embedding** when it is injective (so `𝑩 ≤ ⨅ 𝒜`) and every coordinate map is
+surjective.
+
+```agda
+module _ {I : Type ι}{𝑩 : Algebra β ρᵇ}(𝒜 : I → Algebra α ρ) where
+
+  -- The i-th coordinate map projᵢ ∘ h of a hom into the product.
+  coord : hom 𝑩 (⨅ 𝒜) → (i : I) → hom 𝑩 (𝒜 i)
+  coord h i = ⊙-hom h (⨅-proj 𝒜 i)
+
+  record IsSubdirectEmbedding (h : hom 𝑩 (⨅ 𝒜)) : Type (ι ⊔ α ⊔ ρ ⊔ β ⊔ ρᵇ) where
+    field
+      embed-inj  : IsInjective (proj₁ h)
+      proj-onto  : (i : I) → IsSurjective (proj₁ (coord h i))
+
+  open IsSubdirectEmbedding public
+
+  -- A subdirect embedding of 𝑩 into ⨅ 𝒜 (equivalently: 𝑩 is a subdirect product of 𝒜).
+  SubdirectEmbedding : Type (𝓞 ⊔ 𝓥 ⊔ ι ⊔ α ⊔ ρ ⊔ β ⊔ ρᵇ)
+  SubdirectEmbedding = Σ[ h ∈ hom 𝑩 (⨅ 𝒜) ] IsSubdirectEmbedding h
+
+  -- A subdirect embedding is in particular a subalgebra inclusion 𝑩 ≤ ⨅ 𝒜.
+  subdirect→≤ : SubdirectEmbedding → 𝑩 ≤ ⨅ 𝒜
+  subdirect→≤ (h , emb) = h , embed-inj emb
+```
+
+#### The bridge: a separating family of congruences gives a subdirect embedding
+
+Now the constructive heart.  Fix an algebra `𝑨` and a family of congruences
+`θ : I → Con 𝑨`.  Form the family of quotients `i ↦ 𝑨 ╱ θ i` and the natural map into
+their product, assembled from the canonical quotient projections `πhom (θ i)`.
+
+```agda
+module _ {I : Type ι}{𝑨 : Algebra α ρ}(θ : I → Con 𝑨 ℓ) where
+  open Algebra 𝑨 using () renaming ( Domain to A )
+  open Setoid A  using ( _≈_ )
+
+  -- the family of quotient algebras and the natural map into their product
+  𝑨╱ : I → Algebra α ℓ
+  𝑨╱ i = 𝑨 ╱ θ i
+
+  natmap : hom 𝑨 (⨅ 𝑨╱)
+  natmap = ⨅-hom-co 𝑨╱ (λ i → πhom 𝒾𝒹 (θ i))
+```
+
+The family **separates points** when the only pairs related by *every* `θ i` are the
+`≈`-equal ones — i.e. the meet `⋂ θ` is the diagonal `0ᴬ`.  This is *exactly* the
+injectivity of the natural map: an element's image in the product is its tuple of
+congruence classes, and two elements have the same tuple iff every `θ i` relates them.
+
+```agda
+  -- ⋂ θ ≅ 0ᴬ : every θ i relating a,b forces a ≈ b.
+  Separates : Type (ι ⊔ α ⊔ ρ ⊔ ℓ)
+  Separates = ∀ {a b} → (∀ i → proj₁ (θ i) a b) → a ≈ b
+
+  -- Injectivity of the natural map is definitionally the separation property.
+  natmap-injective : Separates → IsInjective (proj₁ natmap)
+  natmap-injective sep = sep
+
+  natmap-separates : IsInjective (proj₁ natmap) → Separates
+  natmap-separates inj = inj
+```
+
+Each coordinate map `projᵢ ∘ natmap` *is* the canonical quotient epimorphism
+`𝑨 ↠ 𝑨 ╱ θ i`, hence surjective — with no decidability or choice assumption on the index.
+
+```agda
+  natmap-proj-onto : (i : I) → IsSurjective (proj₁ (coord 𝑨╱ natmap i))
+  natmap-proj-onto i = IsEpi.isSurjective (proj₂ (πepi 𝒾𝒹 (θ i)))
+```
+
+Assembling injectivity and the surjective coordinate maps gives the subdirect embedding.
+
+```agda
+  separating→subdirect : Separates → IsSubdirectEmbedding 𝑨╱ natmap
+  separating→subdirect sep =
+    record { embed-inj = natmap-injective sep ; proj-onto = natmap-proj-onto }
+
+  separating→SubdirectEmbedding : Separates → SubdirectEmbedding 𝑨╱
+  separating→SubdirectEmbedding sep = natmap , separating→subdirect sep
+```
+
+#### Birkhoff's subdirect representation theorem
+
+The conclusion of Birkhoff's theorem is that an algebra is a subdirect product of
+*subdirectly irreducible* algebras: a family of SI algebras and a subdirect embedding
+into their product.
+
+```agda
+SubdirectlyRepresentable : (𝑨 : Algebra α ρ) → (ℓ ι : Level) → Type _
+SubdirectlyRepresentable {α}{ρ} 𝑨 ℓ ι =
+  Σ[ I ∈ Type ι ] Σ[ 𝒜 ∈ (I → Algebra α ℓ) ]
+    ((∀ i → IsSubdirectlyIrreducible (𝒜 i)) × SubdirectEmbedding {𝑩 = 𝑨} 𝒜)
+```
+
+A **subdirect SI-representation** of `𝑨` packages exactly the data that the bridge
+consumes: an index type, a family of congruences whose quotients are subdirectly
+irreducible, and a proof that the family separates points.  This is the precise
+content that Zorn's lemma supplies classically (and is the only non-constructive input).
+
+```agda
+SubdirectSIRep : (𝑨 : Algebra α ρ) → (ℓ ι : Level) → Type _
+SubdirectSIRep {α}{ρ} 𝑨 ℓ ι =
+  Σ[ I ∈ Type ι ] Σ[ θ ∈ (I → Con 𝑨 ℓ) ]
+    (Separates θ × (∀ i → IsSubdirectlyIrreducible (𝑨 ╱ θ i)))
+```
+
+The choice-free reduction: a subdirect SI-representation yields a subdirect-product
+representation by subdirectly irreducible algebras.  This is the whole theorem *modulo*
+the existence of the representation.
+
+```agda
+SIRep→Representable : {𝑨 : Algebra α ρ}
+  → SubdirectSIRep 𝑨 ℓ ι → SubdirectlyRepresentable 𝑨 ℓ ι
+SIRep→Representable (I , θ , sep , si) =
+  I , (λ i → _ ╱ θ i) , si , separating→SubdirectEmbedding θ sep
+```
+
+Birkhoff's theorem, relative to the choice principle that every algebra admits a
+subdirect SI-representation, then says every algebra is subdirectly representable.
+
+```agda
+module _ (sirep : (𝑨 : Algebra α ρ) → SubdirectSIRep 𝑨 ℓ ι) where
+
+  Birkhoff-subdirect : (𝑨 : Algebra α ρ) → SubdirectlyRepresentable 𝑨 ℓ ι
+  Birkhoff-subdirect 𝑨 = SIRep→Representable (sirep 𝑨)
+```
+
+--------------------------------------
+
+<span style="float:left;">[← Setoid.Subalgebras.Subalgebras](Setoid.Subalgebras.Subalgebras.html)</span>
+<span style="float:right;">[Setoid.Subalgebras.Properties →](Setoid.Subalgebras.Properties.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Subalgebras/Subdirect.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect.lagda.md
@@ -47,18 +47,20 @@ module Setoid.Subalgebras.Subdirect {𝑆 : Signature 𝓞 𝓥} where
 -- Imports from Agda and the Agda Standard Library ----------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
 open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax ; proj₁ ; proj₂ )
-open import Function         using () renaming ( Func to _⟶_ )
-open import Level            using ( Level ; _⊔_ )
+open import Function         using ( id ) renaming ( Func to _⟶_ )
+open import Level            using ( Level ; _⊔_ ) renaming ( suc to lsuc )
 open import Relation.Binary  using ( Setoid )
+open import Relation.Binary.PropositionalEquality using ( _≡_ ) renaming ( refl to ≡refl )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Setoid.Functions  using ( IsInjective ; IsSurjective )
+open import Setoid.Functions                         using ( IsInjective ; IsSurjective )
 
-open import Setoid.Algebras       {𝑆 = 𝑆}  using ( Algebra ; ov ; _^_ ; ⨅ ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Congruences    {𝑆 = 𝑆}  using ( Con ; _╱_ )
-open import Setoid.Homomorphisms  {𝑆 = 𝑆}
-  using ( hom ; IsHom ; epi ; IsEpi ; 𝒾𝒹 ; ⊙-hom ; ⨅-hom-co ; πhom ; πepi )
-open import Setoid.Subalgebras.Subalgebras {𝑆 = 𝑆}  using ( _≤_ )
+open import Setoid.Algebras                 {𝑆 = 𝑆}  using ( Algebra ; ⨅ ; 𝔻[_] )
+open import Setoid.Congruences              {𝑆 = 𝑆}  using ( Con ; _╱_ )
+open import Setoid.Homomorphisms            {𝑆 = 𝑆}  using  ( hom ; IsHom ; epi ; IsEpi
+                                                            ; 𝒾𝒹 ; ⊙-hom ; ⨅-hom-co
+                                                            ; πhom ; πepi )
+open import Setoid.Subalgebras.Subalgebras  {𝑆 = 𝑆}  using ( _≤_ )
 open import Setoid.Congruences.Monolith     {𝑆 = 𝑆}  using ( IsSubdirectlyIrreducible )
 
 open _⟶_  using ( cong ) renaming ( to to _⟨$⟩_ )
@@ -80,12 +82,12 @@ module _ {I : Type ι}(𝒜 : I → Algebra α ρ) where
   ⨅-proj : (i : I) → hom (⨅ 𝒜) (𝒜 i)
   ⨅-proj i = F , isHom
     where
-    open Algebra (𝒜 i) using () renaming ( Domain to Aᵢ )
-    open Setoid Aᵢ     using () renaming ( refl to reflᵢ )
+    open Algebra (𝒜 i)  using () renaming ( Domain to Aᵢ )
+    open Setoid Aᵢ       using ( refl )
     F : ⨅A ⟶ Aᵢ
     F = record { to = λ x → x i ; cong = λ xy → xy i }
     isHom : IsHom (⨅ 𝒜) (𝒜 i) F
-    isHom = record { compatible = reflᵢ }
+    isHom = record { compatible = refl }
 ```
 
 #### Subdirect products and subdirect embeddings
@@ -126,8 +128,7 @@ their product, assembled from the canonical quotient projections `πhom (θ i)`.
 
 ```agda
 module _ {I : Type ι}{𝑨 : Algebra α ρ}(θ : I → Con 𝑨 ℓ) where
-  open Algebra 𝑨 using () renaming ( Domain to A )
-  open Setoid A  using ( _≈_ )
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
 
   -- the family of quotient algebras and the natural map into their product
   𝑨╱ : I → Algebra α ℓ
@@ -149,10 +150,13 @@ congruence classes, and two elements have the same tuple iff every `θ i` relate
 
   -- Injectivity of the natural map is definitionally the separation property.
   natmap-injective : Separates → IsInjective (proj₁ natmap)
-  natmap-injective sep = sep
+  natmap-injective = id
 
   natmap-separates : IsInjective (proj₁ natmap) → Separates
-  natmap-separates inj = inj
+  natmap-separates = id
+
+  _ : IsInjective (proj₁ natmap) ≡ Separates
+  _ = ≡refl
 ```
 
 Each coordinate map `projᵢ ∘ natmap` *is* the canonical quotient epimorphism
@@ -181,7 +185,7 @@ The conclusion of Birkhoff's theorem is that an algebra is a subdirect product o
 into their product.
 
 ```agda
-SubdirectlyRepresentable : (𝑨 : Algebra α ρ) → (ℓ ι : Level) → Type _
+SubdirectlyRepresentable : (𝑨 : Algebra α ρ) → (ℓ ι : Level) → Type (𝓞 ⊔ 𝓥  ⊔ ρ ⊔ lsuc (α ⊔ ℓ ⊔ ι))
 SubdirectlyRepresentable {α}{ρ} 𝑨 ℓ ι =
   Σ[ I ∈ Type ι ] Σ[ 𝒜 ∈ (I → Algebra α ℓ) ]
     ((∀ i → IsSubdirectlyIrreducible (𝒜 i)) × SubdirectEmbedding {𝑩 = 𝑨} 𝒜)
@@ -193,8 +197,8 @@ irreducible, and a proof that the family separates points.  This is the precise
 content that Zorn's lemma supplies classically (and is the only non-constructive input).
 
 ```agda
-SubdirectSIRep : (𝑨 : Algebra α ρ) → (ℓ ι : Level) → Type _
-SubdirectSIRep {α}{ρ} 𝑨 ℓ ι =
+SubdirectSIRep : (𝑨 : Algebra α ρ) → (ℓ ι : Level) → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ ⊔ lsuc (ℓ ⊔ ι))
+SubdirectSIRep 𝑨 ℓ ι =
   Σ[ I ∈ Type ι ] Σ[ θ ∈ (I → Con 𝑨 ℓ) ]
     (Separates θ × (∀ i → IsSubdirectlyIrreducible (𝑨 ╱ θ i)))
 ```

--- a/src/Setoid/Subalgebras/Subdirect.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect.lagda.md
@@ -144,7 +144,7 @@ injectivity of the natural map: an element's image in the product is its tuple o
 congruence classes, and two elements have the same tuple iff every `θ i` relates them.
 
 ```agda
-  -- ⋂ θ ≅ 0ᴬ : every θ i relating a,b forces a ≈ b.
+  -- the meet ⋂ θ is the diagonal 0ᴬ: every θ i relating a,b forces a ≈ b.
   Separates : Type (ι ⊔ α ⊔ ρ ⊔ ℓ)
   Separates = ∀ {a b} → (∀ i → proj₁ (θ i) a b) → a ≈ b
 


### PR DESCRIPTION
## Summary

Begins [M6-2][] (#272) — the foundational subdirect-representation infrastructure the M6 track skipped when it did congruence permutability (M6-3/#273) and the CP converse (#410/#411) first.  Mirrors M6-3's discipline: the **constructive core is proved in full**, and the one genuinely choice-dependent statement (the *existence* half of Birkhoff's theorem) is isolated as an explicit module parameter rather than postulated, so the library stays postulate-free under `--safe`.

Two new modules, both `--cubical-compatible --exact-split --safe`.

### `Setoid.Congruences.Monolith` — the order-theoretic core of subdirect irreducibility

+  `Nontrivial` / `Trivial` algebras (and `trivial⇒¬nontrivial`); `BelowDiagonal` / `Nonzero` congruences.
+  `⋂` — the infinitary meet of an `ℓ`-small family at the algebra's own relation level (the natural-level instance of `CompleteLattice`'s `⋀`).
+  `IsMonolith` (the least nonzero congruence), `HasMonolith`, `monolith-unique`.
+  `IsSubdirectlyIrreducible = Nontrivial × HasMonolith`, with `si⇒nontrivial` and `trivial⇒¬si`.
+  The characterization `monolith⇒cmi` (a monolith makes `0ᴬ` completely meet-irreducible, stated in the constructive contrapositive form) and its binary instance `monolith⇒∧-irreducible` (`0ᴬ` is meet-irreducible).

### `Setoid.Subalgebras.Subdirect` — subdirect products and Birkhoff

+  `⨅-proj` (coordinate projection out of a product) and `coord` (the `i`-th coordinate map `projᵢ ∘ h`).
+  `IsSubdirectEmbedding` (injective, with every coordinate map surjective), `SubdirectEmbedding`, `subdirect→≤`.
+  **The bridge** — for a family `θ : I → Con 𝑨`, the natural map into `⨅ (λ i → 𝑨 ╱ θ i)`.  `Separates θ` says the meet `⋂ θ` is the diagonal `0ᴬ`; `natmap-injective` / `natmap-separates` show injectivity of the natural map is *definitionally* this separation hypothesis, and `natmap-proj-onto` shows each coordinate map *is* the canonical quotient epimorphism (hence onto, with no choice/decidability on the index).  `separating→SubdirectEmbedding` assembles them.  This is the choice-free heart.
+  **Birkhoff, reduced to existence** — `SubdirectlyRepresentable 𝑨` (a family of SI algebras with a subdirect embedding of `𝑨` into their product); `SubdirectSIRep 𝑨` packages the bridge's input; `SIRep→Representable` is the unconditional reduction; and `Birkhoff-subdirect` proves the theorem relative to the choice principle `(∀ 𝑨 → SubdirectSIRep 𝑨)`.

## The choice/Zorn decision (option (a))

Birkhoff needs, for each `a ≢ b`, a congruence maximal among those not relating `a , b` (it is completely meet-irreducible, so its quotient is SI) — a Zorn step incompatible with postulate-free `--safe`.  Following option (a) of the brief, `Birkhoff-subdirect` abstracts over an explicit `SubdirectSIRep`-existence parameter, so the theorem is proved *relative to* a precisely-stated assumption and **nothing is postulated**; the choice-free half is proved unconditionally, so the theorem reduces to exactly the choice-dependent existence claim.

The design note `docs/notes/m6-2-subdirect.md` records the full rationale: why the parameter is a separating SI-*family* rather than per-pair maximal congruences (the per-pair route gives `⋂ θ ⊆ Δ` only up to `¬¬` constructively, since forming the index for a fixed pair requires deciding `a ≈ b`); the predicativity wall blocking the `cmi ⟹ monolith` converse; the level conventions (SI congruences fixed at the algebra's own relation level `ρ`); and follow-ups (the constructive finite case discharging the parameter by search; the impredicative converse; linking SI to the absence of a nontrivial subdirect decomposition).

## Verification

+  `nix develop --command make check` is green (209 modules; the only output is pre-existing `Legacy/` deprecation warnings).
+  Individually: `nix develop --command agda src/Setoid/Congruences/Monolith.lagda.md` and `… src/Setoid/Subalgebras/Subdirect.lagda.md`.

## Also

+  Barrel entries (`Setoid.Congruences`, `Setoid.Subalgebras`) and `mkdocs/_includes/UALib.Links.md` link entries for the two modules.
+  Issue-#272 task/acceptance checkboxes and a status section updated in `docs/GITHUB_PROJECT.md`.
+  The theorem is named `Birkhoff-subdirect` (distinct from the HSP variety theorem's `Birkhoff`) so both re-export through the top-level `Setoid` barrel without an ambiguous-name clash.

Closes #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[M6-2]: https://github.com/ualib/agda-algebras/issues/272

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9q9aP34sakGdPgZVaXU2s)_