### PR TITLE
[M10-3] Cache-bust site CSS/JS so deploys don't render a stale mix (follow-up to #448)

### DIFF
--- a/docs/assets/js/agda-toggle.js
+++ b/docs/assets/js/agda-toggle.js
@@ -68,7 +68,7 @@
       var note = document.createElement("button");
       note.type = "button";
       note.className = "ualib-hidden-note";
-      note.title = "Reveal this block (the header's Show more Agda reveals all of them)";
+      note.title = "Reveal this block (the header's Show all Agda reveals all of them)";
 
       function setNote(open) {
         note.textContent =

--- a/docs/site-guide.md
+++ b/docs/site-guide.md
@@ -97,6 +97,8 @@ Publishing is a two-repository chain: the Docs workflow here builds `./site` and
 
 Merging any content change to `master` also re-pushes `gh-pages` and re-triggers publication as a side effect.  When checking what is actually live, remember the Pages CDN caches responses for up to ten minutes and your browser caches the HTML and CSS on top of that — hard-refresh, or probe a file headers-only with `curl -sI https://agda-algebras.universalalgebra.org/assets/js/agda-copy.js`.
 
+The site's own CSS/JS are **content-hashed** so that a returning visitor never renders fresh HTML against a stale-cached stylesheet or script (the assets carry a multi-hour `max-age`, far longer than the HTML's ten minutes).  `on_config` in [`scripts/python/mkdocs_hooks.py`](../../scripts/python/mkdocs_hooks.py) appends an eight-character hash of each `extra_css` / `extra_javascript` file to its URL (`custom.css?h=…`); a changed asset therefore gets a fresh URL, which the short-lived HTML picks up within minutes (#429).  The copied file keeps its plain name — only the reference carries the query — so the headers-only probe above is unaffected.
+
 Resist the temptation to add a deployment workflow to the `gh-pages` branch itself: that branch is disposable build output which the publish action overwrites, and keeping such a file alive would require `keep_files: true`, which never deletes anything and so leaks renamed or removed pages onto the live site forever.
 
 ## Changing the settings

--- a/scripts/python/mkdocs_hooks.py
+++ b/scripts/python/mkdocs_hooks.py
@@ -15,8 +15,10 @@ is never altered.  External (http/mailto), root-relative (/…), and pure-anchor
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
+from pathlib import Path
 
 log = logging.getLogger("mkdocs.plugins.ualib.render")
 
@@ -76,6 +78,48 @@ def _retarget(target: str) -> str:
     if re.search(r"\.[A-Za-z0-9]+$", base) and not base.endswith(".md"):
         return f"{REPO_BLOB}{base}{anchor}"
     return target
+
+
+def _cache_bust(entry, docs_dir: Path):
+    """Append a short content hash to a local asset reference so a changed file
+    gets a fresh URL.  ``entry`` is a ``str`` (extra_css) or an
+    ``ExtraScriptValue`` carrying a ``.path`` (extra_javascript).  Absolute URLs
+    (CDN links) and already-queried refs pass through untouched.
+    """
+    has_path = hasattr(entry, "path")
+    ref = entry.path if has_path else entry
+    if "://" in ref or "?" in ref:
+        return entry
+    try:
+        digest = hashlib.md5((docs_dir / ref).read_bytes()).hexdigest()[:8]
+    except OSError:
+        return entry                       # not a local file we can hash
+    busted = f"{ref}?h={digest}"
+    if has_path:
+        entry.path = busted
+        return entry
+    return busted
+
+
+def on_config(config):
+    """Cache-bust the site's own CSS/JS (#429).
+
+    The deployed assets carry a multi-hour ``max-age``, so when custom.css or a
+    ``docs/assets/js/*.js`` file changes, a returning visitor can render a stale
+    mix — e.g. an updated script against a cached older stylesheet — until the
+    cache expires.  Appending an 8-char content hash to each local extra_css /
+    extra_javascript URL gives a changed file a fresh URL, which the short-lived
+    HTML (``max-age`` 600) picks up within minutes, so the CSS/JS a page loads
+    always match the page.  The copied file keeps its plain name; the query
+    string is ignored by the server.
+    """
+    docs_dir = Path(config["docs_dir"])
+    config["extra_css"] = [_cache_bust(e, docs_dir) for e in config["extra_css"]]
+    config["extra_javascript"] = [_cache_bust(e, docs_dir) for e in config["extra_javascript"]]
+    n = sum(1 for e in config["extra_css"] + config["extra_javascript"]
+            if "?h=" in (getattr(e, "path", None) or str(e)))
+    log.info(f"🔖  cache-busted {n} local asset URL(s)")
+    return config
 
 
 def on_files(files, config):


### PR DESCRIPTION
## Summary

Follow-up to the merged #448 (M10-3 tooltips + header switches).  The switch redesign rendered correctly under `make serve-full` but broke on the **deployed** site for returning visitors — the old "Show more Agda" pill and an unstyled "Tooltips" button.  This content-hashes the site's own CSS/JS so a changed asset always gets a fresh URL, which fixes the breakage and hardens every future deploy.

## Related issues

Part of #429.  Follow-up to #448 (merged).

## Type of change

+  [x] Infrastructure (build hook) + Documentation

## Root cause

The deployed **server** files were already correct — the cause was **asset caching**, not code.  The site serves CSS/JS with a multi-hour `max-age` (Cloudflare) while HTML carries `max-age=600`, so a returning visitor loaded fresh HTML and the newly-added `agda-hover.js` (never cached) against a **still-cached older `custom.css` + `agda-toggle.js`** — a broken combination that `make serve-full` (no CDN, always-fresh assets) can never reproduce.

## What changed

+  **`scripts/python/mkdocs_hooks.py`** — a new `on_config` hook appends an 8-char content hash of each local `extra_css` / `extra_javascript` file to its URL (`custom.css?h=b9640cc2`).  A changed asset gets a fresh URL that the short-lived HTML picks up within minutes, so the CSS/JS a page loads always match the page.  The copied file keeps its plain name; the query is ignored by the server, so headers-only probes still work.
+  **`docs/assets/js/agda-toggle.js`** — fix a stale "Show more Agda" reference in the per-block note tooltip (the control is now "Show all Agda").
+  **`docs/site-guide.md`** — document the cache-busting where the guide already covers the Pages/CDN cache.

## Checklist

+  [x] `make site` builds clean under `--strict` (`mkdocs build --strict --clean`).
+  [x] Commits are coherent and have explanatory messages.
+  [ ] `make check` — n/a: no `src/`/Agda changes (a build hook + docs-site assets only).

## Notes for reviewers

+  **Verification.**  After the build, every page references `stylesheets/custom.css?h=…` and `assets/js/agda-*.js?h=…` (relative `../../…` on deep pages), while the files still copy to their plain names — confirmed on both the landing page and a deep module page.
+  **Why this is a separate PR.**  #448 was already merged, so per the no-stacking-on-merged-history rule this follow-up is rebased directly onto `master` (one commit) and opened as a new PR.
+  **Effect on the live breakage.**  Once this deploys and the 10-minute HTML refreshes, the hashed URLs propagate and every visitor gets the correct switches automatically — no hard-refresh needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JDbKmmAUvAtiKYWy24brU

---
_Generated by [Claude Code](https://claude.ai/code/session_012JDbKmmAUvAtiKYWy24brU)_