### PR TITLE
Move FiniteAlgebra to canonical homes, splitting off FiniteCongruences (#464)

### DIFF
--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -3135,46 +3135,6 @@ https://claude.ai/code/session_01MvPrLTCxKjFgsnTMK8j2qZ
 
 ---
 
-### Issue M6-4: Sub(A) as a complete lattice (next Setoid.Algebras.Lattices instance) (#373, closed)
-
-**Labels**: `milestone-6-flrp`
-
-## Description
-
-With the congruence lattice now in place ([#271][], modules `Setoid.Algebras.Congruences.{Lattice,Generation,CompleteLattice}` plus the general `Setoid.Algebras.Lattices.CompleteLattice` record), the natural companion is the **subalgebra lattice**: the subuniverses of a setoid algebra `𝑨`, ordered by inclusion, form a complete lattice `Sub 𝑨`.  This is the second motivating instance of the `CompleteLattice` record and is foundational for the FLRP (every finite lattice question is, after all, about lattices of the form `Con 𝑨` / `Sub 𝑨`).
-
-Most of the hard work already exists in `Setoid.Subalgebras.Subuniverses`:
-
-+  `Subuniverses 𝑨` — the predicate "is a subuniverse" (closed under the basic operations);
-+  `Sg 𝑨 G` — the inductively generated subuniverse, with `sgIsSub` (it is a subuniverse) and `sgIsSmallest` (the generation theorem / universal property);
-+  `⋂s` — an arbitrary intersection of subuniverses is a subuniverse (the infinitary meet).
-
-So assembling the lattice is a "step-3"-style task, closely parallel to the congruence-lattice assembly.
-
-## Tasks
-
-+  [ ] Define `Sub 𝑨` (the type of subuniverses, as a Σ of a predicate with its subuniverse proof) and the inclusion order `_≤_` (= `_⊆_`).
-+  [ ] Meet `B ∧ C = B ∩ C`, join `B ∨ C = Sg(B ∪ C)`.
-+  [ ] `Sub-Lattice : (𝑨 : Algebra α ρ)(ℓ₀ : Level) → Lattice _ _ _`, at the absorbing level `L = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ₀` (where `Sg` stays at `L`).
-+  [ ] Bounds: bottom `Sg ∅` (smallest subuniverse) and top `U` (the whole carrier); `Sub-BoundedLattice`.
-+  [ ] Infinitary meet `⋂` (via `⋂s`) and join `Sg(⋃ …)`; `Sub-CompleteLattice` instantiating the `CompleteLattice` record.
-+  [ ] A small worked example.
-
-## Acceptance criteria
-
-+  [ ] `Sub-Lattice 𝑨` / `Sub-CompleteLattice 𝑨` type-check and satisfy the (complete-)lattice axioms.
-+  [ ] Bounds proved as `⊥`/`⊤`.
-+  [ ] At least one small worked example.
-
-## Notes
-
-+  Placement, mirroring the congruence case (`Setoid.Algebras.Congruences.CompleteLattice`): the instance goes in `Setoid.Subalgebras.CompleteLattice`, instantiating the general record in `Setoid.Algebras.Lattices.CompleteLattice`.
-+  A richer worked example — the **subgroup lattice of a concrete finite group** — is appealing but a sizeable undertaking (defining the group over a signature, classifying its subgroups); it is tracked as a separate follow-up so this PR can stay focused.
-
-[#271]: https://github.com/ualib/agda-algebras/issues/271
-
----
-
 ### Issue M6-5: Converse of Maltsev's theorem: congruence-permutable ⟹ Maltsev term (#411, closed)
 
 **Labels**: `milestone-6-flrp`
@@ -3220,32 +3180,6 @@ Note: #273's text says "the free algebra on two generators"; the standard constr
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 https://claude.ai/code/session_01MvPrLTCxKjFgsnTMK8j2qZ
-
----
-
-### Issue M6-5: Worked example: the subgroup lattice of a concrete finite group (#374, closed)
-
-**Labels**: `milestone-6-flrp`
-
-## Description
-
-Follow-up to the subalgebra-lattice infrastructure (#373).  Once `Sub 𝑨` is available as a complete lattice, a compelling worked example is the **subgroup lattice of a concrete finite group** — e.g. `ℤ/4ℤ` (the 3-element chain `0 < ⟨2⟩ < ℤ/4ℤ`), the Klein four-group `V₄` (the diamond `M₃`-minus, i.e. `2³`-style with three order-2 subgroups), or `S₃` (the well-known six-subgroup lattice).
-
-This is separated from #373 because it is a sizeable undertaking on its own:
-
-+  realize the group concretely as a setoid algebra over a group signature (the `Classical/` tree has group machinery to draw on);
-+  identify the subuniverses (= subgroups, since the signature includes inverse and identity);
-+  classify them and exhibit the lattice order, ideally matching a known finite lattice.
-
-## Acceptance criteria
-
-+  [ ] A concrete finite group built as a `Setoid` algebra.
-+  [ ] Its subgroups exhibited as elements of `Sub 𝑨`, with the lattice order between them.
-+  [ ] Prose identifying the resulting lattice (chain / diamond / `S₃` lattice).
-
-## Notes
-
-+  Subuniverses of a group algebra are exactly its subgroups precisely because the signature carries the unary inverse and the nullary identity, so closure under the operations forces the subgroup axioms — worth stating explicitly in the example.
 
 ---
 
@@ -3484,6 +3418,310 @@ https://claude.ai/code/session_01B9q9aP34sakGdPgZVaXU2s
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 https://claude.ai/code/session_01B9q9aP34sakGdPgZVaXU2s
+
+---
+
+### Issue M6-11: Sub(A) as a complete lattice (next Setoid.Algebras.Lattices instance) (#373, closed)
+
+**Labels**: `milestone-6-flrp`
+
+## Description
+
+With the congruence lattice now in place ([#271][], modules `Setoid.Algebras.Congruences.{Lattice,Generation,CompleteLattice}` plus the general `Setoid.Algebras.Lattices.CompleteLattice` record), the natural companion is the **subalgebra lattice**: the subuniverses of a setoid algebra `𝑨`, ordered by inclusion, form a complete lattice `Sub 𝑨`.  This is the second motivating instance of the `CompleteLattice` record and is foundational for the FLRP (every finite lattice question is, after all, about lattices of the form `Con 𝑨` / `Sub 𝑨`).
+
+Most of the hard work already exists in `Setoid.Subalgebras.Subuniverses`:
+
++  `Subuniverses 𝑨` — the predicate "is a subuniverse" (closed under the basic operations);
++  `Sg 𝑨 G` — the inductively generated subuniverse, with `sgIsSub` (it is a subuniverse) and `sgIsSmallest` (the generation theorem / universal property);
++  `⋂s` — an arbitrary intersection of subuniverses is a subuniverse (the infinitary meet).
+
+So assembling the lattice is a "step-3"-style task, closely parallel to the congruence-lattice assembly.
+
+## Tasks
+
++  [ ] Define `Sub 𝑨` (the type of subuniverses, as a Σ of a predicate with its subuniverse proof) and the inclusion order `_≤_` (= `_⊆_`).
++  [ ] Meet `B ∧ C = B ∩ C`, join `B ∨ C = Sg(B ∪ C)`.
++  [ ] `Sub-Lattice : (𝑨 : Algebra α ρ)(ℓ₀ : Level) → Lattice _ _ _`, at the absorbing level `L = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ℓ₀` (where `Sg` stays at `L`).
++  [ ] Bounds: bottom `Sg ∅` (smallest subuniverse) and top `U` (the whole carrier); `Sub-BoundedLattice`.
++  [ ] Infinitary meet `⋂` (via `⋂s`) and join `Sg(⋃ …)`; `Sub-CompleteLattice` instantiating the `CompleteLattice` record.
++  [ ] A small worked example.
+
+## Acceptance criteria
+
++  [ ] `Sub-Lattice 𝑨` / `Sub-CompleteLattice 𝑨` type-check and satisfy the (complete-)lattice axioms.
++  [ ] Bounds proved as `⊥`/`⊤`.
++  [ ] At least one small worked example.
+
+## Notes
+
++  Placement, mirroring the congruence case (`Setoid.Algebras.Congruences.CompleteLattice`): the instance goes in `Setoid.Subalgebras.CompleteLattice`, instantiating the general record in `Setoid.Algebras.Lattices.CompleteLattice`.
++  A richer worked example — the **subgroup lattice of a concrete finite group** — is appealing but a sizeable undertaking (defining the group over a signature, classifying its subgroups); it is tracked as a separate follow-up so this PR can stay focused.
+
+[#271]: https://github.com/ualib/agda-algebras/issues/271
+
+---
+
+### Issue M6-12: Worked example: the subgroup lattice of a concrete finite group (#374, closed)
+
+**Labels**: `milestone-6-flrp`
+
+## Description
+
+Follow-up to the subalgebra-lattice infrastructure (#373).  Once `Sub 𝑨` is available as a complete lattice, a compelling worked example is the **subgroup lattice of a concrete finite group** — e.g. `ℤ/4ℤ` (the 3-element chain `0 < ⟨2⟩ < ℤ/4ℤ`), the Klein four-group `V₄` (the diamond `M₃`-minus, i.e. `2³`-style with three order-2 subgroups), or `S₃` (the well-known six-subgroup lattice).
+
+This is separated from #373 because it is a sizeable undertaking on its own:
+
++  realize the group concretely as a setoid algebra over a group signature (the `Classical/` tree has group machinery to draw on);
++  identify the subuniverses (= subgroups, since the signature includes inverse and identity);
++  classify them and exhibit the lattice order, ideally matching a known finite lattice.
+
+## Acceptance criteria
+
++  [ ] A concrete finite group built as a `Setoid` algebra.
++  [ ] Its subgroups exhibited as elements of `Sub 𝑨`, with the lattice order between them.
++  [ ] Prose identifying the resulting lattice (chain / diamond / `S₃` lattice).
+
+## Notes
+
++  Subuniverses of a group algebra are exactly its subgroups precisely because the signature carries the unary inverse and the nullary identity, so closure under the operations forces the subgroup axioms — worth stating explicitly in the example.
+
+---
+
+### Issue M6-13: FLRP research program — tracking issue (#451)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Umbrella issue for the research program on the Finite Lattice Representation Problem.  The roadmap is `docs/notes/flrp-research-roadmap.md` (added in #450), and the interval-enforceable-properties note it builds on is vendored at `docs/papers/flrp/ieprops/` (arXiv:1205.1927, v4).
+
+The program is organized as six PR-sized work packages (WP-1…WP-6) building the formal infrastructure, and four research phases (RP-1…RP-4) pursuing the interval-enforceable-properties attack described in roadmap § 4.  The critical path to RP-1 is WP-1 → WP-2 → WP-3 → WP-4.
+
+This program is a separate research track from the M7 algebraic-complexity / CSP work and from the M6 infrastructure milestone; do not conflate them (see `CLAUDE.md`).
+
+## Structure
+
++  WP-1…WP-6 — infrastructure and formalization steps, each intended to land as one focused PR; tracked as sub-issues.
++  RP-1…RP-4 — open-ended research phases with the success/kill criteria of roadmap § 4; tracked as sub-issues and reviewed quarterly.
+
+## Acceptance criteria
+
+- [ ] All WP sub-issues are closed.
+- [ ] Each RP phase has either produced results or hit its documented kill criterion.
+
+---
+
+### Issue M6-13a: FLRP WP-1: FLRP.Problem — formal statement and representability predicate (#452)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Create the new top-level tree `src/FLRP/` (barrel plus first submodule `FLRP.Problem`) containing the formal core of the problem: a `Representable` predicate — "there exists a finite algebra whose congruence lattice is isomorphic to `L`" — and the FLRP statement as a type, together with at least one worked instance.  Design guidance: roadmap §§ 6–7 (`docs/notes/flrp-research-roadmap.md`).  Reuse the `FiniteAlgebra` interface from `Setoid.Subalgebras.Subdirect.Finite` and the congruence lattice from `Setoid.Congruences.CompleteLattice`.
+
+Part of #451.
+
+## Tasks
+
+- [ ] `src/FLRP.lagda.md` barrel and `src/FLRP/Problem.lagda.md`, scaffolded per house conventions.
+- [ ] `Representable L` for a finite lattice `L`; choose and document the lattice-presentation and isomorphism notions, preferring existing library or stdlib infrastructure.
+- [ ] The FLRP statement as a type, with prose making clear that it is stated, not asserted.
+- [ ] One worked instance wired to existing examples (e.g. the two-element chain as `Con` of a two-element algebra with no operations), with `L7` referenced in prose as the distinguished open instance.
+
+## Acceptance criteria
+
+- [ ] New modules type-check under `--cubical-compatible --exact-split --safe`.
+- [ ] Every public definition has an explicit type signature and a prose comment.
+- [ ] Changes to existing modules are limited to what promotion of `FiniteAlgebra` (if needed) strictly requires.
+
+---
+
+### Issue M6-13b: FLRP WP-2: group-action infrastructure — subgroups, core, cosets, G-sets, Sub(G), intervals (#453)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Reusable group-theoretic infrastructure needed by the Pálfy–Pudlák bridge (WP-3) and the enforceability framework (WP-4): subgroups as subalgebras with `Sub(G)` as a complete lattice (generalizing the Klein-four worked example `Examples.Setoid.SubgroupLattice`), conjugation/normality and the normal core `Core_G(H)`, cosets with the transitive coset G-set as a unary algebra, and upper intervals `[H, G]` as bounded lattices.  Per roadmap § 6 this lands in the `Classical/` and `Setoid/` trees, not in `FLRP/`, so the library gains value independently of the research program.
+
+Part of #451.
+
+## Tasks
+
+- [ ] Subgroups of a `Group` as subuniverses/subalgebras; `Sub(G)` via `Setoid.Subalgebras.CompleteLattice`.
+- [ ] Conjugation, normal subgroups, and `Core_G(H)` (largest normal subgroup of `G` below `H`).
+- [ ] Cosets `G/H` and the coset G-set as a unary algebra (one operation per group element).
+- [ ] Upper intervals `[H, G]` in `Sub(G)` as bounded lattices.
+- [ ] Dedekind's rule `A ≤ B → A(C ∩ B) = AC ∩ B` at least stated (its proof may land here or in RP-1).
+
+## Acceptance criteria
+
+- [ ] New modules type-check under the standard pragma; changes are additive.
+- [ ] The Klein-four subgroup-lattice example still type-checks.
+
+Scope note: this is the largest WP; splitting into WP-2a (subgroups/core) and WP-2b (cosets/G-sets/intervals) at PR time is acceptable and expected if the diff grows.
+
+---
+
+### Issue M6-13c: FLRP WP-3: Pálfy–Pudlák bridge, easy direction — Con(G ↷ G/H) ≅ [H, G] (#454)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+The first substantive FLRP theorem in the library: the congruence lattice of the transitive G-set on the cosets `G/H` is isomorphic to the upper interval `[H, G]` in `Sub(G)`.  Classical references: McKenzie–McNulty–Taylor (Lemma 4.20) and Dixon–Mortimer (Theorem 1.5A); see roadmap § 2 and the introduction of the vendored note `docs/papers/flrp/ieprops/`.  Corollary, wired into `FLRP.Problem`: every group-representable lattice is representable as the congruence lattice of a finite algebra.
+
+Depends on WP-1 and WP-2.  Part of #451.
+
+## Tasks
+
+- [ ] Congruences of the coset G-set correspond to intermediate subgroups (both directions as separate named lemmas).
+- [ ] The order/lattice isomorphism `Con(G ↷ G/H) ≅ [H, G]`, assembled from small lemmas.
+- [ ] Corollary: group representable implies representable, in `FLRP.Problem` terms.
+
+## Acceptance criteria
+
+- [ ] Type-checks under `--safe`; each direction of the correspondence is its own lemma; every public definition carries prose.
+
+---
+
+### Issue M6-13d: FLRP WP-4: FLRP.Enforceable — IE, cf-IE, min-IE, and the no-go lemmas (#455)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Formalize § 2 of the vendored note (`docs/papers/flrp/ieprops/`): the definitions of *interval enforceable* (IE), *core-free interval enforceable* (cf-IE), *min-IE*, and *group representable*, with the vacuity subtlety handled by tracking group representability of the enforcing lattice explicitly.  Then the first structural results of its § 3: Lemma 3.1 (if the complementary class is closed under homomorphic images, cf-IE upgrades to IE), the fattening remark (`[H × K, G × K] ≅ [H, G]`, so solvability is not IE), and Lemma 3.2 (a property and its negation cannot both be IE via group-representable lattices).  This machine-checks why the program lives at the core-free level (roadmap § 4).
+
+Depends on WP-2 (WP-3 is helpful but not required).  Part of #451.
+
+## Tasks
+
+- [ ] `FLRP/Enforceable.lagda.md` with the four definitions and representability tracking.
+- [ ] Fattening lemma `[H × K, G × K] ≅ [H, G]` (needs direct products of groups).
+- [ ] Lemma 3.1 and Lemma 3.2, with names traceable to the note.
+- [ ] Statement (hypotheses named, proof deferred to RP-1) of the parachute meta-theorem.
+
+## Acceptance criteria
+
+- [ ] Type-checks under `--safe`; no postulates; deferred results appear only as explicit hypotheses.
+
+---
+
+### Issue M6-13e: FLRP WP-5: closure toolkit — products, ordinal sums, Kurzweil–Netter duality (#456)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Formalize closure of the class of representable lattices under finite direct products and ordinal sums, and establish the `FLRP.Assumptions` registry pattern by recording duality (Kurzweil 1985, Netter 1986) as its first entry — a precise statement with citation, imported as an explicit hypothesis, keeping `--safe`.  Stretch goal: reprove Netter's duality construction formally; the content is finite and combinatorial, plausibly tractable, and Netter's proof may never have been published, so a formal reproof is independently valuable (roadmap § 7).
+
+Depends on WP-1.  Part of #451.
+
+## Tasks
+
+- [ ] Product closure of `Representable`.
+- [ ] Ordinal-sum closure of `Representable`.
+- [ ] `FLRP/Assumptions.lagda.md` with the duality entry (statement, source, citation discipline documented).
+- [ ] Stretch: formal proof of duality closure via the Kurzweil–Netter construction.
+
+## Acceptance criteria
+
+- [ ] Type-checks under `--safe`; the assumptions registry documents every imported statement with its citation.
+
+---
+
+### Issue M6-13f: FLRP WP-6: certificate pipeline — schema, Agda checker, GAP/SAT emitters (#457)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+External searches (GAP, UACalc, SAT/model finders) must never be trusted directly: they emit finite certificate data — operation tables plus a lattice-isomorphism witness — which Agda re-checks by decision over the finite carrier, in exactly the style of `Examples.Classical.Lattices.L7`.  Build the certificate schema, the generic Agda checker, at least one emitter script, and a pilot re-verification of one thesis-era small-lattice representation end-to-end.  Search scripts and raw logs live outside `src/` (roadmap § 6; they move to a companion repo if they grow).
+
+Depends on WP-1.  Part of #451.
+
+## Tasks
+
+- [ ] Certificate schema (finite algebra tables, target lattice, isomorphism witness).
+- [ ] Generic checker: given a certificate, decide `Con(𝑨) ≅ L` over the finite carrier.
+- [ ] One emitter (GAP or SAT side) producing the schema.
+- [ ] Pilot: re-verify one small-lattice representation from the thesis era.
+
+## Acceptance criteria
+
+- [ ] A certificate produced by an external tool round-trips to a type-checked Agda proof with no manual editing beyond file placement.
+
+---
+
+### Issue M6-13g: FLRP RP-1: formalize the IE framework end-to-end (parachute theorems) (#458)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Research phase continuing from WP-4 through § 3 of the vendored note (`docs/papers/flrp/ieprops/`): Dedekind's rule and the antichain corollary (Corollary 3.5), the parachute construction `𝒫(L₁, …, Lₙ)`, Theorem 3.6 ((B) ⟺ (C)), Lemma 3.7 (a core-free parachute representation forces `G` subdirectly irreducible, nonsolvable, with `NH = G` and `C_G(N) = 1` for all nontrivial `N ⊴ G`), and Corollary 3.8 (cf-IE properties are closed under finite conjunction).  The phase is capped by the machine-checked strategy meta-theorem: finitely many cf-IE classes with empty intersection imply the corresponding parachute is not group representable, hence — with Pálfy–Pudlák imported as an explicit hypothesis — the FLRP has a negative answer.  The wreath Lemma 3.3 (requires wreath products and the double Kurzweil construction) either closes this phase or moves to RP-4.
+
+Depends on WP-2 and WP-4.  Part of #451; roadmap § 4.
+
+## Exit criterion
+
+- [ ] The strategy meta-theorem type-checks under `--safe` with an explicit, auditable assumption registry.
+- [ ] A short design note in `docs/notes/` records the formalization decisions and any divergences from the note's paper proofs.
+
+---
+
+### Issue M6-13h: FLRP RP-2: the enforcement catalog (#459)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Build the machine-readable catalog of "interval shape forces group structure" theorems, each recast as a precise (cf-/min-)IE statement with an Agda statement — assumption-parameterized wherever the proof stays on paper.  Seed entries, per roadmap § 4: the note's classes `𝒢₀` (nonsolvable; IE), `𝒢₁` (neither alternating nor symmetric; IE), `𝒢₂` (subdirectly irreducible), `𝒢₃` (no nontrivial abelian normal subgroup), `𝒢₄` (`C_G(M) = 1` for all nontrivial normal `M`) — the last three cf-IE via parachutes.  External entries: Pálfy's solvable-exclusion lattices; Köhler/Feit `M₇` and Pálfy's minimality analysis of Feit's examples (min-IE); Baddeley–Lucchini reductions; Börner; Aschbacher's `D∆`/signalizer theorems specialized to parachutes (whose interiors are disconnected); Lucchini–Moscatiello–Palcoux–Spiga Boolean overgroup lattices.
+
+Depends on WP-4; grows alongside RP-1.  Part of #451.
+
+## Exit criterion
+
+- [ ] A catalog module plus survey note exists, with at least the note's five classes and two external entries formalized as statements.
+- [ ] Each entry records its source, its enforcing lattice(s), and whether the proof is formalized or imported as a hypothesis.
+
+---
+
+### Issue M6-13i: FLRP RP-3: hunt for an empty intersection of cf-IE classes (#460)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+The kill shot, per Theorem 3.6 of the vendored note: exhibit finitely many cf-IE classes whose intersection is empty, and the FLRP has a negative answer (a property and its negation is the special case `n = 2`).  The wreath no-go (Lemma 3.3) constrains the hunt: every cf-IE-by-group-representable class contains wreath products `S ≀ Ū` for every finite nonabelian simple `S`, so every member of a candidate family is wreath-rich, and the joint tension must come from finer invariants — the structure of the unique minimal normal subgroup forced by Lemma 3.7, its centralizer and complement behavior, and the permutation action on it.
+
+Method discipline: use computation as cheap falsification.  Before investing in a non-representability proof for a candidate parachute, search for representations of it over the small-groups and primitive-groups libraries (Hulpke's intermediate-subgroup algorithms), and attempt UA-side representations of small candidates directly; certificates flow through the WP-6 pipeline.
+
+Depends on RP-1 and RP-2.  Part of #451; success/kill criteria in roadmap § 4.
+
+## Exit criterion
+
+- [ ] Success: a finite lattice with a machine-checked non-representability proof (modulo the explicit assumption registry).
+- [ ] Kill: two consecutive quarterly reviews with no viable candidate family, documented in the tracking issue.
+
+---
+
+### Issue M6-13j: FLRP RP-4: dead-end branch — can a property and its negation both be cf-IE? (#461)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Prove or refute the implicit conjecture of the vendored note: a group property and its negation cannot both be core-free interval enforceable by group-representable lattices.  The wreath no-go (Lemma 3.3, via the double Kurzweil construction) is the prototype tool and already excludes the classes omitting wreath products `S ≀ Ū` (solvable, alternating/symmetric, almost simple); the phase extends it toward a structure theory of the cf-IE class, and more generally characterizes what an empty-intersection family (RP-3) would have to look like.
+
+Either outcome is valuable.  A proof is the honorable dead end for the `n = 2` case and independently a publishable structure theorem about intervals in subgroup lattices; a refutation is a concrete path toward a negative FLRP answer.  A sobering asymmetry to keep in view: the existence of empty-intersection families cannot be ruled out without proving statement (B) itself, so the realistic aim is structure theorems constraining the families we can actually construct.
+
+Depends on RP-1 (wreath products, Kurzweil construction).  Part of #451; roadmap § 4.
+
+## Exit criterion
+
+- [ ] A theorem (formalized, or paper-proved with a formal statement) settling the `n = 2` conjecture in either direction, or a documented reduction of it to named open questions.
 
 <!-- END GENERATED: milestone-6 -->
 
@@ -3895,7 +4133,7 @@ GitHub's "Transfer ownership" feature (Settings → General → Danger zone → 
 
 ---
 
-### Issue M10-3: Type-on-hover tooltips for Agda tokens (1Lab-style), with a toggle (#429)
+### Issue M10-3: Type-on-hover tooltips for Agda tokens (1Lab-style), with a toggle (#429, closed)
 
 **Labels**: `documentation`, `milestone-10-polish`
 

--- a/docs/_links.md
+++ b/docs/_links.md
@@ -30,6 +30,7 @@
 [Setoid]: /Setoid/
 [Setoid.Algebras]: /Setoid/Algebras/
 [Setoid.Algebras.Basic]: /Setoid/Algebras/Basic/
+[Setoid.Algebras.Finite]: /Setoid/Algebras/Finite/
 [Setoid.Algebras.Products]: /Setoid/Algebras/Products/
 [Setoid.Algebras.Reduct]: /Setoid/Algebras/Reduct/
 [Setoid.Categories]: /Setoid/Categories/
@@ -48,6 +49,7 @@
 [Setoid.Congruences.Basic]: /Setoid/Congruences/Basic/
 [Setoid.Congruences.ChainJoin]: /Setoid/Congruences/ChainJoin/
 [Setoid.Congruences.CompleteLattice]: /Setoid/Congruences/CompleteLattice/
+[Setoid.Congruences.Finite]: /Setoid/Congruences/Finite/
 [Setoid.Congruences.Generation]: /Setoid/Congruences/Generation/
 [Setoid.Congruences.Lattice]: /Setoid/Congruences/Lattice/
 [Setoid.Congruences.Monolith]: /Setoid/Congruences/Monolith/
@@ -327,6 +329,7 @@
 [Setoid.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid.lagda.md
 [Setoid/Algebras.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras.lagda.md
 [Setoid/Algebras/Basic.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Basic.lagda.md
+[Setoid/Algebras/Finite.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Finite.lagda.md
 [Setoid/Algebras/Products.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Products.lagda.md
 [Setoid/Algebras/Reduct.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Reduct.lagda.md
 [Setoid/Categories.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Categories.lagda.md
@@ -345,6 +348,7 @@
 [Setoid/Congruences/Basic.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Congruences/Basic.lagda.md
 [Setoid/Congruences/ChainJoin.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Congruences/ChainJoin.lagda.md
 [Setoid/Congruences/CompleteLattice.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Congruences/CompleteLattice.lagda.md
+[Setoid/Congruences/Finite.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Congruences/Finite.lagda.md
 [Setoid/Congruences/Generation.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Congruences/Generation.lagda.md
 [Setoid/Congruences/Lattice.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Congruences/Lattice.lagda.md
 [Setoid/Congruences/Monolith.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Congruences/Monolith.lagda.md

--- a/docs/notes/m6-2-subdirect.md
+++ b/docs/notes/m6-2-subdirect.md
@@ -185,7 +185,8 @@ decomposition, i.e. every subdirect embedding `𝑨 ↪ ⨅ 𝒜` has an isomorp
    *structural ⟹ monolith* is not added: the natural witness `μ = ⋀ {θ : Nonzero θ}` is
    indexed by `Σ[ θ ∈ Con 𝑨 ρ ] Nonzero θ`, a universe up, so the meet is a `Con 𝑨 ℓ′` with
    `ℓ′ > ρ` — not a monolith *at level `ρ`*; and the finite escape fails too, since the
-   constructive complete congruence lists (`FiniteAlgebra.cons`, [M6-8][]) live at the
+   constructive complete congruence lists (`FiniteCongruences.cons`, [M6-8][], relocated
+   to `Setoid.Congruences.Finite` by #464) live at the
    absorbing level `clv α ρ ⊒ ρ`.  This is the same predicativity wall as the
    `cmi ⟹ monolith` direction above (and [M6-9][]); recorded, not forced.
 

--- a/docs/notes/m6-8-finite-birkhoff.md
+++ b/docs/notes/m6-8-finite-birkhoff.md
@@ -105,11 +105,33 @@ the index — distinct pairs — at `α ⊔ ρ`, so `finiteSubdirectSIRep` has t
 +  A genuinely subdirectly irreducible **worked example** over a concrete signature
    (a small algebra whose congruence lattice is enumerated by hand), exercising the
    maximal-congruence search rather than the degenerate `𝟏` witness.
-+  A **builder** producing `FiniteAlgebra` from more primitive data for tractable
-   classes — e.g. a carrier `≃ Fin n` whose every congruence is *given* with a
-   decision procedure — packaging the `complete` field once and for all.
++  A **builder** producing the finiteness witnesses from more primitive data for
+   tractable classes — e.g. a carrier `≃ Fin n` whose every congruence is *given*
+   with a decision procedure — packaging the `complete` field once and for all.
 +  Connecting finite subdirect representation to the FLRP setting (M6's target),
    where finiteness is exactly the hypothesis.
+
+## Update: the interface was split and relocated (#464)
+
+The `FiniteAlgebra` record described above originally lived in
+`Setoid.Subalgebras.Subdirect.Finite` and bundled the carrier-level and the
+congruence-level finiteness data in one record.  Issue #464 split it into two
+records at canonical locations, anticipating reuse in the FLRP work:
+
++  `FiniteAlgebra 𝑨` (`Setoid.Algebras.Finite`) — the *bare* interface: decidable
+   `≈`, `card`, `enum`, `enum-sur`.
++  `FiniteCongruences 𝑨` (`Setoid.Congruences.Finite`) — the congruence-side
+   interface: `clv`, `DecCon`, and the `cons`/`complete` enumeration with its
+   `witness*` helpers; the module also proves `≈-dec` (a `FiniteCongruences`
+   witness decides setoid equality, via the diagonal's listed representative).
+
+The two are logically independent (an infinite, constructively simple algebra with
+decidable equality inhabits the second but not the first), and
+`Setoid.Subalgebras.Subdirect.Finite` now takes both as module parameters:
+`finite-Birkhoff 𝑭 𝑪`.  The `𝟏` non-vacuity witnesses moved with their records
+(`𝟏` / `𝟏-FiniteAlgebra` to `Setoid.Algebras.Finite`, `𝟏-Δ` /
+`𝟏-FiniteCongruences` to `Setoid.Congruences.Finite`), while the theorem
+application `𝟏-SubdirectlyRepresentable` stays with the theorem.
 
 [M6-8]: https://github.com/ualib/agda-algebras/issues/419
 [M6-2]: https://github.com/ualib/agda-algebras/issues/272

--- a/src/Setoid/Algebras.lagda.md
+++ b/src/Setoid/Algebras.lagda.md
@@ -16,6 +16,7 @@ open import Overture using (𝓞 ; 𝓥 ; Signature)
 module Setoid.Algebras {𝑆 : Signature 𝓞 𝓥} where
 
 open import Setoid.Algebras.Basic {𝑆 = 𝑆} public
+open import Setoid.Algebras.Finite {𝑆 = 𝑆} public
 open import Setoid.Algebras.Products {𝑆 = 𝑆} public
 open import Setoid.Algebras.Reduct public
 ```

--- a/src/Setoid/Algebras/Finite.lagda.md
+++ b/src/Setoid/Algebras/Finite.lagda.md
@@ -10,30 +10,30 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Algebras.Finite][] module of the [Agda Universal Algebra Library][].
 
-This module defines the *bare* finiteness interface for setoid algebras: the record
+This module defines the finiteness interface for setoid algebras.  The record
 `FiniteAlgebra`{.AgdaRecord} `𝑨` bundles decidable setoid equality on the carrier of
-`𝑨` with a finite, surjective enumeration of that carrier.  It says nothing about
-the congruences of `𝑨`; it is carrier-level data only.
+`𝑨` with a finite, surjective enumeration of that carrier.  (It says nothing about
+the congruences of `𝑨`; it is carrier-level data only.)
 
 Two design points deserve comment.
 
-+  **The enumeration is surjective, not bijective.**  A map `Fin card → 𝕌[ 𝑨 ]`
++  **The enumeration is surjective, not bijective**.  A map `Fin card → 𝕌[ 𝑨 ]`
    hitting every element up to `≈` is exactly what downstream constructions need in
-   order to *search* the carrier and to *count* — e.g. counting the pairs related by a
+   order to *search* the carrier and to *count*; e.g., counting the pairs related by a
    congruence in [Setoid.Subalgebras.Subdirect.Finite][].  Demanding injectivity as
    well would burden every instance with distinctness proofs that no consumer uses,
    so `card`{.AgdaField} is an upper bound on, not the exact size of, the carrier.
 
-+  **Decidable `≈` is a separate field.**  Surjective enumerability of a setoid
++  **Decidable `≈` is a separate field**.  Surjective enumerability of a setoid
    carrier does not imply decidability of its equality, so the interface must ask
    for both.
 
 The name `FiniteAlgebra`{.AgdaRecord} is deliberately reserved for this bare
-interface (#464).  Finite-algebra theorems about the *congruence lattice* — for
-instance Birkhoff's subdirect representation theorem for finite algebras — need
-strictly more than carrier finiteness: a complete, decidable enumeration of the
-congruences, which carrier finiteness cannot supply constructively.  That stronger,
-logically independent interface is `FiniteCongruences`{.AgdaRecord}, defined in
+interface.  Finite-algebra theorems about the *congruence lattice* — for instance
+Birkhoff's subdirect representation theorem for finite algebras — need strictly more
+than carrier finiteness: a complete, decidable enumeration of the congruences, which
+carrier finiteness cannot supply constructively.  That stronger, logically
+independent interface is `FiniteCongruences`{.AgdaRecord}, defined in
 [Setoid.Congruences.Finite][]; the two are consumed together in
 [Setoid.Subalgebras.Subdirect.Finite][].
 
@@ -45,11 +45,12 @@ open import Overture using ( 𝓞 ; 𝓥 ; Signature )
 
 module Setoid.Algebras.Finite {𝑆 : Signature 𝓞 𝓥} where
 
--- Imports from Agda and the Agda Standard Library ----------------------------
-open import Agda.Primitive    using () renaming ( Set to Type )
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -----------------------------------
 open import Data.Fin.Base     using ( Fin ; zero )
 open import Data.Nat.Base     using ( ℕ )
-open import Data.Product      using ( _,_ ; Σ-syntax )
+open import Data.Product      using ( _,_  ; ∃-syntax )
 open import Data.Unit.Base    using ( ⊤ ; tt )
 open import Function          using ( Func )
 open import Level             using ( Level ; _⊔_ ; 0ℓ )
@@ -59,8 +60,10 @@ open import Relation.Nullary  using ( Dec ; yes )
 -- Imports from the Agda Universal Algebra Library ----------------------------
 open import Setoid.Algebras.Basic {𝑆 = 𝑆} using ( Algebra ; 𝕌[_] ; 𝔻[_] )
 
-open Algebra using ( Domain ; Interp )
-open Func    using ( cong ) renaming ( to to _⟨$⟩_ )
+open Algebra  using ( Domain ; Interp )
+open Func     using ( cong ) renaming ( to to _⟨$⟩_ )
+open Relation.Binary.IsEquivalence
+
 
 private variable α ρ : Level
 ```
@@ -75,13 +78,11 @@ equality and a surjective enumeration of its carrier by a finite index type.
 record FiniteAlgebra (𝑨 : Algebra α ρ) : Type (α ⊔ ρ) where
   open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
   field
-    -- setoid equality on the carrier of 𝑨 is decidable
-    _≟_       : (x y : 𝕌[ 𝑨 ]) → Dec (x ≈ y)
-    -- a finite enumeration of the carrier ...
+    _≟_       : ∀ x y → Dec (x ≈ y)      -- decidable setoid equality carrier of 𝑨
     card      : ℕ
-    enum      : Fin card → 𝕌[ 𝑨 ]
-    -- ... hitting every element, up to ≈
-    enum-sur  : (x : 𝕌[ 𝑨 ]) → Σ[ i ∈ Fin card ] (enum i ≈ x)
+    enum      : Fin card → 𝕌[ 𝑨 ]       -- finite enumeration of the carrier
+    enum-sur  : ∀ x → ∃[ i ] enum i ≈ x  -- that hits every element, up to ≈
+open FiniteAlgebra
 ```
 
 #### Non-vacuity: the one-element algebra is finite
@@ -89,28 +90,32 @@ record FiniteAlgebra (𝑨 : Algebra α ρ) : Type (α ⊔ ρ) where
 The record is genuine, computational data, so we exhibit an inhabitant.  The
 one-element algebra `𝟏`{.AgdaFunction} over the ambient signature has carrier `⊤`,
 trivial setoid equality, and each operation constantly `tt`; its finiteness witness
-is immediate.  (Its congruence-side finiteness witness is
-`𝟏-FiniteCongruences`{.AgdaFunction} in [Setoid.Congruences.Finite][], and the two
-feed Birkhoff's theorem for finite algebras in
-[Setoid.Subalgebras.Subdirect.Finite][].)
+is immediate.[^1]
 
 ```agda
 -- The one-element algebra over the signature 𝑆.
+open Setoid
+
 𝟏 : Algebra 0ℓ 0ℓ
-𝟏 .Domain = record  { Carrier        = ⊤
-                    ; _≈_            = λ _ _ → ⊤
-                    ; isEquivalence  = record { refl = tt ; sym = λ _ → tt ; trans = λ _ _ → tt } }
-𝟏 .Interp ⟨$⟩ _    = tt
-𝟏 .Interp .cong _ = tt
+𝟏 .Domain .Carrier        = ⊤
+𝟏 .Domain ._≈_            = λ _ _ → ⊤
+𝟏 .Domain .isEquivalence  = record  { refl   = tt
+                                    ; sym    = λ _ → tt
+                                    ; trans  = λ _ _ → tt }
+𝟏 .Interp ⟨$⟩ _           = tt
+𝟏 .Interp .cong _         = tt
 
 -- The one-element algebra is a finite algebra.
 𝟏-FiniteAlgebra : FiniteAlgebra 𝟏
-𝟏-FiniteAlgebra = record
-  { _≟_       = λ _ _ → yes tt
-  ; card      = 1
-  ; enum      = λ _ → tt
-  ; enum-sur  = λ _ → zero , tt
-  }
+𝟏-FiniteAlgebra ._≟_       = λ _ _ → yes tt
+𝟏-FiniteAlgebra .card      = 1
+𝟏-FiniteAlgebra .enum      = λ _ → tt
+𝟏-FiniteAlgebra .enum-sur  = λ _ → zero , tt
 ```
 
 --------------------------------------
+
+[^1]:  The finiteness witness of the congruence lattice of 𝟏 is
+       `𝟏-FiniteCongruences`{.AgdaRecord} in [Setoid.Congruences.Finite][] which,
+       together with the witness `𝟏-FiniteAlgebra`{.AgdaRecord}, is consumed by
+       Birkhoff's theorem for finite algebras in [Setoid.Subalgebras.Subdirect.Finite][].

--- a/src/Setoid/Algebras/Finite.lagda.md
+++ b/src/Setoid/Algebras/Finite.lagda.md
@@ -116,6 +116,6 @@ open Setoid
 --------------------------------------
 
 [^1]:  The finiteness witness of the congruence lattice of 𝟏 is
-       `𝟏-FiniteCongruences`{.AgdaRecord} in [Setoid.Congruences.Finite][] which,
-       together with the witness `𝟏-FiniteAlgebra`{.AgdaRecord}, is consumed by
+       `𝟏-FiniteCongruences`{.AgdaFunction} in [Setoid.Congruences.Finite][] which,
+       together with the witness `𝟏-FiniteAlgebra`{.AgdaFunction}, is consumed by
        Birkhoff's theorem for finite algebras in [Setoid.Subalgebras.Subdirect.Finite][].

--- a/src/Setoid/Algebras/Finite.lagda.md
+++ b/src/Setoid/Algebras/Finite.lagda.md
@@ -1,0 +1,116 @@
+---
+layout: default
+file: "src/Setoid/Algebras/Finite.lagda.md"
+title: "Setoid.Algebras.Finite module (The Agda Universal Algebra Library)"
+date: "2026-07-12"
+author: "the agda-algebras development team"
+---
+
+### Finite setoid algebras
+
+This is the [Setoid.Algebras.Finite][] module of the [Agda Universal Algebra Library][].
+
+This module defines the *bare* finiteness interface for setoid algebras: the record
+`FiniteAlgebra`{.AgdaRecord} `𝑨` bundles decidable setoid equality on the carrier of
+`𝑨` with a finite, surjective enumeration of that carrier.  It says nothing about
+the congruences of `𝑨`; it is carrier-level data only.
+
+Two design points deserve comment.
+
++  **The enumeration is surjective, not bijective.**  A map `Fin card → 𝕌[ 𝑨 ]`
+   hitting every element up to `≈` is exactly what downstream constructions need in
+   order to *search* the carrier and to *count* — e.g. counting the pairs related by a
+   congruence in [Setoid.Subalgebras.Subdirect.Finite][].  Demanding injectivity as
+   well would burden every instance with distinctness proofs that no consumer uses,
+   so `card`{.AgdaField} is an upper bound on, not the exact size of, the carrier.
+
++  **Decidable `≈` is a separate field.**  Surjective enumerability of a setoid
+   carrier does not imply decidability of its equality, so the interface must ask
+   for both.
+
+The name `FiniteAlgebra`{.AgdaRecord} is deliberately reserved for this bare
+interface (#464).  Finite-algebra theorems about the *congruence lattice* — for
+instance Birkhoff's subdirect representation theorem for finite algebras — need
+strictly more than carrier finiteness: a complete, decidable enumeration of the
+congruences, which carrier finiteness cannot supply constructively.  That stronger,
+logically independent interface is `FiniteCongruences`{.AgdaRecord}, defined in
+[Setoid.Congruences.Finite][]; the two are consumed together in
+[Setoid.Subalgebras.Subdirect.Finite][].
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+
+module Setoid.Algebras.Finite {𝑆 : Signature 𝓞 𝓥} where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Agda.Primitive    using () renaming ( Set to Type )
+open import Data.Fin.Base     using ( Fin ; zero )
+open import Data.Nat.Base     using ( ℕ )
+open import Data.Product      using ( _,_ ; Σ-syntax )
+open import Data.Unit.Base    using ( ⊤ ; tt )
+open import Function          using ( Func )
+open import Level             using ( Level ; _⊔_ ; 0ℓ )
+open import Relation.Binary   using ( Setoid )
+open import Relation.Nullary  using ( Dec ; yes )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Setoid.Algebras.Basic {𝑆 = 𝑆} using ( Algebra ; 𝕌[_] ; 𝔻[_] )
+
+open Algebra using ( Domain ; Interp )
+open Func    using ( cong ) renaming ( to to _⟨$⟩_ )
+
+private variable α ρ : Level
+```
+-->
+
+#### The bare finiteness interface
+
+A **finite algebra** is an algebra together with a decision procedure for its setoid
+equality and a surjective enumeration of its carrier by a finite index type.
+
+```agda
+record FiniteAlgebra (𝑨 : Algebra α ρ) : Type (α ⊔ ρ) where
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
+  field
+    -- setoid equality on the carrier of 𝑨 is decidable
+    _≟_       : (x y : 𝕌[ 𝑨 ]) → Dec (x ≈ y)
+    -- a finite enumeration of the carrier ...
+    card      : ℕ
+    enum      : Fin card → 𝕌[ 𝑨 ]
+    -- ... hitting every element, up to ≈
+    enum-sur  : (x : 𝕌[ 𝑨 ]) → Σ[ i ∈ Fin card ] (enum i ≈ x)
+```
+
+#### Non-vacuity: the one-element algebra is finite
+
+The record is genuine, computational data, so we exhibit an inhabitant.  The
+one-element algebra `𝟏`{.AgdaFunction} over the ambient signature has carrier `⊤`,
+trivial setoid equality, and each operation constantly `tt`; its finiteness witness
+is immediate.  (Its congruence-side finiteness witness is
+`𝟏-FiniteCongruences`{.AgdaFunction} in [Setoid.Congruences.Finite][], and the two
+feed Birkhoff's theorem for finite algebras in
+[Setoid.Subalgebras.Subdirect.Finite][].)
+
+```agda
+-- The one-element algebra over the signature 𝑆.
+𝟏 : Algebra 0ℓ 0ℓ
+𝟏 .Domain = record  { Carrier        = ⊤
+                    ; _≈_            = λ _ _ → ⊤
+                    ; isEquivalence  = record { refl = tt ; sym = λ _ → tt ; trans = λ _ _ → tt } }
+𝟏 .Interp ⟨$⟩ _    = tt
+𝟏 .Interp .cong _ = tt
+
+-- The one-element algebra is a finite algebra.
+𝟏-FiniteAlgebra : FiniteAlgebra 𝟏
+𝟏-FiniteAlgebra = record
+  { _≟_       = λ _ _ → yes tt
+  ; card      = 1
+  ; enum      = λ _ → tt
+  ; enum-sur  = λ _ → zero , tt
+  }
+```
+
+--------------------------------------

--- a/src/Setoid/Congruences.lagda.md
+++ b/src/Setoid/Congruences.lagda.md
@@ -18,6 +18,7 @@ module Setoid.Congruences {𝑆 : Signature 𝓞 𝓥} where
 open import Setoid.Congruences.Basic            {𝑆 = 𝑆} public
 open import Setoid.Congruences.ChainJoin                public
 open import Setoid.Congruences.CompleteLattice  {𝑆 = 𝑆} public
+open import Setoid.Congruences.Finite           {𝑆 = 𝑆} public
 open import Setoid.Congruences.Generation       {𝑆 = 𝑆} public
 open import Setoid.Congruences.Lattice          {𝑆 = 𝑆} public
 open import Setoid.Congruences.Monolith         {𝑆 = 𝑆} public

--- a/src/Setoid/Congruences/Finite.lagda.md
+++ b/src/Setoid/Congruences/Finite.lagda.md
@@ -1,0 +1,177 @@
+---
+layout: default
+file: "src/Setoid/Congruences/Finite.lagda.md"
+title: "Setoid.Congruences.Finite module (The Agda Universal Algebra Library)"
+date: "2026-07-12"
+author: "the agda-algebras development team"
+---
+
+### Finitely enumerable congruence lattices
+
+This is the [Setoid.Congruences.Finite][] module of the [Agda Universal Algebra Library][].
+
+[Setoid.Algebras.Finite][] defines the *bare* finiteness interface for a setoid
+algebra: decidable `≈` and a finite surjective enumeration of the carrier.  This
+module supplies the *congruence-side* finiteness interface: **decidable
+congruences** (`DecCon`{.AgdaFunction}) and the record
+`FiniteCongruences`{.AgdaRecord} `𝑨`, which packages a finite list of decidable
+congruences of `𝑨` that is *complete* — every congruence of `𝑨` equals, up to
+mutual containment `≑`, a listed one.  This is the searchable congruence lattice
+that finite-algebra theorems run their algorithms over; its first consumer is the
+finite Birkhoff theorem of [Setoid.Subalgebras.Subdirect.Finite][] (#419, whence
+these definitions were relocated by #464).
+
+#### Why carrier finiteness does not suffice
+
+Crucially, the data packaged here is *strictly stronger* than a
+`FiniteAlgebra`{.AgdaRecord} witness, which is why the two interfaces are separate
+records.  Carrier-finiteness along with decidable setoid equality do not, by
+themselves, admit a complete congruence enumeration constructively.  A congruence
+is a `Type`-valued relation `𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → Type ℓ`, and an arbitrary such
+relation on a finite carrier need not be decidable: e.g. on a bare set of two
+elements, the relation that collapses the two points *iff* `P` holds is a
+congruence for any proposition `P`, and it is `≑`-equal to a decidable congruence
+only iff `P` is decidable.  So a complete enumeration of congruences-up-to-`≑` is
+strictly stronger than decidable equality on a finite set; it is exactly the
+classical content of "finite algebra" for congruence-lattice purposes.  Classically
+every finite algebra furnishes these data; constructively they must be supplied,
+and this record is the interface through which they are.
+
+The two interfaces are logically independent in the other direction as well: an
+infinite algebra can perfectly well have a finitely enumerable congruence lattice
+(consider an algebra that is constructively simple, with decidable equality — its
+complete list is the diagonal and the total congruence), so
+`FiniteCongruences`{.AgdaRecord} does not presuppose a finite carrier.  There is,
+however, one overlap, recorded as `≈-dec`{.AgdaFunction} below: completeness forces
+the *diagonal's* listed representative to decide setoid equality, so the
+`_≟_`{.AgdaField} field of `FiniteAlgebra`{.AgdaRecord} is derivable from a
+`FiniteCongruences`{.AgdaRecord} witness.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+
+module Setoid.Congruences.Finite {𝑆 : Signature 𝓞 𝓥} where
+
+-- Imports from Agda and the Agda Standard Library ----------------------------
+open import Agda.Primitive                      using  ( lsuc ) renaming ( Set to Type )
+open import Data.List.Base                      using  ( List ; [] ; _∷_ )
+open import Data.List.Membership.Propositional  using  ( _∈_ )
+open import Data.List.Relation.Unary.Any        using  ( here )
+open import Data.Product                        using  ( _×_ ; _,_ ; Σ-syntax
+                                                       ; proj₁ ; proj₂ )
+open import Data.Unit.Base                      using  ( ⊤ ; tt )
+open import Function                            using  ( _∘_ )
+open import Level                               using  ( Level ; _⊔_ ; 0ℓ
+                                                       ; Lift ; lift ; lower )
+open import Relation.Binary                     using  ( Setoid )
+                                                renaming ( Rel to BinaryRel )
+open import Relation.Binary.PropositionalEquality  using  ( refl )
+open import Relation.Nullary                    using  ( Dec ; yes ; no )
+
+-- Imports from the Agda Universal Algebra Library ----------------------------
+open import Setoid.Algebras.Basic     {𝑆 = 𝑆}  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite    {𝑆 = 𝑆}  using  ( 𝟏 )
+open import Setoid.Congruences.Basic  {𝑆 = 𝑆}  using  ( Con ; mkcon ; reflexive ; 𝟘[_] )
+open import Setoid.Congruences.Lattice {𝑆 = 𝑆} using  ( _≑_ )
+
+private variable α ρ : Level
+```
+-->
+
+#### Decidable congruences and the working level
+
+A **decidable congruence** is a congruence whose membership relation is decidable.
+The working congruence level is the absorbing level `clv α ρ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ`, at
+which the generated (principal) congruences used downstream (e.g. for the monolith
+in the finite Birkhoff construction) stay put — the same level discipline as
+[Setoid.Congruences.CompleteLattice][].
+
+```agda
+-- The absorbing congruence level at which the enumeration below is carried out.
+clv : (α ρ : Level) → Level
+clv α ρ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ
+
+-- A congruence together with a decision procedure for its membership.
+DecCon : (𝑨 : Algebra α ρ)(ℓ : Level) → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ ⊔ lsuc ℓ)
+DecCon 𝑨 ℓ = Σ[ θ ∈ Con 𝑨 ℓ ] (∀ x y → Dec (proj₁ θ x y))
+
+-- The underlying relation of a decidable congruence.
+ConRel : {𝑨 : Algebra α ρ}{ℓ : Level} → DecCon 𝑨 ℓ → BinaryRel 𝕌[ 𝑨 ] ℓ
+ConRel (θ , _) = proj₁ θ
+```
+
+#### The congruence-side finiteness interface
+
+The record bundles a finite list `cons`{.AgdaField} of decidable congruences and a
+proof `complete`{.AgdaField} that the list exhausts the congruence lattice up to
+`≑`.  The `witness*`{.AgdaFunction} helpers project, for any congruence, its listed
+representative together with the membership and `≑`-equality proofs.
+
+```agda
+record FiniteCongruences (𝑨 : Algebra α ρ) : Type (lsuc (clv α ρ)) where
+  field
+    -- a finite list of decidable congruences of 𝑨 ...
+    cons      : List (DecCon 𝑨 (clv α ρ))
+    -- ... exhausting the congruence lattice of 𝑨, up to ≑
+    complete  : (φ : Con 𝑨 (clv α ρ))
+              → Σ[ d ∈ DecCon 𝑨 (clv α ρ) ] (d ∈ cons) × (φ ≑ proj₁ d)
+
+  witness : (φ : Con 𝑨 (clv α ρ)) → DecCon 𝑨 (clv α ρ)
+  witness = proj₁ ∘ complete
+
+  witness∈ : (φ : Con 𝑨 (clv α ρ)) → witness φ ∈ cons
+  witness∈ = proj₁ ∘ proj₂ ∘ complete
+
+  witness≑ : (φ : Con 𝑨 (clv α ρ)) → φ ≑ proj₁ (witness φ)
+  witness≑ = proj₂ ∘ proj₂ ∘ complete
+```
+
+As promised, a `FiniteCongruences`{.AgdaRecord} witness decides setoid equality:
+the diagonal congruence `𝟘[ 𝑨 ]` has a listed representative whose decidable
+membership coincides, up to the two containments of `≑`, with `≈`.
+
+```agda
+module _ {𝑨 : Algebra α ρ} (𝑪 : FiniteCongruences 𝑨) where
+  open FiniteCongruences 𝑪
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
+
+  private
+    -- The diagonal congruence at the working level.
+    Δ : Con 𝑨 (clv α ρ)
+    Δ = 𝟘[ 𝑨 ] {clv α ρ}
+
+  -- Setoid equality is decidable whenever the congruence lattice is
+  -- finitely enumerable: ask the diagonal's listed representative.
+  ≈-dec : (x y : 𝕌[ 𝑨 ]) → Dec (x ≈ y)
+  ≈-dec x y with proj₂ (witness Δ) x y
+  ... | yes dxy  = yes (lower (proj₂ (witness≑ Δ) dxy))
+  ... | no ¬dxy  = no λ x≈y → ¬dxy (proj₁ (witness≑ Δ) (lift x≈y))
+```
+
+#### Non-vacuity: the one-element algebra
+
+The one-element algebra `𝟏`{.AgdaFunction} of [Setoid.Algebras.Finite][] has, up to
+`≑`, exactly one congruence — the all-relation, which on a one-point carrier is
+also the diagonal — so its complete list is a singleton.
+
+```agda
+-- The sole decidable congruence of 𝟏: the all-relation (= the diagonal on a point).
+𝟏-Δ : DecCon 𝟏 (clv 0ℓ 0ℓ)
+𝟏-Δ = ((λ _ _ → Lift (clv 0ℓ 0ℓ) ⊤)
+      , mkcon  (λ _ → lift tt)
+               (record { refl = lift tt ; sym = λ _ → lift tt ; trans = λ _ _ → lift tt })
+               (λ _ _ → lift tt))
+      , (λ _ _ → yes (lift tt))
+
+-- The congruence lattice of 𝟏 is finitely enumerable.
+𝟏-FiniteCongruences : FiniteCongruences 𝟏
+𝟏-FiniteCongruences = record
+  { cons      = 𝟏-Δ ∷ []
+  ; complete  = λ φ → 𝟏-Δ , here refl , (λ _ → lift tt) , (λ _ → reflexive (proj₂ φ) tt)
+  }
+```
+
+--------------------------------------

--- a/src/Setoid/Congruences/Finite.lagda.md
+++ b/src/Setoid/Congruences/Finite.lagda.md
@@ -10,42 +10,49 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Congruences.Finite][] module of the [Agda Universal Algebra Library][].
 
-[Setoid.Algebras.Finite][] defines the *bare* finiteness interface for a setoid
-algebra: decidable `≈` and a finite surjective enumeration of the carrier.  This
-module supplies the *congruence-side* finiteness interface: **decidable
-congruences** (`DecCon`{.AgdaFunction}) and the record
-`FiniteCongruences`{.AgdaRecord} `𝑨`, which packages a finite list of decidable
-congruences of `𝑨` that is *complete* — every congruence of `𝑨` equals, up to
-mutual containment `≑`, a listed one.  This is the searchable congruence lattice
-that finite-algebra theorems run their algorithms over; its first consumer is the
-finite Birkhoff theorem of [Setoid.Subalgebras.Subdirect.Finite][] (#419, whence
-these definitions were relocated by #464).
+[Setoid.Algebras.Finite][] defines the finiteness interface for a setoid algebra:
+decidable `≈` and a finite surjective enumeration of the carrier.  This module
+supplies the finiteness interface for congruences, that is, **decidable
+congruences** (`DecCon`{.AgdaFunction}) and the record type
+`FiniteCongruences`{.AgdaRecord} `𝑨`.
+
+`FiniteCongruences`{.AgdaRecord} `𝑨` packages a finite list `cons` of decidable
+congruences of `𝑨` along with a proof that this list is *complete* in the sense that
+every congruence of `𝑨` is, up to mutual containment `≑`, one of those in `cons`.
+
+This provides a searchable congruence lattice that finite-algebra theorems run their
+algorithms over; its first consumer is the finite Birkhoff theorem of
+[Setoid.Subalgebras.Subdirect.Finite][].
 
 #### Why carrier finiteness does not suffice
 
 Crucially, the data packaged here is *strictly stronger* than a
 `FiniteAlgebra`{.AgdaRecord} witness, which is why the two interfaces are separate
 records.  Carrier-finiteness along with decidable setoid equality do not, by
-themselves, admit a complete congruence enumeration constructively.  A congruence
-is a `Type`-valued relation `𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → Type ℓ`, and an arbitrary such
-relation on a finite carrier need not be decidable: e.g. on a bare set of two
-elements, the relation that collapses the two points *iff* `P` holds is a
+themselves, admit a complete congruence enumeration constructively.
+
+Indeed, a congruence is a `Type`-valued relation `𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → Type ℓ`, and an
+arbitrary such relation on a finite carrier need not be decidable; e.g., on a bare
+set of two elements, the relation that collapses the two points *iff* `P` holds is a
 congruence for any proposition `P`, and it is `≑`-equal to a decidable congruence
-only iff `P` is decidable.  So a complete enumeration of congruences-up-to-`≑` is
-strictly stronger than decidable equality on a finite set; it is exactly the
-classical content of "finite algebra" for congruence-lattice purposes.  Classically
-every finite algebra furnishes these data; constructively they must be supplied,
-and this record is the interface through which they are.
+only iff `P` is decidable.
+
+Thus, a complete enumeration of congruences-up-to-`≑` is strictly stronger than
+decidable equality on a finite set; it is exactly the classical content of "finite
+algebra" for congruence-lattice purposes.  Classically every finite algebra furnishes
+these data; constructively they must be supplied, and this record is the interface
+through which they are.
 
 The two interfaces are logically independent in the other direction as well: an
 infinite algebra can perfectly well have a finitely enumerable congruence lattice
 (consider an algebra that is constructively simple, with decidable equality — its
 complete list is the diagonal and the total congruence), so
-`FiniteCongruences`{.AgdaRecord} does not presuppose a finite carrier.  There is,
-however, one overlap, recorded as `≈-dec`{.AgdaFunction} below: completeness forces
-the *diagonal's* listed representative to decide setoid equality, so the
-`_≟_`{.AgdaField} field of `FiniteAlgebra`{.AgdaRecord} is derivable from a
-`FiniteCongruences`{.AgdaRecord} witness.
+`FiniteCongruences`{.AgdaRecord} does not presuppose a finite carrier.
+
+There is, however, one overlap, recorded as `≈-dec`{.AgdaFunction} below:
+completeness forces the listed representative of the *diagonal* to decide setoid
+equality, so the `_≟_`{.AgdaField} field of `FiniteAlgebra`{.AgdaRecord} is derivable
+from a `FiniteCongruences`{.AgdaRecord} witness.
 
 <!--
 ```agda
@@ -55,21 +62,23 @@ open import Overture using ( 𝓞 ; 𝓥 ; Signature )
 
 module Setoid.Congruences.Finite {𝑆 : Signature 𝓞 𝓥} where
 
--- Imports from Agda and the Agda Standard Library ----------------------------
-open import Agda.Primitive                      using  ( lsuc ) renaming ( Set to Type )
-open import Data.List.Base                      using  ( List ; [] ; _∷_ )
-open import Data.List.Membership.Propositional  using  ( _∈_ )
-open import Data.List.Relation.Unary.Any        using  ( here )
-open import Data.Product                        using  ( _×_ ; _,_ ; Σ-syntax
-                                                       ; proj₁ ; proj₂ )
-open import Data.Unit.Base                      using  ( ⊤ ; tt )
-open import Function                            using  ( _∘_ )
-open import Level                               using  ( Level ; _⊔_ ; 0ℓ
-                                                       ; Lift ; lift ; lower )
-open import Relation.Binary                     using  ( Setoid )
-                                                renaming ( Rel to BinaryRel )
+open import Agda.Primitive  using  () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ----------------------------------------------
+open import Data.List.Base                         using  ( List ; [] ; _∷_ )
+open import Data.List.Membership.Propositional     using  ( _∈_ )
+open import Data.List.Relation.Unary.Any           using  ( here )
+open import Data.Product                           using  ( _×_ ; _,_ ; Σ-syntax
+                                                          ; proj₁ ; proj₂ )
+open import Data.Unit.Base                         using  ( ⊤ ; tt )
+open import Function                               using  ( _∘_ )
+open import Level                                  using  ( Level ; _⊔_ ; 0ℓ
+                                                          ; Lift ; lift ; lower )
+                                                   renaming ( suc to lsuc )
+open import Relation.Binary                        using  ( Setoid )
+                                                   renaming ( Rel to BinaryRel )
 open import Relation.Binary.PropositionalEquality  using  ( refl )
-open import Relation.Nullary                    using  ( Dec ; yes ; no )
+open import Relation.Nullary                       using  ( Dec ; yes ; no )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
 open import Setoid.Algebras.Basic     {𝑆 = 𝑆}  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
@@ -86,7 +95,7 @@ private variable α ρ : Level
 A **decidable congruence** is a congruence whose membership relation is decidable.
 The working congruence level is the absorbing level `clv α ρ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ`, at
 which the generated (principal) congruences used downstream (e.g. for the monolith
-in the finite Birkhoff construction) stay put — the same level discipline as
+in the finite Birkhoff construction) stay put — the same level discipline as in
 [Setoid.Congruences.CompleteLattice][].
 
 ```agda
@@ -95,12 +104,12 @@ clv : (α ρ : Level) → Level
 clv α ρ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ
 
 -- A congruence together with a decision procedure for its membership.
-DecCon : (𝑨 : Algebra α ρ)(ℓ : Level) → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ ⊔ lsuc ℓ)
-DecCon 𝑨 ℓ = Σ[ θ ∈ Con 𝑨 ℓ ] (∀ x y → Dec (proj₁ θ x y))
+DecCon : (𝑨 : Algebra α ρ)(ℓ : Level) → Type (clv α ρ ⊔ lsuc ℓ)
+DecCon 𝑨 ℓ = Σ[ (_θ_ , _) ∈ Con 𝑨 ℓ ] ∀ x y → Dec (x θ y)
 
 -- The underlying relation of a decidable congruence.
 ConRel : {𝑨 : Algebra α ρ}{ℓ : Level} → DecCon 𝑨 ℓ → BinaryRel 𝕌[ 𝑨 ] ℓ
-ConRel (θ , _) = proj₁ θ
+ConRel ((θ , _) , _) = θ
 ```
 
 #### The congruence-side finiteness interface
@@ -127,6 +136,7 @@ record FiniteCongruences (𝑨 : Algebra α ρ) : Type (lsuc (clv α ρ)) where
 
   witness≑ : (φ : Con 𝑨 (clv α ρ)) → φ ≑ proj₁ (witness φ)
   witness≑ = proj₂ ∘ proj₂ ∘ complete
+
 ```
 
 As promised, a `FiniteCongruences`{.AgdaRecord} witness decides setoid equality:
@@ -167,11 +177,11 @@ also the diagonal — so its complete list is a singleton.
       , (λ _ _ → yes (lift tt))
 
 -- The congruence lattice of 𝟏 is finitely enumerable.
+open FiniteCongruences
 𝟏-FiniteCongruences : FiniteCongruences 𝟏
-𝟏-FiniteCongruences = record
-  { cons      = 𝟏-Δ ∷ []
-  ; complete  = λ φ → 𝟏-Δ , here refl , (λ _ → lift tt) , (λ _ → reflexive (proj₂ φ) tt)
-  }
+𝟏-FiniteCongruences .cons = 𝟏-Δ ∷ []
+𝟏-FiniteCongruences .complete ( _ , φcon ) =
+  𝟏-Δ , here refl , (λ _ → lift tt) , λ x → reflexive φcon tt
 ```
 
 --------------------------------------

--- a/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
@@ -42,7 +42,7 @@ through two independent interfaces.
 1.  `FiniteAlgebra`{.AgdaRecord}, from [Setoid.Algebras.Finite][]: decidable `≈` and
     a finite surjective enumeration of the carrier, used here to count the pairs a
     congruence relates;
-+  `FiniteCongruences`{.AgdaRecord}, from [Setoid.Congruences.Finite][]: a finite
+2.  `FiniteCongruences`{.AgdaRecord}, from [Setoid.Congruences.Finite][]: a finite
     list of *decidable* congruences (`DecCon`{.AgdaFunction}), complete up to `≑` —
     the searchable congruence lattice.
 

--- a/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
@@ -35,23 +35,23 @@ irreducibility (whose monolith condition quantifies over all congruences of the
 quotient) the enumeration must be complete — every congruence must equal, up to
 mutual containment `≑`, a listed one.
 
-Crucially, *carrier-finiteness along with decidable setoid equality* do not, by
-themselves, admit such an enumeration constructively.  A congruence is a
-`Type`-valued relation `𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → Type ℓ`; an arbitrary such relation
-on a finite carrier need not be decidable: e.g. on a bare set of two elements, the
-relation that collapses the two points *iff* `P` holds is a congruence for any
-proposition `P`, and it is `≑`-equal to a decidable congruence only iff `P` is
-decidable.  So a complete enumeration of congruences-up-to-`≑` is strictly stronger
-than decidable equality on a finite set; it is exactly the classical content of
-"finite algebra" for congruence-lattice purposes.
+Crucially, carrier-finiteness along with decidable setoid equality do not, by
+themselves, admit such an enumeration constructively (see
+[Setoid.Congruences.Finite][] for the counterexample), so the finiteness data comes
+through two independent interfaces (#464):
 
-We therefore take that content as the finiteness interface: a `FiniteAlgebra` bundles
-decidable `≈`, a finite enumeration of the carrier, and a finite list of *decidable*
-congruences that is complete up to `≑`.  Everything downstream is then fully
-constructive and computes.  Classically every finite algebra furnishes these data, so
-`finite-Birkhoff` is Birkhoff's theorem for finite algebras; the `FiniteAlgebra`
-record is precisely the constructive witness that makes the search go through under
-`--safe`.
++  `FiniteAlgebra`{.AgdaRecord}, from [Setoid.Algebras.Finite][] — the *bare*
+   interface: decidable `≈` and a finite surjective enumeration of the carrier,
+   used here to count the pairs a congruence relates;
++  `FiniteCongruences`{.AgdaRecord}, from [Setoid.Congruences.Finite][] — the
+   congruence-side interface: a finite list of *decidable* congruences
+   (`DecCon`{.AgdaFunction}), complete up to `≑` — the searchable congruence
+   lattice.
+
+Everything downstream is then fully constructive and computes.  Classically every
+finite algebra furnishes both witnesses, so `finite-Birkhoff` is Birkhoff's theorem
+for finite algebras; the two records are precisely the constructive data that make
+the search go through under `--safe`.
 
 <!--
 ```agda
@@ -62,9 +62,9 @@ open import Overture using ( 𝓞 ; 𝓥 ; Signature )
 module Setoid.Subalgebras.Subdirect.Finite {𝑆 : Signature 𝓞 𝓥} where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
-open import Agda.Primitive                         using  ( lsuc ) renaming ( Set to Type )
+open import Agda.Primitive                         using  () renaming ( Set to Type )
 open import Data.Empty                             using  ( ⊥-elim )
-open import Data.Fin.Base                          using  ( Fin ; zero )
+open import Data.Fin.Base                          using  ( Fin )
 open import Data.Fin.Properties                    using  ( all? ; ¬∀⟶∃¬ )
 open import Data.List.Base                         using  ( List ; [] ; _∷_ ; filter ; length
                                                           ; allFin ; cartesianProduct )
@@ -80,22 +80,24 @@ open import Data.Nat.Properties                    using  ( m≤n⇒m≤1+n ; n<
                                                           ; ≤-<-trans ; n≮n )
 open import Data.Product                           using  ( _×_ ; _,_ ; Σ-syntax ; proj₁ ; proj₂ )
 open import Data.Sum.Base                          using  ( inj₁ ; inj₂ )
-open import Data.Unit.Base                         using  ( ⊤ ; tt )
-open import Function                               using  ( Func ; _∘_ )
-open import Level                                  using  ( Level ; _⊔_ ; 0ℓ ; Lift ; lift ; lower )
+open import Level                                  using  ( Level ; _⊔_ ; 0ℓ ; lower )
 open import Relation.Binary                        using  ( Setoid ; IsEquivalence )
-                                                   renaming (Rel to BinaryRel)
 open import Relation.Binary.PropositionalEquality  using  ( _≡_ ; refl ; subst ; sym )
 open import Relation.Nullary                       using  ( ¬_ ; Dec ; yes ; no )
 open import Relation.Nullary.Decidable             using  ( _→-dec_ ; ¬? )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
 open import Setoid.Algebras.Basic               {𝑆 = 𝑆}  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite              {𝑆 = 𝑆}  using  ( FiniteAlgebra ; 𝟏
+                                                                ; 𝟏-FiniteAlgebra )
 open import Setoid.Congruences.Basic            {𝑆 = 𝑆}  using  ( Con ; mkcon ; reflexive
                                                                 ; is-equivalence ; is-compatible
                                                                 ; _╱_ ; 𝟘[_] )
+open import Setoid.Congruences.Finite           {𝑆 = 𝑆}  using  ( clv ; DecCon ; ConRel
+                                                                ; FiniteCongruences
+                                                                ; 𝟏-FiniteCongruences )
 open import Setoid.Congruences.Generation       {𝑆 = 𝑆}  using  ( Cg ; Cg-least ; base )
-open import Setoid.Congruences.Lattice          {𝑆 = 𝑆}  using  ( _⊆_ ; _≑_ ; ⊆-trans )
+open import Setoid.Congruences.Lattice          {𝑆 = 𝑆}  using  ( _⊆_ ; ⊆-trans )
 open import Setoid.Congruences.Monolith         {𝑆 = 𝑆}  using  ( IsSubdirectlyIrreducible
                                                                 ; mono-nonzero ; mono-least
                                                                 ; Nonzero )
@@ -103,9 +105,6 @@ open import Setoid.Congruences.Monolith         {𝑆 = 𝑆}  using  ( IsSubdir
 open import Setoid.Subalgebras.Subdirect.Basic  {𝑆 = 𝑆}  using ( Separates )
 open import Setoid.Subalgebras.Subdirect.BirkhoffSI {𝑆 = 𝑆}
   using (SubdirectSIRep; SubdirectlyRepresentable ; SIRep→Representable )
-
-open Algebra using ( Domain ; Interp )
-open Func    using ( cong ) renaming ( to to _⟨$⟩_ )
 
 private variable α ρ : Level
 ```
@@ -155,62 +154,18 @@ private
   ¬→-split (no ¬p) ¬pq = ⊥-elim (¬pq (λ p → ⊥-elim (¬p p)))
 ```
 
-#### Decidable congruences and the finiteness interface
-
-A **decidable congruence** is a congruence whose membership relation is decidable.
-The working congruence level is the absorbing level `clv α ρ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ`, at
-which the generated (principal) congruences used for the monolith stay put — the
-same level discipline as [Setoid.Congruences.CompleteLattice][].
-
-```agda
--- The absorbing congruence level at which everything below is carried out.
-clv : (α ρ : Level) → Level
-clv α ρ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ
-
--- A congruence together with a decision procedure for its membership.
-DecCon : (𝑨 : Algebra α ρ)(ℓ : Level) → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ ⊔ lsuc ℓ)
-DecCon 𝑨 ℓ = Σ[ θ ∈ Con 𝑨 ℓ ] (∀ x y → Dec (proj₁ θ x y))
-
-ConRel : {𝑨 : Algebra α ρ}{ℓ : Level} → DecCon 𝑨 ℓ → BinaryRel 𝕌[ 𝑨 ] ℓ
-ConRel (θ , _) = proj₁ θ
-```
-
-The finiteness interface bundles: decidable `≈`; a surjective enumeration of the
-carrier (used to *count* related pairs); and a finite, complete list of decidable
-congruences (the searchable congruence lattice).  See the module header for why
-the last field cannot be derived from the first two.
-
-```agda
-record FiniteAlgebra (𝑨 : Algebra α ρ) : Type (lsuc (clv α ρ)) where
-  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
-  field
-    _≟_       : (x y : 𝕌[ 𝑨 ]) → Dec (x ≈ y)
-    card      : ℕ
-    enum      : Fin card → 𝕌[ 𝑨 ]
-    enum-sur  : (x : 𝕌[ 𝑨 ]) → Σ[ i ∈ Fin card ] (enum i ≈ x)
-    cons      : List (DecCon 𝑨 (clv α ρ))
-    complete  : (φ : Con 𝑨 (clv α ρ)) → Σ[ d ∈ DecCon 𝑨 (clv α ρ) ] (d ∈ cons) × (φ ≑ proj₁ d)
-
-  witness : (φ : Con 𝑨 (clv α ρ)) → DecCon 𝑨 (clv α ρ)
-  witness = proj₁ ∘ complete
-
-  witness∈ : (φ : Con 𝑨 (clv α ρ)) → witness φ ∈ cons
-  witness∈ = proj₁ ∘ proj₂ ∘ complete
-
-  witness≑ : (φ : Con 𝑨 (clv α ρ)) → φ ≑ proj₁ (witness φ)
-  witness≑ = proj₂ ∘ proj₂ ∘ complete
-
-
-```
-
 #### The construction
 
-Fix a finite algebra.  We abbreviate the working level as `ℓ`, and `pairs` is the
-list of all index pairs of the carrier enumeration.
+Fix an algebra `𝑨` equipped with both finiteness witnesses.  We abbreviate the
+working congruence level as `ℓ = clv α ρ` — the absorbing level of
+[Setoid.Congruences.Finite][], at which the generated (principal) congruences used
+for the monolith stay put — and `pairs` is the list of all index pairs of the
+carrier enumeration.
 
 ```agda
-module _ {𝑨 : Algebra α ρ} (𝑭 : FiniteAlgebra 𝑨) where
+module _ {𝑨 : Algebra α ρ} (𝑭 : FiniteAlgebra 𝑨) (𝑪 : FiniteCongruences 𝑨) where
   open FiniteAlgebra 𝑭
+  open FiniteCongruences 𝑪
   open Setoid 𝔻[ 𝑨 ] using ( _≈_ ) renaming ( sym to ≈sym )
 
   ℓ : Level
@@ -447,47 +402,23 @@ subdirect product of subdirectly irreducible algebras.
   finite-Birkhoff = SIRep→Representable finiteSubdirectSIRep
 ```
 
-#### Non-vacuity: the interface is inhabited
+#### Non-vacuity: the theorem fires
 
-The `FiniteAlgebra` record is genuine, computational data — not a disguised choice
-principle — so it must be exhibited, not merely assumed.  The one-element algebra
-over any signature satisfies it: its carrier is `⊤`, decidable equality is trivial,
-and its only congruence (up to `≑`) is the diagonal, so the complete list is a
-singleton.  This confirms `finite-Birkhoff` fires (here on a degenerate input: the
-family of distinct pairs is empty, so the trivial algebra is the subdirect product
-of the empty family).  A genuinely subdirectly irreducible worked example — one
-that exercises the maximal-congruence search — is the natural next addition.
+The finiteness interfaces are genuine, computational data — not disguised choice
+principles — so they must be exhibited, not merely assumed.  The one-element
+algebra `𝟏`{.AgdaFunction} satisfies both: its bare witness
+`𝟏-FiniteAlgebra`{.AgdaFunction} is exhibited in [Setoid.Algebras.Finite][], and
+its congruence-side witness `𝟏-FiniteCongruences`{.AgdaFunction} (a singleton
+complete list) in [Setoid.Congruences.Finite][].  Feeding them to `finite-Birkhoff`
+confirms the theorem fires (here on a degenerate input: the family of distinct
+pairs is empty, so the trivial algebra is the subdirect product of the empty
+family).  A genuinely subdirectly irreducible worked example — one that exercises
+the maximal-congruence search — is the natural next addition.
 
 ```agda
--- The one-element algebra over the signature 𝑆.
-𝟏 : Algebra 0ℓ 0ℓ
-𝟏 .Domain = record  { Carrier        = ⊤
-                    ; _≈_            = λ _ _ → ⊤
-                    ; isEquivalence  = record { refl = tt ; sym = λ _ → tt ; trans = λ _ _ → tt } }
-𝟏 .Interp ⟨$⟩ _    = tt
-𝟏 .Interp .cong _ = tt
-
--- Its sole decidable congruence: the all-relation (= the diagonal on a point).
-𝟏-Δ : DecCon 𝟏 (clv 0ℓ 0ℓ)
-𝟏-Δ = ((λ _ _ → Lift (clv 0ℓ 0ℓ) ⊤)
-      , mkcon  (λ _ → lift tt)
-               (record { refl = lift tt ; sym = λ _ → lift tt ; trans = λ _ _ → lift tt })
-               (λ _ _ → lift tt))
-      , (λ _ _ → yes (lift tt))
-
-𝟏-FiniteAlgebra : FiniteAlgebra 𝟏
-𝟏-FiniteAlgebra = record
-  { _≟_       = λ _ _ → yes tt
-  ; card      = 1
-  ; enum      = λ _ → tt
-  ; enum-sur  = λ _ → zero , tt
-  ; cons      = 𝟏-Δ ∷ []
-  ; complete  = λ φ → 𝟏-Δ , here refl , (λ _ → lift tt) , (λ _ → reflexive (proj₂ φ) tt)
-  }
-
 -- The theorem applied: the one-element algebra is subdirectly representable.
 𝟏-SubdirectlyRepresentable : SubdirectlyRepresentable 𝟏 (clv 0ℓ 0ℓ) 0ℓ
-𝟏-SubdirectlyRepresentable = finite-Birkhoff 𝟏-FiniteAlgebra
+𝟏-SubdirectlyRepresentable = finite-Birkhoff 𝟏-FiniteAlgebra 𝟏-FiniteCongruences
 ```
 
 --------------------------------------

--- a/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
@@ -8,10 +8,9 @@ author: "the agda-algebras development team"
 
 ### Finite Birkhoff: a constructive subdirect SI-representation
 
-This is the [Setoid.Subalgebras.Subdirect.Finite][] module of the
-[Agda Universal Algebra Library][].
+This is the [Setoid.Subalgebras.Subdirect.Finite][] module of the [Agda Universal Algebra Library][].
 
-[Setoid.Subalgebras.Subdirect.BirkhoffSI][] proved the **choice-free core** of
+[Setoid.Subalgebras.Subdirect.BirkhoffSI][] proved the *choice-free core* of
 Birkhoff's subdirect representation theorem and stated the general theorem
 `Birkhoff-subdirect` *relative to* the choice principle `SubdirectSIRep 𝑨` — the
 existence, for every algebra, of a separating family of congruences whose quotients
@@ -19,7 +18,7 @@ are subdirectly irreducible.
 
 Producing that family for an arbitrary algebra is a Zorn's-lemma step (a congruence
 maximal among those excluding a given pair), which is incompatible with a
-postulate-free `--safe` formalization in constructive type theory.
+postulate-free formalization in constructive type theory.
 
 This module discharges that parameter for a class of *finite* algebras: it constructs
 `SubdirectSIRep 𝑨` outright, with no choice and no postulate, and feeds it to the
@@ -27,31 +26,30 @@ choice-free reduction `SIRep→Representable`.[^1]
 
 #### What "finite" must mean here
 
-The classical proof selects, for each pair `a ≢ b`, a congruence **maximal** among
+The classical proof selects, for each pair `a ≢ b`, a congruence *maximal* among
 those not relating `a` and `b`; such a congruence is completely meet-irreducible, so
 its quotient is subdirectly irreducible.  To find that maximal congruence by a
 *search* we must enumerate the congruence lattice, and to recognise subdirect
 irreducibility (whose monolith condition quantifies over all congruences of the
-quotient) the enumeration must be complete — every congruence must equal, up to
-mutual containment `≑`, a listed one.
+quotient) the enumeration must be complete — every congruence must equal a listed
+one, up to mutual containment (denote here `≑`).
 
 Crucially, carrier-finiteness along with decidable setoid equality do not, by
 themselves, admit such an enumeration constructively (see
 [Setoid.Congruences.Finite][] for the counterexample), so the finiteness data comes
-through two independent interfaces (#464):
+through two independent interfaces.
 
-+  `FiniteAlgebra`{.AgdaRecord}, from [Setoid.Algebras.Finite][] — the *bare*
-   interface: decidable `≈` and a finite surjective enumeration of the carrier,
-   used here to count the pairs a congruence relates;
-+  `FiniteCongruences`{.AgdaRecord}, from [Setoid.Congruences.Finite][] — the
-   congruence-side interface: a finite list of *decidable* congruences
-   (`DecCon`{.AgdaFunction}), complete up to `≑` — the searchable congruence
-   lattice.
+1.  `FiniteAlgebra`{.AgdaRecord}, from [Setoid.Algebras.Finite][]: decidable `≈` and
+    a finite surjective enumeration of the carrier, used here to count the pairs a
+    congruence relates;
++  `FiniteCongruences`{.AgdaRecord}, from [Setoid.Congruences.Finite][]: a finite
+    list of *decidable* congruences (`DecCon`{.AgdaFunction}), complete up to `≑` —
+    the searchable congruence lattice.
 
 Everything downstream is then fully constructive and computes.  Classically every
 finite algebra furnishes both witnesses, so `finite-Birkhoff` is Birkhoff's theorem
 for finite algebras; the two records are precisely the constructive data that make
-the search go through under `--safe`.
+the search go through under `--safe` Agda.
 
 <!--
 ```agda

--- a/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
@@ -260,7 +260,7 @@ predicativity reason recorded in the [M6-2 design note][].  The natural construc
 takes `μ = ⋀ {θ : θ nonzero}`, the meet of *all* nonzero congruences: if `0ᴬ` is completely
 meet-irreducible then this family (whose every member is nonzero, so it has no zero
 member) cannot separate, so `μ` is nonzero; and `μ` is below every nonzero congruence,
-hence a monolith.  But that family is indexed by `∃[ θ ] Nonzero θ`, which lives one
+hence a monolith.  But that family is indexed by `Σ[ θ ∈ Con 𝑨 ρ ] Nonzero θ`, which lives one
 universe up, so the resulting meet is a `Con 𝑨 ℓ′` with `ℓ′ > ρ` — not a monolith
 *at level `ρ`*, the level `IsMonolith`{.AgdaRecord} fixes.
 

--- a/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
@@ -263,7 +263,8 @@ lives one universe up, so the resulting meet is a `Con 𝑨 ℓ′` with `ℓ′
 monolith *at level `ρ`*, the level `IsMonolith`{.AgdaRecord} fixes.  Restricting to a
 finite, complete list of congruences does not escape the wall either: the complete
 congruence enumerations available constructively (the `cons`{.AgdaField} field of
-`FiniteAlgebra`{.AgdaRecord}, #419) live at the absorbing level `clv α ρ ⊒ ρ`, so the
+`FiniteCongruences`{.AgdaRecord} in [Setoid.Congruences.Finite][], #419) live at the
+absorbing level `clv α ρ ⊒ ρ`, so the
 finite meet is again above `ρ`.  Stating the converse cleanly would need an impredicative
 (or universe-resized) meet, or a level-generic `IsMonolith`; we record it here as a known
 limitation, as the forward direction is the one consumed downstream.

--- a/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
@@ -203,31 +203,31 @@ module _ {I : Type ι}{𝑨 : Algebra α ρ}{𝒜 : I → Algebra αᵃ ρ}
 
 #### The finite witness: an explicit isomorphic coordinate
 
-For a **finite** index `Fin n`, with a decision for each coordinate of "is this kernel
-the diagonal?" (equivalently, "is this coordinate map injective?"), the contrapositive
-yields an *explicit* isomorphic coordinate: `𝑨` is isomorphic to one of its subdirect
-factors.  This is the witness-extracting form of the characterization, in the spirit of
-the finite Birkhoff theorem of [Setoid.Subalgebras.Subdirect.Finite][] (#419); the
-decision data is exactly what a `FiniteAlgebra`{.AgdaRecord} supplies (decidable `≈`
-and a finite carrier make `BelowDiagonal`, a `Π` over carrier pairs, decidable).
+For a *finite* index `Fin n`, with a decision for each coordinate of "is this kernel
+the diagonal?" (equivalently, "is this coordinate map injective?"), the
+contrapositive yields an *explicit* isomorphic coordinate: `𝑨` is isomorphic to one
+of its subdirect factors.  This is the witness-extracting form of the
+characterization, in the spirit of the finite Birkhoff theorem of
+[Setoid.Subalgebras.Subdirect.Finite][]; the decision data is exactly what a
+`FiniteAlgebra`{.AgdaRecord} supplies (decidable `≈` and a finite carrier make
+`BelowDiagonal`, a `Π` over carrier pairs, decidable).
 
 ```agda
-module _ {n : ℕ}{𝑨 : Algebra α ρ}{𝒜 : Fin n → Algebra αᵃ ρ}
-         (si : IsSubdirectlyIrreducible 𝑨)(sub : SubdirectEmbedding {𝑩 = 𝑨} 𝒜)
-         (dec : (i : Fin n) → Dec (BelowDiagonal 𝑨 (kerfam 𝒜 (proj₁ sub) i))) where
-  private
-    h    = proj₁ sub
-    emb  = proj₂ sub
+module _
+  {n : ℕ} {𝑨 : Algebra α ρ} {𝒜 : Fin n → Algebra αᵃ ρ}
+  ((_ , si)         : IsSubdirectlyIrreducible 𝑨)
+  ((h , emb)  : SubdirectEmbedding {𝑩 = 𝑨} 𝒜)
+  (dec        : (i : Fin n) → Dec (BelowDiagonal 𝑨 (kerfam 𝒜 h i))) where
 
   si⇒iso-coord : IsoToFactor 𝑨 𝒜
   si⇒iso-coord = i , coord-iso 𝒜 h (below→coord-inj 𝒜 h below) (proj-onto emb i)
     where
     -- the kernel family is not all-nonzero (the contrapositive forward direction)
-    ¬all-nz : ¬ (∀ i → Nonzero 𝑨 (kerfam 𝒜 h i))
-    ¬all-nz = monolith⇒¬all-nonzero (proj₂ si) (kerfam 𝒜 h) (embed→separates 𝒜 h (embed-inj emb))
+    ¬all-nz : ¬ ∀ i → Nonzero 𝑨 (kerfam 𝒜 h i)
+    ¬all-nz = monolith⇒¬all-nonzero si (kerfam 𝒜 h) (embed→separates 𝒜 h (embed-inj emb))
 
     -- finite + decidable ⟹ some coordinate's kernel is (¬¬, hence) below the diagonal
-    ex : ∃[ i ] (¬ Nonzero 𝑨 (kerfam 𝒜 h i))
+    ex : ∃[ i ] ¬ Nonzero 𝑨 (kerfam 𝒜 h i)
     ex = ¬∀⟶∃¬ n (λ i → Nonzero 𝑨 (kerfam 𝒜 h i)) (λ i → ¬? (dec i)) ¬all-nz
 
     i : Fin n
@@ -237,37 +237,41 @@ module _ {n : ℕ}{𝑨 : Algebra α ρ}{𝒜 : Fin n → Algebra αᵃ ρ}
     below = decidable-stable (dec i) (proj₂ ex)
 ```
 
-#### The converse bridge, and the converse's cost
+#### The converse bridge and its cost
 
 The *converse* of the family-level forward direction needs no monolith and is
-choice-free: if some coordinate map is injective — an isomorphism, given surjectivity —
-then the kernel family is not all-nonzero.  So at the family level "some `θ i ≑ 0ᴬ`" and
+choice-free: if some coordinate map is injective — and thus an isomorphism — then the
+kernel family is not all-nonzero.  So at the family level "some `θ i ≑ 0ᴬ`" and
 "not all `θ i` nonzero" coincide; together with the forward direction, the subdirect
 decompositions of an SI algebra are exactly those with an isomorphic coordinate.
 
 ```agda
-module _ {I : Type ι}{𝑨 : Algebra α ρ}{𝒜 : I → Algebra αᵃ ρ}(h : hom 𝑨 (⨅ 𝒜)) where
+module _
+  {I : Type ι} {𝑨 : Algebra α ρ} {𝒜 : I → Algebra αᵃ ρ}
+  (h : hom 𝑨 (⨅ 𝒜)) where
 
-  iso-coord⟹¬all-proper :  (∃[ i ] IsInjective (proj₁ (coord 𝒜 h i)))
-                        →  ¬ (∀ i → Nonzero 𝑨 (kerfam 𝒜 h i))
+  iso-coord⟹¬all-proper :
+    ∃[ i ] IsInjective (proj₁ (coord 𝒜 h i)) →  ¬ (∀ i → Nonzero 𝑨 (kerfam 𝒜 h i))
   iso-coord⟹¬all-proper (i , inj) all-nz = all-nz i (coord-inj→below 𝒜 h inj)
 ```
 
-The full converse **structural ⟹ monolith** is *not* added, for the same predicativity
-reason recorded in the [M6-2 design note][].  The natural construction takes
-`μ = ⋀ {θ : θ nonzero}`, the meet of *all* nonzero congruences: if `0ᴬ` is completely
+The full converse **structural ⟹ monolith** is *not* added, for the same
+predicativity reason recorded in the [M6-2 design note][].  The natural construction
+takes `μ = ⋀ {θ : θ nonzero}`, the meet of *all* nonzero congruences: if `0ᴬ` is completely
 meet-irreducible then this family (whose every member is nonzero, so it has no zero
 member) cannot separate, so `μ` is nonzero; and `μ` is below every nonzero congruence,
-hence a monolith.  But that family is indexed by `Σ[ θ ∈ Con 𝑨 ρ ] Nonzero θ`, which
-lives one universe up, so the resulting meet is a `Con 𝑨 ℓ′` with `ℓ′ > ρ` — not a
-monolith *at level `ρ`*, the level `IsMonolith`{.AgdaRecord} fixes.  Restricting to a
-finite, complete list of congruences does not escape the wall either: the complete
-congruence enumerations available constructively (the `cons`{.AgdaField} field of
-`FiniteCongruences`{.AgdaRecord} in [Setoid.Congruences.Finite][], #419) live at the
-absorbing level `clv α ρ ⊒ ρ`, so the
-finite meet is again above `ρ`.  Stating the converse cleanly would need an impredicative
-(or universe-resized) meet, or a level-generic `IsMonolith`; we record it here as a known
-limitation, as the forward direction is the one consumed downstream.
+hence a monolith.  But that family is indexed by `∃[ θ ] Nonzero θ`, which lives one
+universe up, so the resulting meet is a `Con 𝑨 ℓ′` with `ℓ′ > ρ` — not a monolith
+*at level `ρ`*, the level `IsMonolith`{.AgdaRecord} fixes.
+
+Restricting to a finite, complete list of congruences does not escape the wall
+either: the complete congruence enumerations available constructively (the
+`cons`{.AgdaField} field of `FiniteCongruences`{.AgdaRecord} in
+[Setoid.Congruences.Finite][]) live at the absorbing level `clv α ρ ⊒ ρ`, so the
+finite meet is again above `ρ`.  Stating the converse cleanly would need an
+impredicative (or universe-resized) meet, or a level-generic `IsMonolith`; we record
+it here as a known limitation, as the forward direction is the one consumed
+downstream.
 
 --------------------------------------
 


### PR DESCRIPTION
## Summary

Lifts the `FiniteAlgebra` definition out of `Setoid.Subalgebras.Subdirect.Finite` into a new bare-interface module `Setoid.Algebras.Finite`, and folds the congruence-enumeration part of the old record into a new `FiniteCongruences` record in `Setoid.Congruences.Finite`, exactly along the split proposed in #464.

## Related issues

Closes #464

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [x] Refactor / cleanup (user-facing/API change)
- [ ] Refactor / cleanup (no user-facing change)
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop`.
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches `src/`, it targets a supported area such as `Classical/`, `Cubical/`, `Demos/`, `Examples/`, `Exercises/`, `Overture/`, or `Setoid/`.
- [x] If this PR introduces new notation, it doesn't conflict with notation already used elsewhere in the library.

## Notes for reviewers

The one design decision worth scrutiny is that `FiniteCongruences` is a **sibling record parameterized over the algebra**, not an extension containing a `FiniteAlgebra` field.  Rationale:

+  The two interfaces are logically independent: an infinite, constructively simple algebra with decidable equality inhabits `FiniteCongruences` but not `FiniteAlgebra`, so neither presupposes the other.
+  They overlap in exactly one derivable way, which the new lemma `≈-dec` records: completeness forces the diagonal's listed representative to decide `≈`, so the bare record's `_≟_` field is recoverable from a `FiniteCongruences` witness.  Nesting one record in the other would duplicate that data.
+  Consumers needing both (the finite-Birkhoff construction) simply take two module parameters: `finite-Birkhoff 𝑭 𝑪`.

What moved where:

+  **`Setoid.Algebras.Finite` (new)**.  The bare `FiniteAlgebra` record (`_≟_`, `card`, `enum`, `enum-sur`), now at the clean level `Type (α ⊔ ρ)` instead of `Type (lsuc (clv α ρ))`; the one-element algebra `𝟏` and `𝟏-FiniteAlgebra` move here as its non-vacuity witness.
+  **`Setoid.Congruences.Finite` (new)**.  The absorbing level `clv`, `DecCon`, `ConRel`, and the `FiniteCongruences` record (`cons`, `complete`, the `witness*` helpers), plus `≈-dec` and the `𝟏-Δ` / `𝟏-FiniteCongruences` example.  The "carrier finiteness does not suffice" explanation moves here from the Subdirect module's header, since it motivates this record.
+  **`Setoid.Subalgebras.Subdirect.Finite`**.  Keeps the count-based maximal-congruence search and `finiteSubdirectSIRep` / `finite-Birkhoff` unchanged except for the two-parameter module header; `𝟏-SubdirectlyRepresentable` stays with the theorem it exercises.
+  **Wiring**.  Both new modules are re-exported by their `Setoid.Algebras` / `Setoid.Congruences` aggregators and registered in `docs/_links.md`; prose references in `Subdirect.Irreducible` and the M6-2/M6-8 design notes are updated (the M6-8 note gains an update section recording the relocation, keeping the original text as the historical record).

No proof content changed — the construction in `Subdirect.Finite` is untouched apart from where its inputs come from.  `make unused-imports` is clean on all three touched Agda modules, and the full `make check` (Agda 2.8.0, stdlib 2.3) passes with only the pre-existing `Legacy/` deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125Ey9B58xsWAnmjB9kU2WM

---
_Generated by [Claude Code](https://claude.ai/code/session_0125Ey9B58xsWAnmjB9kU2WM)_