### PR TITLE
M10-4: cross-deploy the MkDocs site to agda-algebras.universalalgebra.org (#430)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,15 +7,21 @@
 #  runs locally.  mkdocs-material and the plugins are pinned by flake.nix, so
 #  CI and local builds are identical.
 #
-#  On push to master the freshly built ./site is published to the `gh-pages`
-#  branch.  Pull requests build only (a broken site fails the PR), they do not
+#  On push to master the freshly built ./site is cross-deployed to the
+#  `gh-pages` branch of the new-home repository `universalalgebra/agda-algebras`
+#  (served at https://agda-algebras.universalalgebra.org), using an SSH deploy
+#  key.  Pull requests build only (a broken site fails the PR), they do not
 #  deploy.
 #
-#  Cutover note: this workflow publishes to `gh-pages`, but it does NOT change
-#  where GitHub Pages serves from.  Pointing Pages at `gh-pages`, attaching the
-#  `ualib.org` custom domain (uncomment `cname:` below), and the registrar DNS
-#  change are deliberate manual steps for the maintainer (see PR #295).  Until
-#  then the currently-live site is untouched.
+#  Hosting (ADR-007, #430): the new MkDocs site is served from a subdomain of
+#  `universalalgebra.org`, while the legacy Jekyll site stays parked at
+#  `ualib.org` — this repository's own `gh-pages` branch.  This workflow no
+#  longer touches `ualib/agda-algebras`'s `gh-pages`, so the parked archive is
+#  left undisturbed.  Standing up the new home is a maintainer step: create the
+#  `universalalgebra/agda-algebras` repo, add the deploy key's public half to
+#  its Deploy keys (with write access) and the private half as the
+#  `UNIVERSALALGEBRA_DEPLOY_KEY` secret on this repo, then point DNS + Pages at
+#  the subdomain.
 # =============================================================================
 
 name: Docs
@@ -34,7 +40,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
-  contents: write   # needed to push the built site to the gh-pages branch
+  contents: read   # the cross-deploy authenticates with UNIVERSALALGEBRA_DEPLOY_KEY (SSH), not GITHUB_TOKEN
 
 jobs:
   build-deploy:
@@ -73,12 +79,15 @@ jobs:
           set -euxo pipefail
           nix develop --command make site-full
 
-      - name: Deploy to gh-pages
+      - name: Cross-deploy to universalalgebra/agda-algebras gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+	  # Authenticates over SSH to the external repo; the public half lives in
+	  # universalalgebra/agda-algebras → Settings → Deploy keys (write access).
+	  deploy_key: ${{ secrets.UNIVERSALALGEBRA_DEPLOY_KEY }}
+	  external_repository: universalalgebra/agda-algebras
           publish_dir: ./site
           publish_branch: gh-pages
-          # Attach the custom domain only at the ualib.org cutover:
-          # cname: ualib.org
+	  # Writes the custom-domain CNAME into the published site on every deploy.
+	  cname: agda-algebras.universalalgebra.org

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,15 +7,21 @@
 #  runs locally.  mkdocs-material and the plugins are pinned by flake.nix, so
 #  CI and local builds are identical.
 #
-#  On push to master the freshly built ./site is published to the `gh-pages`
-#  branch.  Pull requests build only (a broken site fails the PR), they do not
+#  On push to master the freshly built ./site is cross-deployed to the
+#  `gh-pages` branch of the new-home repository `universalalgebra/agda-algebras`
+#  (served at https://agda-algebras.universalalgebra.org), using an SSH deploy
+#  key.  Pull requests build only (a broken site fails the PR), they do not
 #  deploy.
 #
-#  Cutover note: this workflow publishes to `gh-pages`, but it does NOT change
-#  where GitHub Pages serves from.  Pointing Pages at `gh-pages`, attaching the
-#  `ualib.org` custom domain (uncomment `cname:` below), and the registrar DNS
-#  change are deliberate manual steps for the maintainer (see PR #295).  Until
-#  then the currently-live site is untouched.
+#  Hosting (ADR-007, #430): the new MkDocs site is served from a subdomain of
+#  `universalalgebra.org`, while the legacy Jekyll site stays parked at
+#  `ualib.org` — this repository's own `gh-pages` branch.  This workflow no
+#  longer touches `ualib/agda-algebras`'s `gh-pages`, so the parked archive is
+#  left undisturbed.  Standing up the new home is a maintainer step: create the
+#  `universalalgebra/agda-algebras` repo, add the deploy key's public half to
+#  its Deploy keys (with write access) and the private half as the
+#  `UNIVERSALALGEBRA_DEPLOY_KEY` secret on this repo, then point DNS + Pages at
+#  the subdomain.
 # =============================================================================
 
 name: Docs
@@ -34,7 +40,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
-  contents: write   # needed to push the built site to the gh-pages branch
+  contents: read   # the cross-deploy authenticates with UNIVERSALALGEBRA_DEPLOY_KEY (SSH), not GITHUB_TOKEN
 
 jobs:
   build-deploy:
@@ -73,12 +79,15 @@ jobs:
           set -euxo pipefail
           nix develop --command make site-full
 
-      - name: Deploy to gh-pages
+      - name: Cross-deploy to universalalgebra/agda-algebras gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Authenticates over SSH to the external repo; the public half lives in
+          # universalalgebra/agda-algebras → Settings → Deploy keys (write access).
+          deploy_key: ${{ secrets.UNIVERSALALGEBRA_DEPLOY_KEY }}
+          external_repository: universalalgebra/agda-algebras
           publish_dir: ./site
           publish_branch: gh-pages
-          # Attach the custom domain only at the ualib.org cutover:
-          # cname: ualib.org
+          # Writes the custom-domain CNAME into the published site on every deploy.
+          cname: agda-algebras.universalalgebra.org

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Agda 2.8.0](https://img.shields.io/badge/Agda-2.8.0-purple.svg)](https://github.com/agda/agda/releases/tag/v2.8.0)
 [![stdlib 2.3](https://img.shields.io/badge/stdlib-2.3-orange.svg)](https://github.com/agda/agda-stdlib/releases/tag/v2.3)
 
-A formalization of universal algebra in [Agda][], built on the [Agda standard library][].  The library defines algebras, homomorphisms, congruences, terms, varieties, and the equational logic that underlies them, with a fully constructive proof of [Birkhoff's HSP theorem](https://ualib.org/Setoid.Varieties.HSP.html#proof-of-the-hsp-theorem) at the centre.  It is being developed both as a working substrate for research in universal algebra and as a high-quality training corpus of Agda proofs for machine learning on formal mathematics.
+A formalization of universal algebra in [Agda][], built on the [Agda standard library][].  The library defines algebras, homomorphisms, congruences, terms, varieties, and the equational logic that underlies them, with a fully constructive proof of [Birkhoff's HSP theorem](https://agda-algebras.universalalgebra.org/Setoid/Varieties/HSP/#proof-of-the-hsp-theorem) at the centre.  It is being developed both as a working substrate for research in universal algebra and as a high-quality training corpus of Agda proofs for machine learning on formal mathematics.
 
 > **Status.** Version 3.0 is under active reconstruction on `master`.  The library currently targets Agda 2.8.0 and standard-library 2.3.  Expect breaking changes until 3.0 is released; see [`docs/GITHUB_PROJECT.md`](docs/GITHUB_PROJECT.md) for the milestone plan and [`CHANGELOG.md`](CHANGELOG.md) for what has landed so far.
 
@@ -36,7 +36,7 @@ The first `nix develop` downloads and builds the pinned Agda and standard librar
 
 ## Documentation
 
-+  Rendered documentation: [https://ualib.org](https://ualib.org).
++  Rendered documentation: [https://agda-algebras.universalalgebra.org](https://agda-algebras.universalalgebra.org) (the pre-3.0 site is archived at [ualib.org](https://ualib.org)).
 +  Installation guide: [`INSTALL.md`](INSTALL.md).
 +  Contributor's guide: [`CONTRIBUTING.md`](CONTRIBUTING.md).
 +  Style guide: [`docs/STYLE_GUIDE.md`](docs/STYLE_GUIDE.md).
@@ -129,7 +129,7 @@ The archival reference is the v2.0.1 Zenodo deposit, made for the TYPES 2021 sub
 
 While the 3.0 reconstruction is in development, please cite the GitHub repository directly and pin a commit hash for reproducibility.  A new Zenodo DOI will be minted at the v3.0 release.
 
-To cite the [formalization of Birkhoff's HSP theorem](https://ualib.org/Setoid.Varieties.HSP.html#proof-of-the-hsp-theorem):
+To cite the [formalization of Birkhoff's HSP theorem](https://agda-algebras.universalalgebra.org/Setoid/Varieties/HSP/#proof-of-the-hsp-theorem):
 
 ```bibtex
 @article{DeMeo:2021,
@@ -147,7 +147,7 @@ To cite the [formalization of Birkhoff's HSP theorem](https://ualib.org/Setoid.V
 }
 ```
 
-The current canonical setoid-based formalization of Birkhoff's theorem is in the [Setoid.Varieties.HSP][] module, with the proof anchor in the rendered HTML at [https://ualib.org/Setoid.Varieties.HSP.html#proof-of-the-hsp-theorem](https://ualib.org/Setoid.Varieties.HSP.html#proof-of-the-hsp-theorem).
+The current canonical setoid-based formalization of Birkhoff's theorem is in the [Setoid.Varieties.HSP][] module, with the proof anchor in the rendered site at [https://agda-algebras.universalalgebra.org/Setoid/Varieties/HSP/#proof-of-the-hsp-theorem](https://agda-algebras.universalalgebra.org/Setoid/Varieties/HSP/#proof-of-the-hsp-theorem).
 
 ---
 

--- a/docs/_links.md
+++ b/docs/_links.md
@@ -3,7 +3,7 @@
 <!-- pymdownx.snippets auto-appends this file to every page so reference-style -->
 <!-- links resolve site-wide without a per-page include directive.  Internal -->
 <!-- targets are ROOT-RELATIVE so cross-references work under `mkdocs serve` -->
-<!-- and at https://ualib.org/ alike.  The module sections are GENERATED from -->
+<!-- and at the deployed site alike.  The module sections are GENERATED from -->
 <!-- the src/ tree by scripts/python/gen_links.py; re-run it rather than -->
 <!-- editing those entries by hand. -->
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
 
       # ---- MkDocs documentation toolchain ---------------------------------
       # The rendering pipeline (ADR-007).  `make site` / `make serve` build
-      # the ualib.org site directly from the `.lagda.md` sources — no
+      # the documentation site directly from the `.lagda.md` sources — no
       # `agda --html` step — relying on kramdown attribute spans + custom CSS
       # for inline Agda highlighting.  Pinning the whole MkDocs stack here (in
       # one Python environment) makes `nix develop --command make site`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 # =============================================================================
 # agda-algebras — MkDocs (Material) site configuration
 # -----------------------------------------------------------------------------
-# The rendering pipeline for ualib.org (ADR-007).  The site is built directly
+# The rendering pipeline for agda-algebras.universalalgebra.org (ADR-007).  The
+# site is built directly
 # from the `.lagda.md` sources — no `agda --html` step.  Inline Agda terms are
 # kramdown attribute spans (`Algebra`{.AgdaRecord}) coloured by
 # docs/stylesheets/custom.css; the module tree and navigation are mounted by
@@ -12,7 +13,7 @@
 # =============================================================================
 
 site_name: The Agda Universal Algebra Library
-site_url: https://ualib.org/
+site_url: https://agda-algebras.universalalgebra.org/
 site_description: >-
   A formalization of universal algebra in dependent type theory — signatures,
   algebras, homomorphisms, terms, subalgebras, varieties, and a
@@ -122,7 +123,8 @@ plugins:
       on_error_fail: false
   - redirects:
       # Legacy flat `Module.Submodule.html` URLs → new directory URLs are added
-      # at the ualib.org cutover (see PR #295 checklist).  Empty for now so the
+      # at the cutover (see #430 checklist).  These resolve on the parked archive
+      # at ualib.org; the map here is for the new host.  Empty for now so the
       # plugin is wired and ready without inventing redirects prematurely.
       redirect_maps: {}
 

--- a/scripts/python/gen_links.py
+++ b/scripts/python/gen_links.py
@@ -8,7 +8,7 @@ module half of that file in sync with the tree by hand is error-prone (it had
 fallen ~130 entries behind), so this tool regenerates it:
 
   + one `[Dotted.Module]: /Slashed/Module/` per module under src/ (root-relative
-    so cross-references work under `mkdocs serve` and at ualib.org alike);
+    so cross-references work under `mkdocs serve` and at the deployed site alike);
   + one `[Slashed/Module.lagda]: <github>/src/Slashed/Module.lagda.md` per module
     for the "view the source" links some prose uses;
   + the external links (and a few fixed library-name / concept links) carried
@@ -35,7 +35,7 @@ HEADER = """\
 <!-- pymdownx.snippets auto-appends this file to every page so reference-style -->
 <!-- links resolve site-wide without a per-page include directive.  Internal -->
 <!-- targets are ROOT-RELATIVE so cross-references work under `mkdocs serve` -->
-<!-- and at https://ualib.org/ alike.  The module sections are GENERATED from -->
+<!-- and at the deployed site alike.  The module sections are GENERATED from -->
 <!-- the src/ tree by scripts/python/gen_links.py; re-run it rather than -->
 <!-- editing those entries by hand. -->
 """

--- a/scripts/python/mkdocs_hooks.py
+++ b/scripts/python/mkdocs_hooks.py
@@ -2,7 +2,7 @@
 
 `on_page_markdown` rewrites the *repo-relative* links that the prose uses for
 GitHub viewing into the site's URL scheme, so cross-references resolve both in
-`mkdocs serve` and at ualib.org:
+`mkdocs serve` and at the deployed site:
 
     ](src/Setoid/Varieties/HSP.lagda.md#…)  ->  ](/Setoid/Varieties/HSP/#…)
     ](docs/adr/001-setoid-as-canonical.md)  ->  ](/adr/001-setoid-as-canonical/)

--- a/src/Overture/Preface.lagda.md
+++ b/src/Overture/Preface.lagda.md
@@ -72,7 +72,7 @@ The library is a working substrate for active mathematical research, not only a 
 
 Readers approaching the library for the first time will typically want one of a few entry points.
 
-+  For the headline result, see the [Proof of the HSP Theorem](https://ualib.org/Setoid.Varieties.HSP.html#proof-of-the-hsp-theorem) in [Setoid.Varieties.HSP][], or the single-file [Demos.HSP][] rendition written to accompany the TYPES 2021 paper.
++  For the headline result, see the [Proof of the HSP Theorem](https://agda-algebras.universalalgebra.org/Setoid/Varieties/HSP/#proof-of-the-hsp-theorem) in [Setoid.Varieties.HSP][], or the single-file [Demos.HSP][] rendition written to accompany the TYPES 2021 paper.
 +  For the core definitions, see [Setoid.Algebras.Basic][], [Setoid.Homomorphisms][], [Setoid.Subalgebras][], and [Setoid.Varieties][].
 +  For the library's layered structure, the milestone plan, and the roadmap, see [`docs/GITHUB_PROJECT.md`](https://github.com/ualib/agda-algebras/blob/master/docs/GITHUB_PROJECT.md).
 +  For the style guide and contribution conventions, see [`docs/STYLE_GUIDE.md`](https://github.com/ualib/agda-algebras/blob/master/docs/STYLE_GUIDE.md) and [`CONTRIBUTING.md`](https://github.com/ualib/agda-algebras/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Repoints the documentation deploy at the relocated home — the new MkDocs site is cross-deployed to `universalalgebra/agda-algebras` and served at `agda-algebras.universalalgebra.org`, while `ualib/agda-algebras`'s own `gh-pages` keeps the parked pre-3.0 archive at `ualib.org`.  This is the code half of the #430 cutover; the standing-up of the new home (repo, deploy key, DNS, Pages) and the deprecation banner remain maintainer-only steps.

## Related issues

Part of #430.

(The ADR-007 amendment recording this hosting decision already landed on `master` in `ce5b98b`; this PR carries the workflow + config changes that implement it.)

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [ ] Refactor / cleanup (user-facing/API change)
- [ ] Refactor / cleanup (no user-facing change)
- [x] Documentation
- [x] Infrastructure (CI, Nix, build)
- [ ] Other

## What changed

+  **`.github/workflows/docs.yml`** — the deploy step now cross-deploys the built `./site` to the `gh-pages` branch of `universalalgebra/agda-algebras` via `peaceiris/actions-gh-pages` with an SSH deploy key (`UNIVERSALALGEBRA_DEPLOY_KEY`) and `cname: agda-algebras.universalalgebra.org`, instead of publishing to this repo's own `gh-pages`.  This makes the parked `ualib.org` archive durable: the workflow no longer touches it.  `permissions` drops to `contents: read`, since the cross-deploy authenticates over SSH rather than the `GITHUB_TOKEN`.
+  **`mkdocs.yml`** — `site_url` is set to the new subdomain; the `redirects` comment now tracks #430 and notes the legacy flat URLs resolve on the parked `ualib.org` archive.
+  **`README.md`** and **`src/Overture/Preface.lagda.md`** — the live "rendered documentation" and Birkhoff HSP-proof links point at the new host (directory URLs), with `ualib.org` kept as the labelled pre-3.0 archive.  The v2.0.1 Zenodo citation note and the TYPES2021 paper artifacts stay pointed at `ualib.org` as genuine archive references.
+  **`scripts/python/gen_links.py`**, the generated **`docs/_links.md`** header, **`scripts/python/mkdocs_hooks.py`**, and **`flake.nix`** — internal pipeline comments now say "the deployed site" rather than naming `ualib.org`, matching the ADR-007 Decision 5 rewording.

## Checklist

- [x] `make check` passes locally under `nix develop`.  *(The only `src/` change is a prose-link URL in `Overture.Preface`, which type-checks — verified with `agda src/Overture/Preface.lagda.md`.  No Agda semantics changed, so the full type-check was not re-run.)*
- [x] New public definitions have prose comment blocks.  *(n/a — no new definitions.)*
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches `src/`, it targets a supported area such as `Classical/`, `Cubical/`, `Demos/`, `Examples/`, `Exercises/`, `Overture/`, or `Setoid/`.  *(`Overture/`, prose only.)*
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.  *(n/a — no new notation.)*

## Notes for reviewers

+  **Do not merge until the new home + secret exist.**  The cross-deploy needs `UNIVERSALALGEBRA_DEPLOY_KEY` (a secret on this repo) and the `universalalgebra/agda-algebras` repo with the matching deploy key.  Once `docs.yml` is on `master`, every push deploys there; if the secret/repo are missing the deploy step fails (but the build still gates PRs).  The remaining maintainer steps are tracked on #430:
   1.  Create `universalalgebra/agda-algebras`; generate an SSH deploy-key pair; add the public half to its **Deploy keys** (write access); add the private half as `UNIVERSALALGEBRA_DEPLOY_KEY` here.
   2.  DNS `CNAME` `agda-algebras` → `universalalgebra.github.io`; Pages → source `gh-pages`, custom domain `agda-algebras.universalalgebra.org`, enforce HTTPS.
   3.  Verify the live site; then add the dated deprecation banner to the parked `ualib.org` (a direct edit to this repo's `gh-pages` `index.html`, since the Jekyll source was removed from `master`), and populate the `mkdocs-redirects` map.
+  This branch needed the GitHub `workflow` OAuth scope to push `docs.yml`; that commit was applied by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ97WrKKgWra8jU7X4Gv41)_