### PR TITLE
[M4-17] Normalize module-body indentation to two spaces (into #435)

### DIFF
--- a/src/Examples/FunctionTypeBijections.lagda.md
+++ b/src/Examples/FunctionTypeBijections.lagda.md
@@ -42,21 +42,21 @@ The first piece of infrastructure is the type of bijections between two types, i
 
 ```agda
 record Bijection (A : Type a)(B : Type b) : Type (a ⊔ b) where
- field
-  to       : A → B
-  from     : B → A
-  to-from  : to ∘ from ≡ id
-  from-to  : from ∘ to ≡ id
+  field
+   to       : A → B
+   from     : B → A
+   to-from  : to ∘ from ≡ id
+   from-to  : from ∘ to ≡ id
 
 ∣_∣=∣_∣ : (A : Type a)(B : Type b) → Type (a ⊔ b)
 ∣ A ∣=∣ B ∣ = Bijection A B
 
 record PointwiseBijection (A : Type a)(B : Type b) : Type (a ⊔ b) where
- field
-  to       : A → B
-  from     : B → A
-  to-from  : to ∘ from ≈ id
-  from-to  : from ∘ to ≈ id
+  field
+   to       : A → B
+   from     : B → A
+   to-from  : to ∘ from ≈ id
+   from-to  : from ∘ to ≈ id
 
 ∣_∣≈∣_∣ : (A : Type a)(B : Type b) → Type (a ⊔ b)
 ∣ A ∣≈∣ B ∣ = PointwiseBijection A B
@@ -66,19 +66,19 @@ uncurry₀ x y = x , y
 
 module _ {A : Type a} {B : Type b} where
 
- Curry : ((A × A) → B) → A → A → B
- Curry f x y = f (uncurry₀ x y)
+  Curry : ((A × A) → B) → A → A → B
+  Curry f x y = f (uncurry₀ x y)
 
- Uncurry : (A → A → B) → A × A → B
- Uncurry f (x , y) = f x y
+  Uncurry : (A → A → B) → A × A → B
+  Uncurry f (x , y) = f x y
 ```
 
 The product and curried forms enjoy a *definitional* bijection — the round-trip composites reduce to `id` on the nose.
 
 ```agda
- A×A→B≅A→A→B : ∣ (A × A → B) ∣=∣ (A → A → B) ∣
- A×A→B≅A→A→B = record  { to = Curry ; from = Uncurry
-                       ; to-from = refl ; from-to = refl }
+  A×A→B≅A→A→B : ∣ (A × A → B) ∣=∣ (A → A → B) ∣
+  A×A→B≅A→A→B = record  { to = Curry ; from = Uncurry
+                        ; to-from = refl ; from-to = refl }
 ```
 
 #### Fin-indexed encodings
@@ -87,49 +87,49 @@ We now introduce the `Fin`-indexed encoding `Fin 2 → A` and transformations be
 
 ```agda
 module _ {A : Type a} where
- open Fin renaming (zero to z ; suc to s)
+  open Fin renaming (zero to z ; suc to s)
 
- A×A→Fin2A : A × A → Fin 2 → A
- A×A→Fin2A (x , y) z = x
- A×A→Fin2A (x , y) (s z) = y
+  A×A→Fin2A : A × A → Fin 2 → A
+  A×A→Fin2A (x , y) z = x
+  A×A→Fin2A (x , y) (s z) = y
 
- Fin2A→A×A : (Fin 2 → A) → A × A
- Fin2A→A×A u = u z , u (s z)
+  Fin2A→A×A : (Fin 2 → A) → A × A
+  Fin2A→A×A u = u z , u (s z)
 
- Fin2A~A×A : {A : Type a} → Fin2A→A×A ∘ A×A→Fin2A ≡ id
- Fin2A~A×A = refl
+  Fin2A~A×A : {A : Type a} → Fin2A→A×A ∘ A×A→Fin2A ≡ id
+  Fin2A~A×A = refl
 
- A×A~Fin2A-ptws : ∀ u → (A×A→Fin2A (Fin2A→A×A u)) ≈ u
- A×A~Fin2A-ptws u z = refl
- A×A~Fin2A-ptws u (s z) = refl
+  A×A~Fin2A-ptws : ∀ u → (A×A→Fin2A (Fin2A→A×A u)) ≈ u
+  A×A~Fin2A-ptws u z = refl
+  A×A~Fin2A-ptws u (s z) = refl
 
- A→A→Fin2A : A → A → Fin 2 → A
- A→A→Fin2A x y z = x
- A→A→Fin2A x y (s _) = y
+  A→A→Fin2A : A → A → Fin 2 → A
+  A→A→Fin2A x y z = x
+  A→A→Fin2A x y (s _) = y
 
- A→A→Fin2A' : A → A → Fin 2 → A
- A→A→Fin2A' x y = u
-  where
-  u : Fin 2 → A
-  u z = x
-  u (s z) = y
+  A→A→Fin2A' : A → A → Fin 2 → A
+  A→A→Fin2A' x y = u
+   where
+   u : Fin 2 → A
+   u z = x
+   u (s z) = y
 
- A→A→Fin2A-ptws-agree : (x y : A) → ∀ i → (A→A→Fin2A x y) i ≡ (A→A→Fin2A' x y) i
- A→A→Fin2A-ptws-agree x y z = refl
- A→A→Fin2A-ptws-agree x y (s z) = refl
+  A→A→Fin2A-ptws-agree : (x y : A) → ∀ i → (A→A→Fin2A x y) i ≡ (A→A→Fin2A' x y) i
+  A→A→Fin2A-ptws-agree x y z = refl
+  A→A→Fin2A-ptws-agree x y (s z) = refl
 
- A→A~Fin2A-ptws : (v : Fin 2 → A) → ∀ i → A→A→Fin2A (v z) (v (s z)) i ≡ v i
- A→A~Fin2A-ptws v z = refl
- A→A~Fin2A-ptws v (s z) = refl
+  A→A~Fin2A-ptws : (v : Fin 2 → A) → ∀ i → A→A→Fin2A (v z) (v (s z)) i ≡ v i
+  A→A~Fin2A-ptws v z = refl
+  A→A~Fin2A-ptws v (s z) = refl
 
- Fin2A : (Fin 2 → A) → Fin 2 → A
- Fin2A u z = u z
- Fin2A u (s z) = u (s z)
- Fin2A u (s (s ()))
+  Fin2A : (Fin 2 → A) → Fin 2 → A
+  Fin2A u z = u z
+  Fin2A u (s z) = u (s z)
+  Fin2A u (s (s ()))
 
- Fin2A≡ : (u : Fin 2 → A) → ∀ i → (Fin2A u) i ≡ u i
- Fin2A≡ u z = refl
- Fin2A≡ u (s z) = refl
+  Fin2A≡ : (u : Fin 2 → A) → ∀ i → (Fin2A u) i ≡ u i
+  Fin2A≡ u z = refl
+  Fin2A≡ u (s z) = refl
 ```
 
 #### Failed bijections
@@ -138,40 +138,40 @@ We can establish that `CurryFin2 ∘ UncurryFin2 ≡ id` reduces to `refl`, but 
 
 ```agda
 module _ {A : Type a} {B : Type b} where
- open Fin renaming (zero to z ; suc to s)
+  open Fin renaming (zero to z ; suc to s)
 
- lemma : (u : Fin 2 → A) → u ≈ (λ {z → u z ; (s z) → u (s z)})
- lemma u z = refl
- lemma u (s z) = refl
+  lemma : (u : Fin 2 → A) → u ≈ (λ {z → u z ; (s z) → u (s z)})
+  lemma u z = refl
+  lemma u (s z) = refl
 
- CurryFin2 : ((Fin 2 → A) → B) → A → A → B
- CurryFin2 f x y = f (A→A→Fin2A x y)
+  CurryFin2 : ((Fin 2 → A) → B) → A → A → B
+  CurryFin2 f x y = f (A→A→Fin2A x y)
 
- UncurryFin2 : (A → A → B) → ((Fin 2 → A) → B)
- UncurryFin2 f u = f (u z) (u (s z))
+  UncurryFin2 : (A → A → B) → ((Fin 2 → A) → B)
+  UncurryFin2 f u = f (u z) (u (s z))
 
- CurryFin2~UncurryFin2 : CurryFin2 ∘ UncurryFin2 ≡ id
- CurryFin2~UncurryFin2 = refl
+  CurryFin2~UncurryFin2 : CurryFin2 ∘ UncurryFin2 ≡ id
+  CurryFin2~UncurryFin2 = refl
 
- CurryFin3 : {A : Type a} → ((Fin 3 → A) → B) → A → A → A → B
- CurryFin3 {A = A} f x₁ x₂ x₃ = f u
-  where
-  u : Fin 3 → A
-  u z = x₁
-  u (s z) = x₂
-  u (s (s z)) = x₃
+  CurryFin3 : {A : Type a} → ((Fin 3 → A) → B) → A → A → A → B
+  CurryFin3 {A = A} f x₁ x₂ x₃ = f u
+   where
+   u : Fin 3 → A
+   u z = x₁
+   u (s z) = x₂
+   u (s (s z)) = x₃
 
- UncurryFin3 : (A → A → A → B) → ((Fin 3 → A) → B)
- UncurryFin3 f u = f (u z) (u (s z)) (u (s (s z)))
+  UncurryFin3 : (A → A → A → B) → ((Fin 3 → A) → B)
+  UncurryFin3 f u = f (u z) (u (s z)) (u (s (s z)))
 
- Fin2A→B-to-A×A→B : ((Fin 2 → A) → B) → A × A → B
- Fin2A→B-to-A×A→B f = f ∘ A×A→Fin2A
+  Fin2A→B-to-A×A→B : ((Fin 2 → A) → B) → A × A → B
+  Fin2A→B-to-A×A→B f = f ∘ A×A→Fin2A
 
- A×A→B-to-Fin2A→B : (A × A → B) → ((Fin 2 → A) → B)
- A×A→B-to-Fin2A→B f = f ∘ Fin2A→A×A
+  A×A→B-to-Fin2A→B : (A × A → B) → ((Fin 2 → A) → B)
+  A×A→B-to-Fin2A→B f = f ∘ Fin2A→A×A
 
- Fin2A→B~A×A→B : Fin2A→B-to-A×A→B ∘ A×A→B-to-Fin2A→B ≡ id
- Fin2A→B~A×A→B = refl
+  Fin2A→B~A×A→B : Fin2A→B-to-A×A→B ∘ A×A→B-to-Fin2A→B ≡ id
+  Fin2A→B~A×A→B = refl
 ```
 
 The symmetric statement `A×A→B-to-Fin2A→B ∘ Fin2A→B-to-A×A→B ≡ id` fails for the same η-expansion reason: it would require `λ u → (λ {z → u z; (s z) → u (s z)}) ≡ u`, which Agda does not reduce.

--- a/src/Examples/PolynomialFunctors/Functors.lagda.md
+++ b/src/Examples/PolynomialFunctors/Functors.lagda.md
@@ -66,10 +66,10 @@ infixl 6 _⊕_
 infixr 7 _⊗_
 
 data Functor₀ : Type (lsuc ℓ₀) where
- Id : Functor₀
- Const : Type → Functor₀
- _⊕_ : Functor₀ → Functor₀ → Functor₀
- _⊗_ : Functor₀ → Functor₀ → Functor₀
+  Id : Functor₀
+  Const : Type → Functor₀
+  _⊕_ : Functor₀ → Functor₀ → Functor₀
+  _⊗_ : Functor₀ → Functor₀ → Functor₀
 
 [_]₀ : Functor₀ → Type → Type
 [ Id ]₀ B = B
@@ -78,10 +78,10 @@ data Functor₀ : Type (lsuc ℓ₀) where
 [ F ⊗ G ]₀ B = [ F ]₀ B × [ G ]₀ B
 
 data Functor {ℓ : Level} : Type (lsuc ℓ) where
- Id : Functor
- Const : Type ℓ → Functor
- _⊕_ : Functor{ℓ} → Functor{ℓ} → Functor
- _⊗_ : Functor{ℓ} → Functor{ℓ} → Functor
+  Id : Functor
+  Const : Type ℓ → Functor
+  _⊕_ : Functor{ℓ} → Functor{ℓ} → Functor
+  _⊗_ : Functor{ℓ} → Functor{ℓ} → Functor
 
 [_]_ : Functor → Type α → Type α
 [ Id ] B = B
@@ -95,7 +95,7 @@ following datatype declaration.
 
 ```agda
 data μ_ (F : Functor) : Type where
- inn : [ F ] (μ F) → μ F
+  inn : [ F ] (μ F) → μ F
 ```
 
 An important example is the polymorphic list datatype.  The standard way to define
@@ -103,8 +103,8 @@ this in Agda is as follows:
 
 ```agda
 data list (A : Type) : Type ℓ₀ where
- [] : list A
- _∷_ : A → list A → list A
+  [] : list A
+  _∷_ : A → list A → list A
 ```
 
 We could instead define a `List` datatype by applying `μ` to a polynomial functor `L`
@@ -125,8 +125,8 @@ define the `Option` type.
 
 ```agda
 data Option (A : Type) : Type where
- some : A → Option A
- none : Option A
+  some : A → Option A
+  none : Option A
 
 _[_] : {A : Type} → List A → ℕ → Option A
 inn (inl x) [ n ] = none

--- a/src/Examples/Setoid/SubgroupLattice.lagda.md
+++ b/src/Examples/Setoid/SubgroupLattice.lagda.md
@@ -74,14 +74,14 @@ x ⊕ y = proj₁ x xor proj₁ y , proj₂ x xor proj₂ y
 
 V₄ : Algebra 0ℓ 0ℓ
 V₄ = record { Domain = setoid (Bool × Bool) ; Interp = interp }
- where
- interp : Func (⟨ Sig-Group ⟩ (setoid (Bool × Bool))) (setoid (Bool × Bool))
- interp ⟨$⟩ (∙-Op , args) = args 0F ⊕ args 1F
- interp ⟨$⟩ (ε-Op , _)  = false , false
- interp ⟨$⟩ (⁻¹-Op , args) = args 0F
- cong interp {∙-Op , _} {.∙-Op , _} (refl , a≈) = cong₂ _⊕_ (a≈ 0F) (a≈ 1F)
- cong interp {ε-Op , _} {.ε-Op , _} (refl , _) = refl
- cong interp {⁻¹-Op , _} {.⁻¹-Op , _} (refl , a≈) = a≈ 0F
+  where
+  interp : Func (⟨ Sig-Group ⟩ (setoid (Bool × Bool))) (setoid (Bool × Bool))
+  interp ⟨$⟩ (∙-Op , args) = args 0F ⊕ args 1F
+  interp ⟨$⟩ (ε-Op , _)  = false , false
+  interp ⟨$⟩ (⁻¹-Op , args) = args 0F
+  cong interp {∙-Op , _} {.∙-Op , _} (refl , a≈) = cong₂ _⊕_ (a≈ 0F) (a≈ 1F)
+  cong interp {ε-Op , _} {.ε-Op , _} (refl , _) = refl
+  cong interp {⁻¹-Op , _} {.⁻¹-Op , _} (refl , a≈) = a≈ 0F
 ```
 
 #### The three order-two subgroups {#the-subgroups}

--- a/src/Examples/Structures/Basic.lagda.md
+++ b/src/Examples/Structures/Basic.lagda.md
@@ -50,12 +50,12 @@ the ternary NAE-3-SAT relation, R = S³ - {(0,0,0), (1,1,1)} (where S = {0, 1}).
 
 ```agda
 data NAE3SAT : Pred (𝟚 × 𝟚 × 𝟚) 0ℓ where
- r1 : (𝟚.𝟎 , 𝟚.𝟎 , 𝟚.𝟏) ∈ NAE3SAT
- r2 : (𝟚.𝟎 , 𝟚.𝟏 , 𝟚.𝟎) ∈ NAE3SAT
- r3 : (𝟚.𝟎 , 𝟚.𝟏 , 𝟚.𝟏) ∈ NAE3SAT
- r4 : (𝟚.𝟏 , 𝟚.𝟎 , 𝟚.𝟎) ∈ NAE3SAT
- r5 : (𝟚.𝟏 , 𝟚.𝟎 , 𝟚.𝟏) ∈ NAE3SAT
- r6 : (𝟚.𝟏 , 𝟚.𝟏 , 𝟚.𝟎) ∈ NAE3SAT
+  r1 : (𝟚.𝟎 , 𝟚.𝟎 , 𝟚.𝟏) ∈ NAE3SAT
+  r2 : (𝟚.𝟎 , 𝟚.𝟏 , 𝟚.𝟎) ∈ NAE3SAT
+  r3 : (𝟚.𝟎 , 𝟚.𝟏 , 𝟚.𝟏) ∈ NAE3SAT
+  r4 : (𝟚.𝟏 , 𝟚.𝟎 , 𝟚.𝟎) ∈ NAE3SAT
+  r5 : (𝟚.𝟏 , 𝟚.𝟎 , 𝟚.𝟏) ∈ NAE3SAT
+  r6 : (𝟚.𝟏 , 𝟚.𝟏 , 𝟚.𝟎) ∈ NAE3SAT
 
 nae3sat : structure S∅    -- (no operation symbols)
                     S0001 -- (one ternary relation symbol)

--- a/src/Exercises/Complexity/FiniteCSP.lagda.md
+++ b/src/Exercises/Complexity/FiniteCSP.lagda.md
@@ -79,25 +79,25 @@ constantly-1 map) is such a homomorphism.  Let's prove this formally.
 ```agda
 module solution-2-1 where
 
- -- The (purely) relational structure with
- -- + 2-element domain,
- -- + one binary relation Rᵃ := \{(0,0), (1, 1)\}
+  -- The (purely) relational structure with
+  -- + 2-element domain,
+  -- + one binary relation Rᵃ := \{(0,0), (1, 1)\}
 
- data Rᵃ : Pred (𝟚 × 𝟚) ℓ₀ where
-  r1 : (𝟚.𝟎 , 𝟚.𝟎 ) ∈ Rᵃ
-  r2 : (𝟚.𝟏 , 𝟚.𝟏 ) ∈ Rᵃ
+  data Rᵃ : Pred (𝟚 × 𝟚) ℓ₀ where
+   r1 : (𝟚.𝟎 , 𝟚.𝟎 ) ∈ Rᵃ
+   r2 : (𝟚.𝟏 , 𝟚.𝟏 ) ∈ Rᵃ
 
- 𝑨 : structure S∅    -- (no operation symbols)
-               S001  -- (one binary relation symbol)
+  𝑨 : structure S∅    -- (no operation symbols)
+                S001  -- (one binary relation symbol)
 
- 𝑨 = record { carrier = 𝟚
-            ; op = λ ()
-            ; rel = λ _ x → ((x 𝟚.𝟎) , (x 𝟚.𝟏)) ∈ Rᵃ
-            }
+  𝑨 = record { carrier = 𝟚
+             ; op = λ ()
+             ; rel = λ _ x → ((x 𝟚.𝟎) , (x 𝟚.𝟏)) ∈ Rᵃ
+             }
 
- -- Claim: Given an arbitrary 𝑩 in the signatures Sig∅ Sig001, we can construct a homomorphism from 𝑩 to 𝑨.
- claim : (𝑩 : structure {ℓ₀}{ℓ₀}{ℓ₀}{ℓ₀} S∅ S001 {ℓ₀}{ℓ₀}) → hom 𝑩 𝑨
- claim 𝑩 = (λ x → 𝟚.𝟎) , (λ _ _ _ → r1) , λ ()
+  -- Claim: Given an arbitrary 𝑩 in the signatures Sig∅ Sig001, we can construct a homomorphism from 𝑩 to 𝑨.
+  claim : (𝑩 : structure {ℓ₀}{ℓ₀}{ℓ₀}{ℓ₀} S∅ S001 {ℓ₀}{ℓ₀}) → hom 𝑩 𝑨
+  claim 𝑩 = (λ x → 𝟚.𝟎) , (λ _ _ _ → r1) , λ ()
 ```
 
 In general, whenever the template structure 𝑨 has a one-element subuniverse, say, \{ a \},
@@ -125,44 +125,44 @@ to check each pair (x, y) ∈ Rᵇ and make sure that the following two implicat
 ```agda
 module solution-2-2 where
 
- -- The (purely) relational structure with
- -- + 2-element domain,
- -- + one binary relation: Rᵃ := { (0,0), (1, 1) }
- -- + two unary relations: C₀ᵃ := { 0 } , C₁ᵃ := { 1 }
+  -- The (purely) relational structure with
+  -- + 2-element domain,
+  -- + one binary relation: Rᵃ := { (0,0), (1, 1) }
+  -- + two unary relations: C₀ᵃ := { 0 } , C₁ᵃ := { 1 }
 
- data Rᵃ : Pred (𝟚 × 𝟚) ℓ₀ where
-  r1 : (𝟚.𝟎 , 𝟚.𝟎 ) ∈ Rᵃ
-  r2 : (𝟚.𝟏 , 𝟚.𝟏 ) ∈ Rᵃ
+  data Rᵃ : Pred (𝟚 × 𝟚) ℓ₀ where
+   r1 : (𝟚.𝟎 , 𝟚.𝟎 ) ∈ Rᵃ
+   r2 : (𝟚.𝟏 , 𝟚.𝟏 ) ∈ Rᵃ
 
- data C₀ᵃ : Pred 𝟚 ℓ₀ where
-  c₀ : 𝟚.𝟎 ∈ C₀ᵃ
+  data C₀ᵃ : Pred 𝟚 ℓ₀ where
+   c₀ : 𝟚.𝟎 ∈ C₀ᵃ
 
- data C₁ᵃ : Pred 𝟚 ℓ₀ where
-  c₁ : 𝟚.𝟏 ∈ C₁ᵃ
+  data C₁ᵃ : Pred 𝟚 ℓ₀ where
+   c₁ : 𝟚.𝟏 ∈ C₁ᵃ
 
- 𝑨 : structure S∅    -- (no operations)
-               S021  -- (two unary relations and one binary relation)
+  𝑨 : structure S∅    -- (no operations)
+                S021  -- (two unary relations and one binary relation)
 
- 𝑨 = record { carrier = 𝟚
-            ; op = λ ()
-            ; rel = rels
-            }
-            where
-            rels : (r : 𝟛) → Rel 𝟚 (arity S021 r)
-            rels 𝟛.𝟎 x = ((x 𝟚.𝟎) , (x 𝟚.𝟏)) ∈ Rᵃ
-            rels 𝟛.𝟏 x = x 𝟎 ∈ C₀ᵃ
-            rels 𝟛.𝟐 x = x 𝟎 ∈ C₁ᵃ
+  𝑨 = record { carrier = 𝟚
+             ; op = λ ()
+             ; rel = rels
+             }
+             where
+             rels : (r : 𝟛) → Rel 𝟚 (arity S021 r)
+             rels 𝟛.𝟎 x = ((x 𝟚.𝟎) , (x 𝟚.𝟏)) ∈ Rᵃ
+             rels 𝟛.𝟏 x = x 𝟎 ∈ C₀ᵃ
+             rels 𝟛.𝟐 x = x 𝟎 ∈ C₁ᵃ
 
- -- Claim: Given an arbitrary 𝑩 in the signatures S∅ S021, we can construct a homomorphism from 𝑩 to 𝑨.
- -- claim :  (𝑩 : structure S∅ S021 {ℓ₀}{ℓ₀})
- --  →       (∀ (x : 𝟚 → carrier 𝑩)
- --           → (rel 𝑩) 𝟛.𝟎 x  -- if ((x 𝟚.𝟎) , (x 𝟚.𝟏)) ∈ Rᵇ, then...
- --           → ((rel 𝑩) 𝟛.𝟏 (λ _ → (x 𝟚.𝟎)) → ¬ (rel 𝑩) 𝟛.𝟐 (λ _ → (x 𝟚.𝟏)))
- --             × ((rel 𝑩) 𝟛.𝟏 (λ _ → (x 𝟚.𝟏)) → ¬ (rel 𝑩) 𝟛.𝟐 (λ _ → (x 𝟚.𝟎)))
- --          --  × (x 𝟚.𝟎 ∈ C₁ᵇ → x 𝟚.𝟏 ∉ C₀ᵇ))
- --          )
- --  →       hom 𝑩 𝑨
- -- claim 𝑩 x = {!!}
+  -- Claim: Given an arbitrary 𝑩 in the signatures S∅ S021, we can construct a homomorphism from 𝑩 to 𝑨.
+  -- claim :  (𝑩 : structure S∅ S021 {ℓ₀}{ℓ₀})
+  --  →       (∀ (x : 𝟚 → carrier 𝑩)
+  --           → (rel 𝑩) 𝟛.𝟎 x  -- if ((x 𝟚.𝟎) , (x 𝟚.𝟏)) ∈ Rᵇ, then...
+  --           → ((rel 𝑩) 𝟛.𝟏 (λ _ → (x 𝟚.𝟎)) → ¬ (rel 𝑩) 𝟛.𝟐 (λ _ → (x 𝟚.𝟏)))
+  --             × ((rel 𝑩) 𝟛.𝟏 (λ _ → (x 𝟚.𝟏)) → ¬ (rel 𝑩) 𝟛.𝟐 (λ _ → (x 𝟚.𝟎)))
+  --          --  × (x 𝟚.𝟎 ∈ C₁ᵇ → x 𝟚.𝟏 ∉ C₀ᵇ))
+  --          )
+  --  →       hom 𝑩 𝑨
+  -- claim 𝑩 x = {!!}
 ```
 
 (The remainder are "todo.")

--- a/src/Setoid/Algebras/Products.lagda.md
+++ b/src/Setoid/Algebras/Products.lagda.md
@@ -44,14 +44,14 @@ open Algebra
 ⨅ : {I : Type ι }(𝒜 : I → Algebra α ρ) → Algebra (α ⊔ ι) (ρ ⊔ ι)
 
 Domain (⨅ {I} 𝒜) =
- record  { Carrier = ∀ i → 𝕌[ 𝒜 i ]
-         ; _≈_ = λ a b → ∀ i → 𝔻[ 𝒜 i ] ._≈_ (a i) (b i)
-         ; isEquivalence =
-            record  { refl   = λ i      → reflE   (isEqv 𝔻[ 𝒜 i ])
-                    ; sym    = λ x i    → symE    (isEqv 𝔻[ 𝒜 i ])(x i)
-                    ; trans  = λ x y i  → transE  (isEqv 𝔻[ 𝒜 i ])(x i)(y i)
-                    }
-         }
+  record  { Carrier = ∀ i → 𝕌[ 𝒜 i ]
+          ; _≈_ = λ a b → ∀ i → 𝔻[ 𝒜 i ] ._≈_ (a i) (b i)
+          ; isEquivalence =
+             record  { refl   = λ i      → reflE   (isEqv 𝔻[ 𝒜 i ])
+                     ; sym    = λ x i    → symE    (isEqv 𝔻[ 𝒜 i ])(x i)
+                     ; trans  = λ x y i  → transE  (isEqv 𝔻[ 𝒜 i ])(x i)(y i)
+                     }
+          }
 
 Interp (⨅ {I} 𝒜) ⟨$⟩ (f , a) = λ i → (f ^ 𝒜 i) (flip a i)
 cong (Interp (⨅ {I} 𝒜)) (refl , f=g ) = λ i → cong  (Interp (𝒜 i)) (refl , flip f=g i )
@@ -64,14 +64,14 @@ cong (Interp (⨅ {I} 𝒜)) (refl , f=g ) = λ i → cong  (Interp (𝒜 i)) (r
 ```agda
 module _ {𝒦 : Pred (Algebra α ρ) (ov α)} where
 
- ℑ : Type (ov (α ⊔ ρ))
- ℑ = Σ[ 𝑨 ∈ (Algebra α ρ) ] 𝑨 ∈ 𝒦
+  ℑ : Type (ov (α ⊔ ρ))
+  ℑ = Σ[ 𝑨 ∈ (Algebra α ρ) ] 𝑨 ∈ 𝒦
 
- 𝔄 : ℑ → Algebra α ρ
- 𝔄 i = (proj₁ i)
+  𝔄 : ℑ → Algebra α ρ
+  𝔄 i = (proj₁ i)
 
- class-product : Algebra (ov (α ⊔ ρ)) _
- class-product = ⨅ 𝔄
+  class-product : Algebra (ov (α ⊔ ρ)) _
+  class-product = ⨅ 𝔄
 ```
 
 
@@ -93,11 +93,11 @@ projection of a product of algebras over such an index type is surjective.
 
 ```agda
 module _  {I : Type ι}                  -- index type
-          {_≟_ : Decidable{A = I} _≡_}  -- with decidable equality
-          {𝒜 : I → Algebra α ρ}         -- indexed collection of algebras
-          {𝒜I : ∀ i → 𝕌[ 𝒜 i ] }        -- each of which is nonempty
-          where
+           {_≟_ : Decidable{A = I} _≡_}  -- with decidable equality
+           {𝒜 : I → Algebra α ρ}         -- indexed collection of algebras
+           {𝒜I : ∀ i → 𝕌[ 𝒜 i ] }        -- each of which is nonempty
+           where
 
- ProjAlgIsOnto : ∀{i} → Σ[ h ∈ (𝕌[ ⨅ 𝒜 ] → 𝕌[ 𝒜 i ]) ] onto h
- ProjAlgIsOnto {i} = (proj _≟_ 𝒜I i) , projIsOnto _≟_ 𝒜I
+  ProjAlgIsOnto : ∀{i} → Σ[ h ∈ (𝕌[ ⨅ 𝒜 ] → 𝕌[ 𝒜 i ]) ] onto h
+  ProjAlgIsOnto {i} = (proj _≟_ 𝒜I i) , projIsOnto _≟_ 𝒜I
 ```

--- a/src/Setoid/Functions/Basic.lagda.md
+++ b/src/Setoid/Functions/Basic.lagda.md
@@ -28,25 +28,25 @@ private variable α ρᵃ β ρᵇ γ ρᶜ : Level
 open _⟶_ renaming ( to to _⟨$⟩_ )
 
 _⊙_ :  {A : Setoid α ρᵃ}{B : Setoid β ρᵇ}{C : Setoid γ ρᶜ}
- →     B ⟶ C → A ⟶ B → A ⟶ C
+  →     B ⟶ C → A ⟶ B → A ⟶ C
 f ⊙ g = record { to = (_⟨$⟩_ f) ∘ (_⟨$⟩_ g); cong = (cong f) ∘ (cong g) }
 
 module _ {𝑨 : Setoid α ρᵃ} where
- open Lift ; open Level ; open Setoid using (_≈_)
- open Setoid 𝑨 using ( sym ; trans ) renaming (Carrier to A ; _≈_ to _≈ₐ_ ; refl to reflₐ)
+  open Lift ; open Level ; open Setoid using (_≈_)
+  open Setoid 𝑨 using ( sym ; trans ) renaming (Carrier to A ; _≈_ to _≈ₐ_ ; refl to reflₐ)
 
- 𝑙𝑖𝑓𝑡 : ∀ ℓ → Setoid (α ⊔ ℓ) ρᵃ
- 𝑙𝑖𝑓𝑡 ℓ = record  { Carrier = Lift ℓ A
-                ; _≈_ = λ x y → (lower x) ≈ₐ (lower y)
-                ; isEquivalence = record { refl = reflₐ ; sym = sym ; trans = trans }
-                }
+  𝑙𝑖𝑓𝑡 : ∀ ℓ → Setoid (α ⊔ ℓ) ρᵃ
+  𝑙𝑖𝑓𝑡 ℓ = record  { Carrier = Lift ℓ A
+                 ; _≈_ = λ x y → (lower x) ≈ₐ (lower y)
+                 ; isEquivalence = record { refl = reflₐ ; sym = sym ; trans = trans }
+                 }
 
- lift∼lower : (a : Lift β A) → (_≈_ (𝑙𝑖𝑓𝑡 β)) (lift (lower a)) a
- lift∼lower a = reflₐ
+  lift∼lower : (a : Lift β A) → (_≈_ (𝑙𝑖𝑓𝑡 β)) (lift (lower a)) a
+  lift∼lower a = reflₐ
 
- lower∼lift : ∀ a → (lower {α}{β}) (lift a) ≈ₐ a
- lower∼lift _ = reflₐ
+  lower∼lift : ∀ a → (lower {α}{β}) (lift a) ≈ₐ a
+  lower∼lift _ = reflₐ
 
- liftFunc : {ℓ : Level} → 𝑨 ⟶ 𝑙𝑖𝑓𝑡 ℓ
- liftFunc = record { to = lift ; cong = id }
+  liftFunc : {ℓ : Level} → 𝑨 ⟶ 𝑙𝑖𝑓𝑡 ℓ
+  liftFunc = record { to = lift ; cong = id }
 ```

--- a/src/Setoid/Functions/Bijective.lagda.md
+++ b/src/Setoid/Functions/Bijective.lagda.md
@@ -39,15 +39,15 @@ IsBijective f = IsInjective f × IsSurjective f
 
 BijInv : (f : 𝑨 ⟶ 𝑩) → IsBijective f → 𝑩 ⟶ 𝑨
 BijInv f (fM , fE) = record { to = finv ; cong = c }
- where
- finv : B → A
- finv b = Inv f fE
+  where
+  finv : B → A
+  finv b = Inv f fE
 
- handler :  ∀ {b₀ b₁}(i₀ : Image f ∋ b₀)(i₁ : Image f ∋ b₁)
-  →         b₀ ≈₂ b₁ → (Inv f i₀) ≈₁ (Inv f i₁)
+  handler :  ∀ {b₀ b₁}(i₀ : Image f ∋ b₀)(i₁ : Image f ∋ b₁)
+   →         b₀ ≈₂ b₁ → (Inv f i₀) ≈₁ (Inv f i₁)
 
- handler (eq a x) (eq a₁ x₁) b₀≈b₁ = fM (trans (sym x) (trans b₀≈b₁ x₁))
+  handler (eq a x) (eq a₁ x₁) b₀≈b₁ = fM (trans (sym x) (trans b₀≈b₁ x₁))
 
- c : ∀ {b₀ b₁} → b₀ ≈₂ b₁ → (finv b₀) ≈₁ (finv b₁)
- c b₀≈b₁ = handler fE fE b₀≈b₁
+  c : ∀ {b₀ b₁} → b₀ ≈₂ b₁ → (finv b₀) ≈₁ (finv b₁)
+  c b₀≈b₁ = handler fE fE b₀≈b₁
 ```

--- a/src/Setoid/Functions/Injective.lagda.md
+++ b/src/Setoid/Functions/Injective.lagda.md
@@ -86,19 +86,19 @@ module _
 
 module _ {𝑨 : Setoid a α}{𝑩 : Setoid b β}{𝑪 : Setoid c γ} where
 
- ⊙-injective :  (f : 𝑨 ⟶ 𝑩)(g : 𝑩 ⟶ 𝑪)
-  →             IsInjective f → IsInjective g
-  →             IsInjective (g ⟨⊙⟩ f)
+  ⊙-injective :  (f : 𝑨 ⟶ 𝑩)(g : 𝑩 ⟶ 𝑪)
+   →             IsInjective f → IsInjective g
+   →             IsInjective (g ⟨⊙⟩ f)
 
- ⊙-injective _ _ finj ginj = finj ∘ ginj
+  ⊙-injective _ _ finj ginj = finj ∘ ginj
 
- ⊙-injection : Injection 𝑨 𝑩 → Injection 𝑩 𝑪 → Injection 𝑨 𝑪
- ⊙-injection fi gi = record
-  { to = to gi ∘ to fi
-  ; cong = cong gi ∘ cong fi
-  ; injective = ⊙-injective (function fi) (function gi) (injective fi) (injective gi)
-  }
-  where open Injection
+  ⊙-injection : Injection 𝑨 𝑩 → Injection 𝑩 𝑪 → Injection 𝑨 𝑪
+  ⊙-injection fi gi = record
+   { to = to gi ∘ to fi
+   ; cong = cong gi ∘ cong fi
+   ; injective = ⊙-injective (function fi) (function gi) (injective fi) (injective gi)
+   }
+   where open Injection
 
 id-is-injective : {𝑨 : Setoid a α} → IsInjective{𝑨 = 𝑨}{𝑨} 𝑖𝑑
 id-is-injective = id

--- a/src/Setoid/Functions/Inverses.lagda.md
+++ b/src/Setoid/Functions/Inverses.lagda.md
@@ -30,12 +30,12 @@ private variable α ρᵃ β ρᵇ : Level
 
 module _ {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ} where
 
- open Setoid 𝑨 using()  renaming ( Carrier to A ; _≈_ to _≈₁_ )
-                        renaming ( refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
- open Setoid 𝑩 using()  renaming ( Carrier to B ; _≈_ to _≈₂_ )
-                        renaming ( refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
+  open Setoid 𝑨 using()  renaming ( Carrier to A ; _≈_ to _≈₁_ )
+                         renaming ( refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝑩 using()  renaming ( Carrier to B ; _≈_ to _≈₂_ )
+                         renaming ( refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
 
- open _⟶_ {a = α}{ρᵃ}{β}{ρᵇ}{From = 𝑨}{To = 𝑩} renaming (to to _⟨$⟩_ )
+  open _⟶_ {a = α}{ρᵃ}{β}{ρᵇ}{From = 𝑨}{To = 𝑩} renaming (to to _⟨$⟩_ )
 ```
 
 
@@ -45,78 +45,78 @@ the second is for functions on setoids.
 
 
 ```agda
- data Img_∋_ (f : A → B) : B → Type (α ⊔ β ⊔ ρᵇ) where
-  eq : {b : B} → (a : A) → b ≈₂ (f a) → Img f ∋ b
+  data Img_∋_ (f : A → B) : B → Type (α ⊔ β ⊔ ρᵇ) where
+   eq : {b : B} → (a : A) → b ≈₂ (f a) → Img f ∋ b
 
 
- data Image_∋_ (F : 𝑨 ⟶ 𝑩) : B → Type (α ⊔ β ⊔ ρᵇ) where
-  eq : {b : B} → (a : A) → b ≈₂ (F ⟨$⟩ a) → Image F ∋ b
+  data Image_∋_ (F : 𝑨 ⟶ 𝑩) : B → Type (α ⊔ β ⊔ ρᵇ) where
+   eq : {b : B} → (a : A) → b ≈₂ (F ⟨$⟩ a) → Image F ∋ b
 
- open Image_∋_
+  open Image_∋_
 
- IsInRange : (𝑨 ⟶ 𝑩) → Pred B (α ⊔ ρᵇ)
- IsInRange F b = ∃[ a ∈ A ] (F ⟨$⟩ a) ≈₂ b
+  IsInRange : (𝑨 ⟶ 𝑩) → Pred B (α ⊔ ρᵇ)
+  IsInRange F b = ∃[ a ∈ A ] (F ⟨$⟩ a) ≈₂ b
 
- Image⊆Range : ∀ {F b} → Image F ∋ b → b ∈ IsInRange F
- Image⊆Range (eq a x) = a , (sym₂ x)
+  Image⊆Range : ∀ {F b} → Image F ∋ b → b ∈ IsInRange F
+  Image⊆Range (eq a x) = a , (sym₂ x)
 
- IsInRange→IsInImage : ∀ {F b} → b ∈ IsInRange F → Image F ∋ b
- IsInRange→IsInImage (a , x) = eq a (sym₂ x)
+  IsInRange→IsInImage : ∀ {F b} → b ∈ IsInRange F → Image F ∋ b
+  IsInRange→IsInImage (a , x) = eq a (sym₂ x)
 
- Imagef∋f : ∀ {F a} → Image F ∋ (F ⟨$⟩ a)
- Imagef∋f = eq _ refl₂
+  Imagef∋f : ∀ {F a} → Image F ∋ (F ⟨$⟩ a)
+  Imagef∋f = eq _ refl₂
 
- -- Alternative representation of the range of a Func as a setoid
+  -- Alternative representation of the range of a Func as a setoid
 
- -- the carrier
- _range : (𝑨 ⟶ 𝑩) → Type (α ⊔ β ⊔ ρᵇ)
- F range = Σ[ b ∈ B ] ∃[ a ∈ A ](F ⟨$⟩ a) ≈₂ b
+  -- the carrier
+  _range : (𝑨 ⟶ 𝑩) → Type (α ⊔ β ⊔ ρᵇ)
+  F range = Σ[ b ∈ B ] ∃[ a ∈ A ](F ⟨$⟩ a) ≈₂ b
 
- _image : (F : 𝑨 ⟶ 𝑩) → F range → B
- (F image) (b , (_ , _)) = b
+  _image : (F : 𝑨 ⟶ 𝑩) → F range → B
+  (F image) (b , (_ , _)) = b
 
- _preimage : (F : 𝑨 ⟶ 𝑩) → F range → A
- (F preimage) (_ , (a , _)) = a
+  _preimage : (F : 𝑨 ⟶ 𝑩) → F range → A
+  (F preimage) (_ , (a , _)) = a
 
- f∈range : ∀ {F} → A → F range
- f∈range {F} a = (F ⟨$⟩ a) , (a , refl₂)
+  f∈range : ∀ {F} → A → F range
+  f∈range {F} a = (F ⟨$⟩ a) , (a , refl₂)
 
- ⌜_⌝ : (F : 𝑨 ⟶ 𝑩) → A → F range
- ⌜ F ⌝ a = f∈range{F} a
+  ⌜_⌝ : (F : 𝑨 ⟶ 𝑩) → A → F range
+  ⌜ F ⌝ a = f∈range{F} a
 
- Ran : (𝑨 ⟶ 𝑩) → Setoid (α ⊔ β ⊔ ρᵇ) ρᵇ
- Ran F = record  { Carrier = F range
-                 ; _≈_ = λ x y → ((F image) x) ≈₂ ((F image) y)
-                 ; isEquivalence = record  { refl = refl₂
-                                           ; sym = sym₂
-                                           ; trans = trans₂
-                                           }
-                 }
-
- RRan : (𝑨 ⟶ 𝑩) → Setoid (α ⊔ β ⊔ ρᵇ) (ρᵃ ⊔ ρᵇ)
- RRan F = record  { Carrier = F range
-                  ; _≈_ = λ x y →  (F preimage) x ≈₁ (F preimage) y
-                                   ∧ (F image) x ≈₂ (F image) y
-
-                  ; isEquivalence =
-                     record  { refl = refl₁ , refl₂
-                             ; sym = λ x → sym₁ (proj₁ x) , sym₂ (proj₂ x)
-                             ; trans = λ x y → trans₁ (proj₁ x) (proj₁ y) , trans₂ (proj₂ x) (proj₂ y)
-                             }
+  Ran : (𝑨 ⟶ 𝑩) → Setoid (α ⊔ β ⊔ ρᵇ) ρᵇ
+  Ran F = record  { Carrier = F range
+                  ; _≈_ = λ x y → ((F image) x) ≈₂ ((F image) y)
+                  ; isEquivalence = record  { refl = refl₂
+                                            ; sym = sym₂
+                                            ; trans = trans₂
+                                            }
                   }
 
- _preimage≈image : ∀ F r → F ⟨$⟩ (F preimage) r ≈₂ (F image) r
- (F preimage≈image) (_ , (_ , p)) = p
+  RRan : (𝑨 ⟶ 𝑩) → Setoid (α ⊔ β ⊔ ρᵇ) (ρᵃ ⊔ ρᵇ)
+  RRan F = record  { Carrier = F range
+                   ; _≈_ = λ x y →  (F preimage) x ≈₁ (F preimage) y
+                                    ∧ (F image) x ≈₂ (F image) y
+
+                   ; isEquivalence =
+                      record  { refl = refl₁ , refl₂
+                              ; sym = λ x → sym₁ (proj₁ x) , sym₂ (proj₂ x)
+                              ; trans = λ x y → trans₁ (proj₁ x) (proj₁ y) , trans₂ (proj₂ x) (proj₂ y)
+                              }
+                   }
+
+  _preimage≈image : ∀ F r → F ⟨$⟩ (F preimage) r ≈₂ (F image) r
+  (F preimage≈image) (_ , (_ , p)) = p
 
 
- Dom : (𝑨 ⟶ 𝑩) → Setoid α ρᵇ
- Dom F = record  { Carrier = A
-                 ; _≈_ = λ x y → F ⟨$⟩ x ≈₂ F ⟨$⟩ y
-                 ; isEquivalence = record  { refl = refl₂
-                                           ; sym = sym₂
-                                           ; trans = trans₂
-                                           }
-                 }
+  Dom : (𝑨 ⟶ 𝑩) → Setoid α ρᵇ
+  Dom F = record  { Carrier = A
+                  ; _≈_ = λ x y → F ⟨$⟩ x ≈₂ F ⟨$⟩ y
+                  ; isEquivalence = record  { refl = refl₂
+                                            ; sym = sym₂
+                                            ; trans = trans₂
+                                            }
+                  }
 ```
 
 
@@ -124,24 +124,24 @@ An inhabitant of `Image f ∋ b` is a dependent pair `(a , p)`, where `a : A` an
 
 
 ```agda
- inv : (f : A → B){b : B} → Img f ∋ b → A
- inv _ (eq a _) = a
+  inv : (f : A → B){b : B} → Img f ∋ b → A
+  inv _ (eq a _) = a
 
- Inv : (F : 𝑨 ⟶ 𝑩){b : B} → Image F ∋ b → A
- Inv _ (eq a _) = a
+  Inv : (F : 𝑨 ⟶ 𝑩){b : B} → Image F ∋ b → A
+  Inv _ (eq a _) = a
 
- Inv' : (F : 𝑨 ⟶ 𝑩){b : B} → b ∈ IsInRange F → A
- Inv' _ (a , _) = a
+  Inv' : (F : 𝑨 ⟶ 𝑩){b : B} → b ∈ IsInRange F → A
+  Inv' _ (a , _) = a
 
- [_]⁻¹ : (F : 𝑨 ⟶ 𝑩) → F range → A
- [ F ]⁻¹ = F preimage
+  [_]⁻¹ : (F : 𝑨 ⟶ 𝑩) → F range → A
+  [ F ]⁻¹ = F preimage
 
- ⟦_⟧⁻¹ : (F : 𝑨 ⟶ 𝑩) → Ran F ⟶ Dom F
- ⟦ F ⟧⁻¹ = record
-   { to = F preimage
-   ; cong = λ {x}{y} ix≈iy → trans₂  ((F preimage≈image) x)
-                                     (trans₂ ix≈iy $ sym₂ $ (F preimage≈image) y)
-   }
+  ⟦_⟧⁻¹ : (F : 𝑨 ⟶ 𝑩) → Ran F ⟶ Dom F
+  ⟦ F ⟧⁻¹ = record
+    { to = F preimage
+    ; cong = λ {x}{y} ix≈iy → trans₂  ((F preimage≈image) x)
+                                      (trans₂ ix≈iy $ sym₂ $ (F preimage≈image) y)
+    }
 ```
 
 
@@ -149,14 +149,14 @@ We can prove that `Inv f` is the range-restricted right-inverse of `f`, as follo
 
 
 ```agda
- invIsInvʳ : {f : A → B}{b : B}(q : Img f ∋ b) → (f (inv f q)) ≈₂ b
- invIsInvʳ (eq _ p) = sym₂ p
+  invIsInvʳ : {f : A → B}{b : B}(q : Img f ∋ b) → (f (inv f q)) ≈₂ b
+  invIsInvʳ (eq _ p) = sym₂ p
 
- InvIsInverseʳ : {F : 𝑨 ⟶ 𝑩}{b : B}(q : Image F ∋ b) → (F ⟨$⟩ (Inv F q)) ≈₂ b
- InvIsInverseʳ (eq _ p) = sym₂ p
+  InvIsInverseʳ : {F : 𝑨 ⟶ 𝑩}{b : B}(q : Image F ∋ b) → (F ⟨$⟩ (Inv F q)) ≈₂ b
+  InvIsInverseʳ (eq _ p) = sym₂ p
 
- ⁻¹IsInverseʳ : {F : 𝑨 ⟶ 𝑩}{bap : F range} → (F ⟨$⟩ ([ F ]⁻¹ bap )) ≈₂ (proj₁ bap)
- ⁻¹IsInverseʳ {bap = (_ , (_ , p))} = p
+  ⁻¹IsInverseʳ : {F : 𝑨 ⟶ 𝑩}{bap : F range} → (F ⟨$⟩ ([ F ]⁻¹ bap )) ≈₂ (proj₁ bap)
+  ⁻¹IsInverseʳ {bap = (_ , (_ , p))} = p
 ```
 
 
@@ -166,9 +166,9 @@ In the following sense, `Inv f` is also a (range-restricted) *left-inverse*.
 
 
 ```agda
- InvIsInverseˡ : ∀ {F a} → Inv F {b = F ⟨$⟩ a} Imagef∋f ≈₁ a
- InvIsInverseˡ = refl₁
+  InvIsInverseˡ : ∀ {F a} → Inv F {b = F ⟨$⟩ a} Imagef∋f ≈₁ a
+  InvIsInverseˡ = refl₁
 
- ⁻¹IsInverseˡ : ∀ {F a} → [ F ]⁻¹ (f∈range{F} a) ≈₁ a
- ⁻¹IsInverseˡ = refl₁
+  ⁻¹IsInverseˡ : ∀ {F a} → [ F ]⁻¹ (f∈range{F} a) ≈₁ a
+  ⁻¹IsInverseˡ = refl₁
 ```

--- a/src/Setoid/Functions/Surjective.lagda.md
+++ b/src/Setoid/Functions/Surjective.lagda.md
@@ -37,54 +37,54 @@ open import Setoid.Functions.Inverses  using ( Img_∋_ ; Image_∋_ ; Inv ; Inv
 
 
 private variable
- α ρᵃ β ρᵇ γ ρᶜ : Level
+  α ρᵃ β ρᵇ γ ρᶜ : Level
 
 open Image_∋_
 
 module _ {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ} where
 
- open Setoid 𝑨  renaming (Carrier to A; _≈_ to _≈₁_; isEquivalence to isEqA ) using ()
- open Setoid 𝑩  renaming (Carrier to B; _≈_ to _≈₂_; isEquivalence to isEqB )
-                using ( trans ; sym )
+  open Setoid 𝑨  renaming (Carrier to A; _≈_ to _≈₁_; isEquivalence to isEqA ) using ()
+  open Setoid 𝑩  renaming (Carrier to B; _≈_ to _≈₂_; isEquivalence to isEqB )
+                 using ( trans ; sym )
 
- open Surjection {a = α}{ρᵃ}{β}{ρᵇ}{From = 𝑨}{To = 𝑩}  renaming (to to _⟨$⟩_)
- open _⟶_ {a = α}{ρᵃ}{β}{ρᵇ}{From = 𝑨}{To = 𝑩}         renaming (to to _⟨$⟩_ )
- open FD
+  open Surjection {a = α}{ρᵃ}{β}{ρᵇ}{From = 𝑨}{To = 𝑩}  renaming (to to _⟨$⟩_)
+  open _⟶_ {a = α}{ρᵃ}{β}{ρᵇ}{From = 𝑨}{To = 𝑩}         renaming (to to _⟨$⟩_ )
+  open FD
 
- isSurj : (A → B) → Type (α ⊔ β ⊔ ρᵇ)
- isSurj f = ∀ {y} → Img_∋_ {𝑨 = 𝑨}{𝑩 = 𝑩} f y
+  isSurj : (A → B) → Type (α ⊔ β ⊔ ρᵇ)
+  isSurj f = ∀ {y} → Img_∋_ {𝑨 = 𝑨}{𝑩 = 𝑩} f y
 
- IsSurjective : (𝑨 ⟶ 𝑩) → Type (α ⊔ β ⊔ ρᵇ)
- IsSurjective F = ∀ {y} → Image F ∋ y
+  IsSurjective : (𝑨 ⟶ 𝑩) → Type (α ⊔ β ⊔ ρᵇ)
+  IsSurjective F = ∀ {y} → Image F ∋ y
 
- isSurj→IsSurjective : (F : 𝑨 ⟶ 𝑩) → isSurj (_⟨$⟩_ F) → IsSurjective F
- isSurj→IsSurjective F isSurjF {y} = hyp isSurjF
-  where
-  hyp : Img (_⟨$⟩_ F) ∋ y → Image F ∋ y
-  hyp (Img_∋_.eq a x) = eq a x
+  isSurj→IsSurjective : (F : 𝑨 ⟶ 𝑩) → isSurj (_⟨$⟩_ F) → IsSurjective F
+  isSurj→IsSurjective F isSurjF {y} = hyp isSurjF
+   where
+   hyp : Img (_⟨$⟩_ F) ∋ y → Image F ∋ y
+   hyp (Img_∋_.eq a x) = eq a x
 
- open Image_∋_
+  open Image_∋_
 
- SurjectionIsSurjective : (Surjection 𝑨 𝑩) → Σ[ g ∈ (𝑨 ⟶ 𝑩) ] (IsSurjective g)
- SurjectionIsSurjective s = g , gE
-  where
-  g : 𝑨 ⟶ 𝑩
-  g = (record { to = _⟨$⟩_ s ; cong = cong s })
-  gE : IsSurjective g
-  gE {y} = eq (proj₁ ((surjective s) y)) (sym (proj₂ (surjective s y) (IsEquivalence.refl isEqA)))
+  SurjectionIsSurjective : (Surjection 𝑨 𝑩) → Σ[ g ∈ (𝑨 ⟶ 𝑩) ] (IsSurjective g)
+  SurjectionIsSurjective s = g , gE
+   where
+   g : 𝑨 ⟶ 𝑩
+   g = (record { to = _⟨$⟩_ s ; cong = cong s })
+   gE : IsSurjective g
+   gE {y} = eq (proj₁ ((surjective s) y)) (sym (proj₂ (surjective s y) (IsEquivalence.refl isEqA)))
 
- SurjectionIsSurjection : (Surjection 𝑨 𝑩) → Σ[ g ∈ (𝑨 ⟶ 𝑩) ] (IsSurjection _≈₁_ _≈₂_ (_⟨$⟩_ g))
- SurjectionIsSurjection s = g , gE
-  where
-  g : 𝑨 ⟶ 𝑩
-  g = record { to = _⟨$⟩_ s ; cong = cong s }
+  SurjectionIsSurjection : (Surjection 𝑨 𝑩) → Σ[ g ∈ (𝑨 ⟶ 𝑩) ] (IsSurjection _≈₁_ _≈₂_ (_⟨$⟩_ g))
+  SurjectionIsSurjection s = g , gE
+   where
+   g : 𝑨 ⟶ 𝑩
+   g = record { to = _⟨$⟩_ s ; cong = cong s }
 
-  gE : IsSurjection _≈₁_ _≈₂_ (_⟨$⟩_ g)
-  gE .IsSurjection.isCongruent = record  { cong = cong g
-                                         ; isEquivalence₁ = isEqA
-                                         ; isEquivalence₂ = isEqB
-                                         }
-  gE .IsSurjection.surjective y = (proj₁ ((surjective s) y)) , (proj₂ ((surjective s) y))
+   gE : IsSurjection _≈₁_ _≈₂_ (_⟨$⟩_ g)
+   gE .IsSurjection.isCongruent = record  { cong = cong g
+                                          ; isEquivalence₁ = isEqA
+                                          ; isEquivalence₂ = isEqB
+                                          }
+   gE .IsSurjection.surjective y = (proj₁ ((surjective s) y)) , (proj₂ ((surjective s) y))
 ```
 
 
@@ -92,8 +92,8 @@ With the next definition we represent a *right-inverse* of a surjective setoid f
 
 
 ```agda
- SurjInv : (f : 𝑨 ⟶ 𝑩) → IsSurjective f → B → A
- SurjInv f fE b = Inv f (fE {b})
+  SurjInv : (f : 𝑨 ⟶ 𝑩) → IsSurjective f → B → A
+  SurjInv f fE b = Inv f (fE {b})
 ```
 
 
@@ -101,10 +101,10 @@ Thus, a right-inverse of `f` is obtained by applying `Inv` to `f` and a proof of
 
 
 ```agda
- SurjInvIsInverseʳ :  (f : 𝑨 ⟶ 𝑩)(fE : IsSurjective f)
-  →                   ∀ {b} → f ⟨$⟩ (SurjInv f fE) b ≈₂ b
+  SurjInvIsInverseʳ :  (f : 𝑨 ⟶ 𝑩)(fE : IsSurjective f)
+   →                   ∀ {b} → f ⟨$⟩ (SurjInv f fE) b ≈₂ b
 
- SurjInvIsInverseʳ f fE = InvIsInverseʳ fE
+  SurjInvIsInverseʳ f fE = InvIsInverseʳ fE
 ```
 
 
@@ -114,50 +114,50 @@ Next, we prove composition laws for epics.
 ```agda
 module _ {𝑨 : Setoid α ρᵃ}{𝑩 : Setoid β ρᵇ}{𝑪 : Setoid γ ρᶜ} where
 
- open Setoid 𝑨  using ()               renaming (Carrier to A; _≈_ to _≈₁_)
- open Setoid 𝑩  using ( trans ; sym )  renaming (Carrier to B; _≈_ to _≈₂_)
- open Surjection  renaming (to to _⟨$⟩_)
- open _⟶_         renaming (to to _⟨$⟩_ )
- open FD
+  open Setoid 𝑨  using ()               renaming (Carrier to A; _≈_ to _≈₁_)
+  open Setoid 𝑩  using ( trans ; sym )  renaming (Carrier to B; _≈_ to _≈₂_)
+  open Surjection  renaming (to to _⟨$⟩_)
+  open _⟶_         renaming (to to _⟨$⟩_ )
+  open FD
 
 
- ⊙-IsSurjective :  {G : 𝑨 ⟶ 𝑪}{H : 𝑪 ⟶ 𝑩}
-  →                IsSurjective G → IsSurjective H → IsSurjective (H ⊙ G)
+  ⊙-IsSurjective :  {G : 𝑨 ⟶ 𝑪}{H : 𝑪 ⟶ 𝑩}
+   →                IsSurjective G → IsSurjective H → IsSurjective (H ⊙ G)
 
- ⊙-IsSurjective {G} {H} gE hE {y} = Goal
-  where
-  mp : Image H ∋ y → Image H ⊙ G ∋ y
-  mp (eq c p) = η gE
+  ⊙-IsSurjective {G} {H} gE hE {y} = Goal
    where
-   η : Image G ∋ c → Image H ⊙ G ∋ y
-   η (eq a q) = eq a $ trans p $ cong H q
+   mp : Image H ∋ y → Image H ⊙ G ∋ y
+   mp (eq c p) = η gE
+    where
+    η : Image G ∋ c → Image H ⊙ G ∋ y
+    η (eq a q) = eq a $ trans p $ cong H q
 
-  Goal : Image H ⊙ G ∋ y
-  Goal = mp hE
-
-
- ∘-epic : Surjection 𝑨 𝑪 → Surjection 𝑪 𝑩 → Surjection 𝑨 𝑩
- Surjection.to           (∘-epic g h) = h ⟨$⟩_ ∘ g ⟨$⟩_
- Surjection.cong        (∘-epic g h) = cong h ∘ cong g
- Surjection.surjective  (∘-epic g h) = surjective $ isOnto  (proj₂ (SurjectionIsSurjection g))
-                                                            (proj₂ (SurjectionIsSurjection h))
-  where open IsSurjection
+   Goal : Image H ⊙ G ∋ y
+   Goal = mp hE
 
 
- epic-factor :  (f : 𝑨 ⟶ 𝑩)(g : 𝑨 ⟶ 𝑪)(h : 𝑪 ⟶ 𝑩)
-  →             IsSurjective f → (∀ i → (f ⟨$⟩ i) ≈₂ ((h ⊙ g) ⟨$⟩ i)) → IsSurjective h
+  ∘-epic : Surjection 𝑨 𝑪 → Surjection 𝑪 𝑩 → Surjection 𝑨 𝑩
+  Surjection.to           (∘-epic g h) = h ⟨$⟩_ ∘ g ⟨$⟩_
+  Surjection.cong        (∘-epic g h) = cong h ∘ cong g
+  Surjection.surjective  (∘-epic g h) = surjective $ isOnto  (proj₂ (SurjectionIsSurjection g))
+                                                             (proj₂ (SurjectionIsSurjection h))
+   where open IsSurjection
 
- epic-factor f g h fE compId {y} = Goal
-  where
-   finv : B → A
-   finv = SurjInv f fE
 
-   ζ : y ≈₂ (f ⟨$⟩ (finv y))
-   ζ = sym $ SurjInvIsInverseʳ f fE
+  epic-factor :  (f : 𝑨 ⟶ 𝑩)(g : 𝑨 ⟶ 𝑪)(h : 𝑪 ⟶ 𝑩)
+   →             IsSurjective f → (∀ i → (f ⟨$⟩ i) ≈₂ ((h ⊙ g) ⟨$⟩ i)) → IsSurjective h
 
-   η : y ≈₂ ((h ⊙ g) ⟨$⟩ (finv y))
-   η = trans ζ $ compId $ finv y
+  epic-factor f g h fE compId {y} = Goal
+   where
+    finv : B → A
+    finv = SurjInv f fE
 
-   Goal : Image h ∋ y
-   Goal = eq (g ⟨$⟩ (finv y)) η
+    ζ : y ≈₂ (f ⟨$⟩ (finv y))
+    ζ = sym $ SurjInvIsInverseʳ f fE
+
+    η : y ≈₂ ((h ⊙ g) ⟨$⟩ (finv y))
+    η = trans ζ $ compId $ finv y
+
+    Goal : Image h ∋ y
+    Goal = eq (g ⟨$⟩ (finv y)) η
 ```

--- a/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
+++ b/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
@@ -62,7 +62,7 @@ HomImages {β = β}{ρᵇ = ρᵇ} 𝑨 = Σ[ 𝑩 ∈ Algebra β ρᵇ ] 𝑩 I
 
 IdHomImage : {𝑨 : Algebra α ρᵃ} → 𝑨 IsHomImageOf 𝑨
 IdHomImage {α = α}{𝑨 = 𝑨} = 𝒾𝒹 , λ {y} → Image_∋_.eq y refl
- where open Setoid (Domain 𝑨) using ( refl )
+  where open Setoid (Domain 𝑨) using ( refl )
 ```
 
 
@@ -79,37 +79,37 @@ the image of given hom.
 
 ```agda
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
- open Algebra 𝑩  using () renaming (Domain to B ; Interp to InterpB )
- open Setoid B   using () renaming ( _≈_ to _≈₂_ ; trans to trans₂ )
- open Func       using ( cong ) renaming ( to to _⟨$⟩_ )
+  open Algebra 𝑩  using () renaming (Domain to B ; Interp to InterpB )
+  open Setoid B   using () renaming ( _≈_ to _≈₂_ ; trans to trans₂ )
+  open Func       using ( cong ) renaming ( to to _⟨$⟩_ )
 
- HomImageOf[_] : hom 𝑨 𝑩 → Algebra (α ⊔ β ⊔ ρᵇ) ρᵇ
- HomImageOf[ h ] =
-   record { Domain = Ran (h .proj₁) ; Interp = record { to = f' ; cong = cong' } }
-     where
-     open Setoid(⟨ 𝑆 ⟩ (Ran (proj₁ h)))
-      using() renaming (Carrier to SRanh ; _≈_ to _≈₃_ )
+  HomImageOf[_] : hom 𝑨 𝑩 → Algebra (α ⊔ β ⊔ ρᵇ) ρᵇ
+  HomImageOf[ h ] =
+    record { Domain = Ran (h .proj₁) ; Interp = record { to = f' ; cong = cong' } }
+      where
+      open Setoid(⟨ 𝑆 ⟩ (Ran (proj₁ h)))
+       using() renaming (Carrier to SRanh ; _≈_ to _≈₃_ )
 
-     hhom :  ∀ {𝑓}(x : ArityOf 𝑆 𝑓 → h .proj₁ range )
-       → h .proj₁ ⟨$⟩ (𝑓 ^ 𝑨) (h .proj₁ preimage ∘ x) ≈₂ (𝑓 ^ 𝑩) (h .proj₁ image ∘ x)
+      hhom :  ∀ {𝑓}(x : ArityOf 𝑆 𝑓 → h .proj₁ range )
+        → h .proj₁ ⟨$⟩ (𝑓 ^ 𝑨) (h .proj₁ preimage ∘ x) ≈₂ (𝑓 ^ 𝑩) (h .proj₁ image ∘ x)
 
-     hhom {𝑓} x = trans₂ (h .proj₂ .compatible) (cong InterpB (≡.refl , h .proj₁ preimage≈image ∘ x))
+      hhom {𝑓} x = trans₂ (h .proj₂ .compatible) (cong InterpB (≡.refl , h .proj₁ preimage≈image ∘ x))
 
-     f' : SRanh → h .proj₁ range
-     f' (𝑓 , x) =  (𝑓 ^ 𝑩)(h .proj₁ image ∘ x)       -- b : the image in ∣B∣
-                   , (𝑓 ^ 𝑨)(h .proj₁ preimage ∘ x)  -- a : the preimage in ∣A∣
-                   , hhom x                          -- p : proof that (proj₁ h ⟨$⟩ a) ≈₂ b
+      f' : SRanh → h .proj₁ range
+      f' (𝑓 , x) =  (𝑓 ^ 𝑩)(h .proj₁ image ∘ x)       -- b : the image in ∣B∣
+                    , (𝑓 ^ 𝑨)(h .proj₁ preimage ∘ x)  -- a : the preimage in ∣A∣
+                    , hhom x                          -- p : proof that (proj₁ h ⟨$⟩ a) ≈₂ b
 
-     cong' : ∀ {x y} → x ≈₃ y → (h .proj₁ image) (f' x) ≈₂ (h .proj₁ image) (f' y)
-     cong' {(𝑓 , u)} {(.𝑓 , v)} (≡.refl , EqA) = Goal
-       where
-       -- Alternative formulation of the goal:
-       goal : (𝑓 ^ 𝑩)(λ i → (h .proj₁ image)(u i)) ≈₂ (𝑓 ^ 𝑩)(λ i → (h .proj₁ image) (v i))
-       goal = cong InterpB (≡.refl , EqA )
+      cong' : ∀ {x y} → x ≈₃ y → (h .proj₁ image) (f' x) ≈₂ (h .proj₁ image) (f' y)
+      cong' {(𝑓 , u)} {(.𝑓 , v)} (≡.refl , EqA) = Goal
+        where
+        -- Alternative formulation of the goal:
+        goal : (𝑓 ^ 𝑩)(λ i → (h .proj₁ image)(u i)) ≈₂ (𝑓 ^ 𝑩)(λ i → (h .proj₁ image) (v i))
+        goal = cong InterpB (≡.refl , EqA )
 
-       Goal : (h .proj₁ image) (f' (𝑓 , u)) ≈₂ (h .proj₁ image) (f' (𝑓 , v))
-       Goal = goal
-       -- Note: `EqA : ∀ i → ((proj₁ h) image) (u i) ≈₂ ((proj₁ h) image) (v i)`
+        Goal : (h .proj₁ image) (f' (𝑓 , u)) ≈₂ (h .proj₁ image) (f' (𝑓 , v))
+        Goal = goal
+        -- Note: `EqA : ∀ i → ((proj₁ h) image) (u i) ≈₂ ((proj₁ h) image) (v i)`
 ```
 
 
@@ -134,51 +134,51 @@ Here are some tools that have been useful (e.g., in the road to the proof of Bir
 
 ```agda
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
- open Setoid 𝔻[ 𝑩 ]   using ( sym ; trans )  renaming ( _≈_ to _≈₂_ )
- open Func       using ( cong )         renaming ( to to _⟨$⟩_ )
- open Level      using ( lift ; lower )
+  open Setoid 𝔻[ 𝑩 ]   using ( sym ; trans )  renaming ( _≈_ to _≈₂_ )
+  open Func       using ( cong )         renaming ( to to _⟨$⟩_ )
+  open Level      using ( lift ; lower )
 
- Lift-epi-is-epiˡ :  (h : hom 𝑨 𝑩)(ℓᵃ ℓᵇ : Level)
-   → IsSurjective (proj₁ h) → IsSurjective (proj₁ (Lift-homˡ {𝑨 = 𝑨}{𝑩} h ℓᵃ ℓᵇ))
+  Lift-epi-is-epiˡ :  (h : hom 𝑨 𝑩)(ℓᵃ ℓᵇ : Level)
+    → IsSurjective (proj₁ h) → IsSurjective (proj₁ (Lift-homˡ {𝑨 = 𝑨}{𝑩} h ℓᵃ ℓᵇ))
 
- Lift-epi-is-epiˡ h ℓᵃ ℓᵇ hepi {b} = Goal
-   where
-   open Setoid 𝔻[ Lift-Algˡ 𝑩 ℓᵇ ] using ( _≈_ )
+  Lift-epi-is-epiˡ h ℓᵃ ℓᵇ hepi {b} = Goal
+    where
+    open Setoid 𝔻[ Lift-Algˡ 𝑩 ℓᵇ ] using ( _≈_ )
 
-   a : 𝕌[ 𝑨 ]
-   a = Inv (h .proj₁) hepi
+    a : 𝕌[ 𝑨 ]
+    a = Inv (h .proj₁) hepi
 
-   lem1 : b ≈ lift (lower b)
-   lem1 = lift∼lower {𝑨 = 𝔻[ 𝑩 ]} b
+    lem1 : b ≈ lift (lower b)
+    lem1 = lift∼lower {𝑨 = 𝔻[ 𝑩 ]} b
 
-   lem2' : lower b ≈₂ h .proj₁ ⟨$⟩ a
-   lem2' = sym  (InvIsInverseʳ hepi)
+    lem2' : lower b ≈₂ h .proj₁ ⟨$⟩ a
+    lem2' = sym  (InvIsInverseʳ hepi)
 
-   lem2 : lift (lower b) ≈ lift (h .proj₁ ⟨$⟩ a)
-   lem2 = cong{From = 𝔻[ 𝑩 ]} (ToLiftˡ{𝑨 = 𝑩}{ℓᵇ} .proj₁) lem2'
+    lem2 : lift (lower b) ≈ lift (h .proj₁ ⟨$⟩ a)
+    lem2 = cong{From = 𝔻[ 𝑩 ]} (ToLiftˡ{𝑨 = 𝑩}{ℓᵇ} .proj₁) lem2'
 
-   lem3 : lift (h .proj₁ ⟨$⟩ a) ≈ (Lift-homˡ h ℓᵃ ℓᵇ) .proj₁ ⟨$⟩ lift a
-   lem3 = lift-hom-lemma h a ℓᵃ ℓᵇ
+    lem3 : lift (h .proj₁ ⟨$⟩ a) ≈ (Lift-homˡ h ℓᵃ ℓᵇ) .proj₁ ⟨$⟩ lift a
+    lem3 = lift-hom-lemma h a ℓᵃ ℓᵇ
 
-   η : b ≈ (Lift-homˡ h ℓᵃ ℓᵇ) .proj₁ ⟨$⟩ lift a
-   η = trans lem1 (trans lem2 lem3)
+    η : b ≈ (Lift-homˡ h ℓᵃ ℓᵇ) .proj₁ ⟨$⟩ lift a
+    η = trans lem1 (trans lem2 lem3)
 
-   Goal : Image (Lift-homˡ h ℓᵃ ℓᵇ) .proj₁ ∋ b
-   Goal = Image_∋_.eq (lift a) η
+    Goal : Image (Lift-homˡ h ℓᵃ ℓᵇ) .proj₁ ∋ b
+    Goal = Image_∋_.eq (lift a) η
 
 
- Lift-Alg-hom-imageˡ :  (ℓᵃ ℓᵇ : Level) → 𝑩 IsHomImageOf 𝑨
-   → (Lift-Algˡ 𝑩 ℓᵇ) IsHomImageOf (Lift-Algˡ 𝑨 ℓᵃ)
+  Lift-Alg-hom-imageˡ :  (ℓᵃ ℓᵇ : Level) → 𝑩 IsHomImageOf 𝑨
+    → (Lift-Algˡ 𝑩 ℓᵇ) IsHomImageOf (Lift-Algˡ 𝑨 ℓᵃ)
 
- Lift-Alg-hom-imageˡ ℓᵃ ℓᵇ ((φ , φhom) , φepic) = Goal
-   where
-   lφ : hom (Lift-Algˡ 𝑨 ℓᵃ) (Lift-Algˡ 𝑩 ℓᵇ)
-   lφ = Lift-homˡ {𝑨 = 𝑨}{𝑩} (φ , φhom) ℓᵃ ℓᵇ
+  Lift-Alg-hom-imageˡ ℓᵃ ℓᵇ ((φ , φhom) , φepic) = Goal
+    where
+    lφ : hom (Lift-Algˡ 𝑨 ℓᵃ) (Lift-Algˡ 𝑩 ℓᵇ)
+    lφ = Lift-homˡ {𝑨 = 𝑨}{𝑩} (φ , φhom) ℓᵃ ℓᵇ
 
-   lφepic : IsSurjective (lφ .proj₁)
-   lφepic = Lift-epi-is-epiˡ (φ , φhom) ℓᵃ ℓᵇ φepic
-   Goal : (Lift-Algˡ 𝑩 ℓᵇ) IsHomImageOf (Lift-Algˡ 𝑨 ℓᵃ)
-   Goal = lφ , lφepic
+    lφepic : IsSurjective (lφ .proj₁)
+    lφepic = Lift-epi-is-epiˡ (φ , φhom) ℓᵃ ℓᵇ φepic
+    Goal : (Lift-Algˡ 𝑩 ℓᵇ) IsHomImageOf (Lift-Algˡ 𝑨 ℓᵃ)
+    Goal = lφ , lφepic
 
 
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where

--- a/src/Setoid/Subalgebras/Basic.lagda.md
+++ b/src/Setoid/Subalgebras/Basic.lagda.md
@@ -36,11 +36,11 @@ open import Setoid.Homomorphisms {𝑆 = 𝑆}
 private variable α ρᵃ β ρᵇ ℓ : Level
 
 _≥_   -- alias for supalgebra (aka overalgebra)
- _IsSupalgebraOf_ : Algebra α ρᵃ → Algebra β ρᵇ → Type _
+  _IsSupalgebraOf_ : Algebra α ρᵃ → Algebra β ρᵇ → Type _
 𝑨 IsSupalgebraOf 𝑩 = Σ[ h ∈ hom 𝑩 𝑨 ] IsInjective (proj₁ h)
 
 _≤_   -- alias for subalgebra relation
- _IsSubalgebraOf_ : Algebra α ρᵃ → Algebra β ρᵇ → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵃ ⊔ β ⊔ ρᵇ)
+  _IsSubalgebraOf_ : Algebra α ρᵃ → Algebra β ρᵇ → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵃ ⊔ β ⊔ ρᵇ)
 𝑨 IsSubalgebraOf 𝑩 = Σ[ h ∈ hom 𝑨 𝑩 ] IsInjective (proj₁ h)
 
 -- Syntactic sugar for sup/sub-algebra relations.
@@ -51,10 +51,10 @@ mon→≤ : {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} → mon 𝑨 𝑩
 mon→≤ {𝑨 = 𝑨}{𝑩} x = mon→intohom 𝑨 𝑩 x
 
 record SubalgebraOf : Type (ov (α ⊔ β ⊔ ρᵃ ⊔ ρᵇ)) where
- field
-  algebra : Algebra α ρᵃ
-  subalgebra : Algebra β ρᵇ
-  issubalgebra : subalgebra ≤ algebra
+  field
+   algebra : Algebra α ρᵃ
+   subalgebra : Algebra β ρᵇ
+   issubalgebra : subalgebra ≤ algebra
 
 Subalgebra : Algebra α ρᵃ → {β ρᵇ : Level} → Type _
 Subalgebra 𝑨 {β}{ρᵇ} = Σ[ 𝑩 ∈ (Algebra β ρᵇ) ] 𝑩 ≤ 𝑨
@@ -83,7 +83,7 @@ assertion as `𝑩 IsSubalgebraOfClass 𝒦`.
 
 ```agda
 _≤c_
- _IsSubalgebraOfClass_ : Algebra β ρᵇ → Pred (Algebra α ρᵃ) ℓ → Type _
+  _IsSubalgebraOfClass_ : Algebra β ρᵇ → Pred (Algebra α ρᵃ) ℓ → Type _
 𝑩 IsSubalgebraOfClass 𝒦 = Σ[ 𝑨 ∈ Algebra _ _ ] ((𝑨 ∈ 𝒦) ∧ (𝑩 ≤ 𝑨))
 
 𝑩 ≤c 𝒦 = 𝑩 IsSubalgebraOfClass 𝒦  -- (alias)

--- a/src/Setoid/Subalgebras/Properties.lagda.md
+++ b/src/Setoid/Subalgebras/Properties.lagda.md
@@ -164,27 +164,27 @@ module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
 
 ```agda
 module _ {I : Type ι}{𝒜 : I → Algebra α ρᵃ}{ℬ : I → Algebra β ρᵇ} where
- open IsHom
+  open IsHom
 
- ⨅-≤ : (∀ i → ℬ i ≤ 𝒜 i) → ⨅ ℬ ≤ ⨅ 𝒜
- ⨅-≤ B≤A = h , hM
-   where
-   h : hom (⨅ ℬ) (⨅ 𝒜)
-   h = hfunc , hhom
-     where
-     homAt : ∀ i → hom (ℬ i) (𝒜 i)
-     homAt = λ i → proj₁ (B≤A i)
+  ⨅-≤ : (∀ i → ℬ i ≤ 𝒜 i) → ⨅ ℬ ≤ ⨅ 𝒜
+  ⨅-≤ B≤A = h , hM
+    where
+    h : hom (⨅ ℬ) (⨅ 𝒜)
+    h = hfunc , hhom
+      where
+      homAt : ∀ i → hom (ℬ i) (𝒜 i)
+      homAt = λ i → proj₁ (B≤A i)
 
-     hmapAt : ∀ i → 𝔻[ ℬ i ] ⟶ 𝔻[ 𝒜 i ]
-     hmapAt = proj₁ ∘ homAt
+      hmapAt : ∀ i → 𝔻[ ℬ i ] ⟶ 𝔻[ 𝒜 i ]
+      hmapAt = proj₁ ∘ homAt
 
-     hfunc : 𝔻[ ⨅ ℬ ] ⟶ 𝔻[ ⨅ 𝒜 ]
-     hfunc ⟨$⟩ x = λ i → (hmapAt i) ⟨$⟩ (x i)
-     hfunc .cong = λ xy i → cong (hmapAt i) (xy i)
+      hfunc : 𝔻[ ⨅ ℬ ] ⟶ 𝔻[ ⨅ 𝒜 ]
+      hfunc ⟨$⟩ x = λ i → (hmapAt i) ⟨$⟩ (x i)
+      hfunc .cong = λ xy i → cong (hmapAt i) (xy i)
 
-     hhom : IsHom (⨅ ℬ) (⨅ 𝒜) hfunc
-     hhom .compatible = λ i → compatible (proj₂ (homAt i))
+      hhom : IsHom (⨅ ℬ) (⨅ 𝒜) hfunc
+      hhom .compatible = λ i → compatible (proj₂ (homAt i))
 
-   hM : IsInjective (proj₁ h)
-   hM = λ xy i → (proj₂ (B≤A i)) (xy i)
+    hM : IsInjective (proj₁ h)
+    hM = λ xy i → (proj₂ (B≤A i)) (xy i)
 ```

--- a/src/Setoid/Subalgebras/Subuniverses.lagda.md
+++ b/src/Setoid/Subalgebras/Subuniverses.lagda.md
@@ -36,8 +36,8 @@ open import Setoid.Terms          {𝑆 = 𝑆}  using ( module Environment )
 open import Setoid.Homomorphisms  {𝑆 = 𝑆}  using ( hom ; IsHom )
 
 private variable
- α β γ ρᵃ ρᵇ ρᶜ ℓ χ : Level
- X : Type χ
+  α β γ ρᵃ ρᵇ ρᶜ ℓ χ : Level
+  X : Type χ
 ```
 
 
@@ -49,22 +49,22 @@ predicate on predicates on `𝕌[ 𝑨 ]`.
 
 ```agda
 module _ (𝑨 : Algebra α ρᵃ) where
- private A = 𝕌[ 𝑨 ] -- the forgetful functor
+  private A = 𝕌[ 𝑨 ] -- the forgetful functor
 
- Subuniverses : Pred (Pred A ℓ) (𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ )
- Subuniverses B = ∀ f a → Im a ⊆ B → (f ^ 𝑨) a ∈ B
+  Subuniverses : Pred (Pred A ℓ) (𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ )
+  Subuniverses B = ∀ f a → Im a ⊆ B → (f ^ 𝑨) a ∈ B
 
- -- Subuniverses as a record type
- record Subuniverse : Type(ov (α ⊔ ℓ)) where
-  constructor mksub
-  field
-   sset  : Pred A ℓ
-   isSub : sset ∈ Subuniverses
+  -- Subuniverses as a record type
+  record Subuniverse : Type(ov (α ⊔ ℓ)) where
+   constructor mksub
+   field
+    sset  : Pred A ℓ
+    isSub : sset ∈ Subuniverses
 
- -- Subuniverse Generation
- data Sg (G : Pred A ℓ) : Pred A (𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ) where
-  var : ∀ {v} → v ∈ G → v ∈ Sg G
-  app : ∀ f a → Im a ⊆ Sg G → (f ^ 𝑨) a ∈ Sg G
+  -- Subuniverse Generation
+  data Sg (G : Pred A ℓ) : Pred A (𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ) where
+   var : ∀ {v} → v ∈ G → v ∈ Sg G
+   app : ∀ f a → Im a ⊆ Sg G → (f ^ 𝑨) a ∈ Sg G
 ```
 
 
@@ -77,8 +77,8 @@ inductive type `Sg` is trivial, as we see here.
 
 
 ```agda
- sgIsSub : {G : Pred A ℓ} → Sg G ∈ Subuniverses
- sgIsSub = app
+  sgIsSub : {G : Pred A ℓ} → Sg G ∈ Subuniverses
+  sgIsSub = app
 ```
 
 
@@ -86,17 +86,17 @@ Next we prove by structural induction that `Sg X` is the smallest subuniverse of
 
 
 ```agda
- sgIsSmallest :  {G : Pred A ℓ}(B : Pred A ρᵇ)
-  →              B ∈ Subuniverses  →  G ⊆ B  →  Sg G ⊆ B
+  sgIsSmallest :  {G : Pred A ℓ}(B : Pred A ρᵇ)
+   →              B ∈ Subuniverses  →  G ⊆ B  →  Sg G ⊆ B
 
- sgIsSmallest _ _ G⊆B (var Gx) = G⊆B Gx
- sgIsSmallest B B≤A G⊆B {.((f ^ 𝑨) a)} (app f a SgGa) = Goal
-  where
-  IH : Im a ⊆ B
-  IH i = sgIsSmallest B B≤A G⊆B (SgGa i)
+  sgIsSmallest _ _ G⊆B (var Gx) = G⊆B Gx
+  sgIsSmallest B B≤A G⊆B {.((f ^ 𝑨) a)} (app f a SgGa) = Goal
+   where
+   IH : Im a ⊆ B
+   IH i = sgIsSmallest B B≤A G⊆B (SgGa i)
 
-  Goal : (f ^ 𝑨) a ∈ B
-  Goal = B≤A f a IH
+   Goal : (f ^ 𝑨) a ∈ B
+   Goal = B≤A f a IH
 ```
 
 
@@ -105,12 +105,12 @@ When the element of `Sg G` is constructed as `app f a SgGa`, we may assume (the 
 
 ```agda
 module _ {𝑨 : Algebra α ρᵃ} where
- private A = 𝕌[ 𝑨 ]
+  private A = 𝕌[ 𝑨 ]
 
- ⋂s :  {ι : Level}(I : Type ι){ρ : Level}{𝒜 : I → Pred A ρ}
-  →    (∀ i → 𝒜 i ∈ Subuniverses 𝑨) → ⋂ I 𝒜 ∈ Subuniverses 𝑨
+  ⋂s :  {ι : Level}(I : Type ι){ρ : Level}{𝒜 : I → Pred A ρ}
+   →    (∀ i → 𝒜 i ∈ Subuniverses 𝑨) → ⋂ I 𝒜 ∈ Subuniverses 𝑨
 
- ⋂s I σ f a ν = λ i → σ i f a (λ x → ν x i)
+  ⋂s I σ f a ν = λ i → σ i f a (λ x → ν x i)
 ```
 
 
@@ -128,21 +128,21 @@ Agda fills in the proof term `λ i → σ i f a (λ x → ν x i)` automatically
 
 ```agda
 module _ {𝑨 : Algebra α ρᵃ} where
- private A = 𝕌[ 𝑨 ]
- open Setoid using ( Carrier )
- open Environment 𝑨
- open Func renaming ( to to _⟨$⟩_ )
+  private A = 𝕌[ 𝑨 ]
+  open Setoid using ( Carrier )
+  open Environment 𝑨
+  open Func renaming ( to to _⟨$⟩_ )
 
- -- subuniverses are closed under the action of term operations
- sub-term-closed :  (B : Pred A ℓ)
-  →                 (B ∈ Subuniverses 𝑨)
-  →                 (t : Term X)
-  →                 (b : Carrier (Env X))
-  →                 (∀ x → b x ∈ B) → ⟦ t ⟧ ⟨$⟩ b ∈ B
+  -- subuniverses are closed under the action of term operations
+  sub-term-closed :  (B : Pred A ℓ)
+   →                 (B ∈ Subuniverses 𝑨)
+   →                 (t : Term X)
+   →                 (b : Carrier (Env X))
+   →                 (∀ x → b x ∈ B) → ⟦ t ⟧ ⟨$⟩ b ∈ B
 
- sub-term-closed _ _ (ℊ x) b Bb = Bb x
- sub-term-closed B B≤A (node f t)b ν =
-  B≤A f  (λ z → ⟦ t z ⟧ ⟨$⟩ b) λ x → sub-term-closed B B≤A (t x) b ν
+  sub-term-closed _ _ (ℊ x) b Bb = Bb x
+  sub-term-closed B B≤A (node f t)b ν =
+   B≤A f  (λ z → ⟦ t z ⟧ ⟨$⟩ b) λ x → sub-term-closed B B≤A (t x) b ν
 ```
 
 
@@ -163,20 +163,20 @@ Alternatively, we could express the preceeding fact using an inductive type repr
 
 
 ```agda
- data TermImage (B : Pred A ρᵃ) : Pred A (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵃ) where
-  var : ∀ {b : A} → b ∈ B → b ∈ TermImage B
-  app : ∀ f ts →  ((i : ArityOf 𝑆 f) → ts i ∈ TermImage B)  → (f ^ 𝑨) ts ∈ TermImage B
+  data TermImage (B : Pred A ρᵃ) : Pred A (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρᵃ) where
+   var : ∀ {b : A} → b ∈ B → b ∈ TermImage B
+   app : ∀ f ts →  ((i : ArityOf 𝑆 f) → ts i ∈ TermImage B)  → (f ^ 𝑨) ts ∈ TermImage B
 
- -- `TermImage B` is a subuniverse of 𝑨 that contains B.
- TermImageIsSub : {B : Pred A ρᵃ} → TermImage B ∈ Subuniverses 𝑨
- TermImageIsSub = app
+  -- `TermImage B` is a subuniverse of 𝑨 that contains B.
+  TermImageIsSub : {B : Pred A ρᵃ} → TermImage B ∈ Subuniverses 𝑨
+  TermImageIsSub = app
 
- B-onlyif-TermImageB : {B : Pred A ρᵃ} → B ⊆ TermImage B
- B-onlyif-TermImageB Ba = var Ba
+  B-onlyif-TermImageB : {B : Pred A ρᵃ} → B ⊆ TermImage B
+  B-onlyif-TermImageB Ba = var Ba
 
- -- Since `Sg B` is the smallest subuniverse containing B, we obtain the following inclusion.
- SgB-onlyif-TermImageB : (B : Pred A ρᵃ) → Sg 𝑨 B ⊆ TermImage B
- SgB-onlyif-TermImageB B = sgIsSmallest 𝑨 (TermImage B) TermImageIsSub B-onlyif-TermImageB
+  -- Since `Sg B` is the smallest subuniverse containing B, we obtain the following inclusion.
+  SgB-onlyif-TermImageB : (B : Pred A ρᵃ) → Sg 𝑨 B ⊆ TermImage B
+  SgB-onlyif-TermImageB B = sgIsSmallest 𝑨 (TermImage B) TermImageIsSub B-onlyif-TermImageB
 ```
 
 
@@ -186,34 +186,34 @@ we call `hom-unique`.
 
 
 ```agda
- module _ {𝑩 : Algebra β ρᵇ} (gh hh : hom 𝑨 𝑩) where
-  open Algebra 𝑩  using ( Interp )  renaming ( Domain to B )
-  open Setoid B   using ( _≈_ ; sym )
-  open Func       using ( cong )    renaming ( to to _⟨$⟩_ )
-  open SetoidReasoning B
+  module _ {𝑩 : Algebra β ρᵇ} (gh hh : hom 𝑨 𝑩) where
+   open Algebra 𝑩  using ( Interp )  renaming ( Domain to B )
+   open Setoid B   using ( _≈_ ; sym )
+   open Func       using ( cong )    renaming ( to to _⟨$⟩_ )
+   open SetoidReasoning B
 
-  private
-   g = _⟨$⟩_ (proj₁ gh)
-   h = _⟨$⟩_ (proj₁ hh)
+   private
+    g = _⟨$⟩_ (proj₁ gh)
+    h = _⟨$⟩_ (proj₁ hh)
 
-  open IsHom
-  open Environment 𝑩
+   open IsHom
+   open Environment 𝑩
 
-  hom-unique :  (G : Pred A ℓ) → ((x : A) → (x ∈ G → g x ≈ h x))
-   →            (a : A) → (a ∈ Sg 𝑨 G → g a ≈ h a)
+   hom-unique :  (G : Pred A ℓ) → ((x : A) → (x ∈ G → g x ≈ h x))
+    →            (a : A) → (a ∈ Sg 𝑨 G → g a ≈ h a)
 
-  hom-unique G σ a (var Ga) = σ a Ga
-  hom-unique G σ .((f ^ 𝑨) a) (app f a SgGa) = Goal
-   where
-   IH : ∀ i → h (a i) ≈ g (a i)
-   IH i = sym (hom-unique G σ (a i) (SgGa i))
+   hom-unique G σ a (var Ga) = σ a Ga
+   hom-unique G σ .((f ^ 𝑨) a) (app f a SgGa) = Goal
+    where
+    IH : ∀ i → h (a i) ≈ g (a i)
+    IH i = sym (hom-unique G σ (a i) (SgGa i))
 
-   Goal : g ((f ^ 𝑨) a) ≈ h ((f ^ 𝑨) a)
-   Goal =  begin
-           g ((f ^ 𝑨) a)    ≈⟨ compatible (proj₂ gh) ⟩
-           (f ^ 𝑩)(g ∘ a )  ≈˘⟨ cong Interp (refl , IH) ⟩
-           (f ^ 𝑩)(h ∘ a)   ≈˘⟨ compatible (proj₂ hh) ⟩
-           h ((f ^ 𝑨) a )   ∎
+    Goal : g ((f ^ 𝑨) a) ≈ h ((f ^ 𝑨) a)
+    Goal =  begin
+            g ((f ^ 𝑨) a)    ≈⟨ compatible (proj₂ gh) ⟩
+            (f ^ 𝑩)(g ∘ a )  ≈˘⟨ cong Interp (refl , IH) ⟩
+            (f ^ 𝑩)(h ∘ a)   ≈˘⟨ compatible (proj₂ hh) ⟩
+            h ((f ^ 𝑨) a )   ∎
 ```
 
 

--- a/src/Setoid/Terms/Basic.lagda.md
+++ b/src/Setoid/Terms/Basic.lagda.md
@@ -35,8 +35,8 @@ open Func renaming ( to to _⟨$⟩_ )
 open Term
 
 private variable
- χ α ℓ : Level
- X Y : Type χ
+  χ α ℓ : Level
+  X Y : Type χ
 ```
 
 #### Equality of terms
@@ -50,29 +50,29 @@ as a Algebra whose carrier is the setoid of terms.
 ```agda
 module _ {X : Type χ } where
 
- -- Equality of terms as an inductive datatype
- data _≐_ : Term X → Term X → Type (ov χ) where
-  rfl :  {x y : X} → x ≡ y → ℊ x ≐ ℊ y
-  gnl :  {f : OperationSymbolsOf 𝑆}{s t : ArityOf 𝑆 f → Term X}
-         → (∀ i → s i ≐ t i) → node f s ≐ node f t
+  -- Equality of terms as an inductive datatype
+  data _≐_ : Term X → Term X → Type (ov χ) where
+   rfl :  {x y : X} → x ≡ y → ℊ x ≐ ℊ y
+   gnl :  {f : OperationSymbolsOf 𝑆}{s t : ArityOf 𝑆 f → Term X}
+          → (∀ i → s i ≐ t i) → node f s ≐ node f t
 
- infix 4 _≐_
+  infix 4 _≐_
 
- -- Equality of terms is an equivalence relation
- ≐-isRefl : Reflexive _≐_
- ≐-isRefl {ℊ _} = rfl refl
- ≐-isRefl {node _ _} = gnl λ _ → ≐-isRefl
+  -- Equality of terms is an equivalence relation
+  ≐-isRefl : Reflexive _≐_
+  ≐-isRefl {ℊ _} = rfl refl
+  ≐-isRefl {node _ _} = gnl λ _ → ≐-isRefl
 
- ≐-isSym : Symmetric _≐_
- ≐-isSym (rfl x) = rfl (sym x)
- ≐-isSym (gnl x) = gnl λ i → ≐-isSym (x i)
+  ≐-isSym : Symmetric _≐_
+  ≐-isSym (rfl x) = rfl (sym x)
+  ≐-isSym (gnl x) = gnl λ i → ≐-isSym (x i)
 
- ≐-isTrans : Transitive _≐_
- ≐-isTrans (rfl x) (rfl y) = rfl (trans x y)
- ≐-isTrans (gnl x) (gnl y) = gnl λ i → ≐-isTrans (x i) (y i)
+  ≐-isTrans : Transitive _≐_
+  ≐-isTrans (rfl x) (rfl y) = rfl (trans x y)
+  ≐-isTrans (gnl x) (gnl y) = gnl λ i → ≐-isTrans (x i) (y i)
 
- ≐-isEquiv : IsEquivalence _≐_
- ≐-isEquiv = record { refl = ≐-isRefl ; sym = ≐-isSym ; trans = ≐-isTrans }
+  ≐-isEquiv : IsEquivalence _≐_
+  ≐-isEquiv = record { refl = ≐-isRefl ; sym = ≐-isSym ; trans = ≐-isTrans }
 
 TermSetoid : (X : Type χ) → Setoid (ov χ) (ov χ)
 TermSetoid X = record { Carrier = Term X ; _≈_ = _≐_ ; isEquivalence = ≐-isEquiv }

--- a/src/Setoid/Terms/Operations.lagda.md
+++ b/src/Setoid/Terms/Operations.lagda.md
@@ -44,8 +44,8 @@ open Term
 open _⟶_ using ( cong ) renaming ( to to _⟨$⟩_ )
 
 private variable
- α ρᵃ β ρᵇ ρ χ ι : Level
- X : Type χ
+  α ρᵃ β ρᵇ ρ χ ι : Level
+  X : Type χ
 ```
 
 
@@ -85,15 +85,15 @@ module _ {X : Type χ} where
 
 ```agda
 module _ {X : Type χ }{I : Type ι}(𝒜 : I → Algebra α ρᵃ) where
- open Algebra (⨅ 𝒜)      using (Interp)  renaming ( Domain to ⨅A )
- open Setoid ⨅A          using ( _≈_ ; refl )
- open Environment (⨅ 𝒜)  using ()        renaming ( ⟦_⟧ to ⟦_⟧₁ )
- open Environment        using ( ⟦_⟧ ; ≐→Equal )
+  open Algebra (⨅ 𝒜)      using (Interp)  renaming ( Domain to ⨅A )
+  open Setoid ⨅A          using ( _≈_ ; refl )
+  open Environment (⨅ 𝒜)  using ()        renaming ( ⟦_⟧ to ⟦_⟧₁ )
+  open Environment        using ( ⟦_⟧ ; ≐→Equal )
 
- interp-prod : (p : Term X)
-   → ∀ ρ → ⟦ p ⟧₁ ⟨$⟩ ρ ≈ λ i → (⟦ 𝒜 i ⟧ p) ⟨$⟩ λ x → (ρ x) i
- interp-prod (ℊ x) = λ ρ i → ≐→Equal (𝒜 i) (ℊ x) (ℊ x) ≐-isRefl λ x' → (ρ x) i
- interp-prod (node f t) = λ ρ i → cong Interp (≡.refl , (λ j k → interp-prod (t j) ρ k)) i
+  interp-prod : (p : Term X)
+    → ∀ ρ → ⟦ p ⟧₁ ⟨$⟩ ρ ≈ λ i → (⟦ 𝒜 i ⟧ p) ⟨$⟩ λ x → (ρ x) i
+  interp-prod (ℊ x) = λ ρ i → ≐→Equal (𝒜 i) (ℊ x) (ℊ x) ≐-isRefl λ x' → (ρ x) i
+  interp-prod (node f t) = λ ρ i → cong Interp (≡.refl , (λ j k → interp-prod (t j) ρ k)) i
 ```
 
 #### Compatibility of terms

--- a/src/Setoid/Terms/Properties.lagda.md
+++ b/src/Setoid/Terms/Properties.lagda.md
@@ -41,8 +41,8 @@ open Term
 open _⟶_ using ( ) renaming ( to to _⟨$⟩_ ; cong to ≈cong )
 
 private variable
- α ρᵃ β ρᵇ ρ χ : Level
- X : Type χ
+  α ρᵃ β ρᵇ ρ χ : Level
+  X : Type χ
 ```
 
 The term algebra `𝑻 X` is *absolutely free* (or *universal*, or *initial*) for
@@ -178,12 +178,12 @@ signature varies along a morphism, is `reduct-interp` in
 
 ```agda
 module _ {𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}(h : hom 𝑨 𝑩)(η : X → 𝕌[ 𝑨 ]) where
- open Setoid 𝔻[ 𝑩 ] using () renaming ( _≈_ to _≈ᵇ_ ; refl to reflᵇ )
+  open Setoid 𝔻[ 𝑩 ] using () renaming ( _≈_ to _≈ᵇ_ ; refl to reflᵇ )
 
- free-lift-natural : (t : Term X)
-  →                  proj₁ h ⟨$⟩ free-lift{𝑨 = 𝑨} η t ≈ᵇ free-lift{𝑨 = 𝑩} (λ x → proj₁ h ⟨$⟩ η x) t
+  free-lift-natural : (t : Term X)
+   →                  proj₁ h ⟨$⟩ free-lift{𝑨 = 𝑨} η t ≈ᵇ free-lift{𝑨 = 𝑩} (λ x → proj₁ h ⟨$⟩ η x) t
 
- free-lift-natural =
-  free-unique {𝑨 = 𝑩} {gh = ⊙-hom (lift-hom η) h} {hh = lift-hom (λ x → proj₁ h ⟨$⟩ η x)}
-   (λ _ → reflᵇ)
+  free-lift-natural =
+   free-unique {𝑨 = 𝑩} {gh = ⊙-hom (lift-hom η) h} {hh = lift-hom (λ x → proj₁ h ⟨$⟩ η x)}
+    (λ _ → reflᵇ)
 ```

--- a/src/Setoid/Varieties/EquationalLogic.lagda.md
+++ b/src/Setoid/Varieties/EquationalLogic.lagda.md
@@ -50,18 +50,18 @@ open _⟶_ using () renaming ( to to _⟨$⟩_ )
 
 module _  {X : Type χ} where
 
- open Setoid   using ( Carrier )
- open Algebra  using ( Domain )
+  open Setoid   using ( Carrier )
+  open Algebra  using ( Domain )
 
- _⊧_≈_ : Algebra α ρᵃ → Term X → Term X → Type _
- 𝑨 ⊧ p ≈ q = ∀ (ρ : Carrier (Env X)) → ⟦ p ⟧ ⟨$⟩ ρ ≈ ⟦ q ⟧ ⟨$⟩ ρ
-  where
-  open Setoid ( Domain 𝑨 )  using ( _≈_ )
-  open Environment 𝑨        using ( Env ; ⟦_⟧ )
- infix 10 _⊧_≈_
+  _⊧_≈_ : Algebra α ρᵃ → Term X → Term X → Type _
+  𝑨 ⊧ p ≈ q = ∀ (ρ : Carrier (Env X)) → ⟦ p ⟧ ⟨$⟩ ρ ≈ ⟦ q ⟧ ⟨$⟩ ρ
+   where
+   open Setoid ( Domain 𝑨 )  using ( _≈_ )
+   open Environment 𝑨        using ( Env ; ⟦_⟧ )
+  infix 10 _⊧_≈_
 
- _⊫_≈_ : Pred(Algebra α ρᵃ) ℓ → Term X → Term X → Type (χ ⊔ ℓ ⊔ ov(α ⊔ ρᵃ))
- 𝒦 ⊫ p ≈ q = {𝑨 : Algebra _ _} → 𝒦 𝑨 → 𝑨 ⊧ p ≈ q
+  _⊫_≈_ : Pred(Algebra α ρᵃ) ℓ → Term X → Term X → Type (χ ⊔ ℓ ⊔ ov(α ⊔ ρᵃ))
+  𝒦 ⊫ p ≈ q = {𝑨 : Algebra _ _} → 𝒦 𝑨 → 𝑨 ⊧ p ≈ q
 ```
 
 (**Unicode tip**. Type \models to get `⊧` ; type \||= to get `⊫`.)
@@ -78,11 +78,11 @@ If 𝒦 denotes a class of structures, then `Th 𝒦` represents the set of iden
 modeled by the members of 𝒦.
 
 ```agda
- Th' : Pred (Algebra α ρᵃ) ℓ → Pred(Term X × Term X) (χ ⊔ ℓ ⊔ ov(α ⊔ ρᵃ))
- Th' 𝒦 = λ (p , q) → 𝒦 ⊫ p ≈ q
+  Th' : Pred (Algebra α ρᵃ) ℓ → Pred(Term X × Term X) (χ ⊔ ℓ ⊔ ov(α ⊔ ρᵃ))
+  Th' 𝒦 = λ (p , q) → 𝒦 ⊫ p ≈ q
 
 Th'' :  {χ α : Level}{X : Type χ} → Pred (Algebra α α) (ov α)
- →      Pred(Term X × Term X) (χ ⊔ ov α)
+  →      Pred(Term X × Term X) (χ ⊔ ov α)
 Th'' 𝒦 = λ (p , q) → 𝒦 ⊫ p ≈ q
 ```
 
@@ -91,24 +91,24 @@ essentially by taking `Th 𝒦` itself to be the index set, as shown below.
 
 ```agda
 module _ {X : Type χ}{𝒦 : Pred (Algebra α ρᵃ) (ov α)} where
- ℐ : Type (ov(α ⊔ ρᵃ ⊔ χ))
- ℐ = Σ[ (p , q) ∈ (Term X × Term X) ] 𝒦 ⊫ p ≈ q
+  ℐ : Type (ov(α ⊔ ρᵃ ⊔ χ))
+  ℐ = Σ[ (p , q) ∈ (Term X × Term X) ] 𝒦 ⊫ p ≈ q
 
- ℰ : ℐ → Term X × Term X
- ℰ ((p , q) , _) = (p , q)
+  ℰ : ℐ → Term X × Term X
+  ℰ ((p , q) , _) = (p , q)
 ```
 
 If `ℰ` denotes a set of identities, then `Mod ℰ` is the class of structures
 satisfying the identities in `ℰ`.
 
 ```agda
- Mod' : Pred(Term X × Term X) (ov α) → Pred(Algebra α ρᵃ) (ρᵃ ⊔ ov(α ⊔ χ))
- Mod' ℰ = λ 𝑨 → ∀ p q → (p , q) ∈ ℰ → 𝑨 ⊧ p ≈ q
+  Mod' : Pred(Term X × Term X) (ov α) → Pred(Algebra α ρᵃ) (ρᵃ ⊔ ov(α ⊔ χ))
+  Mod' ℰ = λ 𝑨 → ∀ p q → (p , q) ∈ ℰ → 𝑨 ⊧ p ≈ q
 ```
 
 It is sometimes more convenient to have a "tupled" version of the previous definition, which we denote by `Modᵗ` and define as follows.
 
 ```agda
- Modᵗ : {I : Type ι} → (I → Term X × Term X) → {α : Level} → Pred(Algebra α ρᵃ) (χ ⊔ ρᵃ ⊔ ι ⊔ α)
- Modᵗ ℰ = λ 𝑨 → ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
+  Modᵗ : {I : Type ι} → (I → Term X × Term X) → {α : Level} → Pred(Algebra α ρᵃ) (χ ⊔ ρᵃ ⊔ ι ⊔ α)
+  Modᵗ ℰ = λ 𝑨 → ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 ```

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -61,29 +61,29 @@ prove a handful of such properties that we need later.
 
 ```agda
 module _  {α ρᵃ ℓ : Level}{𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)} where
- private
-  a = α ⊔ ρᵃ
-  oaℓ = ov (a ⊔ ℓ)
+  private
+   a = α ⊔ ρᵃ
+   oaℓ = ov (a ⊔ ℓ)
 
- S⊆SP : ∀{ι} → S ℓ 𝒦 ⊆ S {β = α}{ρᵃ} (a ⊔ ℓ ⊔ ι) (P {β = α}{ρᵃ} ℓ ι 𝒦)
- S⊆SP {ι} (𝑨 , (kA , B≤A )) = 𝑨 , (pA , B≤A)
-  where
-  pA : 𝑨 ∈ P ℓ ι 𝒦
-  pA = ⊤ , (λ _ → 𝑨) , (λ _ → kA) , ≅⨅⁺-refl
+  S⊆SP : ∀{ι} → S ℓ 𝒦 ⊆ S {β = α}{ρᵃ} (a ⊔ ℓ ⊔ ι) (P {β = α}{ρᵃ} ℓ ι 𝒦)
+  S⊆SP {ι} (𝑨 , (kA , B≤A )) = 𝑨 , (pA , B≤A)
+   where
+   pA : 𝑨 ∈ P ℓ ι 𝒦
+   pA = ⊤ , (λ _ → 𝑨) , (λ _ → kA) , ≅⨅⁺-refl
 
- P⊆SP : ∀{ι} → P ℓ ι 𝒦 ⊆ S (a ⊔ ℓ ⊔ ι) (P {β = α}{ρᵃ}ℓ ι 𝒦)
- P⊆SP {ι} x = S-expa{ℓ = a ⊔ ℓ ⊔ ι} x
+  P⊆SP : ∀{ι} → P ℓ ι 𝒦 ⊆ S (a ⊔ ℓ ⊔ ι) (P {β = α}{ρᵃ}ℓ ι 𝒦)
+  P⊆SP {ι} x = S-expa{ℓ = a ⊔ ℓ ⊔ ι} x
 
 
- P⊆HSP : ∀{ι} →  P {β = α}{ρᵃ} ℓ ι 𝒦
-                 ⊆ H (a ⊔ ℓ ⊔ ι) (S {β = α}{ρᵃ}(a ⊔ ℓ ⊔ ι) (P {β = α}{ρᵃ}ℓ ι 𝒦))
- P⊆HSP {ι} x = H-expa{ℓ = a ⊔ ℓ ⊔ ι}  (S-expa{ℓ = a ⊔ ℓ ⊔ ι} x)
+  P⊆HSP : ∀{ι} →  P {β = α}{ρᵃ} ℓ ι 𝒦
+                  ⊆ H (a ⊔ ℓ ⊔ ι) (S {β = α}{ρᵃ}(a ⊔ ℓ ⊔ ι) (P {β = α}{ρᵃ}ℓ ι 𝒦))
+  P⊆HSP {ι} x = H-expa{ℓ = a ⊔ ℓ ⊔ ι}  (S-expa{ℓ = a ⊔ ℓ ⊔ ι} x)
 
- P⊆V : ∀{ι} → P ℓ ι 𝒦 ⊆ V ℓ ι 𝒦
- P⊆V = P⊆HSP
+  P⊆V : ∀{ι} → P ℓ ι 𝒦 ⊆ V ℓ ι 𝒦
+  P⊆V = P⊆HSP
 
- SP⊆V : ∀{ι} → S{β = α}{ρᵇ = ρᵃ} (a ⊔ ℓ ⊔ ι) (P {β = α}{ρᵃ} ℓ ι 𝒦) ⊆ V ℓ ι 𝒦
- SP⊆V {ι} x = H-expa{ℓ = a ⊔ ℓ ⊔ ι} x
+  SP⊆V : ∀{ι} → S{β = α}{ρᵇ = ρᵃ} (a ⊔ ℓ ⊔ ι) (P {β = α}{ρᵃ} ℓ ι 𝒦) ⊆ V ℓ ι 𝒦
+  SP⊆V {ι} x = H-expa{ℓ = a ⊔ ℓ ⊔ ι} x
 ```
 
 
@@ -92,17 +92,17 @@ in a class 𝒦 is a subalgebra of a product of algebras in 𝒦.
 
 
 ```agda
- PS⊆SP : P (a ⊔ ℓ) oaℓ (S{β = α}{ρᵃ} ℓ 𝒦) ⊆ S oaℓ (P ℓ oaℓ 𝒦)
- PS⊆SP {𝑩} (I , ( 𝒜 , sA , B≅⨅A )) = Goal
-  where
-  ℬ : I → Algebra α ρᵃ
-  ℬ i = (proj₁ (sA i))
-  kB : (i : I) → ℬ i ∈ 𝒦
-  kB i =  proj₁ (proj₂ (sA i))
-  ⨅A≤⨅B : ⨅ 𝒜 ≤ ⨅ ℬ
-  ⨅A≤⨅B = ⨅-≤ λ i → proj₂ (proj₂ (sA i))
-  Goal : 𝑩 ∈ S{β = oaℓ}{oaℓ}oaℓ (P {β = oaℓ}{oaℓ} ℓ oaℓ 𝒦)
-  Goal = ⨅ ℬ , (I , (ℬ , (kB , ≅-refl))) , (≅-trans-≤ B≅⨅A ⨅A≤⨅B)
+  PS⊆SP : P (a ⊔ ℓ) oaℓ (S{β = α}{ρᵃ} ℓ 𝒦) ⊆ S oaℓ (P ℓ oaℓ 𝒦)
+  PS⊆SP {𝑩} (I , ( 𝒜 , sA , B≅⨅A )) = Goal
+   where
+   ℬ : I → Algebra α ρᵃ
+   ℬ i = (proj₁ (sA i))
+   kB : (i : I) → ℬ i ∈ 𝒦
+   kB i =  proj₁ (proj₂ (sA i))
+   ⨅A≤⨅B : ⨅ 𝒜 ≤ ⨅ ℬ
+   ⨅A≤⨅B = ⨅-≤ λ i → proj₂ (proj₂ (sA i))
+   Goal : 𝑩 ∈ S{β = oaℓ}{oaℓ}oaℓ (P {β = oaℓ}{oaℓ} ℓ oaℓ 𝒦)
+   Goal = ⨅ ℬ , (I , (ℬ , (kB , ≅-refl))) , (≅-trans-≤ B≅⨅A ⨅A≤⨅B)
 ```
 
 
@@ -113,13 +113,13 @@ First we prove that the closure operator H is compatible with identities that ho
 
 ```agda
 module _   {α ρᵃ ℓ χ : Level}
-           {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)}
-           {X : Type χ}
-           {p q : Term X}
-           where
+            {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)}
+            {X : Type χ}
+            {p q : Term X}
+            where
 
- H-id1 : 𝒦 ⊫ (p ≈̇ q) → H {β = α}{ρᵃ}ℓ 𝒦 ⊫ (p ≈̇ q)
- H-id1 σ .⊫-proof 𝑩 (𝑨 , kA , BimgA) = ⊧-H-invar{p = p}{q} (σ .⊫-proof 𝑨 kA) BimgA
+  H-id1 : 𝒦 ⊫ (p ≈̇ q) → H {β = α}{ρᵃ}ℓ 𝒦 ⊫ (p ≈̇ q)
+  H-id1 σ .⊫-proof 𝑩 (𝑨 , kA , BimgA) = ⊧-H-invar{p = p}{q} (σ .⊫-proof 𝑨 kA) BimgA
 ```
 
 
@@ -127,8 +127,8 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 ```agda
- H-id2 : H ℓ 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
- H-id2 Hpq .⊫-proof 𝑨 kA = Hpq .⊫-proof 𝑨 (𝑨 , (kA , IdHomImage))
+  H-id2 : H ℓ 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
+  H-id2 Hpq .⊫-proof 𝑨 kA = Hpq .⊫-proof 𝑨 (𝑨 , (kA , IdHomImage))
 ```
 
 
@@ -137,11 +137,11 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 ```agda
- S-id1 : 𝒦 ⊫ (p ≈̇ q) → (S {β = α}{ρᵃ} ℓ 𝒦) ⊫ (p ≈̇ q)
- S-id1 σ .⊫-proof 𝑩 (𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (σ .⊫-proof 𝑨 kA) B≤A
+  S-id1 : 𝒦 ⊫ (p ≈̇ q) → (S {β = α}{ρᵃ} ℓ 𝒦) ⊫ (p ≈̇ q)
+  S-id1 σ .⊫-proof 𝑩 (𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (σ .⊫-proof 𝑨 kA) B≤A
 
- S-id2 : S ℓ 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
- S-id2 Spq .⊫-proof 𝑨 kA = Spq .⊫-proof 𝑨 (𝑨 , (kA , ≤-reflexive))
+  S-id2 : S ℓ 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
+  S-id2 Spq .⊫-proof 𝑨 kA = Spq .⊫-proof 𝑨 (𝑨 , (kA , ≤-reflexive))
 ```
 
 
@@ -151,16 +151,16 @@ The converse of the foregoing result is almost too obvious to bother with. Nonet
 
 
 ```agda
- P-id1 : ∀{ι} → 𝒦 ⊫ (p ≈̇ q) → P {β = α}{ρᵃ}ℓ ι 𝒦 ⊫ (p ≈̇ q)
- P-id1 σ .⊫-proof 𝑨 (I , 𝒜 , kA , A≅⨅A) = ⊧-I-invar 𝑨 p q IH (≅-sym A≅⨅A)
-  where
-  ih : ∀ i → 𝒜 i ⊧ (p ≈̇ q)
-  ih i = σ .⊫-proof (𝒜 i) (kA i)
-  IH : ⨅ 𝒜 ⊧ (p ≈̇ q)
-  IH = ⊧-P-invar {p = p}{q} 𝒜 ih
+  P-id1 : ∀{ι} → 𝒦 ⊫ (p ≈̇ q) → P {β = α}{ρᵃ}ℓ ι 𝒦 ⊫ (p ≈̇ q)
+  P-id1 σ .⊫-proof 𝑨 (I , 𝒜 , kA , A≅⨅A) = ⊧-I-invar 𝑨 p q IH (≅-sym A≅⨅A)
+   where
+   ih : ∀ i → 𝒜 i ⊧ (p ≈̇ q)
+   ih i = σ .⊫-proof (𝒜 i) (kA i)
+   IH : ⨅ 𝒜 ⊧ (p ≈̇ q)
+   IH = ⊧-P-invar {p = p}{q} 𝒜 ih
 
- P-id2 : ∀{ι} → P ℓ ι 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
- P-id2{ι} PKpq .⊫-proof 𝑨 kA = PKpq .⊫-proof 𝑨 (P-expa {ℓ = ℓ}{ι} kA)
+  P-id2 : ∀{ι} → P ℓ ι 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
+  P-id2{ι} PKpq .⊫-proof 𝑨 kA = PKpq .⊫-proof 𝑨 (P-expa {ℓ = ℓ}{ι} kA)
 ```
 
 
@@ -172,31 +172,31 @@ Finally, we prove the analogous preservation lemmas for the closure operator `V`
 
 ```agda
 module _  {α ρᵃ ℓ ι χ : Level}
-          {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)}
-          {X : Type χ}
-          {p q : Term X} where
+           {𝒦 : Pred(Algebra α ρᵃ) (α ⊔ ρᵃ ⊔ ov ℓ)}
+           {X : Type χ}
+           {p q : Term X} where
 
- private aℓι = α ⊔ ρᵃ ⊔ ℓ ⊔ ι
+  private aℓι = α ⊔ ρᵃ ⊔ ℓ ⊔ ι
 
- V-id1 : 𝒦 ⊫ (p ≈̇ q) → V ℓ ι 𝒦 ⊫ (p ≈̇ q)
- V-id1 σ .⊫-proof 𝑩 (𝑨 , (⨅A , p⨅A , A≤⨅A) , BimgA) =
-  H-id1{ℓ = aℓι}{𝒦 = S aℓι (P {β = α}{ρᵃ}ℓ ι 𝒦)} spK⊧pq .⊫-proof 𝑩 (𝑨 , (spA , BimgA))
+  V-id1 : 𝒦 ⊫ (p ≈̇ q) → V ℓ ι 𝒦 ⊫ (p ≈̇ q)
+  V-id1 σ .⊫-proof 𝑩 (𝑨 , (⨅A , p⨅A , A≤⨅A) , BimgA) =
+   H-id1{ℓ = aℓι}{𝒦 = S aℓι (P {β = α}{ρᵃ}ℓ ι 𝒦)} spK⊧pq .⊫-proof 𝑩 (𝑨 , (spA , BimgA))
+    where
+    spA : 𝑨 ∈ S aℓι (P {β = α}{ρᵃ}ℓ ι 𝒦)
+    spA = ⨅A , (p⨅A , A≤⨅A)
+    spK⊧pq : S aℓι (P ℓ ι 𝒦) ⊫ (p ≈̇ q)
+    spK⊧pq = S-id1{ℓ = aℓι} (P-id1{ℓ = ℓ} {𝒦 = 𝒦} σ)
+
+  V-id2 : V ℓ ι 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
+  V-id2 Vpq .⊫-proof 𝑨 kA = Vpq .⊫-proof 𝑨 (V-expa ℓ ι kA)
+
+  Lift-id1 : ∀{β ρᵇ} → 𝒦 ⊫ (p ≈̇ q) → Level-closure{α}{ρᵃ}{β}{ρᵇ} ℓ 𝒦 ⊫ (p ≈̇ q)
+  Lift-id1 pKq .⊫-proof 𝑨 (𝑩 , kB , B≅A) ρ = Goal
    where
-   spA : 𝑨 ∈ S aℓι (P {β = α}{ρᵃ}ℓ ι 𝒦)
-   spA = ⨅A , (p⨅A , A≤⨅A)
-   spK⊧pq : S aℓι (P ℓ ι 𝒦) ⊫ (p ≈̇ q)
-   spK⊧pq = S-id1{ℓ = aℓι} (P-id1{ℓ = ℓ} {𝒦 = 𝒦} σ)
-
- V-id2 : V ℓ ι 𝒦 ⊫ (p ≈̇ q) → 𝒦 ⊫ (p ≈̇ q)
- V-id2 Vpq .⊫-proof 𝑨 kA = Vpq .⊫-proof 𝑨 (V-expa ℓ ι kA)
-
- Lift-id1 : ∀{β ρᵇ} → 𝒦 ⊫ (p ≈̇ q) → Level-closure{α}{ρᵃ}{β}{ρᵇ} ℓ 𝒦 ⊫ (p ≈̇ q)
- Lift-id1 pKq .⊫-proof 𝑨 (𝑩 , kB , B≅A) ρ = Goal
-  where
-  open Environment 𝑨
-  open Setoid (Domain 𝑨) using (_≈_)
-  Goal : ⟦ p ⟧ ⟨$⟩ ρ ≈ ⟦ q ⟧ ⟨$⟩ ρ
-  Goal = ⊧-I-invar 𝑨 p q (pKq .⊫-proof 𝑩 kB) B≅A ρ
+   open Environment 𝑨
+   open Setoid (Domain 𝑨) using (_≈_)
+   Goal : ⟦ p ⟧ ⟨$⟩ ρ ≈ ⟦ q ⟧ ⟨$⟩ ρ
+   Goal = ⊧-I-invar 𝑨 p q (pKq .⊫-proof 𝑩 kB) B≅A ρ
 ```
 
 
@@ -210,9 +210,9 @@ modeled by `𝒦`.   We formalize this observation as follows.
 
 
 ```agda
- classIds-⊆-VIds : 𝒦 ⊫ (p ≈̇ q)  → (p , q) ∈ Th (V ℓ ι 𝒦)
- classIds-⊆-VIds pKq = V-id1 pKq
+  classIds-⊆-VIds : 𝒦 ⊫ (p ≈̇ q)  → (p , q) ∈ Th (V ℓ ι 𝒦)
+  classIds-⊆-VIds pKq = V-id1 pKq
 
- VIds-⊆-classIds : (p , q) ∈ Th (V ℓ ι 𝒦) → 𝒦 ⊫ (p ≈̇ q)
- VIds-⊆-classIds Thpq = V-id2 Thpq
+  VIds-⊆-classIds : (p , q) ∈ Th (V ℓ ι 𝒦) → 𝒦 ⊫ (p ≈̇ q)
+  VIds-⊆-classIds Thpq = V-id2 Thpq
 ```

--- a/src/Setoid/Varieties/Properties.lagda.md
+++ b/src/Setoid/Varieties/Properties.lagda.md
@@ -63,31 +63,31 @@ The binary relation ⊧ would be practically useless if it were not an *algebrai
 
 ```agda
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}(𝑩 : Algebra β ρᵇ)(p q : Term X) where
- open Environment 𝑨      using () renaming ( ⟦_⟧   to ⟦_⟧₁ )
- open Environment 𝑩      using () renaming ( ⟦_⟧   to ⟦_⟧₂ )
- open Setoid (Domain 𝑩)  using ( _≈_ ; sym ; trans )
- open SetoidReasoning (Domain 𝑩)
+  open Environment 𝑨      using () renaming ( ⟦_⟧   to ⟦_⟧₁ )
+  open Environment 𝑩      using () renaming ( ⟦_⟧   to ⟦_⟧₂ )
+  open Setoid (Domain 𝑩)  using ( _≈_ ; sym ; trans )
+  open SetoidReasoning (Domain 𝑩)
 
- ⊧-I-invar : 𝑨 ⊧ (p ≈̇ q)  →  𝑨 ≅ 𝑩  →  𝑩 ⊧ (p ≈̇ q)
- ⊧-I-invar Apq (mkiso fh gh f∼g g∼f) ρ = trans i $ trans ii $ trans iii $ trans iv v
-  where
-  -- TODO: refactor this proof using new relational reasoning syntax/style
-  f = _⟨$⟩_ (proj₁ fh) ; g = _⟨$⟩_ (proj₁ gh)
+  ⊧-I-invar : 𝑨 ⊧ (p ≈̇ q)  →  𝑨 ≅ 𝑩  →  𝑩 ⊧ (p ≈̇ q)
+  ⊧-I-invar Apq (mkiso fh gh f∼g g∼f) ρ = trans i $ trans ii $ trans iii $ trans iv v
+   where
+   -- TODO: refactor this proof using new relational reasoning syntax/style
+   f = _⟨$⟩_ (proj₁ fh) ; g = _⟨$⟩_ (proj₁ gh)
 
-  i : ⟦ p ⟧₂ ⟨$⟩ ρ ≈ ⟦ p ⟧₂ ⟨$⟩ (f ∘ (g ∘ ρ))
-  i = sym $ cong ⟦ p ⟧₂ (f∼g ∘ ρ)
+   i : ⟦ p ⟧₂ ⟨$⟩ ρ ≈ ⟦ p ⟧₂ ⟨$⟩ (f ∘ (g ∘ ρ))
+   i = sym $ cong ⟦ p ⟧₂ (f∼g ∘ ρ)
 
-  ii : ⟦ p ⟧₂ ⟨$⟩ (f ∘ (g ∘ ρ)) ≈ f (⟦ p ⟧₁ ⟨$⟩ (g ∘ ρ))
-  ii = sym $ comm-hom-term fh p (g ∘ ρ)
+   ii : ⟦ p ⟧₂ ⟨$⟩ (f ∘ (g ∘ ρ)) ≈ f (⟦ p ⟧₁ ⟨$⟩ (g ∘ ρ))
+   ii = sym $ comm-hom-term fh p (g ∘ ρ)
 
-  iii : f (⟦ p ⟧₁ ⟨$⟩ (g ∘ ρ)) ≈ f (⟦ q ⟧₁ ⟨$⟩ (g ∘ ρ))
-  iii = cong (proj₁ fh) $ Apq (g ∘ ρ)
+   iii : f (⟦ p ⟧₁ ⟨$⟩ (g ∘ ρ)) ≈ f (⟦ q ⟧₁ ⟨$⟩ (g ∘ ρ))
+   iii = cong (proj₁ fh) $ Apq (g ∘ ρ)
 
-  iv : f (⟦ q ⟧₁ ⟨$⟩ (g ∘ ρ)) ≈ ⟦ q ⟧₂ ⟨$⟩ (f ∘ (g ∘ ρ))
-  iv = comm-hom-term fh q (g ∘ ρ)
+   iv : f (⟦ q ⟧₁ ⟨$⟩ (g ∘ ρ)) ≈ ⟦ q ⟧₂ ⟨$⟩ (f ∘ (g ∘ ρ))
+   iv = comm-hom-term fh q (g ∘ ρ)
 
-  v : ⟦ q ⟧₂ ⟨$⟩ (f ∘ (g ∘ ρ)) ≈ ⟦ q ⟧₂ ⟨$⟩ ρ
-  v = cong ⟦ q ⟧₂ (f∼g ∘ ρ)
+   v : ⟦ q ⟧₂ ⟨$⟩ (f ∘ (g ∘ ρ)) ≈ ⟦ q ⟧₂ ⟨$⟩ ρ
+   v = cong ⟦ q ⟧₂ (f∼g ∘ ρ)
 ```
 
 
@@ -101,11 +101,11 @@ The ⊧ relation is also invariant under the algebraic lift and lower operations
 ```agda
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ} where
 
- ⊧-Lift-invar : (p q : Term X) → 𝑨 ⊧ (p ≈̇ q) → Lift-Algˡ 𝑨 β ⊧ (p ≈̇ q)
- ⊧-Lift-invar p q Apq = ⊧-I-invar (Lift-Algˡ 𝑨 _) p q Apq Lift-≅ˡ
+  ⊧-Lift-invar : (p q : Term X) → 𝑨 ⊧ (p ≈̇ q) → Lift-Algˡ 𝑨 β ⊧ (p ≈̇ q)
+  ⊧-Lift-invar p q Apq = ⊧-I-invar (Lift-Algˡ 𝑨 _) p q Apq Lift-≅ˡ
 
- ⊧-lower-invar : (p q : Term X) → Lift-Algˡ 𝑨 β ⊧ (p ≈̇ q)  →  𝑨 ⊧ (p ≈̇ q)
- ⊧-lower-invar p q lApq = ⊧-I-invar 𝑨 p q lApq (≅-sym Lift-≅ˡ)
+  ⊧-lower-invar : (p q : Term X) → Lift-Algˡ 𝑨 β ⊧ (p ≈̇ q)  →  𝑨 ⊧ (p ≈̇ q)
+  ⊧-lower-invar p q lApq = ⊧-I-invar 𝑨 p q lApq (≅-sym Lift-≅ˡ)
 ```
 
 
@@ -117,22 +117,22 @@ of `𝑨`, which fact can be formalized as follows.
 ```agda
 module _ {X : Type χ}{𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ}{p q : Term X} where
 
- ⊧-H-invar : 𝑨 ⊧ (p ≈̇ q) → 𝑩 IsHomImageOf 𝑨 → 𝑩 ⊧ (p ≈̇ q)
- ⊧-H-invar Apq (φh , φE) ρ =
-  begin
-       ⟦ p ⟧   ⟨$⟩               ρ    ≈˘⟨  cong ⟦ p ⟧(λ _ → InvIsInverseʳ φE)  ⟩
-       ⟦ p ⟧   ⟨$⟩ (φ ∘  φ⁻¹  ∘  ρ)   ≈˘⟨  comm-hom-term φh p (φ⁻¹ ∘ ρ)        ⟩
-   φ(  ⟦ p ⟧ᴬ  ⟨$⟩ (     φ⁻¹  ∘  ρ))  ≈⟨   cong (proj₁ φh) (Apq (φ⁻¹ ∘ ρ))         ⟩
-   φ(  ⟦ q ⟧ᴬ  ⟨$⟩ (     φ⁻¹  ∘  ρ))  ≈⟨   comm-hom-term φh q (φ⁻¹ ∘ ρ)        ⟩
-       ⟦ q ⟧   ⟨$⟩ (φ ∘  φ⁻¹  ∘  ρ)   ≈⟨   cong ⟦ q ⟧(λ _ → InvIsInverseʳ φE)  ⟩
-       ⟦ q ⟧   ⟨$⟩               ρ    ∎
-  where
-  φ⁻¹ : 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ]
-  φ⁻¹ = SurjInv (proj₁ φh) φE
-  φ = (_⟨$⟩_ (proj₁ φh))
-  open Environment 𝑨  using () renaming ( ⟦_⟧ to ⟦_⟧ᴬ)
-  open Environment 𝑩  using ( ⟦_⟧ )
-  open SetoidReasoning 𝔻[ 𝑩 ]
+  ⊧-H-invar : 𝑨 ⊧ (p ≈̇ q) → 𝑩 IsHomImageOf 𝑨 → 𝑩 ⊧ (p ≈̇ q)
+  ⊧-H-invar Apq (φh , φE) ρ =
+   begin
+        ⟦ p ⟧   ⟨$⟩               ρ    ≈˘⟨  cong ⟦ p ⟧(λ _ → InvIsInverseʳ φE)  ⟩
+        ⟦ p ⟧   ⟨$⟩ (φ ∘  φ⁻¹  ∘  ρ)   ≈˘⟨  comm-hom-term φh p (φ⁻¹ ∘ ρ)        ⟩
+    φ(  ⟦ p ⟧ᴬ  ⟨$⟩ (     φ⁻¹  ∘  ρ))  ≈⟨   cong (proj₁ φh) (Apq (φ⁻¹ ∘ ρ))         ⟩
+    φ(  ⟦ q ⟧ᴬ  ⟨$⟩ (     φ⁻¹  ∘  ρ))  ≈⟨   comm-hom-term φh q (φ⁻¹ ∘ ρ)        ⟩
+        ⟦ q ⟧   ⟨$⟩ (φ ∘  φ⁻¹  ∘  ρ)   ≈⟨   cong ⟦ q ⟧(λ _ → InvIsInverseʳ φE)  ⟩
+        ⟦ q ⟧   ⟨$⟩               ρ    ∎
+   where
+   φ⁻¹ : 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ]
+   φ⁻¹ = SurjInv (proj₁ φh) φE
+   φ = (_⟨$⟩_ (proj₁ φh))
+   open Environment 𝑨  using () renaming ( ⟦_⟧ to ⟦_⟧ᴬ)
+   open Environment 𝑩  using ( ⟦_⟧ )
+   open SetoidReasoning 𝔻[ 𝑩 ]
 ```
 
 
@@ -143,27 +143,27 @@ Identities modeled by an algebra `𝑨` are also modeled by every subalgebra of 
 
 ```agda
 module _ {X : Type χ}{p q : Term X}{𝑨 : Algebra α ρᵃ}{𝑩 : Algebra β ρᵇ} where
- open Environment 𝑨      using () renaming ( ⟦_⟧ to ⟦_⟧₁ )
- open Environment 𝑩      using () renaming ( ⟦_⟧ to ⟦_⟧₂ )
- open Setoid (Domain 𝑨)  using ( _≈_ )
- open Setoid (Domain 𝑩)  using () renaming ( _≈_ to _≈₂_ )
- open SetoidReasoning (Domain 𝑨)
+  open Environment 𝑨      using () renaming ( ⟦_⟧ to ⟦_⟧₁ )
+  open Environment 𝑩      using () renaming ( ⟦_⟧ to ⟦_⟧₂ )
+  open Setoid (Domain 𝑨)  using ( _≈_ )
+  open Setoid (Domain 𝑩)  using () renaming ( _≈_ to _≈₂_ )
+  open SetoidReasoning (Domain 𝑨)
 
- ⊧-S-invar : 𝑨 ⊧ (p ≈̇ q) →  𝑩 ≤ 𝑨  →  𝑩 ⊧ (p ≈̇ q)
- ⊧-S-invar Apq B≤A b = goal
-  where
-  hh : hom 𝑩 𝑨
-  hh = (proj₁ B≤A)
-  h = _⟨$⟩_ (proj₁ hh)
-  ξ : ∀ b → h (⟦ p ⟧₂ ⟨$⟩ b) ≈ h (⟦ q ⟧₂ ⟨$⟩ b)
-  ξ b = begin
-         h (⟦ p ⟧₂ ⟨$⟩ b)    ≈⟨ comm-hom-term hh p b ⟩
-         ⟦ p ⟧₁ ⟨$⟩ (h ∘ b)  ≈⟨ Apq (h ∘ b) ⟩
-         ⟦ q ⟧₁ ⟨$⟩ (h ∘ b)  ≈˘⟨ comm-hom-term hh q b ⟩
-         h (⟦ q ⟧₂ ⟨$⟩ b)    ∎
+  ⊧-S-invar : 𝑨 ⊧ (p ≈̇ q) →  𝑩 ≤ 𝑨  →  𝑩 ⊧ (p ≈̇ q)
+  ⊧-S-invar Apq B≤A b = goal
+   where
+   hh : hom 𝑩 𝑨
+   hh = (proj₁ B≤A)
+   h = _⟨$⟩_ (proj₁ hh)
+   ξ : ∀ b → h (⟦ p ⟧₂ ⟨$⟩ b) ≈ h (⟦ q ⟧₂ ⟨$⟩ b)
+   ξ b = begin
+          h (⟦ p ⟧₂ ⟨$⟩ b)    ≈⟨ comm-hom-term hh p b ⟩
+          ⟦ p ⟧₁ ⟨$⟩ (h ∘ b)  ≈⟨ Apq (h ∘ b) ⟩
+          ⟦ q ⟧₁ ⟨$⟩ (h ∘ b)  ≈˘⟨ comm-hom-term hh q b ⟩
+          h (⟦ q ⟧₂ ⟨$⟩ b)    ∎
 
-  goal : ⟦ p ⟧₂ ⟨$⟩ b ≈₂ ⟦ q ⟧₂ ⟨$⟩ b
-  goal = (proj₂ B≤A) (ξ b)
+   goal : ⟦ p ⟧₂ ⟨$⟩ b ≈₂ ⟦ q ⟧₂ ⟨$⟩ b
+   goal = (proj₂ B≤A) (ξ b)
 ```
 
 
@@ -175,10 +175,10 @@ all `𝑨 ∈ 𝒦` is also satisfied by every subalgebra of a member of `𝒦`.
 ```agda
 module _ {X : Type χ}{p q : Term X} where
 
- ⊧-S-class-invar :  {𝒦 : Pred (Algebra α ρᵃ) ℓ}
-  →                 (𝒦 ⊫ (p ≈̇ q)) → ((𝑩 , _) : SubalgebrasOfClass 𝒦 {β}{ρᵇ})
-  →                 𝑩 ⊧ (p ≈̇ q)
- ⊧-S-class-invar Kpq (𝑩 , 𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (Kpq .⊫-proof 𝑨 kA) B≤A
+  ⊧-S-class-invar :  {𝒦 : Pred (Algebra α ρᵃ) ℓ}
+   →                 (𝒦 ⊫ (p ≈̇ q)) → ((𝑩 , _) : SubalgebrasOfClass 𝒦 {β}{ρᵇ})
+   →                 𝑩 ⊧ (p ≈̇ q)
+  ⊧-S-class-invar Kpq (𝑩 , 𝑨 , kA , B≤A) = ⊧-S-invar{p = p}{q} (Kpq .⊫-proof 𝑨 kA) B≤A
 ```
 
 
@@ -192,23 +192,23 @@ by the product of algebras in that collection.
 ```agda
 module _ {X : Type χ}{p q : Term X}{I : Type ℓ}(𝒜 : I → Algebra α ρᵃ) where
 
- ⊧-P-invar : (∀ i → 𝒜 i ⊧ (p ≈̇ q)) → ⨅ 𝒜 ⊧ (p ≈̇ q)
- ⊧-P-invar 𝒜pq a = goal
-  where
-  open Algebra (⨅ 𝒜)      using () renaming ( Domain to ⨅A )
-  open Environment (⨅ 𝒜)  using () renaming ( ⟦_⟧ to ⟦_⟧₁ )
-  open Environment        using ( ⟦_⟧ )
-  open Setoid ⨅A          using ( _≈_ )
-  open SetoidReasoning ⨅A
+  ⊧-P-invar : (∀ i → 𝒜 i ⊧ (p ≈̇ q)) → ⨅ 𝒜 ⊧ (p ≈̇ q)
+  ⊧-P-invar 𝒜pq a = goal
+   where
+   open Algebra (⨅ 𝒜)      using () renaming ( Domain to ⨅A )
+   open Environment (⨅ 𝒜)  using () renaming ( ⟦_⟧ to ⟦_⟧₁ )
+   open Environment        using ( ⟦_⟧ )
+   open Setoid ⨅A          using ( _≈_ )
+   open SetoidReasoning ⨅A
 
-  ξ : (λ i → (⟦ 𝒜 i ⟧ p) ⟨$⟩ (λ x → (a x) i)) ≈ (λ i → (⟦ 𝒜 i ⟧ q) ⟨$⟩ (λ x → (a x) i))
-  ξ = λ i → 𝒜pq i (λ x → (a x) i)
-  goal : ⟦ p ⟧₁ ⟨$⟩ a ≈ ⟦ q ⟧₁ ⟨$⟩ a
-  goal = begin
-          ⟦ p ⟧₁ ⟨$⟩ a                             ≈⟨ interp-prod 𝒜 p a ⟩
-          (λ i → (⟦ 𝒜 i ⟧ p) ⟨$⟩ (λ x → (a x) i))  ≈⟨ ξ ⟩
-          (λ i → (⟦ 𝒜 i ⟧ q) ⟨$⟩ (λ x → (a x) i))  ≈˘⟨ interp-prod 𝒜 q a ⟩
-          ⟦ q ⟧₁ ⟨$⟩ a                             ∎
+   ξ : (λ i → (⟦ 𝒜 i ⟧ p) ⟨$⟩ (λ x → (a x) i)) ≈ (λ i → (⟦ 𝒜 i ⟧ q) ⟨$⟩ (λ x → (a x) i))
+   ξ = λ i → 𝒜pq i (λ x → (a x) i)
+   goal : ⟦ p ⟧₁ ⟨$⟩ a ≈ ⟦ q ⟧₁ ⟨$⟩ a
+   goal = begin
+           ⟦ p ⟧₁ ⟨$⟩ a                             ≈⟨ interp-prod 𝒜 p a ⟩
+           (λ i → (⟦ 𝒜 i ⟧ p) ⟨$⟩ (λ x → (a x) i))  ≈⟨ ξ ⟩
+           (λ i → (⟦ 𝒜 i ⟧ q) ⟨$⟩ (λ x → (a x) i))  ≈˘⟨ interp-prod 𝒜 q a ⟩
+           ⟦ q ⟧₁ ⟨$⟩ a                             ∎
 ```
 
 
@@ -217,10 +217,10 @@ of algebras in the class.
 
 
 ```agda
- ⊧-P-class-invar :  (𝒦 : Pred (Algebra α ρᵃ)(ov α))
-  →                 𝒦 ⊫ (p ≈̇ q) → (∀ i → 𝒜 i ∈ 𝒦) → ⨅ 𝒜 ⊧ (p ≈̇ q)
+  ⊧-P-class-invar :  (𝒦 : Pred (Algebra α ρᵃ)(ov α))
+   →                 𝒦 ⊫ (p ≈̇ q) → (∀ i → 𝒜 i ∈ 𝒦) → ⨅ 𝒜 ⊧ (p ≈̇ q)
 
- ⊧-P-class-invar 𝒦 σ K𝒜 = ⊧-P-invar (λ i ρ → σ .⊫-proof (𝒜 i) (K𝒜 i) ρ)
+  ⊧-P-class-invar 𝒦 σ K𝒜 = ⊧-P-invar (λ i ρ → σ .⊫-proof (𝒜 i) (K𝒜 i) ρ)
 ```
 
 
@@ -230,11 +230,11 @@ algebras models (p ≈̇ q) if the lift of each algebra in the collection models
 
 
 ```agda
- ⊧-P-lift-invar : (∀ i → Lift-Algˡ (𝒜 i) β ⊧ (p ≈̇ q))  →  ⨅ 𝒜 ⊧ (p ≈̇ q)
- ⊧-P-lift-invar α = ⊧-P-invar Aipq
-  where
-  Aipq : ∀ i → (𝒜 i) ⊧ (p ≈̇ q)
-  Aipq i = ⊧-lower-invar{𝑨 = (𝒜 i)} p q (α i)
+  ⊧-P-lift-invar : (∀ i → Lift-Algˡ (𝒜 i) β ⊧ (p ≈̇ q))  →  ⨅ 𝒜 ⊧ (p ≈̇ q)
+  ⊧-P-lift-invar α = ⊧-P-invar Aipq
+   where
+   Aipq : ∀ i → (𝒜 i) ⊧ (p ≈̇ q)
+   Aipq i = ⊧-lower-invar{𝑨 = (𝒜 i)} p q (α i)
 ```
 
 
@@ -248,21 +248,21 @@ every homomorphism from 𝑻 X to 𝑨 maps p and q to the same element of 𝑨.
  
 ```agda
 module _ {X : Type χ}{p q : Term X}{𝑨 : Algebra α ρᵃ}(φh : hom (𝑻 X) 𝑨) where
- open Setoid (Domain 𝑨) using ( _≈_ )
- private φ = _⟨$⟩_ (proj₁ φh)
+  open Setoid (Domain 𝑨) using ( _≈_ )
+  private φ = _⟨$⟩_ (proj₁ φh)
 
- ⊧-H-ker : 𝑨 ⊧ (p ≈̇ q) → φ p ≈ φ q
- ⊧-H-ker β =
-  begin
-   φ p                 ≈⟨ cong (proj₁ φh) (term-agreement p)⟩
-   φ (⟦ p ⟧ ⟨$⟩ ℊ)     ≈⟨ comm-hom-term φh p ℊ ⟩
-   ⟦ p ⟧₂ ⟨$⟩ (φ ∘ ℊ)  ≈⟨ β (φ ∘ ℊ) ⟩
-   ⟦ q ⟧₂ ⟨$⟩ (φ ∘ ℊ)  ≈˘⟨ comm-hom-term φh q ℊ ⟩
-   φ (⟦ q ⟧ ⟨$⟩ ℊ)     ≈˘⟨ cong (proj₁ φh) (term-agreement q)⟩
-   φ q                 ∎
+  ⊧-H-ker : 𝑨 ⊧ (p ≈̇ q) → φ p ≈ φ q
+  ⊧-H-ker β =
+   begin
+    φ p                 ≈⟨ cong (proj₁ φh) (term-agreement p)⟩
+    φ (⟦ p ⟧ ⟨$⟩ ℊ)     ≈⟨ comm-hom-term φh p ℊ ⟩
+    ⟦ p ⟧₂ ⟨$⟩ (φ ∘ ℊ)  ≈⟨ β (φ ∘ ℊ) ⟩
+    ⟦ q ⟧₂ ⟨$⟩ (φ ∘ ℊ)  ≈˘⟨ comm-hom-term φh q ℊ ⟩
+    φ (⟦ q ⟧ ⟨$⟩ ℊ)     ≈˘⟨ cong (proj₁ φh) (term-agreement q)⟩
+    φ q                 ∎
 
-  where
-  open SetoidReasoning (Domain 𝑨)
-  open Environment 𝑨      using () renaming ( ⟦_⟧ to ⟦_⟧₂ )
-  open Environment (𝑻 X)  using ( ⟦_⟧ )
+   where
+   open SetoidReasoning (Domain 𝑨)
+   open Environment 𝑨      using () renaming ( ⟦_⟧ to ⟦_⟧₂ )
+   open Environment (𝑻 X)  using ( ⟦_⟧ )
 ```

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -43,19 +43,19 @@ open _⟶_     renaming ( to to _⟨$⟩_ )
 open Term
 
 private variable
- χ α ρᵃ ι ℓ : Level
- X Γ Δ : Type χ
- f : OperationSymbolsOf 𝑆
- I : Type ι
+  χ α ρᵃ ι ℓ : Level
+  X Γ Δ : Type χ
+  f : OperationSymbolsOf 𝑆
+  I : Type ι
 
 -- Equations
 -- An equation is a pair (s , t) of terms in the same context.
 record Eq : Type (ov χ) where
- constructor _≈̇_
- field
-  {cxt}  : Type χ
-  lhs    : Term cxt
-  rhs    : Term cxt
+  constructor _≈̇_
+  field
+   {cxt}  : Type χ
+   lhs    : Term cxt
+   rhs    : Term cxt
 infix 6 _≈̇_
 open Eq public
 
@@ -84,8 +84,8 @@ _⊧_ : (𝑨 : Algebra α ρᵃ)(term-identity : Eq{χ}) → Type _
 -- interpreter.  (See issue #361.  Note _⊧_ and Equal still reduce
 -- definitionally, so the proofs that compute with them are unaffected.)
 record _⊫_ (𝒦 : Pred (Algebra α ρᵃ) ℓ)(eq : Eq{χ}) : Type (ℓ ⊔ χ ⊔ ov(α ⊔ ρᵃ)) where
- constructor ⊫-intro
- field ⊫-proof : ∀ (𝑨 : Algebra α ρᵃ) → 𝒦 𝑨 → 𝑨 ⊧ eq          -- (type \||= to get ⊫)
+  constructor ⊫-intro
+  field ⊫-proof : ∀ (𝑨 : Algebra α ρᵃ) → 𝒦 𝑨 → 𝑨 ⊧ eq          -- (type \||= to get ⊫)
 open _⊫_ public
 infix 5 _⊫_
 


### PR DESCRIPTION
## Summary

Continue the M4-17 style cleanup by propagating the two-space anonymous-module-body indentation convention to the modules the main cleanup pass on `434-m4-17-style-improvements-and-cleanup` had not yet reached — 22 files across the canonical `Setoid/` tree and its `Examples/` and `Exercises/` consumers.

## Related issues

Part of #434

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [ ] Refactor / cleanup (user-facing/API change)
- [x] Refactor / cleanup (no user-facing change)
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches `src/`, it targets a supported area such as `Classical/`, `Cubical/`, `Demos/`, `Examples/`, `Exercises/`, `Overture/`, or `Setoid/`.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.

## Notes for reviewers

+  Every hunk is pure reindentation.  Each affected line is deepened by exactly one leading space, so insertions equal deletions in every file (`22 files changed, 807 insertions(+), 807 deletions(-)`).  No definitions, type signatures, or proof terms change — only leading whitespace.
+  The pass was applied mechanically with a layout-preserving rule: deepen any indented region whose base indent is a single space (`module _ … where` bodies, `record`/`data` bodies, `where`-clauses, `private variable` blocks), so that nested structure is shifted as a unit.  Comment-only lines that are stylistically dedented below the code they annotate are left in place, and multi-line `open`/`import` statements are untouched, so Agda's layout parse is never disturbed.
+  Scope is exactly the modules the M4-17 pass had not yet reached; files already cleaned on `434-m4-17-style-improvements-and-cleanup` are untouched, so this should merge into that branch without conflicts.  It targets `434-m4-17-style-improvements-and-cleanup` (not `master`) so it can be reviewed and folded into #435 separately.
+  No files under `Legacy/` or `Demos/` are touched.
+  Deliberately out of scope, as candidate follow-ups: import-block header normalization, the `suc`→`lsuc` renaming, and the `record`→copattern rewrites.  Those are less mechanical than a whitespace-only pass and are better applied with human judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g54cNmhmXgGFEQgkvE6ZM

---
_Generated by [Claude Code](https://claude.ai/code/session_015g54cNmhmXgGFEQgkvE6ZM)_