### PR TITLE
[M4-15] Generalize finite op-law deciders to DecSetoid + exhaustive-search witness (#357)

### DIFF
--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -3309,7 +3309,7 @@ https://claude.ai/code/session_01MvPrLTCxKjFgsnTMK8j2qZ
 
 ---
 
-### Issue M6-8: Finite Birkhoff: discharge SubdirectSIRep constructively for finite algebras with decidable equality (#419)
+### Issue M6-8: Finite Birkhoff: discharge SubdirectSIRep constructively for finite algebras with decidable equality (#419, closed)
 
 **Labels**: `enhancement`, `milestone-6-flrp`
 

--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -3309,7 +3309,7 @@ https://claude.ai/code/session_01MvPrLTCxKjFgsnTMK8j2qZ
 
 ---
 
-### Issue M6-8: Finite Birkhoff: discharge SubdirectSIRep constructively for finite algebras with decidable equality (#419, closed)
+### Issue M6-8: Finite Birkhoff: discharge SubdirectSIRep constructively for finite algebras with decidable equality (#419)
 
 **Labels**: `enhancement`, `milestone-6-flrp`
 

--- a/mkdocs/_includes/UALib.Links.md
+++ b/mkdocs/_includes/UALib.Links.md
@@ -11,6 +11,7 @@
 [Overture.Signatures]: https://ualib.org/Overture.Signatures.html
 [Overture.Levels]: https://ualib.org/Overture.Levels.html
 [Overture.Operations]: https://ualib.org/Overture.Operations.html
+[Overture.Operations.Properties]: https://ualib.org/Overture.Operations.Properties.html
 [Overture.Cayley]: https://ualib.org/Overture.Cayley.html
 [Overture.Terms.Interpretation]: https://ualib.org/Overture.Terms.Interpretation.html
 
@@ -106,6 +107,8 @@
 <!-- [Setoid]: Setoid.html -->
 [Setoid]: https://ualib.org/Setoid.html
 
+[Setoid.Operations]: https://ualib.org/Setoid.Operations.html
+[Setoid.Operations.Properties]: https://ualib.org/Setoid.Operations.Properties.html
 [Setoid.Relations]: https://ualib.org/Setoid.Relations.html
 [Setoid.Relations.Discrete]: https://ualib.org/Setoid.Relations.Discrete.html
 [Setoid.Relations.Quotients]: https://ualib.org/Setoid.Relations.Quotients.html
@@ -194,6 +197,7 @@
 [Overture/Signatures.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Overture/Signatures.lagda
 [Overture/Levels.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Overture/Levels.lagda
 [Overture/Operations.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Overture/Operations.lagda
+[Overture/Operations/Properties.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Overture/Operations/Properties.lagda
 
 [Base.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Base.lagda
 [Base/Relations.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Base/Relations.lagda
@@ -279,6 +283,8 @@
 <!-- ///////////////////////////////////////////////////////////////////////////////////////////////// -->
 
 [Setoid.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid.lagda
+[Setoid/Operations.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Operations.lagda
+[Setoid/Operations/Properties.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Operations/Properties.lagda
 
 [Setoid/Relations.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Relations.lagda
 [Setoid/Relations/Discrete.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Relations/Discrete.lagda

--- a/src/Setoid.lagda.md
+++ b/src/Setoid.lagda.md
@@ -22,6 +22,7 @@ open import Setoid.Complexity public
 open import Setoid.Congruences public
 open import Setoid.Functions public
 open import Setoid.Homomorphisms public
+open import Setoid.Operations public
 open import Setoid.Relations public
 open import Setoid.Signatures public
 open import Setoid.Subalgebras public

--- a/src/Setoid/Operations.lagda.md
+++ b/src/Setoid/Operations.lagda.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title : "Setoid.Operations module (The Agda Universal Algebra Library)"
+date : "2026-06-21"
+author: "the agda-algebras development team"
+---
+
+## Operations on setoids
+
+This is the [Setoid.Operations][] module of the [Agda Universal Algebra Library][].
+
+It collects the setoid-level companions to the operation utilities of
+[Overture.Operations][].  At present this is the single submodule
+[Setoid.Operations.Properties][], which generalizes the finite, propositional
+law-checkers of [Overture.Operations.Properties][] to an arbitrary decidable setoid
+equipped with an exhaustive-search witness for its carrier.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Setoid.Operations where
+
+open import Setoid.Operations.Properties  public
+```
+
+-------------------------------------
+
+<span style="float:left;">[↑ Setoid](Setoid.html)</span>
+<span style="float:right;">[Setoid.Operations.Properties →](Setoid.Operations.Properties.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Operations/Properties.lagda.md
+++ b/src/Setoid/Operations/Properties.lagda.md
@@ -180,8 +180,8 @@ module _ {c ℓ} (S : DecSetoid c ℓ) (E : Exhaustible (DecSetoid.Carrier S)) w
     Distributesˡ? = all? λ a → all? λ b → all? λ c → a ∧ (b ∨ c) ≟ (a ∧ b) ∨ (a ∧ c)
 
     -- (b ∨ c) ∧ a ≈ (b ∧ a) ∨ (c ∧ a) for every a, b, c.
-    Distributesʳ? : Dec (∀ a b c → ((b ∨ c) ∧ a) ≈ ((b ∧ a) ∨ (c ∧ a)))
-    Distributesʳ? = all? (λ a → all? (λ b → all? (λ c → ((b ∨ c) ∧ a) ≟ ((b ∧ a) ∨ (c ∧ a)))))
+    Distributesʳ? : Dec ∀ a b c → (b ∨ c) ∧ a ≈ (b ∧ a) ∨ (c ∧ a)
+    Distributesʳ? = all? λ a → all? λ b → all? λ c → (b ∨ c) ∧ a ≟ (b ∧ a) ∨ (c ∧ a)
 ```
 
 #### The finite instance
@@ -214,8 +214,9 @@ instance of the generalized ones — and, because the equalities are definitiona
 concrete checkers keep reducing exactly as before for `from-yes`{.AgdaFunction}, so
 the finite examples are unaffected.
 
-(We leave present each of the remaining observations as an anonymous theorem, since
-they serve to confirm and demonstrate fact which likely will not be used elsewhere.)
+(Each equation is stated as an anonymous definition: it exists only to confirm, at
+type-checking time, that the identity holds, and is not meant to be named or
+referenced elsewhere.)
 
 ```agda
 module _ {n : ℕ} (_·_ : Fin n → Fin n → Fin n) where
@@ -314,7 +315,7 @@ examples.
 
 --------------------------------------
 
-[^1]: See Milestone 9, especially Issue [M9-1].
+[^1]: See Milestone 9 of the project roadmap, especially task M9-1.
 
 [^2]: which is why a future Escardó-style `Searchable`/`Exhaustible` carrier could
 supply it without change.

--- a/src/Setoid/Operations/Properties.lagda.md
+++ b/src/Setoid/Operations/Properties.lagda.md
@@ -1,0 +1,304 @@
+---
+layout: default
+title : "Setoid.Operations.Properties module (The Agda Universal Algebra Library)"
+date : "2026-06-21"
+author: "the agda-algebras development team"
+---
+
+### Decidable equational laws over a searchable decidable setoid
+
+This is the [Setoid.Operations.Properties][] module of the [Agda Universal Algebra Library][].
+
+The finite law-checkers of [Overture.Operations.Properties][] decide each equational
+law of an operation `Fin n → Fin n → Fin n` by nesting `all?`{.AgdaFunction}
+(`Data.Fin.Properties.all?`) over decidable equality `_≟_`{.AgdaFunction} on
+`Fin n`{.AgdaDatatype}.  Their decidability rests on exactly two facts about the
+carrier, and *neither is special to* `Fin n`{.AgdaDatatype} *or to*
+`_≡_`{.AgdaDatatype}:
+
++  the carrier is **exhaustively searchable** — a pointwise decision procedure
+   `∀ x → Dec (P x)` can be turned into a decision `Dec (∀ x → P x)` for the
+   universally-quantified statement (this is what `all?`{.AgdaFunction} provides); and
++  the carrier has **decidable equality** — supplied here by the decidable
+   `_≈_`{.AgdaFunction} of a `DecSetoid`{.AgdaRecord}.
+
+This module restates the eleven checkers over an arbitrary `DecSetoid`{.AgdaRecord}
+`S` — deciding `_≈_`{.AgdaFunction} through `S`'s `_≟_`{.AgdaFunction} — together with
+an exhaustive-search witness for its carrier, writing each law with
+`_≈_`{.AgdaFunction} in place of `_≡_`{.AgdaDatatype}.  The operation stays a *bare*
+function `Carrier → Carrier → Carrier`; the *decision* never needs it to respect
+`_≈_`{.AgdaFunction}, exactly as in the concrete versions.  The finite
+`Fin n`{.AgdaDatatype} / `_≡_`{.AgdaDatatype} checkers are then recovered as a single
+instance: take `S` to be the propositional `DecSetoid`{.AgdaRecord} on
+`Fin n`{.AgdaDatatype} and the search witness to be `Fin`'s `all?`{.AgdaFunction}.
+The final section proves that each concrete checker *equals* its generalized form at
+this instance, by `refl`{.AgdaInductiveConstructor}; so the fast-reducing concrete
+checkers (on which the finite examples and their `from-yes`{.AgdaFunction} proofs
+depend) are kept exactly as they are, with the generalization exhibited alongside
+rather than replacing them.
+
+The search ingredient is isolated below as a one-field interface,
+`Exhaustible`{.AgdaRecord}, deliberately kept independent of `Fin`{.AgdaDatatype}: any
+carrier that admits such a search functional can drive the checkers.  Finite carriers
+are the obvious source, but not the only one — Martín Escardó's work on
+*exhaustively searchable* types shows that even some *infinite* carriers (e.g.
+`ℕ∞`, the one-point compactification of `ℕ`) admit a total search functional.
+Supplying those carriers' search functionals is the planned **M9-1** work; this
+module only fixes the interface they would implement, and is not itself M9-1.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Setoid.Operations.Properties where
+
+-- Imports from Agda and the Agda Standard Library -----------------------------
+open import Agda.Primitive                          using ( Level )
+                                                    renaming ( Set to Type ; Setω to Typeω )
+open import Data.Bool.Base                          using ( Bool ; false ; true ; _∧_ ; _∨_ )
+open import Data.Fin                                using ( Fin )
+open import Data.Nat                                using ( ℕ )
+open import Data.Product                            using ( _×_ ; _,_ )
+open import Relation.Binary.Bundles                 using ( DecSetoid )
+open import Relation.Binary.PropositionalEquality   using ( _≡_ ; refl )
+open import Relation.Nullary.Decidable.Core         using ( Dec ; map′ ; from-yes ; _×-dec_ )
+
+import Data.Bool.Properties              as BoolP
+import Data.Fin.Properties               as FinP
+
+-- Imports from the Agda Universal Algebra Library -----------------------------
+import Overture.Operations.Properties    as Concrete
+```
+
+#### The exhaustive-search interface
+
+A carrier `A` is *exhaustively searchable* — for the purpose of deciding
+universally-quantified decidable predicates — when it carries a single functional
+that turns any pointwise decision procedure `∀ x → Dec (P x)` into a decision
+`Dec (∀ x → P x)` for the universal statement.  This is exactly the shape of
+`Data.Fin.Properties.all?`, with the carrier abstracted away from `Fin`.  We package
+it as a one-field record so that a witness `E : Exhaustible A` can be passed to the
+checkers and its search functional opened under the name `all?`{.AgdaFunction},
+making the generalized call sites read identically to the concrete `Fin` ones.
+
+The field is universe-polymorphic in the predicate level `p`, so the record lives in
+`Typeω`{.AgdaPrimitiveType}; this is needed because the nested checkers apply the same
+functional at two different predicate levels (`ℓ` innermost and `c ⊔ ℓ` after a
+quantifier).  The record mentions no setoid and no `Fin`{.AgdaDatatype}; it is a
+property of a bare carrier, which is why a future Escardó-style
+`Searchable`/`Exhaustible` carrier (M9-1) could supply it without change.
+
+```agda
+-- An exhaustive-search witness for a carrier A: it decides any universally-
+-- quantified predicate whose pointwise instances are decidable.  The abstraction
+-- of Data.Fin.Properties.all?, independent of Fin and of any equality.
+record Exhaustible {c} (A : Type c) : Typeω where
+  field
+    all? : ∀ {p} {P : A → Type p} → (∀ x → Dec (P x)) → Dec (∀ x → P x)
+```
+
+#### Laws of a single operation
+
+Throughout, `S` is a decidable setoid, `E` an exhaustive-search witness for its
+carrier, and `_·_` a bare binary operation on that carrier.  Opening `S` exposes the
+carrier, its setoid equality `_≈_`{.AgdaFunction}, and the decision `_≟_`{.AgdaFunction}
+for `_≈_`{.AgdaFunction}; opening `E` exposes the search functional `all?`{.AgdaFunction}.
+Each law is then decided by nesting `all?`{.AgdaFunction} over `_≟_`{.AgdaFunction},
+one nesting per universally-quantified variable.
+
+```agda
+module _ {c ℓ} (S : DecSetoid c ℓ) (E : Exhaustible (DecSetoid.Carrier S)) where
+  open DecSetoid S   using ( Carrier ; _≈_ ; _≟_ )
+  open Exhaustible E using ( all? )
+
+  module _ (_·_ : Carrier → Carrier → Carrier) where
+
+    -- a · a ≈ a for every a.
+    Idempotentᴰ? : Dec (∀ a → (a · a) ≈ a)
+    Idempotentᴰ? = all? (λ a → (a · a) ≟ a)
+
+    -- a · b ≈ b · a for every a, b.
+    Commutativeᴰ? : Dec (∀ a b → (a · b) ≈ (b · a))
+    Commutativeᴰ? = all? (λ a → all? (λ b → (a · b) ≟ (b · a)))
+
+    -- (a · b) · c ≈ a · (b · c) for every a, b, c.
+    Associativeᴰ? : Dec (∀ a b c → ((a · b) · c) ≈ (a · (b · c)))
+    Associativeᴰ? = all? (λ a → all? (λ b → all? (λ c → ((a · b) · c) ≟ (a · (b · c)))))
+
+    module _ (e : Carrier) where
+
+      -- e · a ≈ a for every a.
+      LeftIdentityᴰ? : Dec (∀ a → (e · a) ≈ a)
+      LeftIdentityᴰ? = all? (λ a → (e · a) ≟ a)
+
+      -- a · e ≈ a for every a.
+      RightIdentityᴰ? : Dec (∀ a → (a · e) ≈ a)
+      RightIdentityᴰ? = all? (λ a → (a · e) ≟ a)
+
+      module _ (i : Carrier → Carrier) where
+
+        -- (i a) · a ≈ e for every a.
+        LeftInverseᴰ? : Dec (∀ a → ((i a) · a) ≈ e)
+        LeftInverseᴰ? = all? (λ a → ((i a) · a) ≟ e)
+
+        -- a · (i a) ≈ e for every a.
+        RightInverseᴰ? : Dec (∀ a → (a · (i a)) ≈ e)
+        RightInverseᴰ? = all? (λ a → (a · (i a)) ≟ e)
+```
+
+#### Laws relating two operations
+
+These take two bare operations `_·_` and `_∘_` over the same decidable setoid; in a
+lattice they are typically the meet `∧` and join `∨`.  The shapes match the
+two-operation checkers of [Overture.Operations.Properties][] — absorption and
+distributivity — now stated over `_≈_`{.AgdaFunction}.
+
+```agda
+module _ {c ℓ} (S : DecSetoid c ℓ) (E : Exhaustible (DecSetoid.Carrier S)) where
+  open DecSetoid S   using ( Carrier ; _≈_ ; _≟_ )
+  open Exhaustible E using ( all? )
+
+  module _ (_·_ _∘_ : Carrier → Carrier → Carrier) where
+
+    -- a · (a ∘ b) ≈ a for every a, b.
+    Absorbsˡᴰ? : Dec (∀ a b → (a · (a ∘ b)) ≈ a)
+    Absorbsˡᴰ? = all? (λ a → all? (λ b → (a · (a ∘ b)) ≟ a))
+
+    -- (a · b) ∘ a ≈ a for every a, b.
+    Absorbsʳᴰ? : Dec (∀ a b → ((a · b) ∘ a) ≈ a)
+    Absorbsʳᴰ? = all? (λ a → all? (λ b → ((a · b) ∘ a) ≟ a))
+
+    -- a · (b ∘ c) ≈ (a · b) ∘ (a · c) for every a, b, c.
+    Distributesˡᴰ? : Dec (∀ a b c → (a · (b ∘ c)) ≈ ((a · b) ∘ (a · c)))
+    Distributesˡᴰ? = all? (λ a → all? (λ b → all? (λ c → (a · (b ∘ c)) ≟ ((a · b) ∘ (a · c)))))
+
+    -- (b ∘ c) · a ≈ (b · a) ∘ (c · a) for every a, b, c.
+    Distributesʳᴰ? : Dec (∀ a b c → ((b ∘ c) · a) ≈ ((b · a) ∘ (c · a)))
+    Distributesʳᴰ? = all? (λ a → all? (λ b → all? (λ c → ((b ∘ c) · a) ≟ ((b · a) ∘ (c · a)))))
+```
+
+#### The finite instance
+
+`Fin n`{.AgdaDatatype} is exhaustively searchable: its search functional is precisely
+`Data.Fin.Properties.all?`.  Wrapping it gives the canonical `Exhaustible`{.AgdaRecord}
+witness for `Fin n`{.AgdaDatatype}, the one that recovers the concrete checkers.
+
+```agda
+-- The exhaustive-search witness for Fin n, given by Fin's all?.
+Fin-Exhaustible : ∀ {n} → Exhaustible (Fin n)
+Fin-Exhaustible = record { all? = FinP.all? }
+```
+
+#### The finite checkers as the propositional instance
+
+Take `S` to be `FinP.≡-decSetoid n` — the propositional decidable setoid on
+`Fin n`{.AgdaDatatype}, whose `_≈_`{.AgdaFunction} is `_≡_`{.AgdaDatatype} and whose
+`_≟_`{.AgdaFunction} is `Data.Fin.Properties._≟_` — and `E` to be
+`Fin-Exhaustible`{.AgdaFunction}.  Each generalized checker then *unfolds definitionally*
+to the corresponding concrete checker of [Overture.Operations.Properties][]: the
+search functional reduces to `Fin`'s `all?`{.AgdaFunction} and `_≟_`{.AgdaFunction}
+reduces to `Fin`'s decidable equality.  We record that as eleven `refl`{.AgdaInductiveConstructor}
+equations, one per checker.  This is the precise sense in which the concrete checkers
+*are* the propositional instance of the generalized ones — and, because the equalities
+are definitional, the concrete checkers keep reducing exactly as before for
+`from-yes`{.AgdaFunction}, so the finite examples are unaffected.
+
+```agda
+module _ {n : ℕ} (_·_ : Fin n → Fin n → Fin n) where
+
+  Idempotent?≡ : Concrete.Idempotent? _·_ ≡ Idempotentᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_
+  Idempotent?≡ = refl
+
+  Commutative?≡ : Concrete.Commutative? _·_ ≡ Commutativeᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_
+  Commutative?≡ = refl
+
+  Associative?≡ : Concrete.Associative? _·_ ≡ Associativeᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_
+  Associative?≡ = refl
+
+  module _ (e : Fin n) where
+
+    LeftIdentity?≡ : Concrete.LeftIdentity? _·_ e ≡ LeftIdentityᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ e
+    LeftIdentity?≡ = refl
+
+    RightIdentity?≡ : Concrete.RightIdentity? _·_ e ≡ RightIdentityᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ e
+    RightIdentity?≡ = refl
+
+    module _ (i : Fin n → Fin n) where
+
+      LeftInverse?≡ : Concrete.LeftInverse? _·_ e i ≡ LeftInverseᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ e i
+      LeftInverse?≡ = refl
+
+      RightInverse?≡ : Concrete.RightInverse? _·_ e i ≡ RightInverseᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ e i
+      RightInverse?≡ = refl
+
+module _ {n : ℕ} (_·_ _∘_ : Fin n → Fin n → Fin n) where
+
+  Absorbsˡ?≡ : Concrete.Absorbsˡ? _·_ _∘_ ≡ Absorbsˡᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ _∘_
+  Absorbsˡ?≡ = refl
+
+  Absorbsʳ?≡ : Concrete.Absorbsʳ? _·_ _∘_ ≡ Absorbsʳᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ _∘_
+  Absorbsʳ?≡ = refl
+
+  Distributesˡ?≡ : Concrete.Distributesˡ? _·_ _∘_ ≡ Distributesˡᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ _∘_
+  Distributesˡ?≡ = refl
+
+  Distributesʳ?≡ : Concrete.Distributesʳ? _·_ _∘_ ≡ Distributesʳᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ _∘_
+  Distributesʳ?≡ = refl
+```
+
+#### A non-Fin instance: the two-element Boolean setoid
+
+To exercise the generality on a carrier that is *not* `Fin n`{.AgdaDatatype}, we
+supply an exhaustive-search witness for `Bool`{.AgdaDatatype} directly and run the
+checkers over the propositional decidable setoid on `Bool`{.AgdaDatatype}.  Searching
+`Bool`{.AgdaDatatype} is immediate: `∀ b → P b` holds iff both `P false` and `P true`
+do, so a pointwise decider for `P` decides the universal by a single
+`_×-dec_`{.AgdaFunction}.  This both demonstrates the abstraction and previews, in
+miniature, the kind of witness an M9-1 `Searchable` carrier would provide
+generically.  The section is `private`{.AgdaKeyword}: it validates the generalization
+without enlarging the module's public surface.
+
+```agda
+private
+
+  -- Bool is exhaustively searchable: ∀ b → P b reduces to P false and P true.
+  Bool-Exhaustible : Exhaustible Bool
+  Bool-Exhaustible = record { all? = bool-all? }
+    where
+    bool-all? : ∀ {p} {P : Bool → Type p} → (∀ b → Dec (P b)) → Dec (∀ b → P b)
+    bool-all? {P = P} P? = map′ to from (P? false ×-dec P? true)
+      where
+      to : P false × P true → (∀ b → P b)
+      to (pf , _ ) false = pf
+      to (_  , pt) true  = pt
+      from : (∀ b → P b) → P false × P true
+      from p = p false , p true
+```
+
+The generalized checkers now decide the Boolean-lattice laws of conjunction and
+disjunction directly over `Bool`{.AgdaDatatype}, with no detour through
+`Fin 2`{.AgdaDatatype}.  Each proof is extracted by `from-yes`{.AgdaFunction} from the
+generalized decision; a wrong claim would make the decision compute to
+`no`{.AgdaInductiveConstructor} and fail to type-check, just as in the finite
+examples.
+
+```agda
+  -- Conjunction is idempotent, commutative, and associative on Bool, and absorbs
+  -- disjunction — each decided by the generalized checkers at the Bool setoid.
+  ∧-idem-bool : ∀ a → (a ∧ a) ≡ a
+  ∧-idem-bool = from-yes (Idempotentᴰ? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
+
+  ∧-comm-bool : ∀ a b → (a ∧ b) ≡ (b ∧ a)
+  ∧-comm-bool = from-yes (Commutativeᴰ? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
+
+  ∧-assoc-bool : ∀ a b c → ((a ∧ b) ∧ c) ≡ (a ∧ (b ∧ c))
+  ∧-assoc-bool = from-yes (Associativeᴰ? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
+
+  ∧-absorbs-∨-bool : ∀ a b → (a ∧ (a ∨ b)) ≡ a
+  ∧-absorbs-∨-bool = from-yes (Absorbsˡᴰ? BoolP.≡-decSetoid Bool-Exhaustible _∧_ _∨_)
+```
+
+--------------------------------------
+
+<span style="float:left;">[↑ Setoid](Setoid.html)</span>
+
+{% include UALib.Links.md %}

--- a/src/Setoid/Operations/Properties.lagda.md
+++ b/src/Setoid/Operations/Properties.lagda.md
@@ -14,23 +14,26 @@ law of an operation `Fin n → Fin n → Fin n` by nesting `all?`{.AgdaFunction}
 (`Data.Fin.Properties.all?`) over decidable equality `_≟_`{.AgdaFunction} on
 `Fin n`{.AgdaDatatype}.  Their decidability rests on exactly two facts about the
 carrier, and *neither is special to* `Fin n`{.AgdaDatatype} *or to*
-`_≡_`{.AgdaDatatype}:
+`_≡_`{.AgdaDatatype}.
 
-+  the carrier is **exhaustively searchable** — a pointwise decision procedure
-   `∀ x → Dec (P x)` can be turned into a decision `Dec (∀ x → P x)` for the
-   universally-quantified statement (this is what `all?`{.AgdaFunction} provides); and
-+  the carrier has **decidable equality** — supplied here by the decidable
-   `_≈_`{.AgdaFunction} of a `DecSetoid`{.AgdaRecord}.
+1.  The carrier is **exhaustively searchable** — a pointwise decision procedure
+    `∀ x → Dec (P x)` can be turned into a decision `Dec (∀ x → P x)` for the
+    universally-quantified statement (this is what `all?`{.AgdaFunction} provides).
+2.  The carrier has **decidable equality** — supplied here by the decidable
+    `_≈_`{.AgdaFunction} of a `DecSetoid`{.AgdaRecord}.
 
 This module restates the eleven checkers over an arbitrary `DecSetoid`{.AgdaRecord}
-`S` — deciding `_≈_`{.AgdaFunction} through `S`'s `_≟_`{.AgdaFunction} — together with
-an exhaustive-search witness for its carrier, writing each law with
-`_≈_`{.AgdaFunction} in place of `_≡_`{.AgdaDatatype}.  The operation stays a *bare*
-function `Carrier → Carrier → Carrier`; the *decision* never needs it to respect
-`_≈_`{.AgdaFunction}, exactly as in the concrete versions.  The finite
-`Fin n`{.AgdaDatatype} / `_≡_`{.AgdaDatatype} checkers are then recovered as a single
-instance: take `S` to be the propositional `DecSetoid`{.AgdaRecord} on
-`Fin n`{.AgdaDatatype} and the search witness to be `Fin`'s `all?`{.AgdaFunction}.
+`S` — deciding `_≈_`{.AgdaFunction} through the decidable equality relation
+`_≟_`{.AgdaFunction} of `S` — together with an exhaustive-search witness for its
+carrier, writing each law with `_≈_`{.AgdaFunction} in place of `_≡_`{.AgdaDatatype}.
+
+The operation remains a bare function `Carrier → Carrier → Carrier`; the decision
+never needs it to respect `_≈_`{.AgdaFunction}, exactly as in the concrete versions.
+The finite `Fin n`{.AgdaDatatype} / `_≡_`{.AgdaDatatype} checkers are then recovered
+as a single instance: take `S` to be the propositional `DecSetoid`{.AgdaRecord} on
+`Fin n`{.AgdaDatatype} and the search witness to be the `all?`{.AgdaFunction} of
+`Fin`.
+
 The final section proves that each concrete checker *equals* its generalized form at
 this instance, by `refl`{.AgdaInductiveConstructor}; so the fast-reducing concrete
 checkers (on which the finite examples and their `from-yes`{.AgdaFunction} proofs
@@ -38,35 +41,36 @@ depend) are kept exactly as they are, with the generalization exhibited alongsid
 rather than replacing them.
 
 The search ingredient is isolated below as a one-field interface,
-`Exhaustible`{.AgdaRecord}, deliberately kept independent of `Fin`{.AgdaDatatype}: any
-carrier that admits such a search functional can drive the checkers.  Finite carriers
-are the obvious source, but not the only one — Martín Escardó's work on
-*exhaustively searchable* types shows that even some *infinite* carriers (e.g.
-`ℕ∞`, the one-point compactification of `ℕ`) admit a total search functional.
-Supplying those carriers' search functionals is the planned **M9-1** work; this
-module only fixes the interface they would implement, and is not itself M9-1.
+`Exhaustible`{.AgdaRecord}, deliberately kept independent of `Fin`{.AgdaDatatype} so
+that any carrier that admits such a search functional can drive the checkers.
+
+Finite carriers are the obvious source, but not the only one.  For instance, Martín
+Escardó's work on *exhaustively searchable* types shows that even some *infinite*
+carriers (e.g. `ℕ∞`, the one-point compactification of `ℕ`) admit a total search
+functional.  Supplying those carriers' search functionals is planned work;[^1]
+this module only fixes the interface they would implement.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Setoid.Operations.Properties where
 
--- Imports from Agda and the Agda Standard Library -----------------------------
-open import Agda.Primitive                          using ( Level )
-                                                    renaming ( Set to Type ; Setω to Typeω )
-open import Data.Bool.Base                          using ( Bool ; false ; true ; _∧_ ; _∨_ )
-open import Data.Fin                                using ( Fin )
-open import Data.Nat                                using ( ℕ )
-open import Data.Product                            using ( _×_ ; _,_ )
-open import Relation.Binary.Bundles                 using ( DecSetoid )
-open import Relation.Binary.PropositionalEquality   using ( _≡_ ; refl )
-open import Relation.Nullary.Decidable.Core         using ( Dec ; map′ ; from-yes ; _×-dec_ )
+open import Agda.Primitive                         renaming ( Set to Type ; Setω to Typeω )
 
-import Data.Bool.Properties              as BoolP
-import Data.Fin.Properties               as FinP
+-- Imports from the Agda Standard Library -------------------------------------
+open import Data.Bool.Base                         using ( Bool ; false ; true ; _∧_ ; _∨_ )
+open import Data.Fin                               using ( Fin )
+open import Data.Nat                               using ( ℕ )
+open import Data.Product                           using ( _×_ ; _,_ )
+open import Relation.Binary.Bundles                using ( DecSetoid )
+open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl )
+open import Relation.Nullary.Decidable.Core        using ( Dec ; map′ ; from-yes ; _×-dec_ )
+
+import Data.Bool.Properties as BoolP
+open import Data.Fin.Properties  using (≡-decSetoid) renaming (all? to FinAll?)
 
 -- Imports from the Agda Universal Algebra Library -----------------------------
-import Overture.Operations.Properties    as Concrete
+import Overture.Operations.Properties as Concrete
 ```
 
 #### The exhaustive-search interface
@@ -75,17 +79,18 @@ A carrier `A` is *exhaustively searchable* — for the purpose of deciding
 universally-quantified decidable predicates — when it carries a single functional
 that turns any pointwise decision procedure `∀ x → Dec (P x)` into a decision
 `Dec (∀ x → P x)` for the universal statement.  This is exactly the shape of
-`Data.Fin.Properties.all?`, with the carrier abstracted away from `Fin`.  We package
-it as a one-field record so that a witness `E : Exhaustible A` can be passed to the
-checkers and its search functional opened under the name `all?`{.AgdaFunction},
-making the generalized call sites read identically to the concrete `Fin` ones.
+`Data.Fin.Properties.all?`, but here we abstract the carrier beyond `Fin`.
+
+We package the interface as a single-field record so that a witness
+`E : Exhaustible A` can be passed to the checkers and its search functional opened
+under the name `all?`{.AgdaFunction}, making the generalized call sites read
+identically to the concrete `Fin` ones.  The record mentions no setoid and no
+`Fin`{.AgdaDatatype}; it is a property of a bare carrier.[^2]
 
 The field is universe-polymorphic in the predicate level `p`, so the record lives in
-`Typeω`{.AgdaPrimitiveType}; this is needed because the nested checkers apply the same
-functional at two different predicate levels (`ℓ` innermost and `c ⊔ ℓ` after a
-quantifier).  The record mentions no setoid and no `Fin`{.AgdaDatatype}; it is a
-property of a bare carrier, which is why a future Escardó-style
-`Searchable`/`Exhaustible` carrier (M9-1) could supply it without change.
+`Typeω`{.AgdaPrimitiveType}.  This is needed because the nested checkers apply the
+same functional at two different predicate levels (`ℓ` innermost and `c ⊔ ℓ` after a
+quantifier).
 
 ```agda
 -- An exhaustive-search witness for a carrier A: it decides any universally-
@@ -99,81 +104,84 @@ record Exhaustible {c} (A : Type c) : Typeω where
 #### Laws of a single operation
 
 Throughout, `S` is a decidable setoid, `E` an exhaustive-search witness for its
-carrier, and `_·_` a bare binary operation on that carrier.  Opening `S` exposes the
-carrier, its setoid equality `_≈_`{.AgdaFunction}, and the decision `_≟_`{.AgdaFunction}
-for `_≈_`{.AgdaFunction}; opening `E` exposes the search functional `all?`{.AgdaFunction}.
+carrier, and `_·_` a bare binary operation on that carrier.
+
++  Opening `S` exposes the carrier, its setoid equality `_≈_`{.AgdaFunction}, and the
+   decidable equality `_≟_`{.AgdaFunction} for `_≈_`{.AgdaFunction};
++  opening `E` exposes the search functional `all?`{.AgdaFunction}.
+
 Each law is then decided by nesting `all?`{.AgdaFunction} over `_≟_`{.AgdaFunction},
 one nesting per universally-quantified variable.
 
 ```agda
 module _ {c ℓ} (S : DecSetoid c ℓ) (E : Exhaustible (DecSetoid.Carrier S)) where
-  open DecSetoid S   using ( Carrier ; _≈_ ; _≟_ )
-  open Exhaustible E using ( all? )
+  open DecSetoid S    using ( Carrier ; _≈_ ; _≟_ )
+  open Exhaustible E  using ( all? )
 
   module _ (_·_ : Carrier → Carrier → Carrier) where
 
     -- a · a ≈ a for every a.
-    Idempotentᴰ? : Dec (∀ a → (a · a) ≈ a)
-    Idempotentᴰ? = all? (λ a → (a · a) ≟ a)
+    Idempotent? : Dec ∀ a → a · a ≈ a
+    Idempotent? = all? λ a → a · a ≟ a
 
     -- a · b ≈ b · a for every a, b.
-    Commutativeᴰ? : Dec (∀ a b → (a · b) ≈ (b · a))
-    Commutativeᴰ? = all? (λ a → all? (λ b → (a · b) ≟ (b · a)))
+    Commutative? : Dec ∀ a b → a · b ≈ b · a
+    Commutative? = all? λ a → all? λ b → a · b ≟ b · a
 
     -- (a · b) · c ≈ a · (b · c) for every a, b, c.
-    Associativeᴰ? : Dec (∀ a b c → ((a · b) · c) ≈ (a · (b · c)))
-    Associativeᴰ? = all? (λ a → all? (λ b → all? (λ c → ((a · b) · c) ≟ (a · (b · c)))))
+    Associative? : Dec ∀ a b c → (a · b) · c ≈ a · (b · c)
+    Associative? = all? λ a → all? λ b → all? λ c → (a · b) · c ≟ a · (b · c)
 
     module _ (e : Carrier) where
 
       -- e · a ≈ a for every a.
-      LeftIdentityᴰ? : Dec (∀ a → (e · a) ≈ a)
-      LeftIdentityᴰ? = all? (λ a → (e · a) ≟ a)
+      LeftIdentity? : Dec ∀ a → e · a ≈ a
+      LeftIdentity? = all? λ a → e · a ≟ a
 
       -- a · e ≈ a for every a.
-      RightIdentityᴰ? : Dec (∀ a → (a · e) ≈ a)
-      RightIdentityᴰ? = all? (λ a → (a · e) ≟ a)
+      RightIdentity? : Dec ∀ a → a · e ≈ a
+      RightIdentity? = all? λ a → a · e ≟ a
 
       module _ (i : Carrier → Carrier) where
 
         -- (i a) · a ≈ e for every a.
-        LeftInverseᴰ? : Dec (∀ a → ((i a) · a) ≈ e)
-        LeftInverseᴰ? = all? (λ a → ((i a) · a) ≟ e)
+        LeftInverse? : Dec ∀ a → (i a) · a ≈ e
+        LeftInverse? = all? λ a → (i a) · a ≟ e
 
         -- a · (i a) ≈ e for every a.
-        RightInverseᴰ? : Dec (∀ a → (a · (i a)) ≈ e)
-        RightInverseᴰ? = all? (λ a → (a · (i a)) ≟ e)
+        RightInverse? : Dec ∀ a → a · (i a) ≈ e
+        RightInverse? = all? λ a → a · (i a) ≟ e
 ```
 
 #### Laws relating two operations
 
-These take two bare operations `_·_` and `_∘_` over the same decidable setoid; in a
-lattice they are typically the meet `∧` and join `∨`.  The shapes match the
-two-operation checkers of [Overture.Operations.Properties][] — absorption and
-distributivity — now stated over `_≈_`{.AgdaFunction}.
+These take two bare operations `_∧_` and `_∨_` over the same decidable setoid; e.g.,
+the meet and join of a lattice.  The shapes match the two-operation checkers
+of [Overture.Operations.Properties][] — absorption and distributivity — now stated
+over `_≈_`{.AgdaFunction}.
 
 ```agda
 module _ {c ℓ} (S : DecSetoid c ℓ) (E : Exhaustible (DecSetoid.Carrier S)) where
-  open DecSetoid S   using ( Carrier ; _≈_ ; _≟_ )
-  open Exhaustible E using ( all? )
+  open DecSetoid S    using ( Carrier ; _≈_ ; _≟_ )
+  open Exhaustible E  using ( all? )
 
-  module _ (_·_ _∘_ : Carrier → Carrier → Carrier) where
+  module _ (_∧_ _∨_ : Carrier → Carrier → Carrier) where
 
-    -- a · (a ∘ b) ≈ a for every a, b.
-    Absorbsˡᴰ? : Dec (∀ a b → (a · (a ∘ b)) ≈ a)
-    Absorbsˡᴰ? = all? (λ a → all? (λ b → (a · (a ∘ b)) ≟ a))
+    -- a ∧ (a ∨ b) ≈ a for every a, b.
+    Absorbsˡ? : Dec ∀ a b → a ∧ (a ∨ b) ≈ a
+    Absorbsˡ? = all? λ a → all? λ b → a ∧ (a ∨ b) ≟ a
 
-    -- (a · b) ∘ a ≈ a for every a, b.
-    Absorbsʳᴰ? : Dec (∀ a b → ((a · b) ∘ a) ≈ a)
-    Absorbsʳᴰ? = all? (λ a → all? (λ b → ((a · b) ∘ a) ≟ a))
+    -- (a ∧ b) ∨ a ≈ a for every a, b.
+    Absorbsʳ? : Dec ∀ a b → (a ∧ b) ∨ a ≈ a
+    Absorbsʳ? = all? λ a → all? λ b → (a ∧ b) ∨ a ≟ a
 
-    -- a · (b ∘ c) ≈ (a · b) ∘ (a · c) for every a, b, c.
-    Distributesˡᴰ? : Dec (∀ a b c → (a · (b ∘ c)) ≈ ((a · b) ∘ (a · c)))
-    Distributesˡᴰ? = all? (λ a → all? (λ b → all? (λ c → (a · (b ∘ c)) ≟ ((a · b) ∘ (a · c)))))
+    -- a ∧ (b ∨ c) ≈ (a ∧ b) ∨ (a ∧ c) for every a, b, c.
+    Distributesˡ? : Dec ∀ a b c → a ∧ (b ∨ c) ≈ (a ∧ b) ∨ (a ∧ c)
+    Distributesˡ? = all? λ a → all? λ b → all? λ c → a ∧ (b ∨ c) ≟ (a ∧ b) ∨ (a ∧ c)
 
-    -- (b ∘ c) · a ≈ (b · a) ∘ (c · a) for every a, b, c.
-    Distributesʳᴰ? : Dec (∀ a b c → ((b ∘ c) · a) ≈ ((b · a) ∘ (c · a)))
-    Distributesʳᴰ? = all? (λ a → all? (λ b → all? (λ c → ((b ∘ c) · a) ≟ ((b · a) ∘ (c · a)))))
+    -- (b ∨ c) ∧ a ≈ (b ∧ a) ∨ (c ∧ a) for every a, b, c.
+    Distributesʳ? : Dec (∀ a b c → ((b ∨ c) ∧ a) ≈ ((b ∧ a) ∨ (c ∧ a)))
+    Distributesʳ? = all? (λ a → all? (λ b → all? (λ c → ((b ∨ c) ∧ a) ≟ ((b ∧ a) ∨ (c ∧ a)))))
 ```
 
 #### The finite instance
@@ -183,66 +191,73 @@ module _ {c ℓ} (S : DecSetoid c ℓ) (E : Exhaustible (DecSetoid.Carrier S)) w
 witness for `Fin n`{.AgdaDatatype}, the one that recovers the concrete checkers.
 
 ```agda
--- The exhaustive-search witness for Fin n, given by Fin's all?.
+-- The exhaustive-search witness for Fin n, given by all? of Fin.
 Fin-Exhaustible : ∀ {n} → Exhaustible (Fin n)
-Fin-Exhaustible = record { all? = FinP.all? }
+Fin-Exhaustible = record { all? = FinAll? }
 ```
 
 #### The finite checkers as the propositional instance
 
-Take `S` to be `FinP.≡-decSetoid n` — the propositional decidable setoid on
+Take `S` to be `≡-decSetoid n` — the propositional decidable setoid on
 `Fin n`{.AgdaDatatype}, whose `_≈_`{.AgdaFunction} is `_≡_`{.AgdaDatatype} and whose
 `_≟_`{.AgdaFunction} is `Data.Fin.Properties._≟_` — and `E` to be
-`Fin-Exhaustible`{.AgdaFunction}.  Each generalized checker then *unfolds definitionally*
-to the corresponding concrete checker of [Overture.Operations.Properties][]: the
-search functional reduces to `Fin`'s `all?`{.AgdaFunction} and `_≟_`{.AgdaFunction}
-reduces to `Fin`'s decidable equality.  We record that as eleven `refl`{.AgdaInductiveConstructor}
-equations, one per checker.  This is the precise sense in which the concrete checkers
-*are* the propositional instance of the generalized ones — and, because the equalities
-are definitional, the concrete checkers keep reducing exactly as before for
-`from-yes`{.AgdaFunction}, so the finite examples are unaffected.
+`Fin-Exhaustible`{.AgdaFunction}.
+
+Each generalized checker then *unfolds definitionally* to the corresponding concrete
+checker of [Overture.Operations.Properties][]: the search functional reduces to
+`all?`{.AgdaFunction} of `Fin` and `_≟_`{.AgdaFunction} reduces to decidable equality
+of `Fin`.  We record this as eleven `refl`{.AgdaInductiveConstructor} equations, one
+per checker.
+
+This is the precise sense in which the concrete checkers *are* the propositional
+instance of the generalized ones — and, because the equalities are definitional, the
+concrete checkers keep reducing exactly as before for `from-yes`{.AgdaFunction}, so
+the finite examples are unaffected.
+
+(We leave present each of the remaining observations as an anonymous theorem, since
+they serve to confirm and demonstrate fact which likely will not be used elsewhere.)
 
 ```agda
 module _ {n : ℕ} (_·_ : Fin n → Fin n → Fin n) where
 
-  Idempotent?≡ : Concrete.Idempotent? _·_ ≡ Idempotentᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_
-  Idempotent?≡ = refl
+  _ : Concrete.Idempotent? _·_ ≡ Idempotent? (≡-decSetoid n) Fin-Exhaustible _·_
+  _ = refl
 
-  Commutative?≡ : Concrete.Commutative? _·_ ≡ Commutativeᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_
-  Commutative?≡ = refl
+  _ : Concrete.Commutative? _·_ ≡ Commutative? (≡-decSetoid n) Fin-Exhaustible _·_
+  _ = refl
 
-  Associative?≡ : Concrete.Associative? _·_ ≡ Associativeᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_
-  Associative?≡ = refl
+  _ : Concrete.Associative? _·_ ≡ Associative? (≡-decSetoid n) Fin-Exhaustible _·_
+  _ = refl
 
   module _ (e : Fin n) where
 
-    LeftIdentity?≡ : Concrete.LeftIdentity? _·_ e ≡ LeftIdentityᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ e
-    LeftIdentity?≡ = refl
+    _ : Concrete.LeftIdentity? _·_ e ≡ LeftIdentity? (≡-decSetoid n) Fin-Exhaustible _·_ e
+    _ = refl
 
-    RightIdentity?≡ : Concrete.RightIdentity? _·_ e ≡ RightIdentityᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ e
-    RightIdentity?≡ = refl
+    _ : Concrete.RightIdentity? _·_ e ≡ RightIdentity? (≡-decSetoid n) Fin-Exhaustible _·_ e
+    _ = refl
 
     module _ (i : Fin n → Fin n) where
 
-      LeftInverse?≡ : Concrete.LeftInverse? _·_ e i ≡ LeftInverseᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ e i
-      LeftInverse?≡ = refl
+      _ : Concrete.LeftInverse? _·_ e i ≡ LeftInverse? (≡-decSetoid n) Fin-Exhaustible _·_ e i
+      _ = refl
 
-      RightInverse?≡ : Concrete.RightInverse? _·_ e i ≡ RightInverseᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ e i
-      RightInverse?≡ = refl
+      _ : Concrete.RightInverse? _·_ e i ≡ RightInverse? (≡-decSetoid n) Fin-Exhaustible _·_ e i
+      _ = refl
 
-module _ {n : ℕ} (_·_ _∘_ : Fin n → Fin n → Fin n) where
+module _ {n : ℕ} (_∧_ _∨_ : Fin n → Fin n → Fin n) where
 
-  Absorbsˡ?≡ : Concrete.Absorbsˡ? _·_ _∘_ ≡ Absorbsˡᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ _∘_
-  Absorbsˡ?≡ = refl
+  _ : Concrete.Absorbsˡ? _∧_ _∨_ ≡ Absorbsˡ? (≡-decSetoid n) Fin-Exhaustible _∧_ _∨_
+  _ = refl
 
-  Absorbsʳ?≡ : Concrete.Absorbsʳ? _·_ _∘_ ≡ Absorbsʳᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ _∘_
-  Absorbsʳ?≡ = refl
+  _ : Concrete.Absorbsʳ? _∧_ _∨_ ≡ Absorbsʳ? (≡-decSetoid n) Fin-Exhaustible _∧_ _∨_
+  _ = refl
 
-  Distributesˡ?≡ : Concrete.Distributesˡ? _·_ _∘_ ≡ Distributesˡᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ _∘_
-  Distributesˡ?≡ = refl
+  _ : Concrete.Distributesˡ? _∧_ _∨_ ≡ Distributesˡ? (≡-decSetoid n) Fin-Exhaustible _∧_ _∨_
+  _ = refl
 
-  Distributesʳ?≡ : Concrete.Distributesʳ? _·_ _∘_ ≡ Distributesʳᴰ? (FinP.≡-decSetoid n) Fin-Exhaustible _·_ _∘_
-  Distributesʳ?≡ = refl
+  _ : Concrete.Distributesʳ? _∧_ _∨_ ≡ Distributesʳ? (≡-decSetoid n) Fin-Exhaustible _∧_ _∨_
+  _ = refl
 ```
 
 #### A non-Fin instance: the two-element Boolean setoid
@@ -269,7 +284,7 @@ private
       where
       to : P false × P true → (∀ b → P b)
       to (pf , _ ) false = pf
-      to (_  , pt) true  = pt
+      to ( _ , pt) true  = pt
       from : (∀ b → P b) → P false × P true
       from p = p false , p true
 ```
@@ -284,20 +299,26 @@ examples.
 ```agda
   -- Conjunction is idempotent, commutative, and associative on Bool, and absorbs
   -- disjunction — each decided by the generalized checkers at the Bool setoid.
-  ∧-idem-bool : ∀ a → (a ∧ a) ≡ a
-  ∧-idem-bool = from-yes (Idempotentᴰ? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
+  ∧-idem-bool : ∀ a → a ∧ a ≡ a
+  ∧-idem-bool = from-yes (Idempotent? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
 
-  ∧-comm-bool : ∀ a b → (a ∧ b) ≡ (b ∧ a)
-  ∧-comm-bool = from-yes (Commutativeᴰ? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
+  ∧-comm-bool : ∀ a b → a ∧ b ≡ b ∧ a
+  ∧-comm-bool = from-yes (Commutative? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
 
-  ∧-assoc-bool : ∀ a b c → ((a ∧ b) ∧ c) ≡ (a ∧ (b ∧ c))
-  ∧-assoc-bool = from-yes (Associativeᴰ? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
+  ∧-assoc-bool : ∀ a b c → (a ∧ b) ∧ c ≡ a ∧ (b ∧ c)
+  ∧-assoc-bool = from-yes (Associative? BoolP.≡-decSetoid Bool-Exhaustible _∧_)
 
-  ∧-absorbs-∨-bool : ∀ a b → (a ∧ (a ∨ b)) ≡ a
-  ∧-absorbs-∨-bool = from-yes (Absorbsˡᴰ? BoolP.≡-decSetoid Bool-Exhaustible _∧_ _∨_)
+  ∧-absorbs-∨-bool : ∀ a b → a ∧ (a ∨ b) ≡ a
+  ∧-absorbs-∨-bool = from-yes (Absorbsˡ? BoolP.≡-decSetoid Bool-Exhaustible _∧_ _∨_)
 ```
 
 --------------------------------------
+
+[^1]: See Milestone 9, especially Issue [M9-1].
+
+[^2]: which is why a future Escardó-style `Searchable`/`Exhaustible` carrier could
+supply it without change.
+
 
 <span style="float:left;">[↑ Setoid](Setoid.html)</span>
 

--- a/src/Setoid/Operations/Properties.lagda.md
+++ b/src/Setoid/Operations/Properties.lagda.md
@@ -121,35 +121,35 @@ module _ {c ℓ} (S : DecSetoid c ℓ) (E : Exhaustible (DecSetoid.Carrier S)) w
   module _ (_·_ : Carrier → Carrier → Carrier) where
 
     -- a · a ≈ a for every a.
-    Idempotent? : Dec ∀ a → a · a ≈ a
+    Idempotent? : Dec (∀ a → a · a ≈ a)
     Idempotent? = all? λ a → a · a ≟ a
 
     -- a · b ≈ b · a for every a, b.
-    Commutative? : Dec ∀ a b → a · b ≈ b · a
+    Commutative? : Dec (∀ a b → a · b ≈ b · a)
     Commutative? = all? λ a → all? λ b → a · b ≟ b · a
 
     -- (a · b) · c ≈ a · (b · c) for every a, b, c.
-    Associative? : Dec ∀ a b c → (a · b) · c ≈ a · (b · c)
+    Associative? : Dec (∀ a b c → (a · b) · c ≈ a · (b · c))
     Associative? = all? λ a → all? λ b → all? λ c → (a · b) · c ≟ a · (b · c)
 
     module _ (e : Carrier) where
 
       -- e · a ≈ a for every a.
-      LeftIdentity? : Dec ∀ a → e · a ≈ a
+      LeftIdentity? : Dec (∀ a → e · a ≈ a)
       LeftIdentity? = all? λ a → e · a ≟ a
 
       -- a · e ≈ a for every a.
-      RightIdentity? : Dec ∀ a → a · e ≈ a
+      RightIdentity? : Dec (∀ a → a · e ≈ a)
       RightIdentity? = all? λ a → a · e ≟ a
 
       module _ (i : Carrier → Carrier) where
 
         -- (i a) · a ≈ e for every a.
-        LeftInverse? : Dec ∀ a → (i a) · a ≈ e
+        LeftInverse? : Dec (∀ a → (i a) · a ≈ e)
         LeftInverse? = all? λ a → (i a) · a ≟ e
 
         -- a · (i a) ≈ e for every a.
-        RightInverse? : Dec ∀ a → a · (i a) ≈ e
+        RightInverse? : Dec (∀ a → a · (i a) ≈ e)
         RightInverse? = all? λ a → a · (i a) ≟ e
 ```
 
@@ -168,19 +168,19 @@ module _ {c ℓ} (S : DecSetoid c ℓ) (E : Exhaustible (DecSetoid.Carrier S)) w
   module _ (_∧_ _∨_ : Carrier → Carrier → Carrier) where
 
     -- a ∧ (a ∨ b) ≈ a for every a, b.
-    Absorbsˡ? : Dec ∀ a b → a ∧ (a ∨ b) ≈ a
+    Absorbsˡ? : Dec (∀ a b → a ∧ (a ∨ b) ≈ a)
     Absorbsˡ? = all? λ a → all? λ b → a ∧ (a ∨ b) ≟ a
 
     -- (a ∧ b) ∨ a ≈ a for every a, b.
-    Absorbsʳ? : Dec ∀ a b → (a ∧ b) ∨ a ≈ a
+    Absorbsʳ? : Dec (∀ a b → (a ∧ b) ∨ a ≈ a)
     Absorbsʳ? = all? λ a → all? λ b → (a ∧ b) ∨ a ≟ a
 
     -- a ∧ (b ∨ c) ≈ (a ∧ b) ∨ (a ∧ c) for every a, b, c.
-    Distributesˡ? : Dec ∀ a b c → a ∧ (b ∨ c) ≈ (a ∧ b) ∨ (a ∧ c)
+    Distributesˡ? : Dec (∀ a b c → a ∧ (b ∨ c) ≈ (a ∧ b) ∨ (a ∧ c))
     Distributesˡ? = all? λ a → all? λ b → all? λ c → a ∧ (b ∨ c) ≟ (a ∧ b) ∨ (a ∧ c)
 
     -- (b ∨ c) ∧ a ≈ (b ∧ a) ∨ (c ∧ a) for every a, b, c.
-    Distributesʳ? : Dec ∀ a b c → (b ∨ c) ∧ a ≈ (b ∧ a) ∨ (c ∧ a)
+    Distributesʳ? : Dec (∀ a b c → (b ∨ c) ∧ a ≈ (b ∧ a) ∨ (c ∧ a))
     Distributesʳ? = all? λ a → all? λ b → all? λ c → (b ∨ c) ∧ a ≟ (b ∧ a) ∨ (c ∧ a)
 ```
 


### PR DESCRIPTION
## Summary

Implements #357.  The eleven decidable equational-law checkers of
[`Overture.Operations.Properties`][] — `Idempotent?`, `Commutative?`,
`Associative?`, the identity/inverse laws, and the two-operation
`Absorbsˡ?`/`Absorbsʳ?`/`Distributesˡ?`/`Distributesʳ?` — are generalized from a
*finite* carrier `Fin n` with propositional equality `_≡_` to an arbitrary
`DecSetoid` equipped with an exhaustive-search witness for its carrier.  The
generalized versions live in a new module `Setoid.Operations.Properties`, as the
issue prescribes (the checkers become genuine setoid-level content).

The two ingredients the deciders actually rest on are isolated and abstracted: an
exhaustive-search functional (the abstraction of `Data.Fin.Properties.all?`) and
decidable equality (here a `DecSetoid`'s `_≟_`).  Neither is specific to `Fin n`
or to `_≡_`.

Closes #357.

## What is added

### The exhaustive-search interface

+  `Exhaustible A` — a one-field record whose field
   `all? : ∀ {p} {P : A → Type p} → (∀ x → Dec (P x)) → Dec (∀ x → P x)` is exactly
   the shape of `Data.Fin.Properties.all?`, with the carrier abstracted away from
   `Fin`.  The record mentions neither `Fin` nor any equality — it is a property of
   a bare carrier — so a future Escardó-style `Searchable`/`Exhaustible` carrier
   (M9-1) can supply it without change.  It is the field's level-polymorphism in the
   predicate level `p` (needed because the nested checkers search at two predicate
   levels, `ℓ` and `c ⊔ ℓ`) that places the record in `Typeω`.

### The generalized checkers

+  Over `(S : DecSetoid c ℓ)` and `(E : Exhaustible (DecSetoid.Carrier S))`, each law
   is restated with `_≈_` in place of `_≡_` over a *bare* operation
   `Carrier → Carrier → Carrier` and decided by nesting `E`'s search functional over
   `S`'s `_≟_`: `Idempotent?`, `Commutative?`, `Associative?`, `LeftIdentity?`,
   `RightIdentity?`, `LeftInverse?`, `RightInverse?`, `Absorbsˡ?`, `Absorbsʳ?`,
   `Distributesˡ?`, `Distributesʳ?`.  The operation stays a plain function: the
   *decision* never needs it to respect `_≈_`, exactly as in the concrete versions.

### The finite instance and the instance relationship

+  `Fin-Exhaustible : ∀ {n} → Exhaustible (Fin n)` wraps `Fin`'s `all?`.

+  Eleven anonymous `refl` equations exhibit each concrete
   `Overture.Operations.Properties` checker as *definitionally* the generalized one
   at `S := Data.Fin.Properties.≡-decSetoid n` and `E := Fin-Exhaustible`.  This is
   the issue's preferred "keep concrete + add generalized + exhibit the instance
   relationship" route: the fast-reducing concrete checkers are left untouched (so
   the finite examples and their `from-yes` proofs are unaffected), and the equalities
   are definitional, which is *why* the concrete forms keep reducing as before.

### A non-Fin instance (demonstration)

+  A `private` section supplies an `Exhaustible Bool` witness (`∀ b → P b` reduces to
   `P false` and `P true`) and decides four Boolean-lattice laws over it — idempotence,
   commutativity, associativity of `∧`, and `∧` absorbing `∨` — so the generality is
   demonstrated over a carrier that is not `Fin n`, not merely asserted.  It is
   `private` so it validates the abstraction without enlarging the public surface.

## Design notes

+  **Home.**  `Setoid.Operations.Properties` (new), wired into the `Setoid` barrel via
   a new `Setoid.Operations` barrel.  `#356` records keeping the concrete versions in
   `Overture.Operations.Properties`; this PR leaves that module byte-for-byte unchanged.

+  **Naming.**  The generalized checkers reuse the canonical names of the concept
   (`Idempotent?`, …, `Distributesʳ?`) in the new `Setoid.Operations.Properties`
   module; the concrete `Fin`/`≡` checkers keep those names in
   `Overture.Operations.Properties`.  The two layers are tied together by the explicit
   `refl` equations, and cross-module references disambiguate by qualification
   (`Concrete.Idempotent?` versus the local `Idempotent?`).  Consumers that need both
   in one scope should import one of them qualified.

+  **M9-1.**  The `Exhaustible` interface is the hook for the planned Escardó-style
   exhaustive-search work; this PR fixes the interface only and is not itself M9-1.

## Checklist

+  `make check` passes locally under `nix develop` (exit 0; only the expected
   `Legacy/` deprecation warnings).
+  New public definitions have explicit type signatures and natural-language comments.
+  `--cubical-compatible --exact-split --safe` throughout; literate `.lagda.md`.
+  The six finite examples named in #357 (the lattices `L7`/`L3Heyting`, the
   `SymmetricGroup3`/`CyclicGroup3`/`KleinFourGroup` groups, and
   `CommutativeIdempotentMagma`) and `Overture.Cayley` compile unchanged.

## Notes for reviewers

+  The `Typeω` record was the one design risk; it type-checks cleanly under the
   project's options, and the level-nesting (search at `ℓ` and `c ⊔ ℓ`) is what forces
   the polymorphism.  Were the record monomorphic in `p`, the nested checkers would not
   type-check without `Lift`-ing the innermost predicate, which would distort the
   `_≈_`-stated laws.

+  Per the milestone-4 instructions, `docs/GITHUB_PROJECT.md` is not hand-edited; the
   issue tracks the work and `make project-plan` regenerates the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sMESpe5AbTj8pHag1EULv