### PR TITLE
[M6-10] structural characterization of subdirect irreducibility (#421)

### DIFF
--- a/docs/notes/m6-2-subdirect.md
+++ b/docs/notes/m6-2-subdirect.md
@@ -154,7 +154,7 @@ the standard product level arithmetic), so the Birkhoff index can be the
 
 ## The structural characterization (M6-10)
 
-[M6-10][] (#421) adds `Setoid.Subalgebras.Subdirect.SI`, tying `IsSubdirectlyIrreducible`
+[M6-10][] (#421) adds `Setoid.Subalgebras.Subdirect.Irreducible`, tying `IsSubdirectlyIrreducible`
 (Monolith) to the subdirect structures (`Subdirect.Basic`) — the equivalence that makes
 "subdirectly irreducible" name what it does: `𝑨` is SI iff it has no nontrivial subdirect
 decomposition, i.e. every subdirect embedding `𝑨 ↪ ⨅ 𝒜` has an isomorphism coordinate.
@@ -205,7 +205,7 @@ decomposition, i.e. every subdirect embedding `𝑨 ↪ ⨅ 𝒜` has an isomorp
 +  ~~Connecting `IsSubdirectlyIrreducible` to the *absence of a nontrivial subdirect
    decomposition* (an SI algebra's every subdirect embedding has an isomorphism
    coordinate) — the equivalence that makes "subdirectly irreducible" name what it
-   does.~~  **Done in [M6-10][] (#421)**: `Setoid.Subalgebras.Subdirect.SI` proves the
+   does.~~  **Done in [M6-10][] (#421)**: `Setoid.Subalgebras.Subdirect.Irreducible` proves the
    constructive direction (contrapositive `si⇒¬no-iso-coord`, and the finite
    witness-extracting `si⇒iso-coord`) and records the converse's predicativity cost; see
    "The structural characterization (M6-10)" above.

--- a/docs/notes/m6-2-subdirect.md
+++ b/docs/notes/m6-2-subdirect.md
@@ -152,6 +152,43 @@ the standard product level arithmetic), so the Birkhoff index can be the
    module is named `BirkhoffSI` for the same reason — to keep it distinct from the HSP
    `Birkhoff`.)
 
+## The structural characterization (M6-10)
+
+[M6-10][] (#421) adds `Setoid.Subalgebras.Subdirect.SI`, tying `IsSubdirectlyIrreducible`
+(Monolith) to the subdirect structures (`Subdirect.Basic`) — the equivalence that makes
+"subdirectly irreducible" name what it does: `𝑨` is SI iff it has no nontrivial subdirect
+decomposition, i.e. every subdirect embedding `𝑨 ↪ ⨅ 𝒜` has an isomorphism coordinate.
+
++  **The kernel bridges are definitional**.  For `h : 𝑨 → ⨅ 𝒜` the kernel family
+   `kerfam h i = kercon (coord 𝒜 h i)` makes three identities hold on the nose (recorded as
+   `id`, exactly the `natmap` injectivity-is-separation pattern): `BelowDiagonal (kerfam i)`
+   *is* `IsInjective (coord h i)` (`coord-inj→below` / `below→coord-inj`); injectivity of
+   `h` *is* `Separates kerfam` (`embed→separates` / `separates→embed`), since equality in
+   `⨅ 𝒜` is pointwise; and — the one bridge with content — a surjective and injective
+   coordinate map is an isomorphism (`coord-iso`, via the new generic `Bijective→≅` added to
+   `Setoid.Homomorphisms.Isomorphisms`).
++  **The constructive direction**.  `monolith⇒¬all-nonzero` is `monolith⇒cmi` read on the
+   separation predicate (`separates≡below-meet` records the definitional identity
+   `Separates θ ≡ BelowDiagonal (⋂ θ)` for a `ρ`-small index): a monolithic `𝑨` whose
+   kernel family separates points cannot have all coordinates proper.  The direct proof
+   drops the `ρ`-small-index restriction that `⋂` imposes, so it covers the `Fin n`-indexed
+   case.  At the embedding level this is `si⇒¬no-iso-coord : ¬ (∀ i → ¬ (𝑨 ≅ 𝒜 i))`, the
+   choice-free contrapositive form.
++  **The finite witness**.  `si⇒iso-coord` extracts an *explicit* isomorphic coordinate
+   `∃[ i ] 𝑨 ≅ 𝒜 i` for a `Fin n` index given a decision of `BelowDiagonal (kerfam i)` per
+   coordinate, via `¬∀⟶∃¬` and `decidable-stable` (the same finite toolset as [M6-8][]).
+   Decidable `≈` on a finite carrier makes that `Π`-over-pairs decision go through, so a
+   `FiniteAlgebra` supplies the data — the constructive, witness-producing reading of the
+   characterization.
++  **The converse**.  The family-level converse `iso-coord⟹¬all-proper` (an injective
+   coordinate forces the kernel family not-all-nonzero) is choice-free.  The full
+   *structural ⟹ monolith* is not added: the natural witness `μ = ⋀ {θ : Nonzero θ}` is
+   indexed by `Σ[ θ ∈ Con 𝑨 ρ ] Nonzero θ`, a universe up, so the meet is a `Con 𝑨 ℓ′` with
+   `ℓ′ > ρ` — not a monolith *at level `ρ`*; and the finite escape fails too, since the
+   constructive complete congruence lists (`FiniteAlgebra.cons`, [M6-8][]) live at the
+   absorbing level `clv α ρ ⊒ ρ`.  This is the same predicativity wall as the
+   `cmi ⟹ monolith` direction above (and [M6-9][]); recorded, not forced.
+
 ## What remains (follow-ups)
 
 +  ~~The constructive finite case (option (b)): for an algebra with decidable `≈` and a
@@ -165,11 +202,17 @@ the standard product level arithmetic), so the Birkhoff index can be the
    plus decidable `≈` alone).
 +  The impredicative converse `cmi ⟹ monolith`, if/when the library adopts an
    impredicative or resized meet.
-+  Connecting `IsSubdirectlyIrreducible` to the *absence of a nontrivial subdirect
++  ~~Connecting `IsSubdirectlyIrreducible` to the *absence of a nontrivial subdirect
    decomposition* (an SI algebra's every subdirect embedding has an isomorphism
-   coordinate) — the equivalence that makes "subdirectly irreducible" name what it does.
+   coordinate) — the equivalence that makes "subdirectly irreducible" name what it
+   does.~~  **Done in [M6-10][] (#421)**: `Setoid.Subalgebras.Subdirect.SI` proves the
+   constructive direction (contrapositive `si⇒¬no-iso-coord`, and the finite
+   witness-extracting `si⇒iso-coord`) and records the converse's predicativity cost; see
+   "The structural characterization (M6-10)" above.
 
 [M6-2]: https://github.com/ualib/agda-algebras/issues/272
 [M6-8]: https://github.com/ualib/agda-algebras/issues/419
+[M6-9]: https://github.com/ualib/agda-algebras/issues/420
+[M6-10]: https://github.com/ualib/agda-algebras/issues/421
 [`GITHUB_PROJECT.md`]: ../GITHUB_PROJECT.md
 [`m6-8-finite-birkhoff.md`]: ./m6-8-finite-birkhoff.md

--- a/mkdocs/_includes/UALib.Links.md
+++ b/mkdocs/_includes/UALib.Links.md
@@ -156,6 +156,7 @@
 [Setoid.Subalgebras.Subdirect.Basic]: https://ualib.org/Setoid.Subalgebras.Subdirect.Basic.html
 [Setoid.Subalgebras.Subdirect.BirkhoffSI]: https://ualib.org/Setoid.Subalgebras.Subdirect.BirkhoffSI.html
 [Setoid.Subalgebras.Subdirect.Finite]: https://ualib.org/Setoid.Subalgebras.Subdirect.Finite.html
+[Setoid.Subalgebras.Subdirect.SI]: https://ualib.org/Setoid.Subalgebras.Subdirect.SI.html
 
 [Setoid.Varieties]: https://ualib.org/Setoid.Varieties.html
 [Setoid.Varieties.Closure]: https://ualib.org/Setoid.Varieties.Closure.html

--- a/mkdocs/_includes/UALib.Links.md
+++ b/mkdocs/_includes/UALib.Links.md
@@ -156,7 +156,7 @@
 [Setoid.Subalgebras.Subdirect.Basic]: https://ualib.org/Setoid.Subalgebras.Subdirect.Basic.html
 [Setoid.Subalgebras.Subdirect.BirkhoffSI]: https://ualib.org/Setoid.Subalgebras.Subdirect.BirkhoffSI.html
 [Setoid.Subalgebras.Subdirect.Finite]: https://ualib.org/Setoid.Subalgebras.Subdirect.Finite.html
-[Setoid.Subalgebras.Subdirect.SI]: https://ualib.org/Setoid.Subalgebras.Subdirect.SI.html
+[Setoid.Subalgebras.Subdirect.Irreducible]: https://ualib.org/Setoid.Subalgebras.Subdirect.Irreducible.html
 
 [Setoid.Varieties]: https://ualib.org/Setoid.Varieties.html
 [Setoid.Varieties.Closure]: https://ualib.org/Setoid.Varieties.Closure.html

--- a/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
@@ -30,7 +30,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using ()
 
 -- Imports from the Agda Universal Algebra Library -----------------------------------------
 open import Overture          using ( proj₁ ; proj₂ )
-open import Setoid.Functions  using ( _⊙_ ; eq ; IsInjective ; IsSurjective )
+open import Setoid.Functions  using ( _⊙_ ; eq ; IsInjective ; IsSurjective ; SurjInv ; SurjInvIsInverseʳ )
 
 open import Setoid.Algebras {𝑆 = 𝑆}  using ( Algebra ; Lift-Alg ; _^_ )
                                      using ( Lift-Algˡ ; Lift-Algʳ ; ⨅ )
@@ -41,7 +41,7 @@ open import Setoid.Homomorphisms.Properties  {𝑆 = 𝑆} using
  ; ToLiftʳ ; FromLiftʳ ; ToFromLiftʳ ; FromToLiftʳ )
 
 open _⟶_      using ( cong ) renaming ( to to _⟨$⟩_ )
-open Algebra  using ( Domain )
+open Algebra  using ( Domain ; Interp )
 
 private variable  α ρᵃ β ρᵇ γ ρᶜ ι : Level
 ```
@@ -149,6 +149,50 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
                   (φ : 𝑨 ≅ 𝑩) → IsInjective (proj₁ (from φ))
 
 ≅fromInjective φ = ≅toInjective (≅-sym φ)
+```
+
+
+#### A bijective homomorphism is an isomorphism
+
+A homomorphism that is both injective and surjective is an isomorphism.  The witness
+is the surjective right inverse `g = SurjInv h`, which is a *two-sided* inverse because
+`h` is injective; and `g` is again a homomorphism — to see `g (f b) ≈ f (g ∘ b)` it
+suffices, by injectivity of `h`, to compare the `h`-images, where `h ∘ g` cancels.
+This is the converse of `≅toInjective`/`toIsSurjective` and lets one promote a
+bijective `hom` to an `_≅_` without exhibiting the inverse homomorphism by hand.
+
+
+```agda
+module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
+ open Setoid (Domain 𝑨)  using ()              renaming ( Carrier to A ; _≈_ to _≈₁_ )
+ open Setoid (Domain 𝑩)  using ( sym ; trans ) renaming ( Carrier to B ; _≈_ to _≈₂_ )
+ open IsHom
+
+ Bijective→≅ :  (h : hom 𝑨 𝑩) → IsInjective (proj₁ h) → IsSurjective (proj₁ h) → 𝑨 ≅ 𝑩
+ Bijective→≅ h hM hE = mkiso h (g , gHom) (λ _ → invʳ) (λ _ → hM invʳ)
+  where
+  hf : Domain 𝑨 ⟶ Domain 𝑩
+  hf = proj₁ h
+
+  -- the surjective right inverse of h, made two-sided by injectivity
+  ginv : B → A
+  ginv = SurjInv hf hE
+
+  invʳ : ∀ {b} → hf ⟨$⟩ (ginv b) ≈₂ b
+  invʳ = SurjInvIsInverseʳ hf hE
+
+  -- ginv preserves setoid equality: pull b₀ ≈ b₁ back through h and cancel h ∘ ginv
+  gcong : ∀ {b₀ b₁} → b₀ ≈₂ b₁ → ginv b₀ ≈₁ ginv b₁
+  gcong b₀≈b₁ = hM (trans invʳ (trans b₀≈b₁ (sym invʳ)))
+
+  g : Domain 𝑩 ⟶ Domain 𝑨
+  g = record { to = ginv ; cong = gcong }
+
+  -- ginv is a homomorphism: compare h-images (h injective) and cancel h ∘ ginv
+  gHom : IsHom 𝑩 𝑨 g
+  compatible gHom {f}{b} =
+   hM (trans invʳ (sym (trans (compatible (proj₂ h))
+                              (cong (Interp 𝑩) (≡.refl , λ _ → invʳ)))))
 ```
 
 

--- a/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
@@ -9,7 +9,6 @@ author: "agda-algebras development team"
 
 This is the [Setoid.Homomorphisms.Factor][] module of the [Agda Universal Algebra Library][].
 
-
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
@@ -17,96 +16,93 @@ open import Overture using (𝓞 ; 𝓥 ; Signature)
 
 module Setoid.Homomorphisms.Isomorphisms {𝑆 : Signature 𝓞 𝓥}  where
 
--- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
-open import Agda.Primitive              using ()      renaming ( Set to Type )
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -------------------------------------------------
 open import Data.Product                using ( _,_ )
-open import Data.Unit.Polymorphic.Base  using ()      renaming ( ⊤ to 𝟙 ; tt to ∗ )
+open import Data.Unit.Polymorphic.Base  using () renaming ( ⊤ to 𝟙 ; tt to ∗ )
 open import Data.Unit.Base              using ( ⊤ ; tt )
-open import Function                    using ( id )  renaming ( Func to _⟶_ )
+open import Function                    using ( id ; _∘_ ) renaming ( Func to _⟶_ )
 open import Level                       using ( Level ; Lift ; lift ; lower ; _⊔_ )
 open import Relation.Binary             using ( Setoid ; Reflexive ; Sym ; Trans )
 
 open import Relation.Binary.PropositionalEquality as ≡ using ()
 
 -- Imports from the Agda Universal Algebra Library -----------------------------------------
-open import Overture          using ( proj₁ ; proj₂ )
-open import Setoid.Functions  using ( _⊙_ ; eq ; IsInjective ; IsSurjective ; SurjInv ; SurjInvIsInverseʳ )
-
-open import Setoid.Algebras {𝑆 = 𝑆}  using ( Algebra ; Lift-Alg ; _^_ )
-                                     using ( Lift-Algˡ ; Lift-Algʳ ; ⨅ )
-
-open import Setoid.Homomorphisms.Basic       {𝑆 = 𝑆} using  ( hom ; IsHom )
-open import Setoid.Homomorphisms.Properties  {𝑆 = 𝑆} using
- ( 𝒾𝒹 ; ⊙-hom ; ToLiftˡ ; FromLiftˡ ; ToFromLiftˡ ; FromToLiftˡ
- ; ToLiftʳ ; FromLiftʳ ; ToFromLiftʳ ; FromToLiftʳ )
-
+open import Overture                                  using  ( proj₁ ; proj₂ )
+open import Setoid.Functions                          using  ( _⊙_ ; eq ; IsInjective
+                                                             ; IsSurjective ; SurjInv
+                                                             ; SurjInvIsInverseʳ )
+open import Setoid.Algebras                  {𝑆 = 𝑆}  using  ( Algebra ; Lift-Alg ; _^_ ; 𝔻[_]
+                                                             ; 𝕌[_] ; Lift-Algˡ ; Lift-Algʳ ; ⨅ )
+open import Setoid.Homomorphisms.Basic       {𝑆 = 𝑆}  using  ( hom ; IsHom )
+open import Setoid.Homomorphisms.Properties  {𝑆 = 𝑆}  using  ( 𝒾𝒹 ; ⊙-hom ; ToLiftˡ ; FromLiftˡ
+                                                             ; ToFromLiftˡ ; FromToLiftˡ ; ToLiftʳ
+                                                             ; FromLiftʳ ; ToFromLiftʳ ; FromToLiftʳ )
 open _⟶_      using ( cong ) renaming ( to to _⟨$⟩_ )
-open Algebra  using ( Domain ; Interp )
+open Algebra  using ( Interp )
+open IsHom
 
 private variable  α ρᵃ β ρᵇ γ ρᶜ ι : Level
 ```
 
-
-Recall, `f ~ g` means f and g are *extensionally* (or pointwise) equal; i.e., `∀ x, f x ≡ g x`. We use this notion of equality of functions in the following definition of *isomorphism*.
+Recall, `f ~ g` means f and g are *extensionally* (or pointwise) equal; i.e.,
+`∀ x, f x ≡ g x`.  We use this notion of equality of functions in the following
+definition of *isomorphism*.
 
 We could define this using Sigma types, like this.
 
-    _≅_ : {α β : Level}(𝑨 : Algebra α 𝑆)(𝑩 : Algebra β ρᵇ) → Type(𝓞 ⊔ 𝓥 ⊔ α ⊔ β)
-    𝑨 ≅ 𝑩 =  Σ[ f ∈ (hom 𝑨 𝑩)] Σ[ g ∈ hom 𝑩 𝑨 ] (((proj₁ f) ∘ (proj₁ g) ≈ (proj₁ (𝒾𝒹 𝑩))) × ((proj₁ g) ∘ (proj₁ f) ≈ (proj₁ (𝒾𝒹 𝑨))))
+    _≅_ : {α β : Level}(𝑨 : Algebra α 𝑆)(𝑩 : Algebra β ρᵇ) → Type _
+    𝑨 ≅ 𝑩 =  Σ[ (f , _) ∈ hom 𝑨 𝑩 ] Σ[ (g , _) ∈ hom 𝑩 𝑨 ] ((f ∘ g ≈ proj₁ (𝒾𝒹 𝑩)) × (g ∘ f ≈ proj₁ (𝒾𝒹 𝑨)))
 
-However, with four components, an equivalent record type is easier to work with.
-
+However, with four components, a record type is easier to work with.
 
 ```agda
 module _ (𝑨 : Algebra α ρᵃ) (𝑩 : Algebra β ρᵇ) where
- open Setoid (Domain 𝑨) using ( sym ; trans ) renaming ( _≈_ to _≈₁_ )
- open Setoid (Domain 𝑩) using () renaming ( _≈_ to _≈₂_ ; sym to sym₂ ; trans to trans₂)
+  open Setoid 𝔻[ 𝑨 ] using ( sym ; trans ) renaming ( _≈_ to _≈₁_ )
+  open Setoid 𝔻[ 𝑩 ] using () renaming ( _≈_ to _≈₂_ ; sym to sym₂ ; trans to trans₂)
 
- record _≅_ : Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ β ⊔ ρᵃ ⊔ ρᵇ ) where
-  constructor mkiso
-  field
-   to : hom 𝑨 𝑩
-   from : hom 𝑩 𝑨
-   to∼from : ∀ b → ((proj₁ to) ⟨$⟩ ((proj₁ from) ⟨$⟩ b)) ≈₂ b
-   from∼to : ∀ a → ((proj₁ from) ⟨$⟩ ((proj₁ to) ⟨$⟩ a)) ≈₁ a
+  record _≅_ : Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ β ⊔ ρᵃ ⊔ ρᵇ ) where
+    constructor mkiso
+    field
+      to : hom 𝑨 𝑩
+      from : hom 𝑩 𝑨
+      to∼from : ∀ b → to .proj₁ ⟨$⟩ (from .proj₁ ⟨$⟩ b) ≈₂ b
+      from∼to : ∀ a → from .proj₁ ⟨$⟩ (to .proj₁ ⟨$⟩ a) ≈₁ a
 
-  toIsSurjective : IsSurjective (proj₁ to)
-  toIsSurjective {y} = eq ((proj₁ from) ⟨$⟩ y) (sym₂ (to∼from y))
+    toIsSurjective : IsSurjective (proj₁ to)
+    toIsSurjective {y} = eq (from .proj₁ ⟨$⟩ y) (sym₂ (to∼from y))
 
-  toIsInjective : IsInjective (proj₁ to)
-  toIsInjective {x} {y} xy = Goal
-   where
-   ξ : (proj₁ from) ⟨$⟩ ((proj₁ to) ⟨$⟩ x) ≈₁ (proj₁ from) ⟨$⟩ ((proj₁ to) ⟨$⟩ y)
-   ξ = cong (proj₁ from) xy
-   Goal : x ≈₁ y
-   Goal = trans (sym (from∼to x)) (trans ξ (from∼to y))
+    toIsInjective : IsInjective (proj₁ to)
+    toIsInjective {x} {y} xy = Goal
+      where
+      ξ : from .proj₁ ⟨$⟩ (to .proj₁ ⟨$⟩ x) ≈₁ from .proj₁ ⟨$⟩ (to .proj₁ ⟨$⟩ y)
+      ξ = cong (from .proj₁) xy
+      Goal : x ≈₁ y
+      Goal = trans (sym (from∼to x)) (trans ξ (from∼to y))
 
+    fromIsSurjective : IsSurjective (from .proj₁)
+    fromIsSurjective {y} = eq (to .proj₁ ⟨$⟩ y) (sym (from∼to y))
 
-  fromIsSurjective : IsSurjective (proj₁ from)
-  fromIsSurjective {y} = eq ((proj₁ to) ⟨$⟩ y) (sym (from∼to y))
-
-  fromIsInjective : IsInjective (proj₁ from)
-  fromIsInjective {x} {y} xy = Goal
-   where
-   ξ : (proj₁ to) ⟨$⟩ ((proj₁ from) ⟨$⟩ x) ≈₂ (proj₁ to) ⟨$⟩ ((proj₁ from) ⟨$⟩ y)
-   ξ = cong (proj₁ to) xy
-   Goal : x ≈₂ y
-   Goal = trans₂ (sym₂ (to∼from x)) (trans₂ ξ (to∼from y))
+    fromIsInjective : IsInjective (from .proj₁)
+    fromIsInjective {x} {y} xy = Goal
+      where
+      ξ : to .proj₁ ⟨$⟩ (from .proj₁ ⟨$⟩ x) ≈₂ to .proj₁ ⟨$⟩ (from .proj₁ ⟨$⟩ y)
+      ξ = cong (to .proj₁) xy
+      Goal : x ≈₂ y
+      Goal = trans₂ (sym₂ (to∼from x)) (trans₂ ξ (to∼from y))
 ```
-
 
 That is, two structures are *isomorphic* provided there are homomorphisms going back and forth between them which compose to the identity map.
 
-
 #### Properties of isomorphism of setoid algebras
-
 
 ```agda
 open _≅_
 
 ≅-refl : Reflexive (_≅_ {α}{ρᵃ})
 ≅-refl {α}{ρᵃ}{𝑨} = mkiso 𝒾𝒹 𝒾𝒹 (λ b → refl) λ a → refl
- where open Setoid (Domain 𝑨) using ( refl )
+ where open Setoid 𝔻[ 𝑨 ] using ( refl )
 
 ≅-sym : Sym (_≅_{β}{ρᵇ}) (_≅_{α}{ρᵃ})
 ≅-sym φ = mkiso (from φ) (to φ) (from∼to φ) (to∼from φ)
@@ -114,43 +110,42 @@ open _≅_
 ≅-trans : Trans (_≅_ {α}{ρᵃ})(_≅_{β}{ρᵇ})(_≅_{α}{ρᵃ}{γ}{ρᶜ})
 ≅-trans {ρᶜ = ρᶜ}{𝑨}{𝑩}{𝑪} ab bc = mkiso f g τ ν
   where
-  open Setoid (Domain 𝑨) using () renaming ( _≈_ to _≈₁_ ; trans to trans₁ )
-  open Setoid (Domain 𝑪) using () renaming ( _≈_ to _≈₃_ ; trans to trans₃ )
+  open Setoid 𝔻[ 𝑨 ] using () renaming ( _≈_ to _≈₁_ ; trans to trans₁ )
+  open Setoid 𝔻[ 𝑪 ] using () renaming ( _≈_ to _≈₃_ ; trans to trans₃ )
   f : hom 𝑨 𝑪
   f = ⊙-hom (to ab) (to bc)
 
   g : hom 𝑪 𝑨
   g = ⊙-hom (from bc) (from ab)
 
-  τ : ∀ b → ((proj₁ f) ⟨$⟩ ((proj₁ g) ⟨$⟩ b)) ≈₃ b
-  τ b = trans₃ (cong (proj₁ (to bc)) (to∼from ab ((proj₁ (from bc)) ⟨$⟩ b))) (to∼from bc b)
+  τ : ∀ b → f .proj₁ ⟨$⟩ (g .proj₁ ⟨$⟩ b) ≈₃ b
+  τ b = trans₃ (cong (to bc .proj₁) (to∼from ab (from bc .proj₁ ⟨$⟩ b))) (to∼from bc b)
 
-  ν : ∀ a → ((proj₁ g) ⟨$⟩ ((proj₁ f) ⟨$⟩ a)) ≈₁ a
-  ν a = trans₁ (cong (proj₁ (from ab)) (from∼to bc ((proj₁ (to ab)) ⟨$⟩ a))) (from∼to ab a)
+  ν : ∀ a → g .proj₁ ⟨$⟩ (f .proj₁ ⟨$⟩ a) ≈₁ a
+  ν a = trans₁ (cong (from ab .proj₁) (from∼to bc (to ab .proj₁ ⟨$⟩ a))) (from∼to ab a)
 
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
- open Setoid (Domain 𝑨) using ( _≈_ ; sym ; trans )
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ; sym ; trans )
 
- -- The "to" map of an isomorphism is injective.
- ≅toInjective : (φ : 𝑨 ≅ 𝑩) → IsInjective (proj₁ (to φ))
- ≅toInjective (mkiso (f , _) (g , _) _ g∼f){a₀}{a₁} fafb = Goal
-  where
-  lem1 : a₀ ≈ (g ⟨$⟩ (f ⟨$⟩ a₀))
-  lem1 = sym (g∼f a₀)
-  lem2 : (g ⟨$⟩ (f ⟨$⟩ a₀)) ≈ (g ⟨$⟩ (f ⟨$⟩ a₁))
-  lem2 = cong g fafb
-  lem3 : (g ⟨$⟩ (f ⟨$⟩ a₁)) ≈ a₁
-  lem3 = g∼f a₁
-  Goal : a₀ ≈ a₁
-  Goal = trans lem1 (trans lem2 lem3)
+  -- The "to" map of an isomorphism is injective.
+  ≅toInjective : (φ : 𝑨 ≅ 𝑩) → IsInjective (proj₁ (to φ))
+  ≅toInjective (mkiso (f , _) (g , _) _ g∼f){a₀}{a₁} fafb = Goal
+    where
+    lem1 : a₀ ≈ (g ⟨$⟩ (f ⟨$⟩ a₀))
+    lem1 = sym (g∼f a₀)
+    lem2 : (g ⟨$⟩ (f ⟨$⟩ a₀)) ≈ (g ⟨$⟩ (f ⟨$⟩ a₁))
+    lem2 = cong g fafb
+    lem3 : (g ⟨$⟩ (f ⟨$⟩ a₁)) ≈ a₁
+    lem3 = g∼f a₁
+    Goal : a₀ ≈ a₁
+    Goal = trans lem1 (trans lem2 lem3)
 
- -- The "from" map of an isomorphism is injective.
+-- The "from" map of an isomorphism is injective.
 ≅fromInjective :  {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}
-                  (φ : 𝑨 ≅ 𝑩) → IsInjective (proj₁ (from φ))
+  (φ : 𝑨 ≅ 𝑩) → IsInjective (proj₁ (from φ))
 
 ≅fromInjective φ = ≅toInjective (≅-sym φ)
 ```
-
 
 #### A bijective homomorphism is an isomorphism
 
@@ -161,72 +156,69 @@ suffices, by injectivity of `h`, to compare the `h`-images, where `h ∘ g` canc
 This is the converse of `≅toInjective`/`toIsSurjective` and lets one promote a
 bijective `hom` to an `_≅_` without exhibiting the inverse homomorphism by hand.
 
-
 ```agda
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
- open Setoid (Domain 𝑨)  using ()              renaming ( Carrier to A ; _≈_ to _≈₁_ )
- open Setoid (Domain 𝑩)  using ( sym ; trans ) renaming ( Carrier to B ; _≈_ to _≈₂_ )
- open IsHom
 
- Bijective→≅ :  (h : hom 𝑨 𝑩) → IsInjective (proj₁ h) → IsSurjective (proj₁ h) → 𝑨 ≅ 𝑩
- Bijective→≅ h hM hE = mkiso h (g , gHom) (λ _ → invʳ) (λ _ → hM invʳ)
-  where
-  hf : Domain 𝑨 ⟶ Domain 𝑩
-  hf = proj₁ h
+  Bijective→≅ :  (h : hom 𝑨 𝑩) → IsInjective (proj₁ h) → IsSurjective (proj₁ h) → 𝑨 ≅ 𝑩
+  Bijective→≅ h hM hE = mkiso h (g , gHom) (λ _ → invʳ) (λ _ → hM invʳ)
+    where
+    open Setoid 𝔻[ 𝑨 ]  using () renaming ( _≈_ to _≈₁_ )
+    open Setoid 𝔻[ 𝑩 ]  using ( sym ; trans ) renaming ( _≈_ to _≈₂_ )
 
-  -- the surjective right inverse of h, made two-sided by injectivity
-  ginv : B → A
-  ginv = SurjInv hf hE
+    hf : 𝔻[ 𝑨 ] ⟶ 𝔻[ 𝑩 ]
+    hf = proj₁ h
 
-  invʳ : ∀ {b} → hf ⟨$⟩ (ginv b) ≈₂ b
-  invʳ = SurjInvIsInverseʳ hf hE
+    -- the surjective right inverse of h, made two-sided by injectivity
+    ginv : 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ]
+    ginv = SurjInv hf hE
 
-  -- ginv preserves setoid equality: pull b₀ ≈ b₁ back through h and cancel h ∘ ginv
-  gcong : ∀ {b₀ b₁} → b₀ ≈₂ b₁ → ginv b₀ ≈₁ ginv b₁
-  gcong b₀≈b₁ = hM (trans invʳ (trans b₀≈b₁ (sym invʳ)))
+    invʳ : ∀ {b} → hf ⟨$⟩ (ginv b) ≈₂ b
+    invʳ = SurjInvIsInverseʳ hf hE
 
-  g : Domain 𝑩 ⟶ Domain 𝑨
-  g = record { to = ginv ; cong = gcong }
+    -- ginv preserves setoid equality: pull b₀ ≈ b₁ back through h and cancel h ∘ ginv
+    gcong : ∀ {b₀ b₁} → b₀ ≈₂ b₁ → ginv b₀ ≈₁ ginv b₁
+    gcong b₀≈b₁ = hM (trans invʳ (trans b₀≈b₁ (sym invʳ)))
 
-  -- ginv is a homomorphism: compare h-images (h injective) and cancel h ∘ ginv
-  gHom : IsHom 𝑩 𝑨 g
-  compatible gHom {f}{b} =
-   hM (trans invʳ (sym (trans (compatible (proj₂ h))
-                              (cong (Interp 𝑩) (≡.refl , λ _ → invʳ)))))
+    g : 𝔻[ 𝑩 ] ⟶ 𝔻[ 𝑨 ]
+    g = record { to = ginv ; cong = gcong }
+
+    -- ginv is a homomorphism: compare h-images (h injective) and cancel h ∘ ginv
+    gHom : IsHom 𝑩 𝑨 g
+    compatible gHom {f}{b} =
+     hM (trans invʳ (sym (trans (compatible (proj₂ h))
+                                (cong (Interp 𝑩) (≡.refl , λ _ → invʳ)))))
 ```
-
 
 Fortunately, the lift operation preserves isomorphism (i.e., it's an *algebraic
 invariant*). As our focus is universal algebra, this is important and is what
 makes the lift operation a workable solution to the technical problems that arise
 from the noncumulativity of Agda's universe hierarchy.
 
-
 ```agda
 module _ {𝑨 : Algebra α ρᵃ}{ℓ : Level} where
- Lift-≅ˡ : 𝑨 ≅ (Lift-Algˡ 𝑨 ℓ)
- Lift-≅ˡ = mkiso ToLiftˡ FromLiftˡ (ToFromLiftˡ{𝑨 = 𝑨}) (FromToLiftˡ{𝑨 = 𝑨}{ℓ})
+  Lift-≅ˡ : 𝑨 ≅ (Lift-Algˡ 𝑨 ℓ)
+  Lift-≅ˡ = mkiso ToLiftˡ FromLiftˡ (ToFromLiftˡ{𝑨 = 𝑨}) (FromToLiftˡ{𝑨 = 𝑨}{ℓ})
 
- Lift-≅ʳ : 𝑨 ≅ (Lift-Algʳ 𝑨 ℓ)
- Lift-≅ʳ = mkiso ToLiftʳ FromLiftʳ (ToFromLiftʳ{𝑨 = 𝑨}) (FromToLiftʳ{𝑨 = 𝑨}{ℓ})
+  Lift-≅ʳ : 𝑨 ≅ (Lift-Algʳ 𝑨 ℓ)
+  Lift-≅ʳ = mkiso ToLiftʳ FromLiftʳ (ToFromLiftʳ{𝑨 = 𝑨}) (FromToLiftʳ{𝑨 = 𝑨}{ℓ})
 
 Lift-≅ : {𝑨 : Algebra α ρᵃ}{ℓ ρ : Level} → 𝑨 ≅ (Lift-Alg 𝑨 ℓ ρ)
 Lift-≅ = ≅-trans Lift-≅ˡ Lift-≅ʳ
 
-
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}{ℓᵃ ℓᵇ : Level} where
 
- Lift-Alg-isoˡ : 𝑨 ≅ 𝑩 → Lift-Algˡ 𝑨 ℓᵃ ≅ Lift-Algˡ 𝑩 ℓᵇ
- Lift-Alg-isoˡ A≅B = ≅-trans (≅-trans (≅-sym Lift-≅ˡ ) A≅B) Lift-≅ˡ
+  Lift-Alg-isoˡ : 𝑨 ≅ 𝑩 → Lift-Algˡ 𝑨 ℓᵃ ≅ Lift-Algˡ 𝑩 ℓᵇ
+  Lift-Alg-isoˡ A≅B = ≅-trans (≅-trans (≅-sym Lift-≅ˡ ) A≅B) Lift-≅ˡ
 
- Lift-Alg-isoʳ : 𝑨 ≅ 𝑩 →  Lift-Algʳ 𝑨 ℓᵃ ≅ Lift-Algʳ 𝑩 ℓᵇ
- Lift-Alg-isoʳ A≅B = ≅-trans (≅-trans (≅-sym Lift-≅ʳ ) A≅B) Lift-≅ʳ
+  Lift-Alg-isoʳ : 𝑨 ≅ 𝑩 →  Lift-Algʳ 𝑨 ℓᵃ ≅ Lift-Algʳ 𝑩 ℓᵇ
+  Lift-Alg-isoʳ A≅B = ≅-trans (≅-trans (≅-sym Lift-≅ʳ ) A≅B) Lift-≅ʳ
 
 
 Lift-Alg-iso :  {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}{ℓᵃ rᵃ ℓᵇ rᵇ : Level}
- →              𝑨 ≅ 𝑩 → Lift-Alg 𝑨 ℓᵃ rᵃ ≅ Lift-Alg 𝑩 ℓᵇ rᵇ
+  → 𝑨 ≅ 𝑩 → Lift-Alg 𝑨 ℓᵃ rᵃ ≅ Lift-Alg 𝑩 ℓᵇ rᵇ
 Lift-Alg-iso {ℓᵇ = ℓᵇ} A≅B =
-  ≅-trans  (Lift-Alg-isoʳ{ℓᵇ = ℓᵇ}(≅-trans (Lift-Alg-isoˡ{ℓᵇ = ℓᵇ} A≅B) (≅-sym Lift-≅ˡ)))
+  ≅-trans  (Lift-Alg-isoʳ{ℓᵇ = ℓᵇ}(≅-trans  (Lift-Alg-isoˡ{ℓᵇ = ℓᵇ} A≅B)
+                                            (≅-sym Lift-≅ˡ)))
            (Lift-Alg-isoʳ Lift-≅ˡ)
 ```
 
@@ -236,59 +228,55 @@ The lift is also associative, up to isomorphism at least.
 
 ```agda
 module _ {𝑨 : Algebra α ρᵃ}{ℓ₁ ℓ₂ : Level} where
+  Lift-assocˡ : Lift-Algˡ 𝑨 (ℓ₁ ⊔ ℓ₂) ≅  Lift-Algˡ (Lift-Algˡ 𝑨 ℓ₁) ℓ₂
+  Lift-assocˡ = ≅-trans (≅-trans (≅-sym Lift-≅ˡ) Lift-≅ˡ) Lift-≅ˡ
 
- Lift-assocˡ : Lift-Algˡ 𝑨 (ℓ₁ ⊔ ℓ₂) ≅  Lift-Algˡ (Lift-Algˡ 𝑨 ℓ₁) ℓ₂
- Lift-assocˡ = ≅-trans (≅-trans (≅-sym Lift-≅ˡ) Lift-≅ˡ) Lift-≅ˡ
+  Lift-assocʳ : Lift-Algʳ 𝑨 (ℓ₁ ⊔ ℓ₂) ≅  Lift-Algʳ (Lift-Algʳ 𝑨 ℓ₁) ℓ₂
+  Lift-assocʳ = ≅-trans (≅-trans (≅-sym Lift-≅ʳ) Lift-≅ʳ) Lift-≅ʳ
 
- Lift-assocʳ : Lift-Algʳ 𝑨 (ℓ₁ ⊔ ℓ₂) ≅  Lift-Algʳ (Lift-Algʳ 𝑨 ℓ₁) ℓ₂
- Lift-assocʳ = ≅-trans (≅-trans (≅-sym Lift-≅ʳ) Lift-≅ʳ) Lift-≅ʳ
-
-Lift-assoc :  {𝑨 : Algebra α ρᵃ}{ℓ ρ : Level}
- →            Lift-Alg 𝑨 ℓ ρ ≅  Lift-Algʳ (Lift-Algˡ 𝑨 ℓ) ρ
+Lift-assoc : {𝑨 : Algebra α ρᵃ}{ℓ ρ : Level}
+  → Lift-Alg 𝑨 ℓ ρ ≅  Lift-Algʳ (Lift-Algˡ 𝑨 ℓ) ρ
 Lift-assoc {𝑨 = 𝑨}{ℓ}{ρ} = ≅-trans (≅-sym Lift-≅) (≅-trans Lift-≅ˡ Lift-≅ʳ)
 
-Lift-assoc' :  {𝑨 : Algebra α α}{β γ : Level}
- →             Lift-Alg 𝑨 (β ⊔ γ) (β ⊔ γ) ≅ Lift-Alg (Lift-Alg 𝑨 β β) γ γ
+Lift-assoc' : {𝑨 : Algebra α α}{β γ : Level}
+  → Lift-Alg 𝑨 (β ⊔ γ) (β ⊔ γ) ≅ Lift-Alg (Lift-Alg 𝑨 β β) γ γ
 Lift-assoc'{𝑨 = 𝑨}{β}{γ} = ≅-trans (≅-sym Lift-≅) (≅-trans Lift-≅ Lift-≅)
 ```
-
 
 Products of isomorphic families of algebras are themselves isomorphic. The proof
 looks a bit technical, but it is as straightforward as it ought to be.
 
-
 ```agda
 module _ {𝓘 : Level}{I : Type 𝓘} {𝒜 : I → Algebra α ρᵃ} {ℬ : I → Algebra β ρᵇ} where
- open Algebra (⨅ 𝒜)  using () renaming (Domain to ⨅A )
- open Setoid ⨅A      using () renaming ( _≈_ to _≈₁_ )
- open Algebra (⨅ ℬ)  using () renaming (Domain to ⨅B )
- open Setoid ⨅B      using () renaming ( _≈_ to _≈₂_ )
- open IsHom
+  open Algebra (⨅ 𝒜)  using () renaming (Domain to ⨅A )
+  open Setoid ⨅A      using () renaming ( _≈_ to _≈₁_ )
+  open Algebra (⨅ ℬ)  using () renaming (Domain to ⨅B )
+  open Setoid ⨅B      using () renaming ( _≈_ to _≈₂_ )
 
- ⨅≅ : (∀ (i : I) → 𝒜 i ≅ ℬ i) → ⨅ 𝒜 ≅ ⨅ ℬ
- ⨅≅ AB = mkiso (ϕ , ϕhom) (ψ , ψhom) ϕ∼ψ ψ∼ϕ
-  where
-   ϕ : ⨅A ⟶ ⨅B
-   ϕ = record  { to = λ a i → (proj₁ (to (AB i))) ⟨$⟩ (a i)
-               ; cong = λ a i → cong (proj₁ (to (AB i))) (a i)
-               }
+  ⨅≅ : (∀ (i : I) → 𝒜 i ≅ ℬ i) → ⨅ 𝒜 ≅ ⨅ ℬ
+  ⨅≅ AB = mkiso (ϕ , ϕhom) (ψ , ψhom) ϕ∼ψ ψ∼ϕ
+    where
+    ϕ : ⨅A ⟶ ⨅B
+    ϕ = record  { to = λ a i → to (AB i) .proj₁ ⟨$⟩ (a i)
+                ; cong = λ a i → cong (to (AB i) .proj₁) (a i)
+                }
 
-   ϕhom : IsHom (⨅ 𝒜) (⨅ ℬ) ϕ
-   ϕhom = record { compatible = λ i → compatible (proj₂ (to (AB i))) }
+    ϕhom : IsHom (⨅ 𝒜) (⨅ ℬ) ϕ
+    ϕhom .compatible = λ i → compatible (to (AB i) .proj₂)
 
-   ψ : ⨅B ⟶ ⨅A
-   ψ = record  { to = λ b i → (proj₁ (from (AB i))) ⟨$⟩ (b i)
-               ; cong = λ b i → cong (proj₁ (from (AB i))) (b i)
-               }
+    ψ : ⨅B ⟶ ⨅A
+    ψ = record  { to = λ b i → from (AB i) .proj₁ ⟨$⟩ (b i)
+                ; cong = λ b i → cong (from (AB i) .proj₁) (b i)
+                }
 
-   ψhom : IsHom (⨅ ℬ) (⨅ 𝒜) ψ
-   ψhom = record { compatible = λ i → compatible (proj₂ (from (AB i))) }
+    ψhom : IsHom (⨅ ℬ) (⨅ 𝒜) ψ
+    ψhom .compatible = λ i → compatible (from (AB i) .proj₂)
 
-   ϕ∼ψ : ∀ b → (ϕ ⟨$⟩ (ψ ⟨$⟩ b)) ≈₂ b
-   ϕ∼ψ b = λ i → to∼from (AB i) (b i)
+    ϕ∼ψ : ∀ b → ϕ ⟨$⟩ (ψ ⟨$⟩ b) ≈₂ b
+    ϕ∼ψ b = λ i → to∼from (AB i) (b i)
 
-   ψ∼ϕ : ∀ a → (ψ ⟨$⟩ (ϕ ⟨$⟩ a)) ≈₁ a
-   ψ∼ϕ a = λ i → from∼to (AB i)(a i)
+    ψ∼ϕ : ∀ a → ψ ⟨$⟩ (ϕ ⟨$⟩ a) ≈₁ a
+    ψ∼ϕ a = λ i → from∼to (AB i)(a i)
 ```
 
 
@@ -296,47 +284,46 @@ A nearly identical proof goes through for isomorphisms of lifted products.
 
 
 ```agda
-module _  {𝓘 : Level}{I : Type 𝓘}
-          {𝒜 : I → Algebra α ρᵃ}
-          {ℬ : (Lift γ I) → Algebra β ρᵇ} where
-
- open Algebra (⨅ 𝒜)  using () renaming (Domain to ⨅A )
- open Setoid ⨅A      using () renaming ( _≈_ to _≈₁_ )
- open Algebra (⨅ ℬ)  using () renaming (Domain to ⨅B )
- open Setoid ⨅B      using () renaming ( _≈_ to _≈₂_ )
- open IsHom
-
- Lift-Alg-⨅≅ˡ : (∀ i → 𝒜 i ≅ ℬ (lift i)) → Lift-Algˡ (⨅ 𝒜) γ ≅ ⨅ ℬ
- Lift-Alg-⨅≅ˡ AB = ≅-trans (≅-sym Lift-≅ˡ) A≅B
+module _
+  {𝓘 : Level}{I : Type 𝓘}
+  {𝒜 : I → Algebra α ρᵃ}
+  {ℬ : (Lift γ I) → Algebra β ρᵇ}
   where
-   ϕ : ⨅A ⟶ ⨅B
-   ϕ = record  { to = λ a i → (proj₁ (to (AB (lower i)))) ⟨$⟩ (a (lower i))
-               ; cong = λ a i → cong (proj₁ (to (AB (lower i)))) (a (lower i))
-               }
 
-   ϕhom : IsHom (⨅ 𝒜) (⨅ ℬ) ϕ
-   ϕhom = record { compatible = λ i → compatible (proj₂ (to (AB (lower i)))) }
+  open Algebra (⨅ 𝒜)  using () renaming (Domain to ⨅A )
+  open Setoid ⨅A      using () renaming ( _≈_ to _≈₁_ )
+  open Algebra (⨅ ℬ)  using () renaming (Domain to ⨅B )
+  open Setoid ⨅B      using () renaming ( _≈_ to _≈₂_ )
 
-   ψ : ⨅B ⟶ ⨅A
-   ψ = record  { to = λ b i → (proj₁ (from (AB i))) ⟨$⟩ (b (lift i))
-               ; cong = λ b i → cong (proj₁ (from (AB i))) (b (lift i))
-               }
+  Lift-Alg-⨅≅ˡ : (∀ i → 𝒜 i ≅ ℬ (lift i)) → Lift-Algˡ (⨅ 𝒜) γ ≅ ⨅ ℬ
+  Lift-Alg-⨅≅ˡ AB = ≅-trans (≅-sym Lift-≅ˡ) A≅B
+    where
+    ϕ : ⨅A ⟶ ⨅B
+    ϕ = record  { to = λ a i → to (AB (lower i)) .proj₁ ⟨$⟩ a (lower i)
+                ; cong = λ a i → cong (to (AB (lower i)) .proj₁) (a (lower i))
+                }
 
-   ψhom : IsHom (⨅ ℬ) (⨅ 𝒜) ψ
-   ψhom = record { compatible = λ i → compatible (proj₂ (from (AB i))) }
+    ϕhom : IsHom (⨅ 𝒜) (⨅ ℬ) ϕ
+    ϕhom = record { compatible = λ i → compatible (proj₂ (to (AB (lower i)))) }
 
-   ϕ∼ψ : ∀ b → (ϕ ⟨$⟩ (ψ ⟨$⟩ b)) ≈₂ b
-   ϕ∼ψ b = λ i → to∼from (AB (lower i)) (b i)
+    ψ : ⨅B ⟶ ⨅A
+    ψ = record  { to = λ b i → from (AB i) .proj₁ ⟨$⟩ b (lift i)
+                ; cong = λ b i → cong (from (AB i) .proj₁) (b (lift i))
+                }
 
-   ψ∼ϕ : ∀ a → (ψ ⟨$⟩ (ϕ ⟨$⟩ a)) ≈₁ a
-   ψ∼ϕ a = λ i → from∼to (AB i)(a i)
+    ψhom : IsHom (⨅ ℬ) (⨅ 𝒜) ψ
+    ψhom .compatible = λ i → compatible (from (AB i) .proj₂)
 
-   A≅B : ⨅ 𝒜 ≅ ⨅ ℬ
-   A≅B = mkiso (ϕ , ϕhom) (ψ , ψhom) ϕ∼ψ ψ∼ϕ
+    ϕ∼ψ : ∀ b → ϕ ⟨$⟩ (ψ ⟨$⟩ b) ≈₂ b
+    ϕ∼ψ b = λ i → AB (lower i) .to∼from (b i)
+
+    ψ∼ϕ : ∀ a → ψ ⟨$⟩ (ϕ ⟨$⟩ a) ≈₁ a
+    ψ∼ϕ a = λ i → (AB i) .from∼to (a i)
+
+    A≅B : ⨅ 𝒜 ≅ ⨅ ℬ
+    A≅B = mkiso (ϕ , ϕhom) (ψ , ψhom) ϕ∼ψ ψ∼ϕ
 
 module _ {𝓘 : Level}{I : Type 𝓘} {𝒜 : I → Algebra α ρᵃ} where
- open IsHom
- open Algebra  using (Domain)
  open Setoid   using (_≈_ )
 
  ⨅≅⨅ℓ : ∀ {ℓ} → ⨅ 𝒜 ≅ ⨅ (λ i → Lift-Alg (𝒜 (lower{ℓ = ℓ} i)) ℓ ℓ)
@@ -351,30 +338,30 @@ module _ {𝓘 : Level}{I : Type 𝓘} {𝒜 : I → Algebra α ρᵃ} where
   open Algebra ⨅ℓ𝒜 using () renaming (Domain to ⨅ℓA)
 
   φ : ⨅A ⟶ ⨅ℓA
-  (φ ⟨$⟩ x) i = lift (x (lower i))
-  cong φ x i = lift (x (lower i))
+  φ ⟨$⟩ x = λ i → lift (x (lower i))
+  φ .cong x = λ i → lift (x (lower i))
+
   φhom : IsHom (⨅ 𝒜) ⨅ℓ𝒜  φ
-  compatible φhom i = lift refl
-   where open Setoid (Domain (𝒜 (lower i))) using ( refl )
+  φhom .compatible i = lift refl
+    where open Setoid 𝔻[ 𝒜 (lower i) ] using ( refl )
 
   ψ : ⨅ℓA ⟶ ⨅A
-  (ψ ⟨$⟩ x) i = lower (x (lift i))
-  cong ψ x i = lower (x (lift i))
+  ψ ⟨$⟩ x = λ i → lower (x (lift i))
+  ψ .cong x = λ i → lower (x (lift i))
+
   ψhom : IsHom ⨅ℓ𝒜 (⨅ 𝒜) ψ
-  compatible ψhom i = refl
-   where open Setoid (Domain (𝒜 i)) using ( refl )
+  ψhom .compatible i = refl
+    where open Setoid 𝔻[ 𝒜 i ] using ( refl )
 
-  φ∼ψ : ∀ b i → (Domain (Lift-Alg (𝒜 (lower i)) ℓ ℓ)) ._≈_ ((φ ⟨$⟩ (ψ ⟨$⟩ b)) i) (b i)
+  φ∼ψ : ∀ b i → 𝔻[ Lift-Alg (𝒜 (lower i)) ℓ ℓ ] ._≈_ ((φ ⟨$⟩ (ψ ⟨$⟩ b)) i) (b i)
   φ∼ψ _ i = lift (reflexive ≡.refl)
-   where open Setoid (Domain (𝒜 (lower i))) using ( reflexive )
+   where open Setoid 𝔻[ 𝒜 (lower i) ] using ( reflexive )
 
-  ψ∼φ : ∀ a i → (Domain (𝒜 i)) ._≈_ ((ψ ⟨$⟩ (φ ⟨$⟩ a)) i) (a i)
+  ψ∼φ : ∀ a i → 𝔻[ 𝒜 i ] ._≈_ ((ψ ⟨$⟩ (φ ⟨$⟩ a)) i) (a i)
   ψ∼φ _ i = (reflexive ≡.refl)
-   where open Setoid (Domain (𝒜  i)) using ( reflexive )
+   where open Setoid 𝔻[ 𝒜  i ] using ( reflexive )
 
 module _ {ι : Level}{I : Type ι}{𝒜 : I → Algebra α ρᵃ} where
- open IsHom
- open Algebra  using (Domain)
  open Setoid   using (_≈_ )
 
  ⨅≅⨅ℓρ : ∀ {ℓ ρ} → ⨅ 𝒜 ≅ ⨅ (λ i → Lift-Alg (𝒜 i) ℓ ρ)
@@ -386,38 +373,37 @@ module _ {ι : Level}{I : Type ι}{𝒜 : I → Algebra α ρᵃ} where
   open Setoid ⨅lA                            using () renaming ( _≈_ to _≈⨅lA≈_ )
 
   φfunc : ⨅A ⟶ ⨅lA
-  (φfunc ⟨$⟩ x) i = lift (x i)
-  cong φfunc x i = lift (x i)
+  φfunc ⟨$⟩ x = lift ∘ x
+  φfunc .cong x = lift ∘ x
 
   φhom : IsHom (⨅ 𝒜) (⨅ λ i → Lift-Alg (𝒜 i) ℓ ρ) φfunc
-  compatible φhom i = refl
-   where open Setoid (Domain (Lift-Alg (𝒜 i) ℓ ρ)) using ( refl )
+  φhom .compatible i = refl
+    where open Setoid 𝔻[ Lift-Alg (𝒜 i) ℓ ρ ] using ( refl )
 
   φ : hom (⨅ 𝒜) (⨅ λ i → Lift-Alg (𝒜 i) ℓ ρ)
   φ = φfunc , φhom
 
   ψfunc : ⨅lA ⟶ ⨅A
-  (ψfunc ⟨$⟩ x) i = lower (x i)
-  cong ψfunc x i = lower (x i)
+  ψfunc ⟨$⟩ x = lower ∘ x
+  ψfunc .cong x = lower ∘ x
 
   ψhom : IsHom (⨅ λ i → Lift-Alg (𝒜 i) ℓ ρ) (⨅ 𝒜) ψfunc
-  compatible ψhom i = refl
-   where open Setoid (Domain (𝒜 i)) using (refl)
+  ψhom .compatible i = refl
+    where open Setoid 𝔻[ 𝒜 i ] using (refl)
 
   ψ : hom (⨅ λ i → Lift-Alg (𝒜 i) ℓ ρ) (⨅ 𝒜)
   ψ = ψfunc , ψhom
 
-  φ∼ψ : ∀ b → (proj₁ φ) ⟨$⟩ ((proj₁ ψ) ⟨$⟩ b) ≈⨅lA≈ b
+  φ∼ψ : ∀ b → φ .proj₁ ⟨$⟩ (ψ .proj₁ ⟨$⟩ b) ≈⨅lA≈ b
   φ∼ψ _ i = reflexive ≡.refl
-   where open Setoid (Domain (Lift-Alg (𝒜 i) ℓ ρ)) using ( reflexive )
+    where open Setoid 𝔻[ Lift-Alg (𝒜 i) ℓ ρ ] using ( reflexive )
 
   ψ∼φ : ∀ a → (proj₁ ψ) ⟨$⟩ ((proj₁ φ) ⟨$⟩ a) ≈⨅A≈ a
   ψ∼φ _ = reflexive ≡.refl
-   where open Setoid (Domain (⨅ 𝒜)) using ( reflexive )
+    where open Setoid 𝔻[ ⨅ 𝒜 ] using ( reflexive )
 
 
 module _ {ℓᵃ : Level}{I : Type ℓᵃ}{𝒜 : I → Algebra α ρᵃ}where
- open IsHom
  open Algebra  using (Domain)
  open Setoid   using (_≈_ )
 
@@ -435,7 +421,7 @@ module _ {ℓᵃ : Level}{I : Type ℓᵃ}{𝒜 : I → Algebra α ρᵃ}where
 
   φhom : IsHom (⨅ 𝒜) (⨅ λ i → Lift-Alg (𝒜 (lower i)) ℓ ρ) φfunc
   compatible φhom i = refl
-   where open Setoid (Domain (Lift-Alg (𝒜 (lower i)) ℓ ρ)) using ( refl )
+   where open Setoid 𝔻[ Lift-Alg (𝒜 (lower i)) ℓ ρ ] using ( refl )
 
   φ : hom (⨅ 𝒜) (⨅ λ i → Lift-Alg (𝒜 (lower i)) ℓ ρ)
   φ = φfunc , φhom
@@ -446,18 +432,18 @@ module _ {ℓᵃ : Level}{I : Type ℓᵃ}{𝒜 : I → Algebra α ρᵃ}where
 
   ψhom : IsHom (⨅ λ i → Lift-Alg (𝒜 (lower i)) ℓ ρ) (⨅ 𝒜) ψfunc
   compatible ψhom i = refl
-   where open Setoid (Domain (𝒜 i)) using (refl)
+   where open Setoid 𝔻[ 𝒜 i ] using (refl)
 
   ψ : hom (⨅ λ i → Lift-Alg (𝒜 (lower i)) ℓ ρ) (⨅ 𝒜)
   ψ = ψfunc , ψhom
 
   φ∼ψ : ∀ b → (proj₁ φ) ⟨$⟩ ((proj₁ ψ) ⟨$⟩ b) ≈⨅lA≈ b
   φ∼ψ _ i = reflexive ≡.refl
-   where open Setoid (Domain (Lift-Alg (𝒜 (lower i)) ℓ ρ)) using (reflexive)
+   where open Setoid 𝔻[ Lift-Alg (𝒜 (lower i)) ℓ ρ ] using (reflexive)
 
   ψ∼φ : ∀ a → (proj₁ ψ) ⟨$⟩ ((proj₁ φ) ⟨$⟩ a) ≈⨅A≈ a
   ψ∼φ _ = reflexive ≡.refl
-   where open Setoid (Domain (⨅ 𝒜)) using (reflexive)
+   where open Setoid 𝔻[ ⨅ 𝒜 ] using (reflexive)
 
  ℓ⨅≅⨅ℓ : ∀ {ℓ} → Lift-Alg (⨅ 𝒜) ℓ ℓ ≅ ⨅ λ i → Lift-Alg (𝒜 (lower{ℓ = ℓ} i)) ℓ ℓ
  ℓ⨅≅⨅ℓ {ℓ} = mkiso (φ , φhom) (ψ , ψhom) φ∼ψ ψ∼φ -- φ∼ψ ψ∼φ
@@ -477,29 +463,28 @@ module _ {ℓᵃ : Level}{I : Type ℓᵃ}{𝒜 : I → Algebra α ρᵃ}where
   cong φ x i = lift ((lower x)(lower i))
   φhom : IsHom ℓ⨅𝒜 ⨅ℓ𝒜  φ
   compatible φhom i = lift refl
-   where open Setoid (Domain (𝒜 (lower i))) using ( refl )
+   where open Setoid 𝔻[ 𝒜 (lower i) ] using ( refl )
 
   ψ : ⨅ℓA ⟶ ℓ⨅A
   (ψ ⟨$⟩ x) = lift λ i → lower (x (lift i))
   cong ψ x = lift λ i → lower (x (lift i))
   ψhom : IsHom ⨅ℓ𝒜 ℓ⨅𝒜 ψ
   lower (compatible ψhom) i = refl
-   where open Setoid (Domain (𝒜 i)) using ( refl )
+   where open Setoid 𝔻[ 𝒜 i ] using ( refl )
 
   φ∼ψ : ∀ b → (φ ⟨$⟩ (ψ ⟨$⟩ b)) ≈₂ b
   lower (φ∼ψ _ i) = reflexive ≡.refl
-   where open Setoid (Domain (𝒜 (lower i))) using ( reflexive )
+   where open Setoid 𝔻[ 𝒜 (lower i) ] using ( reflexive )
 
   ψ∼φ : ∀ a → (ψ ⟨$⟩ (φ ⟨$⟩ a)) ≈₁ a
   lower (ψ∼φ _) i = reflexive ≡.refl
-   where open Setoid (Domain (𝒜  i)) using ( reflexive )
+   where open Setoid 𝔻[ 𝒜  i ] using ( reflexive )
 
 module _ {ι : Level}{𝑨 : Algebra α ρᵃ} where
  open Algebra 𝑨                     using() renaming ( Domain to A )
  open Algebra (⨅ λ (i : 𝟙{ι}) → 𝑨)  using() renaming ( Domain to ⨅A )
  open Setoid A                      using ( refl )
  open _≅_
- open IsHom
 
  private
   to𝟙 : A ⟶ ⨅A
@@ -525,7 +510,6 @@ module _ {𝑨 : Algebra α ρᵃ} where
  open Algebra (⨅ λ (i : ⊤) → 𝑨)  using () renaming ( Domain to ⨅A )
  open Setoid A                   using ( refl )
  open _≅_
- open IsHom
 
  private
   to⊤ : A ⟶ ⨅A

--- a/src/Setoid/Homomorphisms/Products.lagda.md
+++ b/src/Setoid/Homomorphisms/Products.lagda.md
@@ -9,7 +9,6 @@ author: "agda-algebras development team"
 
 This is the [Setoid.Homomorphisms.Products][] module of the [Agda Universal Algebra Library][].
 
-
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
@@ -18,17 +17,17 @@ open import Overture using (𝓞 ; 𝓥 ; Signature)
 module Setoid.Homomorphisms.Products {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library --------------------------
-open import Agda.Primitive   using () renaming ( Set to Type )
-open import Function         using () renaming ( Func to _⟶_ )
-open import Data.Product     using ( _,_ )
-open import Level            using ( Level )
-open import Relation.Binary  using ( Setoid )
-open import Relation.Binary.PropositionalEquality as ≡ using ( _≡_ )
+open import Agda.Primitive                         using () renaming ( Set to Type )
+open import Function                               using () renaming ( Func to _⟶_ )
+open import Data.Product                           using ( _,_ )
+open import Level                                  using ( Level )
+open import Relation.Binary                        using ( Setoid )
+open import Relation.Binary.PropositionalEquality  using ( _≡_ )
 
 -- Imports from the Agda Universal Algebras Library ----------------------
-open import Overture                             using ( proj₁ ; proj₂)
-open import Setoid.Algebras             {𝑆 = 𝑆}  using ( Algebra ; _^_ ; ⨅ ; 𝔻[_] )
-open import Setoid.Homomorphisms.Basic  {𝑆 = 𝑆}  using ( hom ; IsHom ; epi )
+open import Overture                               using ( proj₁ ; proj₂)
+open import Setoid.Algebras               {𝑆 = 𝑆}  using ( Algebra ; _^_ ; ⨅ ; 𝔻[_] )
+open import Setoid.Homomorphisms.Basic    {𝑆 = 𝑆}  using ( hom ; IsHom ; epi )
 
 open _⟶_ using ( cong )  renaming ( to to _⟨$⟩_ )
 open IsHom
@@ -36,14 +35,11 @@ open IsHom
 private variable α ρ β ρᵇ 𝓘 : Level
 ```
 
-
 Suppose we have an algebra `𝑨`, a type `I : Type 𝓘`, and a family
 `ℬ : I → Algebra β 𝑆` of algebras.  We sometimes refer to the inhabitants of `I`
-as *indices*, and call `ℬ` an *indexed family of algebras*.
-
-If in addition we have a family `𝒽 : (i : I) → hom 𝑨 (ℬ i)` of homomorphisms, then
-we can construct a homomorphism from `𝑨` to the product `⨅ ℬ` in the natural way.
-
+as *indices*, and call `ℬ` an *indexed family of algebras*.  If in addition we have a
+family `𝒽 : (i : I) → hom 𝑨 (ℬ i)` of homomorphisms, then we can construct a
+homomorphism from `𝑨` to the product `⨅ ℬ` in the natural way.
 
 ```agda
 module _ {I : Type 𝓘}{𝑨 : Algebra α ρ }(ℬ : I → Algebra β ρᵇ)  where
@@ -53,13 +49,12 @@ module _ {I : Type 𝓘}{𝑨 : Algebra α ρ }(ℬ : I → Algebra β ρᵇ)  w
   ⨅-hom-co 𝒽 = h , hhom
     where
     h : 𝔻[ 𝑨 ] ⟶ ⨅B
-    (h ⟨$⟩ a) i = (proj₁ (𝒽 i)) ⟨$⟩ a
-    cong h xy i = cong (proj₁ (𝒽 i)) xy
+    h ⟨$⟩ a = λ i → proj₁ (𝒽 i) ⟨$⟩ a
+    h .cong xy = λ i → cong (proj₁ (𝒽 i)) xy
 
     hhom : IsHom 𝑨 (⨅ ℬ) h
-    compatible hhom = λ i → compatible (proj₂ (𝒽 i))
+    hhom .compatible = λ i → compatible (proj₂ (𝒽 i))
 ```
-
 
 The family `𝒽` of homomorphisms inhabits the dependent type `Π i ꞉ I , hom 𝑨 (ℬ i)`.
 The syntax we use to represent this type is available to us because of the way `-Π`
@@ -76,7 +71,6 @@ a family of algebras. That is, if we are given `𝒜 : I → Algebra α 𝑆` an
 `𝒽 :  Π i ꞉ I , hom (𝒜 i)(ℬ i)` (a family of homomorphisms), then we can construct
 a homomorphism from `⨅ 𝒜` to `⨅ ℬ` in the following natural way.
 
-
 ```agda
 module _ {I : Type 𝓘}(𝒜 : I → Algebra α ρ) where
   open Algebra (⨅ 𝒜) using () renaming ( Domain to ⨅A )
@@ -87,14 +81,12 @@ module _ {I : Type 𝓘}(𝒜 : I → Algebra α ρ) where
     open Algebra (⨅ ℬ) using () renaming ( Domain to ⨅B )
 
     F : ⨅A ⟶ ⨅B
-    (F ⟨$⟩ x) i = (proj₁ (𝒽 i)) ⟨$⟩ x i
-    cong F xy i = cong (proj₁ (𝒽 i)) (xy i)
+    F ⟨$⟩ x = λ i → proj₁ (𝒽 i) ⟨$⟩ x i
+    F .cong xy = λ i → cong (proj₁ (𝒽 i)) (xy i)
 
     isHom : IsHom (⨅ 𝒜) (⨅ ℬ) F
-    compatible isHom i = compatible (proj₂ (𝒽 i))
+    isHom .compatible = λ i → compatible (proj₂ (𝒽 i))
 ```
-
-
 
 #### Projection out of products
 
@@ -109,10 +101,10 @@ The projection of a product algebra onto its `i`-th factor is a homomorphism.
 
     F : ⨅A ⟶ Ai
     F ⟨$⟩ x = x i
-    cong F xy = xy i
+    F .cong xy = xy i
 
     isHom : IsHom (⨅ 𝒜) (𝒜 i) F
-    compatible isHom {f} {a} = refli
+    isHom .compatible = refli
 ```
 
 We could prove a more general result involving projections onto multiple factors, but

--- a/src/Setoid/Subalgebras/Subdirect.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect.lagda.md
@@ -20,7 +20,7 @@ module Setoid.Subalgebras.Subdirect {𝑆 : Signature 𝓞 𝓥} where
 open import Setoid.Subalgebras.Subdirect.Basic {𝑆 = 𝑆} public
 open import Setoid.Subalgebras.Subdirect.BirkhoffSI {𝑆 = 𝑆} public
 open import Setoid.Subalgebras.Subdirect.Finite {𝑆 = 𝑆} public
-open import Setoid.Subalgebras.Subdirect.SI {𝑆 = 𝑆} public
+open import Setoid.Subalgebras.Subdirect.Irreducible {𝑆 = 𝑆} public
 ```
 
 --------------------------------------

--- a/src/Setoid/Subalgebras/Subdirect.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect.lagda.md
@@ -20,6 +20,7 @@ module Setoid.Subalgebras.Subdirect {𝑆 : Signature 𝓞 𝓥} where
 open import Setoid.Subalgebras.Subdirect.Basic {𝑆 = 𝑆} public
 open import Setoid.Subalgebras.Subdirect.BirkhoffSI {𝑆 = 𝑆} public
 open import Setoid.Subalgebras.Subdirect.Finite {𝑆 = 𝑆} public
+open import Setoid.Subalgebras.Subdirect.SI {𝑆 = 𝑆} public
 ```
 
 --------------------------------------

--- a/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
@@ -487,6 +487,6 @@ that exercises the maximal-congruence search — is the natural next addition.
 [^1]: This is option (b) of the design note `docs/notes/m6-2-subdirect.md`.
 
 <span style="float:left;">[← Setoid.Subalgebras.Subdirect.BirkhoffSI](Setoid.Subalgebras.Subdirect.BirkhoffSI.html)</span>
-<span style="float:right;">[Setoid.Subalgebras.Subdirect.SI →](Setoid.Subalgebras.Subdirect.SI.html)</span>
+<span style="float:right;">[Setoid.Subalgebras.Subdirect.Irreducible →](Setoid.Subalgebras.Subdirect.Irreducible.html)</span>
 
 {% include UALib.Links.md %}

--- a/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
@@ -487,6 +487,6 @@ that exercises the maximal-congruence search — is the natural next addition.
 [^1]: This is option (b) of the design note `docs/notes/m6-2-subdirect.md`.
 
 <span style="float:left;">[← Setoid.Subalgebras.Subdirect.BirkhoffSI](Setoid.Subalgebras.Subdirect.BirkhoffSI.html)</span>
-<span style="float:right;">[Setoid.Subalgebras.Properties →](Setoid.Subalgebras.Properties.html)</span>
+<span style="float:right;">[Setoid.Subalgebras.Subdirect.SI →](Setoid.Subalgebras.Subdirect.SI.html)</span>
 
 {% include UALib.Links.md %}

--- a/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
@@ -1,24 +1,26 @@
 ---
 layout: default
-file: "src/Setoid/Subalgebras/Subdirect/SI.lagda.md"
-title: "Setoid.Subalgebras.Subdirect.SI module (The Agda Universal Algebra Library)"
+file: "src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md"
+title: "Setoid.Subalgebras.Subdirect.Irreducible module (The Agda Universal Algebra Library)"
 date: "2026-06-22"
 author: "the agda-algebras development team"
 ---
 
 ### The structural characterization of subdirect irreducibility
 
-This is the [Setoid.Subalgebras.Subdirect.SI][] module of the [Agda Universal Algebra Library][].
+This is the [Setoid.Subalgebras.Subdirect.Irreducible][] module of the
+[Agda Universal Algebra Library][].
 
 [Setoid.Congruences.Monolith][] *defines* subdirect irreducibility order-theoretically:
 `IsSubdirectlyIrreducible 𝑨`{.AgdaFunction} is `Nontrivial 𝑨`{.AgdaFunction} together
 with the existence of a **monolith** (a least nonzero congruence).  What makes the name
-apt is the **structural** characterization (Burris and Sankappanavar, *A Course in
-Universal Algebra*, Def. II.8.3 / Thm. II.8.4): `𝑨` is subdirectly irreducible iff it
+apt is the **structural** characterization: `𝑨` is subdirectly irreducible iff it
 has no *nontrivial subdirect decomposition* — in every subdirect embedding
-`𝑨 ↪ ⨅ 𝒜`, some coordinate projection `projᵢ ∘ h` is an isomorphism.  This module ties
-[Setoid.Congruences.Monolith][] to [Setoid.Subalgebras.Subdirect.Basic][], proving the
-constructive direction in full and recording the converse's cost.
+`𝑨 ↪ ⨅ 𝒜`, some coordinate projection `projᵢ ∘ h` is an isomorphism.[^1]
+
+This module ties [Setoid.Congruences.Monolith][] to
+[Setoid.Subalgebras.Subdirect.Basic][], proving the constructive direction in full
+and recording the converse's cost.
 
 The clean constructive route goes through the **kernels**.  A subdirect embedding
 `h : 𝑨 ↪ ⨅ 𝒜` is the same data as a *separating family* of congruences `θ` (with
@@ -34,39 +36,38 @@ congruence-lattice statement about separating families, where the monolith argum
 
 open import Overture using ( 𝓞 ; 𝓥 ; Signature )
 
-module Setoid.Subalgebras.Subdirect.SI {𝑆 : Signature 𝓞 𝓥} where
+module Setoid.Subalgebras.Subdirect.Irreducible {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
-open import Agda.Primitive       using () renaming ( Set to Type )
-open import Data.Fin.Base        using ( Fin )
-open import Data.Fin.Properties  using ( ¬∀⟶∃¬ )
-open import Data.Nat.Base        using ( ℕ )
-open import Data.Product         using ( _,_ ; Σ-syntax ; ∃-syntax ; proj₁ ; proj₂ )
-open import Function             using ( id )
-open import Level                using ( Level ; _⊔_ )
-open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl )
-open import Relation.Nullary             using ( ¬_ ; Dec )
-open import Relation.Nullary.Decidable    using ( ¬? ; decidable-stable )
+open import Agda.Primitive                         using () renaming ( Set to Type )
+open import Data.Fin.Base                          using ( Fin )
+open import Data.Fin.Properties                    using ( ¬∀⟶∃¬ )
+open import Data.Nat.Base                          using ( ℕ )
+open import Data.Product                           using ( _,_ ; Σ-syntax ; ∃-syntax ; proj₁ ; proj₂ )
+open import Function                               using ( id )
+open import Level                                  using ( Level ; _⊔_ )
+open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl )
+open import Relation.Nullary                       using ( ¬_ ; Dec )
+open import Relation.Nullary.Decidable             using ( ¬? ; decidable-stable )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Setoid.Functions                    using  ( IsInjective ; IsSurjective )
-open import Setoid.Algebras              {𝑆 = 𝑆} using  ( Algebra ; ⨅ )
-open import Setoid.Congruences           {𝑆 = 𝑆} using  ( Con )
-open import Setoid.Homomorphisms         {𝑆 = 𝑆} using  ( hom ; kercon ; _≅_ ; Bijective→≅ )
-open import Setoid.Congruences.Monolith  {𝑆 = 𝑆}
-  using  ( HasMonolith ; Nonzero ; BelowDiagonal ; IsSubdirectlyIrreducible
-         ; mono-nonzero ; mono-least ; ⋂ )
+open import Setoid.Functions                       using  ( IsInjective ; IsSurjective )
+open import Setoid.Algebras              {𝑆 = 𝑆}   using  ( Algebra ; ⨅ )
+open import Setoid.Congruences           {𝑆 = 𝑆}   using  ( Con )
+open import Setoid.Homomorphisms         {𝑆 = 𝑆}   using  ( hom ; kercon ; _≅_ ; Bijective→≅ )
+open import Setoid.Congruences.Monolith  {𝑆 = 𝑆}   using  ( HasMonolith ; Nonzero ; BelowDiagonal
+                                                          ; IsSubdirectlyIrreducible
+                                                          ; mono-nonzero ; mono-least ; ⋂ )
 open import Setoid.Subalgebras.Subdirect.Basic {𝑆 = 𝑆}
-  using  ( coord ; IsSubdirectEmbedding ; SubdirectEmbedding ; Separates
-         ; embed-inj ; proj-onto )
+  using  ( coord ; IsSubdirectEmbedding ; SubdirectEmbedding ; Separates ; embed-inj ; proj-onto )
 
 private variable α ρ αᵃ ι : Level
 ```
 
-#### The kernel family of a homomorphism into a product, and the definitional bridges
+#### The kernel family of a homomorphism into a product
 
-Fix an algebra `𝑨`, a factor family `𝒜` whose relation level matches `𝑨`'s (so the
-kernels are `Con 𝑨 ρ`), and a homomorphism `h : 𝑨 → ⨅ 𝒜`.  The `i`-th **kernel** of
+Fix an algebra `𝑨`, a factor family `𝒜` whose relation level matches that of `𝑨` (so
+the kernels are `Con 𝑨 ρ`), and a homomorphism `h : 𝑨 → ⨅ 𝒜`.  The `i`-th **kernel** of
 `h` is the kernel congruence of the `i`-th coordinate map `coord 𝒜 h i = projᵢ ∘ h`.
 
 ```agda
@@ -85,11 +86,17 @@ unfold to `coordᵢ a ≈ coordᵢ b → a ≈ b`, since `BelowDiagonal (kercon 
 `IsInjective g`.
 
 ```agda
-  coord-inj→below : (i : I) → IsInjective (proj₁ (coord 𝒜 h i)) → BelowDiagonal 𝑨 (kerfam i)
-  coord-inj→below i = id
+  coord-inj→below : {i : I} → IsInjective (proj₁ (coord 𝒜 h i)) → BelowDiagonal 𝑨 (kerfam i)
+  coord-inj→below = id
 
-  below→coord-inj : (i : I) → BelowDiagonal 𝑨 (kerfam i) → IsInjective (proj₁ (coord 𝒜 h i))
-  below→coord-inj i = id
+  below→coord-inj : {i : I} → BelowDiagonal 𝑨 (kerfam i) → IsInjective (proj₁ (coord 𝒜 h i))
+  below→coord-inj = id
+
+  injective↔0kernel : {i : I} → IsInjective (proj₁ (coord 𝒜 h i)) ≡ BelowDiagonal 𝑨 (kerfam i)
+  injective↔0kernel = refl
+
+  injective⇔0kernel : (λ {i : I} → IsInjective (proj₁ (coord 𝒜 h i))) ≡ (λ {i : I} → BelowDiagonal 𝑨 (kerfam i))
+  injective⇔0kernel = refl
 ```
 
 Likewise, the injectivity of `h` itself is *definitionally* the assertion that the
@@ -102,17 +109,20 @@ to `∀ i, coordᵢ a ≈ coordᵢ b`, exactly the meet of the kernels.
 
   separates→embed : Separates kerfam → IsInjective (proj₁ h)
   separates→embed = id
+
+  embed↔separates : IsInjective (proj₁ h) ≡ Separates kerfam
+  embed↔separates = refl
+
 ```
 
-The third bridge is the only one with content: a coordinate map that is **surjective**
-(every coordinate of a subdirect embedding is) and **injective** is an isomorphism
-`𝑨 ≅ 𝒜 i`, via the generic `Bijective→≅`{.AgdaFunction} of
+The third bridge is the only one with content: a coordinate map that is surjective
+and injective is an isomorphism `𝑨 ≅ 𝒜 i`, via the generic `Bijective→≅`{.AgdaFunction} of
 [Setoid.Homomorphisms.Isomorphisms][].
 
 ```agda
-  coord-iso : (i : I) → IsSurjective (proj₁ (coord 𝒜 h i))
-                      → IsInjective (proj₁ (coord 𝒜 h i)) → 𝑨 ≅ 𝒜 i
-  coord-iso i surj inj = Bijective→≅ (coord 𝒜 h i) inj surj
+  coord-iso : {i : I}
+    → IsInjective (proj₁ (coord 𝒜 h i)) → IsSurjective (proj₁ (coord 𝒜 h i)) → 𝑨 ≅ 𝒜 i
+  coord-iso = Bijective→≅ (coord 𝒜 h _)
 ```
 
 #### The congruence-lattice forward direction
@@ -186,8 +196,7 @@ module _ {I : Type ι}{𝑨 : Algebra α ρ}{𝒜 : I → Algebra αᵃ ρ}
   -- index — see `si⇒iso-coord` below.)
   si⇒¬no-iso-coord : ¬ (∀ i → ¬ (𝑨 ≅ 𝒜 i))
   si⇒¬no-iso-coord no-iso =
-    si⇒¬all-proper (λ i below → no-iso i (coord-iso 𝒜 h i (proj-onto emb i)
-                                                          (below→coord-inj 𝒜 h i below)))
+    si⇒¬all-proper (λ i 0ker → no-iso i (coord-iso 𝒜 h (below→coord-inj 𝒜 h 0ker) (proj-onto emb i)))
 ```
 
 #### The finite witness: an explicit isomorphic coordinate
@@ -209,7 +218,7 @@ module _ {n : ℕ}{𝑨 : Algebra α ρ}{𝒜 : Fin n → Algebra αᵃ ρ}
     emb  = proj₂ sub
 
   si⇒iso-coord : IsoToFactor 𝑨 𝒜
-  si⇒iso-coord = i , coord-iso 𝒜 h i (proj-onto emb i) (below→coord-inj 𝒜 h i below)
+  si⇒iso-coord = i , coord-iso 𝒜 h (below→coord-inj 𝒜 h below) (proj-onto emb i)
     where
     -- the kernel family is not all-nonzero (the contrapositive forward direction)
     ¬all-nz : ¬ (∀ i → Nonzero 𝑨 (kerfam 𝒜 h i))
@@ -239,7 +248,7 @@ module _ {I : Type ι}{𝑨 : Algebra α ρ}{𝒜 : I → Algebra αᵃ ρ}(h : 
 
   iso-coord⟹¬all-proper :  (∃[ i ] IsInjective (proj₁ (coord 𝒜 h i)))
                         →  ¬ (∀ i → Nonzero 𝑨 (kerfam 𝒜 h i))
-  iso-coord⟹¬all-proper (i , inj) all-nz = all-nz i (coord-inj→below 𝒜 h i inj)
+  iso-coord⟹¬all-proper (i , inj) all-nz = all-nz i (coord-inj→below 𝒜 h inj)
 ```
 
 The full converse **structural ⟹ monolith** is *not* added, for the same predicativity
@@ -258,6 +267,8 @@ finite meet is again above `ρ`.  Stating the converse cleanly would need an imp
 limitation, as the forward direction is the one consumed downstream.
 
 --------------------------------------
+
+[^1]: See e.g. Burris and Sankappanavar, *A Course in Universal Algebra*, Def. II.8.3 / Thm. II.8.4.
 
 [M6-2 design note]: https://github.com/ualib/agda-algebras/blob/master/docs/notes/m6-2-subdirect.md
 

--- a/src/Setoid/Subalgebras/Subdirect/SI.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/SI.lagda.md
@@ -1,0 +1,267 @@
+---
+layout: default
+file: "src/Setoid/Subalgebras/Subdirect/SI.lagda.md"
+title: "Setoid.Subalgebras.Subdirect.SI module (The Agda Universal Algebra Library)"
+date: "2026-06-22"
+author: "the agda-algebras development team"
+---
+
+### The structural characterization of subdirect irreducibility
+
+This is the [Setoid.Subalgebras.Subdirect.SI][] module of the [Agda Universal Algebra Library][].
+
+[Setoid.Congruences.Monolith][] *defines* subdirect irreducibility order-theoretically:
+`IsSubdirectlyIrreducible 𝑨`{.AgdaFunction} is `Nontrivial 𝑨`{.AgdaFunction} together
+with the existence of a **monolith** (a least nonzero congruence).  What makes the name
+apt is the **structural** characterization (Burris and Sankappanavar, *A Course in
+Universal Algebra*, Def. II.8.3 / Thm. II.8.4): `𝑨` is subdirectly irreducible iff it
+has no *nontrivial subdirect decomposition* — in every subdirect embedding
+`𝑨 ↪ ⨅ 𝒜`, some coordinate projection `projᵢ ∘ h` is an isomorphism.  This module ties
+[Setoid.Congruences.Monolith][] to [Setoid.Subalgebras.Subdirect.Basic][], proving the
+constructive direction in full and recording the converse's cost.
+
+The clean constructive route goes through the **kernels**.  A subdirect embedding
+`h : 𝑨 ↪ ⨅ 𝒜` is the same data as a *separating family* of congruences `θ` (with
+`θ i` the kernel of the `i`-th coordinate map and `⋂ θ ≑ 0ᴬ` ⟺ `h` injective); the
+coordinate maps are already surjective, so "`projᵢ ∘ h` is an isomorphism" ⟺ "the
+`i`-th coordinate map is injective" ⟺ "`θ i ≑ 0ᴬ`".  Each of these equivalences is in
+fact a *definitional* identity here, so the embedding-level statement reduces to a
+congruence-lattice statement about separating families, where the monolith argument
+(`monolith⇒cmi`{.AgdaFunction} of [Setoid.Congruences.Monolith][]) applies.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+
+module Setoid.Subalgebras.Subdirect.SI {𝑆 : Signature 𝓞 𝓥} where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Agda.Primitive       using () renaming ( Set to Type )
+open import Data.Fin.Base        using ( Fin )
+open import Data.Fin.Properties  using ( ¬∀⟶∃¬ )
+open import Data.Nat.Base        using ( ℕ )
+open import Data.Product         using ( _,_ ; Σ-syntax ; ∃-syntax ; proj₁ ; proj₂ )
+open import Function             using ( id )
+open import Level                using ( Level ; _⊔_ )
+open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl )
+open import Relation.Nullary             using ( ¬_ ; Dec )
+open import Relation.Nullary.Decidable    using ( ¬? ; decidable-stable )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Setoid.Functions                    using  ( IsInjective ; IsSurjective )
+open import Setoid.Algebras              {𝑆 = 𝑆} using  ( Algebra ; ⨅ )
+open import Setoid.Congruences           {𝑆 = 𝑆} using  ( Con )
+open import Setoid.Homomorphisms         {𝑆 = 𝑆} using  ( hom ; kercon ; _≅_ ; Bijective→≅ )
+open import Setoid.Congruences.Monolith  {𝑆 = 𝑆}
+  using  ( HasMonolith ; Nonzero ; BelowDiagonal ; IsSubdirectlyIrreducible
+         ; mono-nonzero ; mono-least ; ⋂ )
+open import Setoid.Subalgebras.Subdirect.Basic {𝑆 = 𝑆}
+  using  ( coord ; IsSubdirectEmbedding ; SubdirectEmbedding ; Separates
+         ; embed-inj ; proj-onto )
+
+private variable α ρ αᵃ ι : Level
+```
+
+#### The kernel family of a homomorphism into a product, and the definitional bridges
+
+Fix an algebra `𝑨`, a factor family `𝒜` whose relation level matches `𝑨`'s (so the
+kernels are `Con 𝑨 ρ`), and a homomorphism `h : 𝑨 → ⨅ 𝒜`.  The `i`-th **kernel** of
+`h` is the kernel congruence of the `i`-th coordinate map `coord 𝒜 h i = projᵢ ∘ h`.
+
+```agda
+module _ {I : Type ι}{𝑨 : Algebra α ρ}(𝒜 : I → Algebra αᵃ ρ)(h : hom 𝑨 (⨅ 𝒜)) where
+
+  -- The kernel of the i-th coordinate map: the congruence on 𝑨 whose quotient is the
+  -- image of 𝑨 under projᵢ ∘ h.
+  kerfam : I → Con 𝑨 ρ
+  kerfam i = kercon (coord 𝒜 h i)
+```
+
+The first two bridges are *definitional identities*, recorded as `id` (the
+injectivity-is-separation pattern of [Setoid.Subalgebras.Subdirect.Basic][]).  A
+coordinate map is injective exactly when its kernel is below the diagonal — both
+unfold to `coordᵢ a ≈ coordᵢ b → a ≈ b`, since `BelowDiagonal (kercon g)` *is*
+`IsInjective g`.
+
+```agda
+  coord-inj→below : (i : I) → IsInjective (proj₁ (coord 𝒜 h i)) → BelowDiagonal 𝑨 (kerfam i)
+  coord-inj→below i = id
+
+  below→coord-inj : (i : I) → BelowDiagonal 𝑨 (kerfam i) → IsInjective (proj₁ (coord 𝒜 h i))
+  below→coord-inj i = id
+```
+
+Likewise, the injectivity of `h` itself is *definitionally* the assertion that the
+kernel family separates points: equality in `⨅ 𝒜` is pointwise, so `h a ≈ h b` unfolds
+to `∀ i, coordᵢ a ≈ coordᵢ b`, exactly the meet of the kernels.
+
+```agda
+  embed→separates : IsInjective (proj₁ h) → Separates kerfam
+  embed→separates = id
+
+  separates→embed : Separates kerfam → IsInjective (proj₁ h)
+  separates→embed = id
+```
+
+The third bridge is the only one with content: a coordinate map that is **surjective**
+(every coordinate of a subdirect embedding is) and **injective** is an isomorphism
+`𝑨 ≅ 𝒜 i`, via the generic `Bijective→≅`{.AgdaFunction} of
+[Setoid.Homomorphisms.Isomorphisms][].
+
+```agda
+  coord-iso : (i : I) → IsSurjective (proj₁ (coord 𝒜 h i))
+                      → IsInjective (proj₁ (coord 𝒜 h i)) → 𝑨 ≅ 𝒜 i
+  coord-iso i surj inj = Bijective→≅ (coord 𝒜 h i) inj surj
+```
+
+#### The congruence-lattice forward direction
+
+Now the monolith argument, stated at the family level.  If `𝑨` has a monolith `μ` and a
+family `θ` of congruences **separates points**, then the members cannot *all* be
+nonzero: `μ` would lie below every `θ i`, hence below their meet, hence (by separation)
+below the diagonal — contradicting that `μ` is nonzero.  This is the constructively
+honest, contrapositive reading of "`0ᴬ` is completely meet-irreducible".
+
+```agda
+module _ {𝑨 : Algebra α ρ} where
+
+  monolith⇒¬all-nonzero :  HasMonolith 𝑨 → {I : Type ι}(θ : I → Con 𝑨 ρ)
+                        →  Separates θ → ¬ (∀ i → Nonzero 𝑨 (θ i))
+  monolith⇒¬all-nonzero (μ , mono) θ sep all-nz = mono-nonzero mono μ-below
+    where
+    -- μ lies below every θ i (the monolith is the least nonzero congruence), hence the
+    -- separation hypothesis forces μ below the diagonal.
+    μ-below : BelowDiagonal 𝑨 μ
+    μ-below p = sep (λ i → mono-least mono (θ i) (all-nz i) p)
+```
+
+This is `monolith⇒cmi`{.AgdaFunction} (of [Setoid.Congruences.Monolith][]) read on the
+separation predicate.  Indeed, for a `ρ`-small index, separation is *definitionally* the
+assertion that the meet `⋂ θ` is below the diagonal — the exact hypothesis of complete
+meet-irreducibility — so the two coincide.  The direct proof above additionally removes
+the `ρ`-small-index restriction that `⋂`{.AgdaFunction} imposes (it is needed below for a
+`Fin n`-indexed decomposition).
+
+```agda
+  separates≡below-meet : {I : Type ρ}(θ : I → Con 𝑨 ρ) → Separates θ ≡ BelowDiagonal 𝑨 (⋂ 𝑨 θ)
+  separates≡below-meet θ = refl
+```
+
+#### No nontrivial subdirect decomposition
+
+`𝑨` **is isomorphic to one of the factors** `𝒜` of a subdirect decomposition when some
+coordinate map is an isomorphism.  "`𝑨` has no nontrivial subdirect decomposition" means
+that *every* subdirect embedding of `𝑨` has such a coordinate.
+
+```agda
+IsoToFactor : {I : Type ι}(𝑨 : Algebra α ρ)(𝒜 : I → Algebra αᵃ ρ) → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ αᵃ ⊔ ρ ⊔ ι)
+IsoToFactor 𝑨 𝒜 = ∃[ i ] (𝑨 ≅ 𝒜 i)
+```
+
+Fix a subdirectly irreducible algebra `𝑨` and a subdirect embedding `𝑨 ↪ ⨅ 𝒜`.  Its
+kernel family separates points (the embedding's injectivity *is* separation), so by the
+forward direction the coordinates cannot all be proper quotients.
+
+```agda
+module _ {I : Type ι}{𝑨 : Algebra α ρ}{𝒜 : I → Algebra αᵃ ρ}
+         (si : IsSubdirectlyIrreducible 𝑨)(sub : SubdirectEmbedding {𝑩 = 𝑨} 𝒜) where
+  private
+    h    = proj₁ sub
+    emb  = proj₂ sub
+
+  -- The kernel family of a subdirect embedding separates points.
+  sub-separates : Separates (kerfam 𝒜 h)
+  sub-separates = embed→separates 𝒜 h (embed-inj emb)
+
+  -- Constructive structural irreducibility (contrapositive): in a subdirect embedding
+  -- of a subdirectly irreducible algebra, the coordinates cannot all be proper
+  -- quotients.
+  si⇒¬all-proper : ¬ (∀ i → Nonzero 𝑨 (kerfam 𝒜 h i))
+  si⇒¬all-proper = monolith⇒¬all-nonzero (proj₂ si) (kerfam 𝒜 h) sub-separates
+
+  -- Equivalently, it is impossible that *no* coordinate is an isomorphism.  (The
+  -- positive form "some coordinate is an isomorphism" needs to extract a witness from a
+  -- negated statement, so it is available constructively only for a finite/decidable
+  -- index — see `si⇒iso-coord` below.)
+  si⇒¬no-iso-coord : ¬ (∀ i → ¬ (𝑨 ≅ 𝒜 i))
+  si⇒¬no-iso-coord no-iso =
+    si⇒¬all-proper (λ i below → no-iso i (coord-iso 𝒜 h i (proj-onto emb i)
+                                                          (below→coord-inj 𝒜 h i below)))
+```
+
+#### The finite witness: an explicit isomorphic coordinate
+
+For a **finite** index `Fin n`, with a decision for each coordinate of "is this kernel
+the diagonal?" (equivalently, "is this coordinate map injective?"), the contrapositive
+yields an *explicit* isomorphic coordinate: `𝑨` is isomorphic to one of its subdirect
+factors.  This is the witness-extracting form of the characterization, in the spirit of
+the finite Birkhoff theorem of [Setoid.Subalgebras.Subdirect.Finite][] (#419); the
+decision data is exactly what a `FiniteAlgebra`{.AgdaRecord} supplies (decidable `≈`
+and a finite carrier make `BelowDiagonal`, a `Π` over carrier pairs, decidable).
+
+```agda
+module _ {n : ℕ}{𝑨 : Algebra α ρ}{𝒜 : Fin n → Algebra αᵃ ρ}
+         (si : IsSubdirectlyIrreducible 𝑨)(sub : SubdirectEmbedding {𝑩 = 𝑨} 𝒜)
+         (dec : (i : Fin n) → Dec (BelowDiagonal 𝑨 (kerfam 𝒜 (proj₁ sub) i))) where
+  private
+    h    = proj₁ sub
+    emb  = proj₂ sub
+
+  si⇒iso-coord : IsoToFactor 𝑨 𝒜
+  si⇒iso-coord = i , coord-iso 𝒜 h i (proj-onto emb i) (below→coord-inj 𝒜 h i below)
+    where
+    -- the kernel family is not all-nonzero (the contrapositive forward direction)
+    ¬all-nz : ¬ (∀ i → Nonzero 𝑨 (kerfam 𝒜 h i))
+    ¬all-nz = monolith⇒¬all-nonzero (proj₂ si) (kerfam 𝒜 h) (embed→separates 𝒜 h (embed-inj emb))
+
+    -- finite + decidable ⟹ some coordinate's kernel is (¬¬, hence) below the diagonal
+    ex : ∃[ i ] (¬ Nonzero 𝑨 (kerfam 𝒜 h i))
+    ex = ¬∀⟶∃¬ n (λ i → Nonzero 𝑨 (kerfam 𝒜 h i)) (λ i → ¬? (dec i)) ¬all-nz
+
+    i : Fin n
+    i = proj₁ ex
+
+    below : BelowDiagonal 𝑨 (kerfam 𝒜 h i)
+    below = decidable-stable (dec i) (proj₂ ex)
+```
+
+#### The converse bridge, and the converse's cost
+
+The *converse* of the family-level forward direction needs no monolith and is
+choice-free: if some coordinate map is injective — an isomorphism, given surjectivity —
+then the kernel family is not all-nonzero.  So at the family level "some `θ i ≑ 0ᴬ`" and
+"not all `θ i` nonzero" coincide; together with the forward direction, the subdirect
+decompositions of an SI algebra are exactly those with an isomorphic coordinate.
+
+```agda
+module _ {I : Type ι}{𝑨 : Algebra α ρ}{𝒜 : I → Algebra αᵃ ρ}(h : hom 𝑨 (⨅ 𝒜)) where
+
+  iso-coord⟹¬all-proper :  (∃[ i ] IsInjective (proj₁ (coord 𝒜 h i)))
+                        →  ¬ (∀ i → Nonzero 𝑨 (kerfam 𝒜 h i))
+  iso-coord⟹¬all-proper (i , inj) all-nz = all-nz i (coord-inj→below 𝒜 h i inj)
+```
+
+The full converse **structural ⟹ monolith** is *not* added, for the same predicativity
+reason recorded in the [M6-2 design note][].  The natural construction takes
+`μ = ⋀ {θ : θ nonzero}`, the meet of *all* nonzero congruences: if `0ᴬ` is completely
+meet-irreducible then this family (whose every member is nonzero, so it has no zero
+member) cannot separate, so `μ` is nonzero; and `μ` is below every nonzero congruence,
+hence a monolith.  But that family is indexed by `Σ[ θ ∈ Con 𝑨 ρ ] Nonzero θ`, which
+lives one universe up, so the resulting meet is a `Con 𝑨 ℓ′` with `ℓ′ > ρ` — not a
+monolith *at level `ρ`*, the level `IsMonolith`{.AgdaRecord} fixes.  Restricting to a
+finite, complete list of congruences does not escape the wall either: the complete
+congruence enumerations available constructively (the `cons`{.AgdaField} field of
+`FiniteAlgebra`{.AgdaRecord}, #419) live at the absorbing level `clv α ρ ⊒ ρ`, so the
+finite meet is again above `ρ`.  Stating the converse cleanly would need an impredicative
+(or universe-resized) meet, or a level-generic `IsMonolith`; we record it here as a known
+limitation, as the forward direction is the one consumed downstream.
+
+--------------------------------------
+
+[M6-2 design note]: https://github.com/ualib/agda-algebras/blob/master/docs/notes/m6-2-subdirect.md
+
+<span style="float:left;">[← Setoid.Subalgebras.Subdirect.Finite](Setoid.Subalgebras.Subdirect.Finite.html)</span>
+<span style="float:right;">[Setoid.Subalgebras.Properties →](Setoid.Subalgebras.Properties.html)</span>
+
+{% include UALib.Links.md %}


### PR DESCRIPTION
## Summary

Closes #421 (M6-10).  Adds `Setoid.Subalgebras.Subdirect.SI`, the **structural characterization** of subdirect irreducibility, tying `IsSubdirectlyIrreducible` (`Setoid.Congruences.Monolith`) to subdirect decompositions (`Setoid.Subalgebras.Subdirect.Basic`): an algebra is subdirectly irreducible iff it has *no nontrivial subdirect decomposition* — in every subdirect embedding `𝑨 ↪ ⨅ 𝒜`, some coordinate projection `projᵢ ∘ h` is an isomorphism (Burris & Sankappanavar, Def. II.8.3 / Thm. II.8.4).

## The kernel route (three bridges, two definitional)

For `h : 𝑨 → ⨅ 𝒜` the kernel family is `kerfam h i = kercon (coord 𝒜 h i)`.  Two bridges hold *on the nose* (recorded as `id`, exactly the `natmap` injectivity-is-separation pattern):

+  `coord-inj→below` / `below→coord-inj` — a coordinate map is injective exactly when its kernel is below the diagonal (`kerfam i ≑ 0ᴬ`), since `BelowDiagonal (kercon g)` *is* `IsInjective g`.
+  `embed→separates` / `separates→embed` — injectivity of the embedding *is* that the kernel family separates points, since equality in `⨅ 𝒜` is pointwise.
+  `coord-iso` — the one bridge with content: a surjective-and-injective coordinate map is an isomorphism, via a new generic `Bijective→≅` added to `Setoid.Homomorphisms.Isomorphisms` (a bijective `hom` is an `_≅_`; the surjective right inverse is two-sided by injectivity and is again a homomorphism).

## Constructive direction

+  `monolith⇒¬all-nonzero` — the family-level core: a monolithic `𝑨` whose kernel family separates cannot have all coordinates proper.  This is `monolith⇒cmi` read on the separation predicate (`separates≡below-meet` records `Separates θ ≡ BelowDiagonal (⋂ θ)` for a ρ-small index), proved directly so it also covers a `Fin n`-indexed decomposition.
+  `si⇒¬no-iso-coord : ¬ (∀ i → ¬ (𝑨 ≅ 𝒜 i))` — the choice-free embedding-level contrapositive.
+  `si⇒iso-coord : ∃[ i ] 𝑨 ≅ 𝒜 i` — the **finite witness**: for a `Fin n` index with a per-coordinate decision of `BelowDiagonal (kerfam i)`, an *explicit* isomorphic coordinate, via `¬∀⟶∃¬` and `decidable-stable` (the M6-8 finite toolset; decidable `≈` on a finite carrier discharges the decision).

## Converse

+  `iso-coord⟹¬all-proper` — the family-level converse bridge (an injective coordinate forces the kernel family not-all-nonzero); choice-free.
+  The full *structural ⟹ monolith* is **documented, not added**: the natural witness `μ = ⋀ {θ : Nonzero θ}` is indexed by `Σ[ θ ] Nonzero θ`, a universe up, so the meet is a `Con 𝑨 ℓ′` with `ℓ′ > ρ` — not a monolith at level `ρ`; and the finite escape fails too, since the constructive complete congruence lists (`FiniteAlgebra.cons`, #419) live at the absorbing level `clv α ρ ⊒ ρ`.  This is the same predicativity wall as M6-2's `cmi ⟹ monolith` and M6-9 (#420).

## Home and dependencies

New module under `Setoid.Subalgebras.Subdirect.` (one-way dependency Subdirect → Monolith), wired into the `Subdirect` barrel.  The purely congruence-lattice half stays `monolith⇒cmi` in `Monolith` (it cannot move there, as the new lemma speaks of `Separates`, a Subdirect notion).

## Docs

Extends `docs/notes/m6-2-subdirect.md` with a "structural characterization (M6-10)" section and marks the third follow-up done.  `docs/GITHUB_PROJECT.md` is left untouched (regenerated from the issue tracker).

## Checks

Type-checks under `--cubical-compatible --exact-split --safe` via `nix develop --command make check` (the library's test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfD3AUFAGjd7s6TXjKtEcv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfD3AUFAGjd7s6TXjKtEcv)_