### PR TITLE
[M4-9] fix(varieties): make _⊫_ a record so V-id1 infers {p}{q} (#361)

### DIFF
--- a/src/Examples/Setoid/HSPCommutativeMonoid.lagda.md
+++ b/src/Examples/Setoid/HSPCommutativeMonoid.lagda.md
@@ -49,7 +49,7 @@ open import Overture.Terms {𝑆 = Sig-Monoid}                     using  ( Term
 open import Setoid.Algebras {𝑆 = Sig-Monoid}                    using  ( Algebra ; 𝕌[_] ; ov )
 open import Setoid.Varieties.Closure {𝑆 = Sig-Monoid}           using  ( V ; V′ ; V-expa′ )
 open import Setoid.Varieties.Preservation {𝑆 = Sig-Monoid}      using  ( V-id1 )
-open import Setoid.Varieties.SoundAndComplete {𝑆 = Sig-Monoid}  using  ( _⊧_ ; _⊫_
+open import Setoid.Varieties.SoundAndComplete {𝑆 = Sig-Monoid}  using  ( _⊧_ ; _⊫_ ; ⊫-proof
                                                                        ; _≈̇_ ; Mod ; Th )
 open import Setoid.Varieties.HSP {𝑆 = Sig-Monoid}               using  ( Birkhoff
                                                                        ; Birkhoff-converse )
@@ -118,10 +118,10 @@ x·y = node ∙-Op λ { 0F → ℊ 0F ; 1F → ℊ 1F }
 y·x = node ∙-Op λ { 0F → ℊ 1F ; 1F → ℊ 0F }
 
 𝒦₀⊫comm : 𝒦₀ ⊫ (x·y ≈̇ y·x)
-𝒦₀⊫comm 𝑩 in₀ ρ = +-comm (ρ 0F) (ρ 1F)
+𝒦₀⊫comm .⊫-proof 𝑩 in₀ ρ = +-comm (ρ 0F) (ρ 1F)
 
 V-commutative : 𝕍 ⊫ (x·y ≈̇ y·x)
-V-commutative = V-id1 {p = x·y} {q = y·x} 𝒦₀⊫comm
+V-commutative = V-id1 𝒦₀⊫comm
 ```
 
 #### Birkhoff's theorem, specialized {#birkhoff-specialized}

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -40,7 +40,7 @@ open import Setoid.Terms                       {𝑆 = 𝑆}  using  ( 𝑻 ; _�
 open import Setoid.Varieties.Closure           {𝑆 = 𝑆}  using  ( V ; S )
 
 open import Setoid.Varieties.Preservation      {𝑆 = 𝑆}  using  ( classIds-⊆-VIds ; S-id1 )
-open import Setoid.Varieties.SoundAndComplete  {𝑆 = 𝑆}  using  ( Eq ; _⊫_ ; _≈̇_ ; _⊢_▹_≈_
+open import Setoid.Varieties.SoundAndComplete  {𝑆 = 𝑆}  using  ( Eq ; _⊫_ ; ⊫-proof ; _≈̇_ ; _⊢_▹_≈_
                                                                ; Th ; Mod ; module Soundness
                                                                ; module FreeAlgebra )
 open _⟶_      using ( cong ) renaming ( to to _⟨$⟩_ )
@@ -80,7 +80,7 @@ The relatively free algebra (relative to `Th 𝒦`) is called `M` and is derived
   ℰ (eqv , p) = eqv
 
   ℰ⊢[_]▹Th𝒦 : (X : Type χ) → ∀{p q} → ℰ ⊢ X ▹ p ≈ q → 𝒦 ⊫ (p ≈̇ q)
-  ℰ⊢[ X ]▹Th𝒦 x 𝑨 kA = sound (λ i ρ → (proj₂ i) 𝑨 kA ρ) x
+  ℰ⊢[ X ]▹Th𝒦 x .⊫-proof 𝑨 kA = sound (λ i ρ → (proj₂ i) .⊫-proof 𝑨 kA ρ) x
     where open Soundness ℰ 𝑨
 
  ----------- THE RELATIVELY FREE ALGEBRA -----------
@@ -125,14 +125,14 @@ Finally, we define an epimorphism from `𝑻 X` onto the relatively free algebra
   class-models-kernel {X = X}{p}{q} pKq = ℰ⊢[ X ]▹Th𝒦 pKq
 
   kernel-in-theory : {X : Type χ} → fkerPred (proj₁ (hom𝔽[ X ])) ⊆ Th (V ℓ ι 𝒦)
-  kernel-in-theory {X = X} {p , q} pKq vkA x =
-    classIds-⊆-VIds {ℓ = ℓ} {p = p}{q} (class-models-kernel pKq) vkA x
+  kernel-in-theory {X = X} {p , q} pKq =
+    classIds-⊆-VIds {ℓ = ℓ} (class-models-kernel pKq)
 
 
   module _  {X : Type χ} {𝑨 : Algebra α ρᵃ}{sA : 𝑨 ∈ S {β = α}{ρᵃ} ℓ 𝒦} where
     open Environment 𝑨 using ( Equal )
     ker𝔽⊆Equal : ∀{p q} → (p , q) ∈ fkerPred (proj₁ (hom𝔽[ X ])) → Equal p q
-    ker𝔽⊆Equal{p = p}{q} x = S-id1{ℓ = ℓ}{p = p}{q} (ℰ⊢[ X ]▹Th𝒦 x) 𝑨 sA
+    ker𝔽⊆Equal{p = p}{q} x = S-id1{ℓ = ℓ} (ℰ⊢[ X ]▹Th𝒦 x) .⊫-proof 𝑨 sA
 
   𝒦⊫→ℰ⊢ : {X : Type χ} → ∀{p q} → 𝒦 ⊫ p ≈̇ q → ℰ ⊢ X ▹ p ≈ q
   𝒦⊫→ℰ⊢ {p = p} {q} pKq = hyp (p ≈̇ q , pKq) where open _⊢_▹_≈_ using (hyp)

--- a/src/Setoid/Varieties/HSP.lagda.md
+++ b/src/Setoid/Varieties/HSP.lagda.md
@@ -42,7 +42,7 @@ open import Setoid.Varieties.Closure {𝑆 = 𝑆}           using  ( S ; P ; S-
 open import Setoid.Varieties.FreeAlgebras {𝑆 = 𝑆}      using  ( module FreeHom
                                                               ; 𝔽-ModTh-epi-lift )
 open import Setoid.Varieties.Preservation {𝑆 = 𝑆}      using  ( S-id2 ; PS⊆SP )
-open import Setoid.Varieties.SoundAndComplete {𝑆 = 𝑆}  using  ( module FreeAlgebra ; _⊫_
+open import Setoid.Varieties.SoundAndComplete {𝑆 = 𝑆}  using  ( module FreeAlgebra ; _⊫_ ; ⊫-proof
                                                               ; _≈̇_ ; _⊢_▹_≈_ ; Mod ; Th )
 
 open _⟶_          using () renaming ( to to _⟨$⟩_ )
@@ -103,9 +103,9 @@ so belongs to `S (P 𝒦)`.
    open Algebra 𝔽[ X ]  using () renaming ( Domain to F ; Interp to InterpF )
    open Setoid F        using () renaming ( _≈_  to _≈F≈_ ; refl to reflF )
    S𝒦⊫pq : S{β = α}{ρᵃ} ℓ 𝒦 ⊫ (p ≈̇ q)
-   S𝒦⊫pq 𝑨 sA ρ = x (𝑨 , sA , ρ)
+   S𝒦⊫pq .⊫-proof 𝑨 sA ρ = x (𝑨 , sA , ρ)
    Goal : p ≈F≈ q
-   Goal = 𝒦⊫→ℰ⊢ (S-id2{ℓ = ℓ}{p = p}{q} S𝒦⊫pq)
+   Goal = 𝒦⊫→ℰ⊢ (S-id2{ℓ = ℓ} S𝒦⊫pq)
 
   homℭ : hom (𝑻 X) ℭ
   homℭ = ⨅-hom-co 𝔄⁺ h
@@ -235,7 +235,7 @@ that we formalize this inclusion as well, however trivial the proof.[^1]
     open Setoid (Domain 𝑨) using () renaming ( Carrier to ∣A∣ )
 
     Birkhoff-converse : 𝑨 ∈ V′ ℓ ι 𝒦 → 𝑨 ∈ Mod{X = ∣A∣} (Th (V ℓ ι 𝒦))
-    Birkhoff-converse vA pThq = pThq 𝑨 vA
+    Birkhoff-converse vA pThq = pThq .⊫-proof 𝑨 vA
 ```
 
 We have thus proved that every variety is an equational class.

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -46,7 +46,7 @@ open  import Setoid.Varieties.Closure {𝑆 = 𝑆}
 open  import Setoid.Varieties.Properties {𝑆 = 𝑆}
       using ( ⊧-H-invar ; ⊧-S-invar ; ⊧-P-invar ; ⊧-I-invar )
 open  import Setoid.Varieties.SoundAndComplete {𝑆 = 𝑆}
-      using ( _⊧_ ; _⊨_ ; _⊫_ ; Eq ; _≈̇_ ; lhs ; rhs ; _⊢_▹_≈_ ; Th)
+      using ( _⊧_ ; _⊨_ ; _⊫_ ; ⊫-proof ; Eq ; _≈̇_ ; lhs ; rhs ; _⊢_▹_≈_ ; Th)
 
 open _⟶_      using ( cong ) renaming ( to to _⟨$⟩_ )
 open Algebra  using ( Domain )
@@ -120,7 +120,7 @@ module _   {α ρᵃ ℓ χ : Level}
            where
 
  H-id1 : 𝒦 ⊫ (p ≈̇ q) → H {β = α}{ρᵃ}ℓ 𝒦 ⊫ (p ≈̇ q)
- H-id1 σ 𝑩 (𝑨 , kA , BimgA) = ⊧-H-invar{p = p}{q} (σ 𝑨 kA) BimgA
+ H-id1 σ .⊫-proof 𝑩 (𝑨 , kA , BimgA) = ⊧-H-invar{p = p}{q} (σ .⊫-proof 𝑨 kA) BimgA
 ```
 
 
@@ -129,7 +129,7 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 ```agda
  H-id2 : H ℓ 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
- H-id2 Hpq 𝑨 kA = Hpq 𝑨 (𝑨 , (kA , IdHomImage))
+ H-id2 Hpq .⊫-proof 𝑨 kA = Hpq .⊫-proof 𝑨 (𝑨 , (kA , IdHomImage))
 ```
 
 
@@ -139,10 +139,10 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 ```agda
  S-id1 : 𝒦 ⊫ (p ≈̇ q) → (S {β = α}{ρᵃ} ℓ 𝒦) ⊫ (p ≈̇ q)
- S-id1 σ 𝑩 (𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (σ 𝑨 kA) B≤A
+ S-id1 σ .⊫-proof 𝑩 (𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (σ .⊫-proof 𝑨 kA) B≤A
 
  S-id2 : S ℓ 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
- S-id2 Spq 𝑨 kA = Spq 𝑨 (𝑨 , (kA , ≤-reflexive))
+ S-id2 Spq .⊫-proof 𝑨 kA = Spq .⊫-proof 𝑨 (𝑨 , (kA , ≤-reflexive))
 ```
 
 
@@ -153,15 +153,15 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 ```agda
  P-id1 : ∀{ι} → 𝒦 ⊫ (p ≈̇ q) → P {β = α}{ρᵃ}ℓ ι 𝒦 ⊫ (p ≈̇ q)
- P-id1 σ 𝑨 (I , 𝒜 , kA , A≅⨅A) = ⊧-I-invar 𝑨 p q IH (≅-sym A≅⨅A)
+ P-id1 σ .⊫-proof 𝑨 (I , 𝒜 , kA , A≅⨅A) = ⊧-I-invar 𝑨 p q IH (≅-sym A≅⨅A)
   where
   ih : ∀ i → 𝒜 i ⊧ (p ≈̇ q)
-  ih i = σ (𝒜 i) (kA i)
+  ih i = σ .⊫-proof (𝒜 i) (kA i)
   IH : ⨅ 𝒜 ⊧ (p ≈̇ q)
   IH = ⊧-P-invar {p = p}{q} 𝒜 ih
 
  P-id2 : ∀{ι} → P ℓ ι 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
- P-id2{ι} PKpq 𝑨 kA = PKpq 𝑨 (P-expa {ℓ = ℓ}{ι} kA)
+ P-id2{ι} PKpq .⊫-proof 𝑨 kA = PKpq .⊫-proof 𝑨 (P-expa {ℓ = ℓ}{ι} kA)
 ```
 
 
@@ -180,24 +180,24 @@ module _  {α ρᵃ ℓ ι χ : Level}
  private aℓι = α ⊔ ρᵃ ⊔ ℓ ⊔ ι
 
  V-id1 : 𝒦 ⊫ (p ≈̇ q) → V ℓ ι 𝒦 ⊫ (p ≈̇ q)
- V-id1 σ 𝑩 (𝑨 , (⨅A , p⨅A , A≤⨅A) , BimgA) =
-  H-id1{ℓ = aℓι}{𝒦 = S aℓι (P {β = α}{ρᵃ}ℓ ι 𝒦)}{p = p}{q} spK⊧pq 𝑩 (𝑨 , (spA , BimgA))
+ V-id1 σ .⊫-proof 𝑩 (𝑨 , (⨅A , p⨅A , A≤⨅A) , BimgA) =
+  H-id1{ℓ = aℓι}{𝒦 = S aℓι (P {β = α}{ρᵃ}ℓ ι 𝒦)} spK⊧pq .⊫-proof 𝑩 (𝑨 , (spA , BimgA))
    where
    spA : 𝑨 ∈ S aℓι (P {β = α}{ρᵃ}ℓ ι 𝒦)
    spA = ⨅A , (p⨅A , A≤⨅A)
    spK⊧pq : S aℓι (P ℓ ι 𝒦) ⊫ (p ≈̇ q)
-   spK⊧pq = S-id1{ℓ = aℓι}{p = p}{q} (P-id1{ℓ = ℓ} {𝒦 = 𝒦}{p = p}{q} σ)
+   spK⊧pq = S-id1{ℓ = aℓι} (P-id1{ℓ = ℓ} {𝒦 = 𝒦} σ)
 
  V-id2 : V ℓ ι 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
- V-id2 Vpq 𝑨 kA = Vpq 𝑨 (V-expa ℓ ι kA)
+ V-id2 Vpq .⊫-proof 𝑨 kA = Vpq .⊫-proof 𝑨 (V-expa ℓ ι kA)
 
  Lift-id1 : ∀{β ρᵇ} → 𝒦 ⊫ (p ≈̇ q) → Level-closure{α}{ρᵃ}{β}{ρᵇ} ℓ 𝒦 ⊫ (p ≈̇ q)
- Lift-id1 pKq 𝑨 (𝑩 , kB , B≅A) ρ = Goal
+ Lift-id1 pKq .⊫-proof 𝑨 (𝑩 , kB , B≅A) ρ = Goal
   where
   open Environment 𝑨
   open Setoid (Domain 𝑨) using (_≈_)
   Goal : ⟦ p ⟧ ⟨$⟩ ρ ≈ ⟦ q ⟧ ⟨$⟩ ρ
-  Goal = ⊧-I-invar 𝑨 p q (pKq 𝑩 kB) B≅A ρ
+  Goal = ⊧-I-invar 𝑨 p q (pKq .⊫-proof 𝑩 kB) B≅A ρ
 ```
 
 
@@ -212,10 +212,10 @@ modeled by `𝒦`.   We formalize this observation as follows.
 
 ```agda
  classIds-⊆-VIds : 𝒦 ⊫ (p ≈̇ q)  → (p , q) ∈ Th (V ℓ ι 𝒦)
- classIds-⊆-VIds pKq 𝑨 = V-id1 pKq 𝑨
+ classIds-⊆-VIds pKq = V-id1 pKq
 
  VIds-⊆-classIds : (p , q) ∈ Th (V ℓ ι 𝒦) → 𝒦 ⊫ (p ≈̇ q)
- VIds-⊆-classIds Thpq 𝑨 kA = V-id2 Thpq 𝑨 kA
+ VIds-⊆-classIds Thpq = V-id2 Thpq
 ```
 
 

--- a/src/Setoid/Varieties/Properties.lagda.md
+++ b/src/Setoid/Varieties/Properties.lagda.md
@@ -46,7 +46,7 @@ open  import Setoid.Terms          {𝑆 = 𝑆}
       using  ( 𝑻 ; module Environment ; comm-hom-term ; interp-prod ; term-agreement )
 open  import Setoid.Subalgebras    {𝑆 = 𝑆}  using  ( _≤_ ; SubalgebrasOfClass )
 open  import Setoid.Varieties.SoundAndComplete {𝑆 = 𝑆}
-      using ( _⊧_ ; _⊨_ ; _⊫_ ; Eq ; _≈̇_ ; lhs ; rhs ; _⊢_▹_≈_ )
+      using ( _⊧_ ; _⊨_ ; _⊫_ ; ⊫-proof ; Eq ; _≈̇_ ; lhs ; rhs ; _⊢_▹_≈_ )
 
 private variable α ρᵃ β ρᵇ χ ℓ : Level
 
@@ -179,7 +179,7 @@ module _ {X : Type χ}{p q : Term X} where
  ⊧-S-class-invar :  {𝒦 : Pred (Algebra α ρᵃ) ℓ}
   →                 (𝒦 ⊫ (p ≈̇ q)) → ((𝑩 , _) : SubalgebrasOfClass 𝒦 {β}{ρᵇ})
   →                 𝑩 ⊧ (p ≈̇ q)
- ⊧-S-class-invar Kpq (𝑩 , 𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (Kpq 𝑨 kA) B≤A
+ ⊧-S-class-invar Kpq (𝑩 , 𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (Kpq .⊫-proof 𝑨 kA) B≤A
 ```
 
 
@@ -221,7 +221,7 @@ of algebras in the class.
  ⊧-P-class-invar :  (𝒦 : Pred (Algebra α ρᵃ)(ov α))
   →                 𝒦 ⊫ (p ≈̇ q) → (∀ i → 𝒜 i ∈ 𝒦) → ⨅ 𝒜 ⊧ (p ≈̇ q)
 
- ⊧-P-class-invar 𝒦 σ K𝒜 = ⊧-P-invar (λ i ρ → σ (𝒜 i) (K𝒜 i) ρ)
+ ⊧-P-class-invar 𝒦 σ K𝒜 = ⊧-P-invar (λ i ρ → σ .⊫-proof (𝒜 i) (K𝒜 i) ρ)
 ```
 
 

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -63,8 +63,19 @@ open Eq public
 _⊧_ : (𝑨 : Algebra α ρᵃ)(term-identity : Eq{χ}) → Type _
 𝑨 ⊧ (p ≈̇ q) = Equal p q where open Environment 𝑨
 
-_⊫_ : Pred (Algebra α ρᵃ) ℓ → Eq{χ} → Type (ℓ ⊔ χ ⊔ ov(α ⊔ ρᵃ))
-𝒦 ⊫ eq = ∀ 𝑨 → 𝒦 𝑨 → 𝑨 ⊧ eq                    -- (type \||= to get ⊫)
+-- 𝒦 ⊫ (p ≈̇ q) asserts that every algebra in the class 𝒦 models the equation
+-- p ≈̇ q.  This is a one-field record (a frozen wrapper around the underlying
+-- ∀ 𝑨 → 𝒦 𝑨 → 𝑨 ⊧ eq) rather than a plain function type, so that the equation
+-- stays visible as an Eq during unification.  Inferring the implicit {p}{q} of
+-- a preservation lemma such as V-id1 then unifies the two equations
+-- structurally at the Eq level — the record type former _⊫_ is injective —
+-- instead of unfolding _⊫_ → _⊧_ → Equal → ⟦_⟧ and getting stuck on the term
+-- interpreter.  (See issue #361.  Note _⊧_ and Equal still reduce
+-- definitionally, so the proofs that compute with them are unaffected.)
+record _⊫_ (𝒦 : Pred (Algebra α ρᵃ) ℓ)(eq : Eq{χ}) : Type (ℓ ⊔ χ ⊔ ov(α ⊔ ρᵃ)) where
+ constructor ⊫-intro
+ field ⊫-proof : ∀ (𝑨 : Algebra α ρᵃ) → 𝒦 𝑨 → 𝑨 ⊧ eq          -- (type \||= to get ⊫)
+open _⊫_ public
 infix 5 _⊫_
 
 -- An I-indexed set of equations inhabits the type I → Eq.
@@ -247,7 +258,7 @@ which asserts that every valid consequence is derivable.
     completeness p q V = begin
       p              ≈˘⟨ identity p ⟩
       p [ σ₀ ]       ≈˘⟨ evaluation p σ₀ ⟩
-      ⟦ p ⟧ ⟨$⟩ σ₀   ≈⟨ V 𝔽[ Γ ] satisfies σ₀ ⟩
+      ⟦ p ⟧ ⟨$⟩ σ₀   ≈⟨ V .⊫-proof 𝔽[ Γ ] satisfies σ₀ ⟩
       ⟦ q ⟧ ⟨$⟩ σ₀   ≈⟨ evaluation q σ₀ ⟩
       q [ σ₀ ]       ≈⟨ identity q ⟩
       q              ∎


### PR DESCRIPTION
## Summary

Closes #361 (M4-9).

`Setoid.Varieties.SoundAndComplete._⊫_` (the "class `𝒦` models equation `eq`" relation) was a plain function, `𝒦 ⊫ eq = ∀ 𝑨 → 𝒦 𝑨 → 𝑨 ⊧ eq`.  Inferring the implicit `{p}{q}` of a preservation lemma such as `V-id1` from a goal or argument of type `𝒦 ⊫ (p ≈̇ q)` forced the unifier to unfold `_⊫_ → _⊧_ → Equal → ⟦_⟧`, so the equation's `lhs`/`rhs` became metavariables blocked behind the term interpreter and had to be pinned by hand.

This PR freezes `_⊫_` as a one-field record (field `⊫-proof`).  Because a record type former is injective, a goal `𝒦 ⊫ (p ≈̇ q)` now unifies structurally on both the class predicate and the `Eq`, so `{p}{q}` are solved at the `Eq` level instead of through the interpreter.

## Why this approach

+  The issue offered two routes: make the models relations less reduction-happy (Option A), or restate the preservation lemmas to take the equation explicitly (Option B).  Option B cannot satisfy the acceptance demo `V-id1 𝒦₀⊫comm` — a single-argument call with `{p}{q}` inferred — so Option A is the one that meets the bar.
+  Freezing `_⊧_` or `Equal` would be high blast radius: both reduce definitionally throughout the Varieties subtree (`Soundness`, every `⊧-*-invar` in `Properties`, `FreeAlgebra`, …), and freezing them would force copatterns and projections through all of that machinery.
+  Freezing `_⊫_` instead stops unification at the outermost level, before any `_⊧_`/`Equal` reduction, so those definitions keep reducing and the deep proofs are untouched.  The churn is confined to `_⊫_` producers (now copatterns) and consumers (now `.⊫-proof`).

## Acceptance

+  `V-commutative = V-id1 𝒦₀⊫comm` in `Examples.Setoid.HSPCommutativeMonoid` type-checks without the hand-pinned `{p = x·y}{q = y·x}`.
+  Redundant `{p}{q}` pins at other `*-id1`/`*-id2`/`classIds` call sites (`FreeAlgebras`, `HSP`, `Preservation`) are removed as well.
+  `nix develop --command make check` passes over the whole library (199 modules), including the out-of-scope, self-contained `Demos.HSP`, which is unaffected.

## Files touched

+  `Setoid/Varieties/SoundAndComplete` — `_⊫_` becomes a record; `completeness` projects with `.⊫-proof`.
+  `Setoid/Varieties/Preservation` — `H/S/P/V/Lift-id1`, `H/S/P/V-id2`, `classIds-⊆-VIds`, `VIds-⊆-classIds`.
+  `Setoid/Varieties/Properties` — `⊧-S-class-invar`, `⊧-P-class-invar`.
+  `Setoid/Varieties/FreeAlgebras` — `ℰ⊢[_]▹Th𝒦`, `kernel-in-theory`, `ker𝔽⊆Equal`.
+  `Setoid/Varieties/HSP` — `S𝒦⊫pq`, `Birkhoff-converse`.
+  `Examples/Setoid/HSPCommutativeMonoid` — the acceptance demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeq2xNjEuNz1H1h3mVSnU6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qeq2xNjEuNz1H1h3mVSnU6)_