### PR TITLE
Add FLRP.Enforceable: IE, cf-IE, min-IE, fattening, and Lemma 3.2 (WP-4)

### DIFF
--- a/src/Classical/Structures/Group.lagda.md
+++ b/src/Classical/Structures/Group.lagda.md
@@ -23,6 +23,7 @@ open import Classical.Structures.Group.Cosets public
 open import Classical.Structures.Group.Dedekind public
 open import Classical.Structures.Group.GSet public
 open import Classical.Structures.Group.NormalCore public
+open import Classical.Structures.Group.Product public
 open import Classical.Structures.Group.Subgroups public
 open import Classical.Structures.Group.SubgroupLattice public
 ```

--- a/src/Classical/Structures/Group/Product.lagda.md
+++ b/src/Classical/Structures/Group/Product.lagda.md
@@ -1,0 +1,448 @@
+---
+layout: default
+file: "src/Classical/Structures/Group/Product.lagda.md"
+title: "Classical.Structures.Group.Product module"
+date: "2026-07-18"
+author: "the agda-algebras development team"
+---
+
+### Binary direct products of groups
+
+This is the [Classical.Structures.Group.Product][] module of the [Agda Universal Algebra Library][].
+
+For groups `𝒢`{.AgdaBound} and `𝒦`{.AgdaBound} presented as Σ-typed structures over
+[`Sig-Group`][Classical.Signatures.Group], this module constructs the **binary direct
+product** `𝒢 ×ᵍ 𝒦`{.AgdaFunction}: the algebra on the product setoid whose operations
+act componentwise, together with componentwise proofs of the five group laws.  The
+library's indexed product `⨅`{.AgdaFunction} of [Setoid.Algebras.Products][] would
+give a product with a *function-typed* carrier `∀ i → 𝕌[ 𝒜 i ]`; the binary product
+here instead has the pair carrier `G × K`, which is the form the fattening arguments
+of the FLRP program consume (a fattened subgroup is literally a predicate composed
+with `proj₁`{.AgdaFunction}).  The construction is level-general
+(`Group α ρ → Group β σ → Group (α ⊔ β) (ρ ⊔ σ)`), since full generality costs
+nothing here.
+
+Besides the product itself, the module provides the ingredients of the *fattening
+lemma* `[H × K, G × K] ≅ [H, G]` (the remark following Lemma `lemma:ie-prop-and-neg`
+in the note vendored at `docs/papers/flrp/ieprops/`; see
+`docs/notes/flrp-research-roadmap.md` § 4):
+
++  the **fattened subgroup predicates** `H ×ᶠ 𝒦`{.AgdaFunction} (subgroup in the
+   first coordinate, full second factor) and `𝒢 ᶠ× J`{.AgdaFunction} (mirrored), each
+   an `IsSubgroup`{.AgdaRecord} of the product whenever the input is one — the
+   superscript `ᶠ` points at the factor that is taken *full*;
++  the **slice toolkit** (`Slice₁`{.AgdaModule}, `Slice₂`{.AgdaModule}): for a
+   respecting subgroup `M` of the product lying above a fattened subgroup, membership
+   does not depend on the fattened coordinate — `(g , k) ∈ M ⟺ (g , ε) ∈ M` —
+   because `(g , k) ≈ (g , ε) ∙ (ε , k)` and `(ε , k)` lies in `H ×ᶠ 𝒦 ⊆ M`; hence
+   the restriction of `M` to one coordinate is again a respecting subgroup.
+
+The order-isomorphism packaging of the fattening lemma lives in `FLRP.Enforceable`,
+which consumes exactly these lemmas; everything here is plain group theory, kept in
+the `Classical/` tree per the roadmap's placement discipline.
+
+Following the Cubical-port discipline, the underlying equivalence of the product is
+isolated in `×ᵍ-setoid`{.AgdaFunction} — the pointwise pair of the component
+equivalences — so it can be mechanically substituted on the eventual port.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Group.Product where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Product                  using ( _,_ ; _×_ ; proj₁ ; proj₂ )
+open import Data.Fin.Base                 using ( Fin )
+open import Data.Fin.Patterns             using ( 0F ; 1F )
+open import Function                      using ( _∘_ ; Func )
+open import Level                         using ( Level ; _⊔_ )
+open import Relation.Binary               using ( Setoid )
+open import Relation.Binary.Definitions   using ( _Respects_ )
+open import Relation.Unary                using ( Pred ; _∈_ ; _⊆_ )
+
+import Algebra.Properties.Group as GroupProperties
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Bundles.Group           using ( ⟨_⟩ᵍᵖ )
+open import Classical.Signatures.Group        using ( Sig-Group ; ∙-Op ; ε-Op ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic  using ( Group ; module Group-Op ; _⊨ᵍᵖ_ )
+open import Classical.Structures.Group.Subgroups
+                                              using ( IsSubgroup ; mkIsSubgroup
+                                                    ; sub-∙-closed ; sub-⁻¹-closed )
+open import Classical.Structures.Interpret    using ( interp-cong )
+open import Classical.Theories.Group          using ( Th-Group )
+open import Overture.Signatures               using ( OperationSymbolsOf ; ArityOf )
+open import Overture.Operations               using ( Op )
+open import Overture.Terms                    using ( Term ; ℊ ; node )
+
+open import Setoid.Algebras.Basic {𝑆 = Sig-Group}
+                                              using ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_
+                                                    ; mkAlgebra )
+open import Setoid.Subalgebras.Subuniverses {𝑆 = Sig-Group} using ( Subuniverses )
+open import Setoid.Terms                      using ( module Environment )
+
+open Func renaming ( to to _⟨$⟩_ )
+
+private variable α ρ β σ ℓ ℓᴹ χ : Level
+```
+-->
+
+#### The fattened subgroup predicates
+
+The fattened predicates are pure predicate transformers — they mention no group
+structure beyond the carrier of the full factor — so they are defined up front, ahead
+of the product construction that proves them subgroups.  `H ×ᶠ 𝒦`{.AgdaFunction}
+holds at a pair exactly when the first coordinate lies in `H`; the second coordinate
+ranges over all of `𝒦` (the *fattened*, full factor, marked by `ᶠ`).  The mirror
+`𝒢 ᶠ× J`{.AgdaFunction} fattens the first coordinate instead.
+
+```agda
+infix 7 _×ᶠ_ _ᶠ×_
+
+-- The subgroup H of the first factor, fattened by the full group 𝒦.
+_×ᶠ_ : {G : Type α} (H : Pred G ℓ) (𝒦 : Group β σ) → Pred (G × 𝕌[ proj₁ 𝒦 ]) ℓ
+(H ×ᶠ 𝒦) p = H (proj₁ p)
+
+-- The subgroup J of the second factor, fattened by the full group 𝒢.
+_ᶠ×_ : (𝒢 : Group α ρ) {K : Type β} (J : Pred K ℓ) → Pred (𝕌[ proj₁ 𝒢 ] × K) ℓ
+(𝒢 ᶠ× J) p = J (proj₂ p)
+```
+
+#### The product construction
+
+`GroupProduct 𝒢 𝒦`{.AgdaModule} packages the whole development for a fixed pair of
+groups; opening it provides the product algebra, the product group, the pointwise
+descriptions of its curried operations, the subgroup lemmas for the fattened
+predicates, and the slice toolkit.
+
+```agda
+module GroupProduct (𝒢 : Group α ρ) (𝒦 : Group β σ) where
+  private
+    𝑨 = proj₁ 𝒢
+    𝑩 = proj₁ 𝒦
+    G = 𝕌[ 𝑨 ]
+    K = 𝕌[ 𝑩 ]
+
+  open Setoid 𝔻[ 𝑨 ] using ()
+    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝔻[ 𝑩 ] using ()
+    renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
+```
+
+The carrier of the product is the pair type `G × K`, and its equivalence is the
+pointwise pair of the component equivalences — this is the isolated-equality locus
+for the Cubical port.
+
+```agda
+  ×ᵍ-setoid : Setoid (α ⊔ β) (ρ ⊔ σ)
+  ×ᵍ-setoid = record
+    { Carrier        = G × K
+    ; _≈_            = λ p q → (proj₁ p ≈₁ proj₁ q) × (proj₂ p ≈₂ proj₂ q)
+    ; isEquivalence  = record
+        { refl   = refl₁ , refl₂
+        ; sym    = λ e → sym₁ (proj₁ e) , sym₂ (proj₂ e)
+        ; trans  = λ d e → trans₁ (proj₁ d) (proj₁ e) , trans₂ (proj₂ d) (proj₂ e)
+        }
+    }
+
+  open Setoid ×ᵍ-setoid using ()
+    renaming ( _≈_ to _≈ₓ_ ; refl to reflₓ ; sym to symₓ ; trans to transₓ )
+```
+
+Each operation symbol acts componentwise: the interpretation of `f` at a tuple of
+pairs is the pair of the component interpretations at the projected tuples.  The
+congruence proof is the pair of the component congruences, via the shared
+`interp-cong`{.AgdaFunction} primitive.
+
+```agda
+  ×ᵍ-Algebra : Algebra (α ⊔ β) (ρ ⊔ σ)
+  ×ᵍ-Algebra = mkAlgebra ×ᵍ-setoid interp interp-congruence
+    where
+    interp : (o : OperationSymbolsOf Sig-Group) → Op (ArityOf Sig-Group o) (G × K)
+    interp o a = (o ^ 𝑨) (proj₁ ∘ a) , (o ^ 𝑩) (proj₂ ∘ a)
+
+    interp-congruence : ∀ o {u v : ArityOf Sig-Group o → G × K}
+      → (∀ i → u i ≈ₓ v i) → interp o u ≈ₓ interp o v
+    interp-congruence o e =
+      interp-cong 𝑨 o (λ i → proj₁ (e i)) , interp-cong 𝑩 o (λ i → proj₂ (e i))
+```
+
+#### Componentwise term interpretation
+
+Satisfaction of the group theory transfers componentwise, and the engine is the
+following term-induction lemma: the interpretation of any term in the product is
+(setoid-)equal to the pair of its interpretations in the factors, under the projected
+environments.  The variable case is definitional; the node case pairs the component
+congruences applied to the induction hypotheses.
+
+```agda
+  private
+    module EnvP = Environment ×ᵍ-Algebra
+    module EnvG = Environment 𝑨
+    module EnvK = Environment 𝑩
+
+  interp-factor : {X : Type χ} (t : Term X) (η : X → G × K)
+    → (EnvP.⟦ t ⟧ ⟨$⟩ η) ≈ₓ (EnvG.⟦ t ⟧ ⟨$⟩ (proj₁ ∘ η) , EnvK.⟦ t ⟧ ⟨$⟩ (proj₂ ∘ η))
+  interp-factor (ℊ x) η = refl₁ , refl₂
+  interp-factor (node f args) η =
+      interp-cong 𝑨 f (λ i → proj₁ (interp-factor (args i) η))
+    , interp-cong 𝑩 f (λ i → proj₂ (interp-factor (args i) η))
+```
+
+Every group equation now holds in the product by one uniform argument: factor the
+two sides into components, apply the component groups' satisfaction proofs, and
+refold.  No case analysis on the equation is needed.
+
+```agda
+  ×ᵍ-⊨ : ×ᵍ-Algebra ⊨ᵍᵖ Th-Group
+  ×ᵍ-⊨ i η =
+      trans₁  (proj₁ (interp-factor lhs η))
+              (trans₁ (proj₂ 𝒢 i (proj₁ ∘ η)) (sym₁ (proj₁ (interp-factor rhs η))))
+    , trans₂  (proj₂ (interp-factor lhs η))
+              (trans₂ (proj₂ 𝒦 i (proj₂ ∘ η)) (sym₂ (proj₂ (interp-factor rhs η))))
+    where
+    lhs rhs : Term (Fin 3)
+    lhs = proj₁ (Th-Group i)
+    rhs = proj₂ (Th-Group i)
+
+  -- The direct product group.
+  ×ᵍ-Group : Group (α ⊔ β) (ρ ⊔ σ)
+  ×ᵍ-Group = ×ᵍ-Algebra , ×ᵍ-⊨
+```
+
+#### Pointwise descriptions of the curried operations
+
+The curried accessors of `Group-Op`{.AgdaModule} applied to the product agree, up to
+`≈ₓ`, with the pairs of the component accessors.  (They are not definitionally equal:
+the curried form routes the arguments through a canonical `pair` tuple, and `Fin`-
+indexed tuples lack η under `--cubical-compatible`; each bridge is one
+`interp-cong`{.AgdaFunction} per component, the standard resolution.)
+
+```agda
+  open Group-Op 𝒢 using ()
+    renaming ( _∙_ to _∙₁_ ; ε to ε₁ ; _⁻¹ to _⁻¹₁
+             ; idˡ-law to idˡ-law₁ ; idʳ-law to idʳ-law₁ ; invʳ-law to invʳ-law₁ )
+  open Group-Op 𝒦 using ()
+    renaming ( _∙_ to _∙₂_ ; ε to ε₂ ; _⁻¹ to _⁻¹₂
+             ; idˡ-law to idˡ-law₂ ; idʳ-law to idʳ-law₂ ; invʳ-law to invʳ-law₂ )
+  open Group-Op ×ᵍ-Group using ()
+    renaming ( _∙_ to _∙ₓ_ ; ε to εₓ ; _⁻¹ to _⁻¹ₓ )
+
+  open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ using () renaming ( ε⁻¹≈ε to ε⁻¹≈ε₁ )
+  open GroupProperties ⟨ 𝒦 ⟩ᵍᵖ using () renaming ( ε⁻¹≈ε to ε⁻¹≈ε₂ )
+
+  -- The product multiplication is componentwise.
+  ∙ₓ-pointwise : ∀ x y → (x ∙ₓ y) ≈ₓ (proj₁ x ∙₁ proj₁ y , proj₂ x ∙₂ proj₂ y)
+  ∙ₓ-pointwise x y =
+      interp-cong 𝑨 ∙-Op (λ { 0F → refl₁ ; 1F → refl₁ })
+    , interp-cong 𝑩 ∙-Op (λ { 0F → refl₂ ; 1F → refl₂ })
+
+  -- The product identity is the pair of identities.
+  εₓ-pointwise : εₓ ≈ₓ (ε₁ , ε₂)
+  εₓ-pointwise = interp-cong 𝑨 ε-Op (λ ()) , interp-cong 𝑩 ε-Op (λ ())
+
+  -- The product inverse is componentwise.
+  ⁻¹ₓ-pointwise : ∀ x → (x ⁻¹ₓ) ≈ₓ (proj₁ x ⁻¹₁ , proj₂ x ⁻¹₂)
+  ⁻¹ₓ-pointwise x =
+      interp-cong 𝑨 ⁻¹-Op (λ { 0F → refl₁ })
+    , interp-cong 𝑩 ⁻¹-Op (λ { 0F → refl₂ })
+```
+
+#### The fattened predicates are subgroups
+
+A fattened predicate is a subuniverse of the product *definitionally*: the first
+component of an interpreted operation of the product is the corresponding interpreted
+operation of the first factor, so closure is inherited with no equational reasoning
+at all.  Respecting the product equality is likewise inherited from the respected
+factor.
+
+```agda
+  module _ {H : Pred G ℓ} where
+
+    -- H ×ᶠ 𝒦 respects the product equality whenever H respects ≈₁.
+    ×ᶠ-respects : H Respects _≈₁_ → (H ×ᶠ 𝒦) Respects _≈ₓ_
+    ×ᶠ-respects resp e h = resp (proj₁ e) h
+
+    -- H ×ᶠ 𝒦 is closed under the product operations whenever H is closed (definitional).
+    ×ᶠ-isSubuniverse : H ∈ Subuniverses 𝑨 → (H ×ᶠ 𝒦) ∈ Subuniverses ×ᵍ-Algebra
+    ×ᶠ-isSubuniverse H-sub f a im = H-sub f (proj₁ ∘ a) im
+
+    -- Fattening a subgroup of 𝒢 by the full 𝒦 yields a subgroup of the product.
+    ×ᶠ-isSubgroup : IsSubgroup 𝒢 H → IsSubgroup ×ᵍ-Group (H ×ᶠ 𝒦)
+    ×ᶠ-isSubgroup H-sg = record
+      { respects       = ×ᶠ-respects (IsSubgroup.respects H-sg)
+      ; isSubuniverse  = ×ᶠ-isSubuniverse (IsSubgroup.isSubuniverse H-sg)
+      }
+
+  module _ {J : Pred K ℓ} where
+
+    -- Mirror image: 𝒢 ᶠ× J respects the product equality whenever J respects ≈₂.
+    ᶠ×-respects : J Respects _≈₂_ → (𝒢 ᶠ× J) Respects _≈ₓ_
+    ᶠ×-respects resp e j = resp (proj₂ e) j
+
+    -- 𝒢 ᶠ× J is closed under the product operations whenever J is closed (definitional).
+    ᶠ×-isSubuniverse : J ∈ Subuniverses 𝑩 → (𝒢 ᶠ× J) ∈ Subuniverses ×ᵍ-Algebra
+    ᶠ×-isSubuniverse J-sub f a im = J-sub f (proj₂ ∘ a) im
+
+    -- Fattening a subgroup of 𝒦 by the full 𝒢 yields a subgroup of the product.
+    ᶠ×-isSubgroup : IsSubgroup 𝒦 J → IsSubgroup ×ᵍ-Group (𝒢 ᶠ× J)
+    ᶠ×-isSubgroup J-sg = record
+      { respects       = ᶠ×-respects (IsSubgroup.respects J-sg)
+      ; isSubuniverse  = ᶠ×-isSubuniverse (IsSubgroup.isSubuniverse J-sg)
+      }
+```
+
+#### The slice toolkit, first coordinate
+
+Fix a subgroup `H` of `𝒢` and a respecting subgroup `M` of the product with
+`H ×ᶠ 𝒦 ⊆ M`.  Because `M` contains the whole column `{ε₁} × K` (the identity of
+`𝒢` lies in `H`), membership in `M` is insensitive to the second coordinate:
+`(g , k) ∈ M` iff `(g , ε₂) ∈ M`.  The two directions are
+`slice-out`{.AgdaFunction} and `slice-in`{.AgdaFunction}; each multiplies by a
+column element and rewrites along the pointwise description of `∙ₓ` — this is the
+note's observation that `(g , k) ≈ (g , ε) ∙ (ε , k)` with `(ε , k) ∈ H ×ᶠ 𝒦 ⊆ M`.
+Consequently the restriction `λ g → M (g , ε₂)` is a respecting subgroup of `𝒢`
+containing `H`, and pulling it back along `proj₁` recovers `M` — the mutually
+inverse maps of the fattening lemma.
+
+```agda
+  module Slice₁ (H : Pred G ℓ) (H-sg : IsSubgroup 𝒢 H)
+    (M : Pred (G × K) ℓᴹ)
+    (M-sub : M ∈ Subuniverses ×ᵍ-Algebra)
+    (M-resp : M Respects _≈ₓ_)
+    (HK⊆M : (H ×ᶠ 𝒦) ⊆ M)
+    where
+
+    -- M contains the column {ε₁} × K, because ε₁ ∈ H.
+    ε-column : (k : K) → (ε₁ , k) ∈ M
+    ε-column k = HK⊆M (IsSubgroup.ε-closed H-sg)
+
+    -- Forgetting the second coordinate: (g , k) ∈ M implies (g , ε₂) ∈ M.
+    slice-out : ∀ {g k} → (g , k) ∈ M → (g , ε₂) ∈ M
+    slice-out {g} {k} m =
+      M-resp  (transₓ (∙ₓ-pointwise (g , k) (ε₁ , k ⁻¹₂)) (idʳ-law₁ g , invʳ-law₂ k))
+              (sub-∙-closed ×ᵍ-Group M M-sub m (ε-column (k ⁻¹₂)))
+
+    -- Reinstating any second coordinate: (g , ε₂) ∈ M implies (g , k) ∈ M.
+    slice-in : ∀ {g k} → (g , ε₂) ∈ M → (g , k) ∈ M
+    slice-in {g} {k} m =
+      M-resp  (transₓ (∙ₓ-pointwise (g , ε₂) (ε₁ , k)) (idʳ-law₁ g , idˡ-law₂ k))
+              (sub-∙-closed ×ᵍ-Group M M-sub m (ε-column k))
+
+    -- The restriction of M to the first coordinate.
+    restrict₁ : Pred G ℓᴹ
+    restrict₁ g = M (g , ε₂)
+
+    -- The restriction is a respecting subgroup of 𝒢.
+    restrict₁-isSubgroup : IsSubgroup 𝒢 restrict₁
+    restrict₁-isSubgroup = mkIsSubgroup 𝒢 resp ∙-closed ε-closed ⁻¹-closed
+      where
+      resp : restrict₁ Respects _≈₁_
+      resp e m = M-resp (e , refl₂) m
+
+      ∙-closed : ∀ {x y} → restrict₁ x → restrict₁ y → restrict₁ (x ∙₁ y)
+      ∙-closed {x} {y} mx my =
+        M-resp  (transₓ (∙ₓ-pointwise (x , ε₂) (y , ε₂)) (refl₁ , idˡ-law₂ ε₂))
+                (sub-∙-closed ×ᵍ-Group M M-sub mx my)
+
+      ε-closed : restrict₁ ε₁
+      ε-closed = ε-column ε₂
+
+      ⁻¹-closed : ∀ {x} → restrict₁ x → restrict₁ (x ⁻¹₁)
+      ⁻¹-closed {x} m =
+        M-resp  (transₓ (⁻¹ₓ-pointwise (x , ε₂)) (refl₁ , ε⁻¹≈ε₂))
+                (sub-⁻¹-closed ×ᵍ-Group M M-sub m)
+
+    -- The restriction contains H (specialize HK⊆M to pairs (g , ε₂)).
+    restrict₁-⊇H : H ⊆ restrict₁
+    restrict₁-⊇H h = HK⊆M h
+
+    -- Round trip: pulling the restriction back along proj₁ recovers M.
+    restrict₁-pull-⊆ : (λ p → restrict₁ (proj₁ p)) ⊆ M
+    restrict₁-pull-⊆ m = slice-in m
+
+    restrict₁-pull-⊇ : M ⊆ (λ p → restrict₁ (proj₁ p))
+    restrict₁-pull-⊇ m = slice-out m
+```
+
+#### The slice toolkit, second coordinate
+
+The mirror of `Slice₁`{.AgdaModule}: for a respecting subgroup `M ⊇ 𝒢 ᶠ× J` of the
+product, membership is insensitive to the *first* coordinate, the restriction
+`λ k → M (ε₁ , k)` is a respecting subgroup of `𝒦` containing `J`, and pulling back
+along `proj₂` recovers `M`.  The proofs are the coordinatewise mirrors of the ones
+above.
+
+```agda
+  module Slice₂ (J : Pred K ℓ) (J-sg : IsSubgroup 𝒦 J)
+    (M : Pred (G × K) ℓᴹ)
+    (M-sub : M ∈ Subuniverses ×ᵍ-Algebra)
+    (M-resp : M Respects _≈ₓ_)
+    (GJ⊆M : (𝒢 ᶠ× J) ⊆ M)
+    where
+
+    -- M contains the row G × {ε₂}, because ε₂ ∈ J.
+    ε-row : (g : G) → (g , ε₂) ∈ M
+    ε-row g = GJ⊆M (IsSubgroup.ε-closed J-sg)
+
+    -- Forgetting the first coordinate: (g , k) ∈ M implies (ε₁ , k) ∈ M.
+    slice-out : ∀ {g k} → (g , k) ∈ M → (ε₁ , k) ∈ M
+    slice-out {g} {k} m =
+      M-resp  (transₓ (∙ₓ-pointwise (g , k) (g ⁻¹₁ , ε₂)) (invʳ-law₁ g , idʳ-law₂ k))
+              (sub-∙-closed ×ᵍ-Group M M-sub m (ε-row (g ⁻¹₁)))
+
+    -- Reinstating any first coordinate: (ε₁ , k) ∈ M implies (g , k) ∈ M.
+    slice-in : ∀ {g k} → (ε₁ , k) ∈ M → (g , k) ∈ M
+    slice-in {g} {k} m =
+      M-resp  (transₓ (∙ₓ-pointwise (g , ε₂) (ε₁ , k)) (idʳ-law₁ g , idˡ-law₂ k))
+              (sub-∙-closed ×ᵍ-Group M M-sub (ε-row g) m)
+
+    -- The restriction of M to the second coordinate.
+    restrict₂ : Pred K ℓᴹ
+    restrict₂ k = M (ε₁ , k)
+
+    -- The restriction is a respecting subgroup of 𝒦.
+    restrict₂-isSubgroup : IsSubgroup 𝒦 restrict₂
+    restrict₂-isSubgroup = mkIsSubgroup 𝒦 resp ∙-closed ε-closed ⁻¹-closed
+      where
+      resp : restrict₂ Respects _≈₂_
+      resp e m = M-resp (refl₁ , e) m
+
+      ∙-closed : ∀ {x y} → restrict₂ x → restrict₂ y → restrict₂ (x ∙₂ y)
+      ∙-closed {x} {y} mx my =
+        M-resp  (transₓ (∙ₓ-pointwise (ε₁ , x) (ε₁ , y)) (idʳ-law₁ ε₁ , refl₂))
+                (sub-∙-closed ×ᵍ-Group M M-sub mx my)
+
+      ε-closed : restrict₂ ε₂
+      ε-closed = ε-row ε₁
+
+      ⁻¹-closed : ∀ {x} → restrict₂ x → restrict₂ (x ⁻¹₂)
+      ⁻¹-closed {x} m =
+        M-resp  (transₓ (⁻¹ₓ-pointwise (ε₁ , x)) (ε⁻¹≈ε₁ , refl₂))
+                (sub-⁻¹-closed ×ᵍ-Group M M-sub m)
+
+    -- The restriction contains J.
+    restrict₂-⊇J : J ⊆ restrict₂
+    restrict₂-⊇J j = GJ⊆M j
+
+    -- Round trip: pulling the restriction back along proj₂ recovers M.
+    restrict₂-pull-⊆ : (λ p → restrict₂ (proj₂ p)) ⊆ M
+    restrict₂-pull-⊆ m = slice-in m
+
+    restrict₂-pull-⊇ : M ⊆ (λ p → restrict₂ (proj₂ p))
+    restrict₂-pull-⊇ m = slice-out m
+```
+
+#### The product as a binary operation on groups
+
+The infix form, for use at call sites.
+
+```agda
+infixr 7 _×ᵍ_
+
+_×ᵍ_ : Group α ρ → Group β σ → Group (α ⊔ β) (ρ ⊔ σ)
+𝒢 ×ᵍ 𝒦 = GroupProduct.×ᵍ-Group 𝒢 𝒦
+```

--- a/src/Classical/Structures/Group/Product.lagda.md
+++ b/src/Classical/Structures/Group/Product.lagda.md
@@ -11,20 +11,20 @@ author: "the agda-algebras development team"
 This is the [Classical.Structures.Group.Product][] module of the [Agda Universal Algebra Library][].
 
 For groups `𝒢`{.AgdaBound} and `𝒦`{.AgdaBound} presented as Σ-typed structures over
-[`Sig-Group`][Classical.Signatures.Group], this module constructs the **binary direct
-product** `𝒢 ×ᵍ 𝒦`{.AgdaFunction}: the algebra on the product setoid whose operations
-act componentwise, together with componentwise proofs of the five group laws.  The
-library's indexed product `⨅`{.AgdaFunction} of [Setoid.Algebras.Products][] would
-give a product with a *function-typed* carrier `∀ i → 𝕌[ 𝒜 i ]`; the binary product
-here instead has the pair carrier `G × K`, which is the form the fattening arguments
-of the FLRP program consume (a fattened subgroup is literally a predicate composed
-with `proj₁`{.AgdaFunction}).  The construction is level-general
-(`Group α ρ → Group β σ → Group (α ⊔ β) (ρ ⊔ σ)`), since full generality costs
-nothing here.
+[`Sig-Group`][Classical.Signatures.Group], this module constructs the
+**binary direct product** `𝒢 ×ᵍ 𝒦`{.AgdaFunction}: the algebra on the product setoid
+whose operations act componentwise, together with componentwise proofs of the five
+group laws.  The library's indexed product `⨅`{.AgdaFunction} of
+[Setoid.Algebras.Products][] would give a product with a *function-typed* carrier
+`∀ i → 𝕌[ 𝒜 i ]`; the binary product here instead has the pair carrier `G × K`, which
+is the form the fattening arguments of the FLRP program consume (a fattened subgroup
+is literally a predicate composed with `proj₁`{.AgdaFunction}).  The construction is
+level-general (`Group α ρ → Group β σ → Group (α ⊔ β) (ρ ⊔ σ)`), since full
+generality costs nothing here.
 
-Besides the product itself, the module provides the ingredients of the *fattening
-lemma* `[H × K, G × K] ≅ [H, G]` (the remark following Lemma `lemma:ie-prop-and-neg`
-in the note vendored at `docs/papers/flrp/ieprops/`; see
+Besides the product itself, the module provides the ingredients of the
+*fattening lemma* `[H × K, G × K] ≅ [H, G]` (the remark following Lemma
+`lemma:ie-prop-and-neg` in the note vendored at `docs/papers/flrp/ieprops/`; see
 `docs/notes/flrp-research-roadmap.md` § 4):
 
 +  the **fattened subgroup predicates** `H ×ᶠ 𝒦`{.AgdaFunction} (subgroup in the
@@ -42,7 +42,7 @@ which consumes exactly these lemmas; everything here is plain group theory, kept
 the `Classical/` tree per the roadmap's placement discipline.
 
 Following the Cubical-port discipline, the underlying equivalence of the product is
-isolated in `×ᵍ-setoid`{.AgdaFunction} — the pointwise pair of the component
+isolated in `G×K`{.AgdaFunction} — the pointwise pair of the component
 equivalences — so it can be mechanically substituted on the eventual port.
 
 <!--
@@ -103,32 +103,32 @@ ranges over all of `𝒦` (the *fattened*, full factor, marked by `ᶠ`).  The m
 infix 7 _×ᶠ_ _ᶠ×_
 
 -- The subgroup H of the first factor, fattened by the full group 𝒦.
-_×ᶠ_ : {G : Type α} (H : Pred G ℓ) (𝒦 : Group β σ) → Pred (G × 𝕌[ proj₁ 𝒦 ]) ℓ
-(H ×ᶠ 𝒦) p = H (proj₁ p)
+_×ᶠ_ : {G : Type α} (H : Pred G ℓ) ((𝑲 , _) : Group β σ) → Pred (G × 𝕌[ 𝑲 ]) ℓ
+(H ×ᶠ 𝒦) (g , _) = H g
 
 -- The subgroup J of the second factor, fattened by the full group 𝒢.
-_ᶠ×_ : (𝒢 : Group α ρ) {K : Type β} (J : Pred K ℓ) → Pred (𝕌[ proj₁ 𝒢 ] × K) ℓ
-(𝒢 ᶠ× J) p = J (proj₂ p)
+_ᶠ×_ : ((𝑮 , _) : Group α ρ) {K : Type β} (J : Pred K ℓ) → Pred (𝕌[ 𝑮 ] × K) ℓ
+(𝒢 ᶠ× J) (_ , k) = J k
 ```
 
 #### The product construction
 
-`GroupProduct 𝒢 𝒦`{.AgdaModule} packages the whole development for a fixed pair of
-groups; opening it provides the product algebra, the product group, the pointwise
+`GroupProduct`{.AgdaModule} `𝒢` `𝒦` packages the whole development for a fixed pair
+of groups; opening it provides the product algebra, the product group, the pointwise
 descriptions of its curried operations, the subgroup lemmas for the fattened
 predicates, and the slice toolkit.
 
 ```agda
 module GroupProduct (𝒢 : Group α ρ) (𝒦 : Group β σ) where
   private
-    𝑨 = proj₁ 𝒢
-    𝑩 = proj₁ 𝒦
-    G = 𝕌[ 𝑨 ]
-    K = 𝕌[ 𝑩 ]
+    𝑮 = proj₁ 𝒢
+    𝑲 = proj₁ 𝒦
+    G = 𝕌[ 𝑮 ]
+    K = 𝕌[ 𝑲 ]
 
-  open Setoid 𝔻[ 𝑨 ] using ()
+  open Setoid 𝔻[ 𝑮 ] using ()
     renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
-  open Setoid 𝔻[ 𝑩 ] using ()
+  open Setoid 𝔻[ 𝑲 ] using ()
     renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
 ```
 
@@ -137,18 +137,18 @@ pointwise pair of the component equivalences — this is the isolated-equality l
 for the Cubical port.
 
 ```agda
-  ×ᵍ-setoid : Setoid (α ⊔ β) (ρ ⊔ σ)
-  ×ᵍ-setoid = record
+  G×K : Setoid (α ⊔ β) (ρ ⊔ σ)
+  G×K = record
     { Carrier        = G × K
     ; _≈_            = λ p q → (proj₁ p ≈₁ proj₁ q) × (proj₂ p ≈₂ proj₂ q)
     ; isEquivalence  = record
         { refl   = refl₁ , refl₂
         ; sym    = λ e → sym₁ (proj₁ e) , sym₂ (proj₂ e)
-        ; trans  = λ d e → trans₁ (proj₁ d) (proj₁ e) , trans₂ (proj₂ d) (proj₂ e)
+        ; trans  = λ (d₁ , d₂) (e₁ , e₂) → trans₁ d₁ e₁ , trans₂ d₂ e₂
         }
     }
 
-  open Setoid ×ᵍ-setoid using ()
+  open Setoid G×K using ()
     renaming ( _≈_ to _≈ₓ_ ; refl to reflₓ ; sym to symₓ ; trans to transₓ )
 ```
 
@@ -158,16 +158,16 @@ congruence proof is the pair of the component congruences, via the shared
 `interp-cong`{.AgdaFunction} primitive.
 
 ```agda
-  ×ᵍ-Algebra : Algebra (α ⊔ β) (ρ ⊔ σ)
-  ×ᵍ-Algebra = mkAlgebra ×ᵍ-setoid interp interp-congruence
+  𝑮×𝑲 : Algebra (α ⊔ β) (ρ ⊔ σ)
+  𝑮×𝑲 = mkAlgebra G×K interp interp-congruence
     where
     interp : (o : OperationSymbolsOf Sig-Group) → Op (ArityOf Sig-Group o) (G × K)
-    interp o a = (o ^ 𝑨) (proj₁ ∘ a) , (o ^ 𝑩) (proj₂ ∘ a)
+    interp o a = (o ^ 𝑮) (proj₁ ∘ a) , (o ^ 𝑲) (proj₂ ∘ a)
 
     interp-congruence : ∀ o {u v : ArityOf Sig-Group o → G × K}
       → (∀ i → u i ≈ₓ v i) → interp o u ≈ₓ interp o v
     interp-congruence o e =
-      interp-cong 𝑨 o (λ i → proj₁ (e i)) , interp-cong 𝑩 o (λ i → proj₂ (e i))
+      interp-cong 𝑮 o (λ i → proj₁ (e i)) , interp-cong 𝑲 o (λ i → proj₂ (e i))
 ```
 
 #### Componentwise term interpretation
@@ -179,17 +179,16 @@ environments.  The variable case is definitional; the node case pairs the compon
 congruences applied to the induction hypotheses.
 
 ```agda
-  private
-    module EnvP = Environment ×ᵍ-Algebra
-    module EnvG = Environment 𝑨
-    module EnvK = Environment 𝑩
-
+  open Environment 𝑮×𝑲  using () renaming ( ⟦_⟧ to ⟦_⟧G×K )
+  open Environment 𝑮    using () renaming ( ⟦_⟧ to ⟦_⟧G )
+  open Environment 𝑲    using () renaming ( ⟦_⟧ to ⟦_⟧K )
   interp-factor : {X : Type χ} (t : Term X) (η : X → G × K)
-    → (EnvP.⟦ t ⟧ ⟨$⟩ η) ≈ₓ (EnvG.⟦ t ⟧ ⟨$⟩ (proj₁ ∘ η) , EnvK.⟦ t ⟧ ⟨$⟩ (proj₂ ∘ η))
+    → ⟦ t ⟧G×K ⟨$⟩ η ≈ₓ (⟦ t ⟧G ⟨$⟩ (proj₁ ∘ η) , ⟦ t ⟧K ⟨$⟩ (proj₂ ∘ η))
+
   interp-factor (ℊ x) η = refl₁ , refl₂
   interp-factor (node f args) η =
-      interp-cong 𝑨 f (λ i → proj₁ (interp-factor (args i) η))
-    , interp-cong 𝑩 f (λ i → proj₂ (interp-factor (args i) η))
+      interp-cong 𝑮 f (λ i → proj₁ (interp-factor (args i) η))
+    , interp-cong 𝑲 f (λ i → proj₂ (interp-factor (args i) η))
 ```
 
 Every group equation now holds in the product by one uniform argument: factor the
@@ -197,7 +196,7 @@ two sides into components, apply the component groups' satisfaction proofs, and
 refold.  No case analysis on the equation is needed.
 
 ```agda
-  ×ᵍ-⊨ : ×ᵍ-Algebra ⊨ᵍᵖ Th-Group
+  ×ᵍ-⊨ : 𝑮×𝑲 ⊨ᵍᵖ Th-Group
   ×ᵍ-⊨ i η =
       trans₁  (proj₁ (interp-factor lhs η))
               (trans₁ (proj₂ 𝒢 i (proj₁ ∘ η)) (sym₁ (proj₁ (interp-factor rhs η))))
@@ -210,7 +209,7 @@ refold.  No case analysis on the equation is needed.
 
   -- The direct product group.
   ×ᵍ-Group : Group (α ⊔ β) (ρ ⊔ σ)
-  ×ᵍ-Group = ×ᵍ-Algebra , ×ᵍ-⊨
+  ×ᵍ-Group = 𝑮×𝑲 , ×ᵍ-⊨
 ```
 
 #### Pointwise descriptions of the curried operations
@@ -237,18 +236,18 @@ indexed tuples lack η under `--cubical-compatible`; each bridge is one
   -- The product multiplication is componentwise.
   ∙ₓ-pointwise : ∀ x y → (x ∙ₓ y) ≈ₓ (proj₁ x ∙₁ proj₁ y , proj₂ x ∙₂ proj₂ y)
   ∙ₓ-pointwise x y =
-      interp-cong 𝑨 ∙-Op (λ { 0F → refl₁ ; 1F → refl₁ })
-    , interp-cong 𝑩 ∙-Op (λ { 0F → refl₂ ; 1F → refl₂ })
+      interp-cong 𝑮 ∙-Op (λ { 0F → refl₁ ; 1F → refl₁ })
+    , interp-cong 𝑲 ∙-Op (λ { 0F → refl₂ ; 1F → refl₂ })
 
   -- The product identity is the pair of identities.
   εₓ-pointwise : εₓ ≈ₓ (ε₁ , ε₂)
-  εₓ-pointwise = interp-cong 𝑨 ε-Op (λ ()) , interp-cong 𝑩 ε-Op (λ ())
+  εₓ-pointwise = interp-cong 𝑮 ε-Op (λ ()) , interp-cong 𝑲 ε-Op (λ ())
 
   -- The product inverse is componentwise.
   ⁻¹ₓ-pointwise : ∀ x → (x ⁻¹ₓ) ≈ₓ (proj₁ x ⁻¹₁ , proj₂ x ⁻¹₂)
   ⁻¹ₓ-pointwise x =
-      interp-cong 𝑨 ⁻¹-Op (λ { 0F → refl₁ })
-    , interp-cong 𝑩 ⁻¹-Op (λ { 0F → refl₂ })
+      interp-cong 𝑮 ⁻¹-Op (λ { 0F → refl₁ })
+    , interp-cong 𝑲 ⁻¹-Op (λ { 0F → refl₂ })
 ```
 
 #### The fattened predicates are subgroups
@@ -267,7 +266,7 @@ factor.
     ×ᶠ-respects resp e h = resp (proj₁ e) h
 
     -- H ×ᶠ 𝒦 is closed under the product operations whenever H is closed (definitional).
-    ×ᶠ-isSubuniverse : H ∈ Subuniverses 𝑨 → (H ×ᶠ 𝒦) ∈ Subuniverses ×ᵍ-Algebra
+    ×ᶠ-isSubuniverse : H ∈ Subuniverses 𝑮 → (H ×ᶠ 𝒦) ∈ Subuniverses 𝑮×𝑲
     ×ᶠ-isSubuniverse H-sub f a im = H-sub f (proj₁ ∘ a) im
 
     -- Fattening a subgroup of 𝒢 by the full 𝒦 yields a subgroup of the product.
@@ -284,7 +283,7 @@ factor.
     ᶠ×-respects resp e j = resp (proj₂ e) j
 
     -- 𝒢 ᶠ× J is closed under the product operations whenever J is closed (definitional).
-    ᶠ×-isSubuniverse : J ∈ Subuniverses 𝑩 → (𝒢 ᶠ× J) ∈ Subuniverses ×ᵍ-Algebra
+    ᶠ×-isSubuniverse : J ∈ Subuniverses 𝑲 → (𝒢 ᶠ× J) ∈ Subuniverses 𝑮×𝑲
     ᶠ×-isSubuniverse J-sub f a im = J-sub f (proj₂ ∘ a) im
 
     -- Fattening a subgroup of 𝒦 by the full 𝒢 yields a subgroup of the product.
@@ -311,7 +310,7 @@ inverse maps of the fattening lemma.
 ```agda
   module Slice₁ (H : Pred G ℓ) (H-sg : IsSubgroup 𝒢 H)
     (M : Pred (G × K) ℓᴹ)
-    (M-sub : M ∈ Subuniverses ×ᵍ-Algebra)
+    (M-sub : M ∈ Subuniverses 𝑮×𝑲)
     (M-resp : M Respects _≈ₓ_)
     (HK⊆M : (H ×ᶠ 𝒦) ⊆ M)
     where
@@ -379,7 +378,7 @@ above.
 ```agda
   module Slice₂ (J : Pred K ℓ) (J-sg : IsSubgroup 𝒦 J)
     (M : Pred (G × K) ℓᴹ)
-    (M-sub : M ∈ Subuniverses ×ᵍ-Algebra)
+    (M-sub : M ∈ Subuniverses 𝑮×𝑲)
     (M-resp : M Respects _≈ₓ_)
     (GJ⊆M : (𝒢 ᶠ× J) ⊆ M)
     where

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -33,12 +33,16 @@ Two standing warnings apply to everything under this namespace.
 +  [FLRP.Problem][] — the representability predicate `Representable`, the
    formal statement of the problem, the first worked instance (the one-element
    chain), and the constructive no-go theorem for the two-element chain.
++  [FLRP.Enforceable][] — group representability of a lattice, the
+   interval-enforceability classification (IE, cf-IE, min-IE), the fattening
+   isomorphism `[H × K, G × K] ≅ [H, G]`, the no-contradictory-IE theorem
+   (the note's Lemma 3.2), and hypothesis-parameterized statements of Lemma 3.1
+   and the parachute meta-theorem.
 
 **Planned submodules** (per § 6 of the roadmap).
 
 +  `FLRP.Closure` (closure properties of the representable class);
 +  `FLRP.Intervals` (intervals in subgroup lattices and core-free normalization);
-+  `FLRP.Enforceable` (interval-enforceable properties);
 +  `FLRP.Reductions` (the catalog of reduction theorems);
 +  `FLRP.Certificates` (machine-checked representation certificates);
 +  `FLRP.Assumptions` (the registry of classical theorems imported as explicit
@@ -50,4 +54,5 @@ Two standing warnings apply to everything under this namespace.
 module FLRP where
 
 open import FLRP.Problem public
+open import FLRP.Enforceable public
 ```

--- a/src/FLRP/Enforceable.lagda.md
+++ b/src/FLRP/Enforceable.lagda.md
@@ -1,4 +1,4 @@
----
+n---
 layout: default
 file: "src/FLRP/Enforceable.lagda.md"
 title: "FLRP.Enforceable module (The Agda Universal Algebra Library)"
@@ -10,37 +10,39 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.Enforceable][] module of the [Agda Universal Algebra Library][].
 
-This module opens work package WP-4 of the FLRP research program: the formalization
-of *interval enforceable* group properties, after the note *Interval enforceable
-properties of finite groups* (arXiv:1205.1927, vendored at
-`docs/papers/flrp/ieprops/`; see `docs/notes/flrp-research-roadmap.md` § 4).  A group
-property `P` is **interval enforceable (IE) via a lattice `𝑳`** when every group
-whose subgroup lattice has an upper interval isomorphic to `𝑳` must satisfy `P`;
-it is **core-free interval enforceable (cf-IE)** when the same is only required of
-representations over a *core-free* subgroup.  The note's program is to combine
-enforceable properties into a contradiction, which by Pálfy–Pudlák would answer the
-Finite Lattice Representation Problem negatively.
+This module opens work on an exploratory research program to solve the FLRP — namely,
+the formalization of *interval enforceable* group properties — modeled after the note
+*Interval enforceable properties of finite groups*, hereinafter "the note."[^1]
 
-The contents, keyed to the note:
+A group property `P` is **interval-enforceable** (IE) if there exists a lattice `𝑳`
+such that every group whose subgroup lattice has an upper interval isomorphic to `𝑳`
+must satisfy `P`; it is **core-free interval enforceable** (cf-IE) when the same is
+true of representations over a *core-free* subgroup.
 
-+  `GroupRepresentable`{.AgdaRecord} — the lattice occurs as an upper interval
-   `[H , G]` in the subgroup lattice of a group, with all witnesses carried
-   explicitly;
-+  `IE`{.AgdaFunction}, `cfIE`{.AgdaFunction}, `minIE`{.AgdaFunction} — the note's
-   § 2 definitions, with core-freeness expressed through WP-2's normal core;
-+  the **fattening isomorphism** `[H × K , G × K] ≅ [H , G]`
-   (`Fatten`{.AgdaModule}), in both coordinates;
+The note's program is to combine interval-enforceable properties into a
+contradiction, which, by Pálfy–Pudlák, would answer the Finite Lattice Representation
+Problem negatively.
+
+#### Summary of the <span class="AgdaModule">FLRP.Enforceable</span> module
+
+The module contents, keyed to the note, are as follows:
+
++  `GroupRepresentable`{.AgdaRecord} — the lattice occurs as an upper interval `[H , G]`
+   in the subgroup lattice of a group, with all witnesses carried explicitly;
++  `IE`{.AgdaFunction}, `cfIE`{.AgdaFunction}, `minIE`{.AgdaFunction} — § 2
+   definitions in the note, with core-freeness expressed through the normal core;[^wp-2]
++  the **fattening isomorphism** `[H × K , G × K] ≅ [H , G]` (`Fatten`{.AgdaModule}),
+   in both coordinates;
 +  **Lemma 3.2** (`lemma:ie-prop-and-neg`): a property and its negation cannot both
    be IE via group representable lattices (`no-contradictory-IE`{.AgdaFunction}),
-   with the note's fattening remark as the companion
-   `IE-fattens`{.AgdaFunction};
-+  **Lemma 3.1** (`lemma-wjd-2`) and the parachute meta-theorem
-   (`thm-wjd-1`) as *statements only*, their proofs deferred to RP-1 behind named
-   hypothesis records in the `FLRP.Assumptions` style.
+   with the note's fattening remark as the companion `IE-fattens`{.AgdaFunction};
++  **Lemma 3.1** (`lemma-wjd-2`) and the parachute meta-theorem (`thm-wjd-1`) as
+   *statements only*, their proofs deferred to RP-1 behind named hypothesis records
+   in the `FLRP.Assumptions` style.
 
 Two disciplines from the roadmap govern the definitions.
 
-+  **Representability tracking (vacuity discipline)**.  If no group realizes `𝑳` as
++  **Representability tracking** (vacuity discipline).  If no group realizes `𝑳` as
    an upper interval then *every* property is vacuously enforceable via `𝑳`, and
    deciding that emptiness is the original problem.  So `IE`{.AgdaFunction} and
    `cfIE`{.AgdaFunction} are the bare universally quantified notions, and group
@@ -52,9 +54,7 @@ Two disciplines from the roadmap govern the definitions.
    groups and predicates, and Agda cannot quantify existentially over universe
    levels, so the levels must be pinned; `0ℓ` suffices for every finite (indeed
    every set-sized) instance.  Group *properties* appear only in universally
-   quantified positions, so they keep a polymorphic level `ℓP`.  Note that
-   properties are *not* required to be isomorphism-invariant: the note's Lemma 3.2
-   proof never uses invariance, and no definition below needs it.
+   quantified positions, so they keep a polymorphic level `ℓP`.[^2]
 
 <!--
 ```agda
@@ -65,142 +65,146 @@ module FLRP.Enforceable where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
-open import Data.Empty                    using ( ⊥ )
-open import Data.Fin.Base                 using ( Fin )
-open import Data.Nat.Base                 using ( ℕ ; _+_ )
-                                          renaming ( _≤_ to _≤ⁿ_ )
-open import Data.Product                  using ( _,_ ; _×_ ; Σ-syntax ; proj₁ ; proj₂ )
-open import Data.Unit.Base                using ( tt )
-open import Level                         using ( Level ; 0ℓ ; _⊔_ ; Lift ; lift )
-                                          renaming ( suc to lsuc )
-open import Relation.Binary               using ( Setoid )
-open import Relation.Binary.Definitions   using ( _Respects_ )
-open import Relation.Binary.PropositionalEquality using ( _≡_ )
-open import Relation.Nullary              using ( ¬_ )
-open import Relation.Unary                using ( Pred ; _∈_ ; _⊆_ )
+open import Data.Empty                              using  ( ⊥ )
+open import Data.Fin.Base                           using  ( Fin )
+open import Data.Nat.Base renaming ( _≤_ to _≤ⁿ_ )  using  ( ℕ ; _+_ )
+open import Data.Product                            using  ( _,_ ; _×_ ; Σ-syntax
+                                                           ; proj₁ ; proj₂ )
+open import Data.Unit.Base                          using  ( tt )
+open import Level         renaming ( suc to lsuc )  using  ( Level ; 0ℓ ; _⊔_
+                                                           ; Lift ; lift )
+open import Relation.Binary                         using  ( Setoid )
+open import Relation.Binary.Definitions             using  ( _Respects_ )
+open import Relation.Binary.PropositionalEquality   using  ( _≡_ )
+open import Relation.Nullary                        using  ( ¬_ )
+open import Relation.Unary                          using  ( Pred ; _∈_ ; _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Properties.Lattice          using ( module Lattice-Order )
-open import Classical.Small.Structures.Lattice    using ( Lattice )
-open import Classical.Structures.Group.Basic      using ( Group )
-open import Classical.Structures.Group.NormalCore using ( module Core )
-open import Classical.Structures.Group.Product    using ( module GroupProduct
-                                                        ; _×ᵍ_ ; _×ᶠ_ ; _ᶠ×_ )
-open import Classical.Structures.Group.SubgroupLattice
-                                                  using ( module GroupSublattice )
-open import Classical.Structures.Group.Subgroups  using ( IsSubgroup ; trivialSubgroup )
-open import FLRP.Problem                          using ( OrderIso ; FiniteLattice
-                                                        ; toLattice )
-open import Setoid.Algebras.Basic                 using ( 𝔻[_] ; 𝕌[_] )
-open import Setoid.Algebras.Finite                using ( FiniteAlgebra )
-open import Setoid.Homomorphisms.HomomorphicImages using ( _IsHomImageOf_ )
-open import Setoid.Subalgebras.Subuniverses       using ( Subuniverses )
+open import Classical.Properties.Lattice  using  ( module Lattice-Order )
+open import Classical.Small.Structures    using  ( Lattice )
+open import Classical.Structures.Group    using  ( module Core ; Group ; _×ᵍ_ ; _×ᶠ_
+                                                 ; module GroupProduct ; _ᶠ×_
+                                                 ; module GroupSublattice
+                                                 ; IsSubgroup ; trivialSubgroup )
+open import FLRP.Problem                  using  ( OrderIso ; FiniteLattice ; toLattice )
+open import Setoid.Algebras               using  ( 𝔻[_] ; 𝕌[_] ; FiniteAlgebra )
+open import Setoid.Homomorphisms          using  ( _IsHomImageOf_ )
+open import Setoid.Subalgebras            using  ( Subuniverses )
+open import Order.Interval                        using ( module IntervalLattice )
+-- open import Setoid.Subalgebras.CompleteLattice using (module Sublattice)
+
+
+
+
+
 ```
 -->
 
 #### Upper intervals of respecting subgroups
 
-The group side of a representation is an upper interval `[H , G]` in the subgroup
-lattice, presented through WP-2's machinery: `H` enters as a `Subᴸ`{.AgdaFunction}
-element of the subuniverse lattice of [Setoid.Subalgebras.CompleteLattice][]
-(packaged for groups by [Classical.Structures.Group.SubgroupLattice][]), and the
-interval `[H , full]` is the `SubInterval`{.AgdaModule} instance of the generic
-[Order.Interval][] construction.
+A group representation is an upper interval `[H , G]` in the subgroup lattice,
+presented through the group-action infrastructure:[^wp-2] `H` enters as a
+`Subᴸ`{.AgdaFunction} element of the subuniverse lattice of
+[Setoid.Subalgebras.CompleteLattice][] (packaged for groups by
+[Classical.Structures.Group.SubgroupLattice][]), and the interval `[H , G]` is the
+`SubInterval`{.AgdaModule} instance of the generic [Order.Interval][] construction.
 
-One refinement is needed.  The elements of `SubInterval`{.AgdaModule} are *bare*
+One refinement is needed.  The elements of `SubInterval`{.AgdaModule} are bare
 subuniverses, with no compatibility between the predicate and the setoid equality of
 the carrier.  Over a setoid-presented group that is too permissive: a subgroup is a
 sub*set* of the carrier, i.e. an `≈`-saturated predicate, and bare subuniverses can
 distinguish `≈`-equal elements.  The distinction is not cosmetic — over a carrier
 with a redundant representative the bare interval `[H × K , G × K]` can be strictly
 larger than `[H , G]`, so the fattening isomorphism below is *false* at the bare
-level.[^1]  We therefore take as interval elements the bare interval elements
-*paired with a proof that the predicate respects `≈`* — exactly the
-`respects`{.AgdaField} field of `IsSubgroup`{.AgdaRecord}.  Over a group presented
-on a propositional-equality setoid (the `eqsToGroup`{.AgdaFunction} builders, and
-every finite Cayley-table group) the extra field is inhabited by `subst`, so nothing
-is lost in the concrete cases the FLRP cares about.
+level.[^3]
 
-`UpperInterval 𝒢 H H-sg`{.AgdaModule} packages the respecting upper interval
-`[H , full]` for a fixed subgroup: the carrier `Interval≈`{.AgdaFunction}, its
+We therefore take as interval elements the bare interval elements
+*paired with a proof that the predicate respects `≈`* — exactly the
+`respects`{.AgdaField} field of `IsSubgroup`{.AgdaRecord}.
+Over a group presented on a propositional-equality setoid (the
+`eqsToGroup`{.AgdaFunction} builders, and every finite Cayley-table group) the extra
+field is inhabited by `subst`, so nothing is lost in the concrete cases the FLRP
+cares about.
+
+`UpperInterval`{.AgdaModule} `𝒢` `H` `H-sg` packages the respecting upper interval
+`[H , G]` for a fixed subgroup: the carrier `Interval≈`{.AgdaFunction}, its
 equality and order (those of the bare interval, which ignore all proof components),
 accessors, and the smart constructor `mk`{.AgdaFunction}.
 
 ```agda
 module UpperInterval
-  (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
+  (𝒢     : Group 0ℓ 0ℓ)
+  (H     : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ)
+  (H-sg  : IsSubgroup 𝒢 H)
   where
 
   open Setoid 𝔻[ proj₁ 𝒢 ] using ( _≈_ )
-  open GroupSublattice 𝒢 0ℓ using ( Subᴸ ; 1ˢ ; 1ˢ-maximum ; subgroup→Subᴸ
-                                  ; module SubInterval )
+  open GroupSublattice 𝒢 0ℓ  using  ( Subᴸ ; 1ˢ ; 1ˢ-maximum ; subgroup→Subᴸ
+                                    ; module SubInterval ; Sub-Lattice )
 
   -- The bottom of the interval: H as an element of the subuniverse lattice.
   H↑ : Subᴸ
   H↑ = subgroup→Subᴸ H H-sg
 
-  -- The bare interval [H , full], by the generic construction.
-  module Bare = SubInterval H↑ 1ˢ (1ˢ-maximum H↑)
+  -- The bare interval [H , G], by the generic construction.
+  open IntervalLattice Sub-Lattice H↑ 1ˢ (1ˢ-maximum H↑)
+    renaming (_≈_ to _≈↑_ ; _≤_ to _≤↑_)
 
   -- An interval element: a bare element whose predicate respects ≈.
   Interval≈ : Type (lsuc 0ℓ)
-  Interval≈ = Σ[ M ∈ Bare.Interval ] (proj₁ (proj₁ M) Respects _≈_)
+  Interval≈ = Σ[ ((M , _) , _) ∈ Interval ] (M Respects _≈_)
 
   -- Accessors: the underlying predicate and its three certificates.
   pred : Interval≈ → Pred 𝕌[ proj₁ 𝒢 ] 0ℓ
-  pred M = proj₁ (proj₁ (proj₁ M))
+  pred (((M , _) , _) , _) = M
 
   pred-isSubuniverse : (M : Interval≈) → pred M ∈ Subuniverses (proj₁ 𝒢)
-  pred-isSubuniverse M = proj₂ (proj₁ (proj₁ M))
+  pred-isSubuniverse (((_ , Mp) , _) , _) = Mp
 
   pred-respects : (M : Interval≈) → pred M Respects _≈_
-  pred-respects M = proj₂ M
+  pred-respects (_ , Mresp) = Mresp
 
   above : (M : Interval≈) → H ⊆ pred M
-  above M = proj₁ (proj₂ (proj₁ M))
+  above ((_ , H⊆ , _) , _) = H⊆
 
+  open IsSubgroup
   -- An interval element is a respecting subgroup.
   element-isSubgroup : (M : Interval≈) → IsSubgroup 𝒢 (pred M)
-  element-isSubgroup M = record  { respects       = pred-respects M
-                                 ; isSubuniverse  = pred-isSubuniverse M }
+  element-isSubgroup M .respects       = pred-respects M
+  element-isSubgroup M .isSubuniverse  = pred-isSubuniverse M
 
   -- Conversely, a respecting subgroup above H is an interval element
   -- (the top bound against the full subuniverse is trivial).
   mk : (M : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) → IsSubgroup 𝒢 M → H ⊆ M → Interval≈
-  mk M M-sg H⊆M =
-    ((M , IsSubgroup.isSubuniverse M-sg) , H⊆M , (λ _ → lift tt))
-    , IsSubgroup.respects M-sg
+  mk M M-sg H⊆M = ((M , M-sg .isSubuniverse) , H⊆M , (λ _ → lift tt)) , M-sg .respects
 
-  -- Equality and order come from the bare interval (they compare the
-  -- underlying predicates and ignore the respects proof).
+  -- Equality and order come from the bare interval
+  -- (they compare the underlying predicates and ignore the respects proof).
   infix 4 _≈ᵢ_ _≤ᵢ_
 
   _≈ᵢ_ : Interval≈ → Interval≈ → Type 0ℓ
-  M ≈ᵢ N = Bare._≈_ (proj₁ M) (proj₁ N)
+  (M , _) ≈ᵢ (N , _) = M ≈↑ N
 
   _≤ᵢ_ : Interval≈ → Interval≈ → Type 0ℓ
-  M ≤ᵢ N = Bare._≤_ (proj₁ M) (proj₁ N)
+  (M , _) ≤ᵢ (N , _) =  M ≤↑ N
 ```
 
 #### Interval isomorphism with a classical lattice
 
-`IntervalIso 𝒢 H H-sg 𝑳`{.AgdaFunction} is the group-side analog of
-`ConIso`{.AgdaFunction} of [FLRP.Problem][], and deliberately the *same
-presentation*: an `OrderIso`{.AgdaRecord} between the respecting upper interval
-`[H , full]` of `Sub(𝒢)` and the meet order of the classical lattice
-`𝑳`{.AgdaBound} of [Classical.Small.Structures.Lattice][].  Order isomorphisms
-transport meets and joins, so this is exactly "`[H , G] ≅ 𝑳` as lattices" with no
-redundant clauses.  (`OrderIso`{.AgdaRecord} still lives in [FLRP.Problem][]; its
-planned migration to the `Order/` tree, foreseen there, is left to a dedicated
-change.)
+`IntervalIso`{.AgdaFunction} `𝒢` `H` `H-sg` `𝑳` is the group-side analog of
+`ConIso`{.AgdaFunction} of [FLRP.Problem][], and deliberately the *same presentation*:
+an `OrderIso`{.AgdaRecord} between the respecting upper interval `[H , G]` of
+`Sub(𝒢)` and the meet order of the classical lattice `𝑳`{.AgdaBound} of
+[Classical.Small.Structures.Lattice][].
+
+Order isomorphisms transport meets and joins, so this is exactly
+"`[H , G] ≅ 𝑳` as lattices" with no redundant clauses.[^4]
 
 ```agda
-IntervalIso :
-  (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
+IntervalIso : (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
   → Lattice → Type (lsuc 0ℓ)
-IntervalIso 𝒢 H H-sg 𝑳 =
-  OrderIso  (UpperInterval._≈ᵢ_ 𝒢 H H-sg) (UpperInterval._≤ᵢ_ 𝒢 H H-sg)
-            (Setoid._≈_ 𝔻[ proj₁ 𝑳 ]) (Lattice-Order._≤_ 𝑳)
+IntervalIso 𝒢 H H-sg 𝑳 = OrderIso _≈ᵢ_ _≤ᵢ_ (Setoid._≈_ 𝔻[ proj₁ 𝑳 ]) (Lattice-Order._≤_ 𝑳)
+  where open UpperInterval 𝒢 H H-sg
 ```
 
 Interval isomorphisms compose with order isomorphisms *between* two intervals: the
@@ -275,36 +279,36 @@ GroupProperty ℓP = Pred (Group 0ℓ 0ℓ) ℓP
 
 ```agda
 IE : {ℓP : Level} → GroupProperty ℓP → Lattice → Type (lsuc 0ℓ ⊔ ℓP)
-IE P 𝑳 =
-  ∀ (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
-  → IntervalIso 𝒢 H H-sg 𝑳
-  → P 𝒢
+IE P 𝑳 = ∀ 𝒢 H H-sg → IntervalIso 𝒢 H H-sg 𝑳 → P 𝒢
+-- ^ here (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
 ```
 
-Core-freeness of a subgroup is expressed through WP-2's normal core: the core of
+Core-freeness of a subgroup is expressed through the normal core:[^wp-2] the core of
 `H` — the greatest normal subgroup below `H`, constructed in
 [Classical.Structures.Group.NormalCore][] as the meet of all conjugates — is
-contained in the trivial subgroup (the `≈`-class of the identity).  The converse
-containment always holds (the core is a subgroup, hence contains the identity's
-class), so this inclusion says exactly "the core *is* trivial".
+contained in the trivial subgroup (the `≈`-class of the identity).
+
+The converse containment always holds (the core is a subgroup, hence contains the
+identity's class), so this inclusion says exactly "the core *is* trivial."
+
+This notion "core-free" is represented by the following type
 
 ```agda
-CoreFree :
-  (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) → IsSubgroup 𝒢 H → Type 0ℓ
+CoreFree : ∀ 𝒢 H → IsSubgroup 𝒢 H → Type 0ℓ
 CoreFree 𝒢 H H-sg = proj₁ (Core.core 𝒢 H H-sg) ⊆ proj₁ (trivialSubgroup 𝒢)
 ```
 
+where `𝒢` and `H` range over `Group 0ℓ 0ℓ` and `Pred 𝕌[ proj₁ 𝒢 ] 0ℓ`, respectively.
+
 `cfIE P 𝑳` weakens `IE` by demanding the conclusion only for representations over a
-core-free subgroup; consequently every IE property is cf-IE (the note's "clearly").
+core-free subgroup; consequently every IE property is cf-IE.
 
 ```agda
 cfIE : {ℓP : Level} → GroupProperty ℓP → Lattice → Type (lsuc 0ℓ ⊔ ℓP)
-cfIE P 𝑳 =
-  ∀ (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
-  → CoreFree 𝒢 H H-sg
-  → IntervalIso 𝒢 H H-sg 𝑳
-  → P 𝒢
+cfIE P 𝑳 = ∀ 𝒢 H H-sg → CoreFree 𝒢 H H-sg → IntervalIso 𝒢 H H-sg 𝑳 → P 𝒢
+```
 
+```agda
 -- Interval enforceable implies core-free interval enforceable.
 IE→cfIE : {ℓP : Level} {P : GroupProperty ℓP} {𝑳 : Lattice} → IE P 𝑳 → cfIE P 𝑳
 IE→cfIE ie 𝒢 H H-sg _ iso = ie 𝒢 H H-sg iso
@@ -313,44 +317,46 @@ IE→cfIE ie 𝒢 H H-sg _ iso = ie 𝒢 H H-sg iso
 `minIE P 𝑳` asks for `P` only of *minimal* representations.  Minimality is measured
 through the `card`{.AgdaField} field of the `FiniteAlgebra`{.AgdaRecord} interface
 on the group's underlying algebra: the given representation's certified cardinality
-is at most that of every other finite representation of `𝑳`.  Since
-`card`{.AgdaField} bounds the carrier from above (the enumeration is surjective, not
-bijective), this is minimality of *certified* cardinalities; with exact enumerations
-it is the note's `|G|`-minimality.  The note has little to say about min-IE and
-neither do we — the definition is recorded because such properties arise in the
-literature (Lucchini's intervals, Pálfy's analysis of Feit's examples) and the
-catalog of RP-2 will want to state them.
+is at most that of every other finite representation of `𝑳`.
+
+Since `card`{.AgdaField} bounds the carrier from above (the enumeration is
+surjective, not bijective), this is minimality of *certified* cardinalities; with
+exact enumerations it is the `|G|`-minimality of the note.  The note has little to
+say about min-IE and neither do we — the definition is recorded because such
+properties arise in the literature (Lucchini's intervals, Pálfy's analysis of Feit's
+examples) and the catalog of RP-2 will want to state them.
+
 
 ```agda
+open FiniteAlgebra using (card)
+
 minIE : {ℓP : Level} → GroupProperty ℓP → Lattice → Type (lsuc 0ℓ ⊔ ℓP)
-minIE P 𝑳 =
-  ∀ (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
-    (fin : FiniteAlgebra (proj₁ 𝒢))
-  → IntervalIso 𝒢 H H-sg 𝑳
-  → ( ∀ (𝒬 : Group 0ℓ 0ℓ) (J : Pred 𝕌[ proj₁ 𝒬 ] 0ℓ) (J-sg : IsSubgroup 𝒬 J)
-        (fin' : FiniteAlgebra (proj₁ 𝒬))
-      → IntervalIso 𝒬 J J-sg 𝑳
-      → FiniteAlgebra.card fin ≤ⁿ FiniteAlgebra.card fin' )
-  → P 𝒢
+minIE P 𝑳 = ∀ 𝒢 𝒬 H J H-sg J-sg
+  → (fin : FiniteAlgebra (proj₁ 𝒢)) → IntervalIso 𝒢 H H-sg 𝑳
+  → (fin' : FiniteAlgebra (proj₁ 𝒬)) → IntervalIso 𝒬 J J-sg 𝑳
+  → fin .card ≤ⁿ fin' .card → P 𝒢
 ```
 
 #### The fattening isomorphism
 
 The heart of this slice: for a subgroup `H` of `𝒢` and any group `𝒦`, the upper
-interval over the fattened subgroup `H ×ᶠ 𝒦` in `Sub(𝒢 ×ᵍ 𝒦)` is order-isomorphic
-to the upper interval over `H` in `Sub(𝒢)` — the note's `[H × K , G × K] ≅ [H , G]`.
+interval over the fattened subgroup `H ×ᶠ 𝒦` in `Sub(𝒢 ×ᵍ 𝒦)` is order-isomorphic to
+the upper interval over `H` in `Sub(𝒢)`; that is, `[H × K , G × K] ≅ [H , G]`.
+
 The two maps are restriction to the first coordinate, `M ↦ (λ g → M (g , ε))`, and
-pullback along the projection, `A ↦ (A ∘ proj₁)`; that they are well-defined,
-monotone, and mutually inverse is the content of the `Slice₁`{.AgdaModule} toolkit
-of [Classical.Structures.Group.Product][] — the pivot being that a respecting
-subgroup `M ⊇ H ×ᶠ 𝒦` satisfies `M (g , k) ⟺ M (g , ε)`, since
-`(g , k) ≈ (g , ε) ∙ (ε , k)` and `(ε , k)` lies in `H ×ᶠ 𝒦 ⊆ M`.  One round trip
-is even definitional: restricting a pulled-back subgroup gives back exactly the
-predicate one started from.
+pullback along the projection, `A ↦ (A ∘ proj₁)`.
+
+That they are well-defined, monotone, and mutually inverse is the content of the
+`Slice₁`{.AgdaModule} toolkit of [Classical.Structures.Group.Product][] — the pivot
+being that a respecting subgroup `M ⊇ H ×ᶠ 𝒦` satisfies `M (g , k) ⟺ M (g , ε)`,
+since `(g , k) ≈ (g , ε) ∙ (ε , k)` and `(ε , k)` lies in `H ×ᶠ 𝒦 ⊆ M`.
+
+One round trip is even definitional: restricting a pulled-back subgroup gives back
+exactly the predicate one started from.
 
 `FattenSnd`{.AgdaModule} fattens by a full *second* factor (the note's displayed
-form); `FattenFst`{.AgdaModule} is the mirror with a full *first* factor.  Lemma 3.2
-needs both, one per witness.
+form); `FattenFst`{.AgdaModule} is the mirror with a full *first* factor.
+Lemma 3.2 needs both, one per witness.
 
 ```agda
 module Fatten (𝒢 𝒦 : Group 0ℓ 0ℓ) where
@@ -359,8 +365,8 @@ module Fatten (𝒢 𝒦 : Group 0ℓ 0ℓ) where
     𝒫 : Group 0ℓ 0ℓ
     𝒫 = 𝒢 ×ᵍ 𝒦
 
-  open GroupProduct 𝒢 𝒦 using ( module Slice₁ ; module Slice₂
-                              ; ×ᶠ-isSubgroup ; ᶠ×-isSubgroup )
+  open GroupProduct 𝒢 𝒦 using  ( module Slice₁ ; module Slice₂
+                               ; ×ᶠ-isSubgroup ; ᶠ×-isSubgroup )
 
   module FattenSnd (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H) where
 
@@ -695,7 +701,19 @@ builds on top of the definitions of this module.
 
 ---
 
-[^1]: Sketch: take `𝒦` presented on a two-element carrier `{a , b}` with `a ≈ b`
+[^1]: arXiv:1205.1927 ("the note") vendored at
+      [`docs/papers/flrp/ieprops/IEProps-1205.1927v4.pdf`](docs/papers/flrp/ieprops/IEProps-1205.1927v4.pdf);
+      see also [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7
+      for the roadmap's description of **Work Product 4** (WP-4): *the core-free reduction*
+      (IE/cf-IE/min-IE with group-representability tracking, core-free reduction,
+      fattening, and the note's Lemmas 3.1 and 3.2 (the plain-IE "no-go").
+
+[^wp-2]: See [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7
+         for the roadmap's description of **Work Product 2** (WP-2): *the group-action infrastructure*
+         (cosets, conjugation, normal core, G-sets as unary algebras, `Sub(G)` as a
+         complete lattice, and intervals `[H, G]` as bounded lattices).
+
+[^2]: Sketch: take `𝒦` presented on a two-element carrier `{a , b}` with `a ≈ b`
       and all operations returning `a` (a one-element group presented redundantly),
       and `𝒢 = ℤ₂` on a propositional-equality carrier with `H` trivial.  The bare
       predicate `{(e , a) , (e , b) , (g , a)}` is closed under the product
@@ -704,3 +722,10 @@ builds on top of the definitions of this module.
       bare interval `[H ×ᶠ 𝒦 , full]` has three elements while `[H , full]` in
       `Sub(ℤ₂)` has two.  Requiring `respects`{.AgdaField} removes exactly this
       presentation junk.
+
+[^3]: Note that properties are not explicitly required to be isomorphism-invariant —
+      the note's Lemma 3.2 proof never uses invariance, and no definition below needs
+      it — however, by a "group property" we typically mean one that is invariant under
+      isomorphism; that is, if `𝑮 ≅ 𝑮'`, then `𝑮` has property `P` iff `𝑮'` does.
+[^4]: `OrderIso`{.AgdaRecord} still lives in [FLRP.Problem][]; its planned migration
+      to the `Order/` tree, foreseen there, is left to a dedicated change.

--- a/src/FLRP/Enforceable.lagda.md
+++ b/src/FLRP/Enforceable.lagda.md
@@ -1,0 +1,706 @@
+---
+layout: default
+file: "src/FLRP/Enforceable.lagda.md"
+title: "FLRP.Enforceable module (The Agda Universal Algebra Library)"
+date: "2026-07-18"
+author: "the agda-algebras development team"
+---
+
+### Interval enforceable properties of finite groups
+
+This is the [FLRP.Enforceable][] module of the [Agda Universal Algebra Library][].
+
+This module opens work package WP-4 of the FLRP research program: the formalization
+of *interval enforceable* group properties, after the note *Interval enforceable
+properties of finite groups* (arXiv:1205.1927, vendored at
+`docs/papers/flrp/ieprops/`; see `docs/notes/flrp-research-roadmap.md` § 4).  A group
+property `P` is **interval enforceable (IE) via a lattice `𝑳`** when every group
+whose subgroup lattice has an upper interval isomorphic to `𝑳` must satisfy `P`;
+it is **core-free interval enforceable (cf-IE)** when the same is only required of
+representations over a *core-free* subgroup.  The note's program is to combine
+enforceable properties into a contradiction, which by Pálfy–Pudlák would answer the
+Finite Lattice Representation Problem negatively.
+
+The contents, keyed to the note:
+
++  `GroupRepresentable`{.AgdaRecord} — the lattice occurs as an upper interval
+   `[H , G]` in the subgroup lattice of a group, with all witnesses carried
+   explicitly;
++  `IE`{.AgdaFunction}, `cfIE`{.AgdaFunction}, `minIE`{.AgdaFunction} — the note's
+   § 2 definitions, with core-freeness expressed through WP-2's normal core;
++  the **fattening isomorphism** `[H × K , G × K] ≅ [H , G]`
+   (`Fatten`{.AgdaModule}), in both coordinates;
++  **Lemma 3.2** (`lemma:ie-prop-and-neg`): a property and its negation cannot both
+   be IE via group representable lattices (`no-contradictory-IE`{.AgdaFunction}),
+   with the note's fattening remark as the companion
+   `IE-fattens`{.AgdaFunction};
++  **Lemma 3.1** (`lemma-wjd-2`) and the parachute meta-theorem
+   (`thm-wjd-1`) as *statements only*, their proofs deferred to RP-1 behind named
+   hypothesis records in the `FLRP.Assumptions` style.
+
+Two disciplines from the roadmap govern the definitions.
+
++  **Representability tracking (vacuity discipline)**.  If no group realizes `𝑳` as
+   an upper interval then *every* property is vacuously enforceable via `𝑳`, and
+   deciding that emptiness is the original problem.  So `IE`{.AgdaFunction} and
+   `cfIE`{.AgdaFunction} are the bare universally quantified notions, and group
+   representability of the enforcing lattice is a separate, explicitly tracked
+   hypothesis (`GroupRepresentable`{.AgdaRecord}) that lemmas assume where the note
+   assumes it — never silently quantified away.
++  **Levels**.  As in [FLRP.Problem][], groups are fixed at `Group 0ℓ 0ℓ` and
+   subgroup predicates at level `0ℓ`: the records here quantify existentially over
+   groups and predicates, and Agda cannot quantify existentially over universe
+   levels, so the levels must be pinned; `0ℓ` suffices for every finite (indeed
+   every set-sized) instance.  Group *properties* appear only in universally
+   quantified positions, so they keep a polymorphic level `ℓP`.  Note that
+   properties are *not* required to be isomorphism-invariant: the note's Lemma 3.2
+   proof never uses invariance, and no definition below needs it.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.Enforceable where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Empty                    using ( ⊥ )
+open import Data.Fin.Base                 using ( Fin )
+open import Data.Nat.Base                 using ( ℕ ; _+_ )
+                                          renaming ( _≤_ to _≤ⁿ_ )
+open import Data.Product                  using ( _,_ ; _×_ ; Σ-syntax ; proj₁ ; proj₂ )
+open import Data.Unit.Base                using ( tt )
+open import Level                         using ( Level ; 0ℓ ; _⊔_ ; Lift ; lift )
+                                          renaming ( suc to lsuc )
+open import Relation.Binary               using ( Setoid )
+open import Relation.Binary.Definitions   using ( _Respects_ )
+open import Relation.Binary.PropositionalEquality using ( _≡_ )
+open import Relation.Nullary              using ( ¬_ )
+open import Relation.Unary                using ( Pred ; _∈_ ; _⊆_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Properties.Lattice          using ( module Lattice-Order )
+open import Classical.Small.Structures.Lattice    using ( Lattice )
+open import Classical.Structures.Group.Basic      using ( Group )
+open import Classical.Structures.Group.NormalCore using ( module Core )
+open import Classical.Structures.Group.Product    using ( module GroupProduct
+                                                        ; _×ᵍ_ ; _×ᶠ_ ; _ᶠ×_ )
+open import Classical.Structures.Group.SubgroupLattice
+                                                  using ( module GroupSublattice )
+open import Classical.Structures.Group.Subgroups  using ( IsSubgroup ; trivialSubgroup )
+open import FLRP.Problem                          using ( OrderIso ; FiniteLattice
+                                                        ; toLattice )
+open import Setoid.Algebras.Basic                 using ( 𝔻[_] ; 𝕌[_] )
+open import Setoid.Algebras.Finite                using ( FiniteAlgebra )
+open import Setoid.Homomorphisms.HomomorphicImages using ( _IsHomImageOf_ )
+open import Setoid.Subalgebras.Subuniverses       using ( Subuniverses )
+```
+-->
+
+#### Upper intervals of respecting subgroups
+
+The group side of a representation is an upper interval `[H , G]` in the subgroup
+lattice, presented through WP-2's machinery: `H` enters as a `Subᴸ`{.AgdaFunction}
+element of the subuniverse lattice of [Setoid.Subalgebras.CompleteLattice][]
+(packaged for groups by [Classical.Structures.Group.SubgroupLattice][]), and the
+interval `[H , full]` is the `SubInterval`{.AgdaModule} instance of the generic
+[Order.Interval][] construction.
+
+One refinement is needed.  The elements of `SubInterval`{.AgdaModule} are *bare*
+subuniverses, with no compatibility between the predicate and the setoid equality of
+the carrier.  Over a setoid-presented group that is too permissive: a subgroup is a
+sub*set* of the carrier, i.e. an `≈`-saturated predicate, and bare subuniverses can
+distinguish `≈`-equal elements.  The distinction is not cosmetic — over a carrier
+with a redundant representative the bare interval `[H × K , G × K]` can be strictly
+larger than `[H , G]`, so the fattening isomorphism below is *false* at the bare
+level.[^1]  We therefore take as interval elements the bare interval elements
+*paired with a proof that the predicate respects `≈`* — exactly the
+`respects`{.AgdaField} field of `IsSubgroup`{.AgdaRecord}.  Over a group presented
+on a propositional-equality setoid (the `eqsToGroup`{.AgdaFunction} builders, and
+every finite Cayley-table group) the extra field is inhabited by `subst`, so nothing
+is lost in the concrete cases the FLRP cares about.
+
+`UpperInterval 𝒢 H H-sg`{.AgdaModule} packages the respecting upper interval
+`[H , full]` for a fixed subgroup: the carrier `Interval≈`{.AgdaFunction}, its
+equality and order (those of the bare interval, which ignore all proof components),
+accessors, and the smart constructor `mk`{.AgdaFunction}.
+
+```agda
+module UpperInterval
+  (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
+  where
+
+  open Setoid 𝔻[ proj₁ 𝒢 ] using ( _≈_ )
+  open GroupSublattice 𝒢 0ℓ using ( Subᴸ ; 1ˢ ; 1ˢ-maximum ; subgroup→Subᴸ
+                                  ; module SubInterval )
+
+  -- The bottom of the interval: H as an element of the subuniverse lattice.
+  H↑ : Subᴸ
+  H↑ = subgroup→Subᴸ H H-sg
+
+  -- The bare interval [H , full], by the generic construction.
+  module Bare = SubInterval H↑ 1ˢ (1ˢ-maximum H↑)
+
+  -- An interval element: a bare element whose predicate respects ≈.
+  Interval≈ : Type (lsuc 0ℓ)
+  Interval≈ = Σ[ M ∈ Bare.Interval ] (proj₁ (proj₁ M) Respects _≈_)
+
+  -- Accessors: the underlying predicate and its three certificates.
+  pred : Interval≈ → Pred 𝕌[ proj₁ 𝒢 ] 0ℓ
+  pred M = proj₁ (proj₁ (proj₁ M))
+
+  pred-isSubuniverse : (M : Interval≈) → pred M ∈ Subuniverses (proj₁ 𝒢)
+  pred-isSubuniverse M = proj₂ (proj₁ (proj₁ M))
+
+  pred-respects : (M : Interval≈) → pred M Respects _≈_
+  pred-respects M = proj₂ M
+
+  above : (M : Interval≈) → H ⊆ pred M
+  above M = proj₁ (proj₂ (proj₁ M))
+
+  -- An interval element is a respecting subgroup.
+  element-isSubgroup : (M : Interval≈) → IsSubgroup 𝒢 (pred M)
+  element-isSubgroup M = record  { respects       = pred-respects M
+                                 ; isSubuniverse  = pred-isSubuniverse M }
+
+  -- Conversely, a respecting subgroup above H is an interval element
+  -- (the top bound against the full subuniverse is trivial).
+  mk : (M : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) → IsSubgroup 𝒢 M → H ⊆ M → Interval≈
+  mk M M-sg H⊆M =
+    ((M , IsSubgroup.isSubuniverse M-sg) , H⊆M , (λ _ → lift tt))
+    , IsSubgroup.respects M-sg
+
+  -- Equality and order come from the bare interval (they compare the
+  -- underlying predicates and ignore the respects proof).
+  infix 4 _≈ᵢ_ _≤ᵢ_
+
+  _≈ᵢ_ : Interval≈ → Interval≈ → Type 0ℓ
+  M ≈ᵢ N = Bare._≈_ (proj₁ M) (proj₁ N)
+
+  _≤ᵢ_ : Interval≈ → Interval≈ → Type 0ℓ
+  M ≤ᵢ N = Bare._≤_ (proj₁ M) (proj₁ N)
+```
+
+#### Interval isomorphism with a classical lattice
+
+`IntervalIso 𝒢 H H-sg 𝑳`{.AgdaFunction} is the group-side analog of
+`ConIso`{.AgdaFunction} of [FLRP.Problem][], and deliberately the *same
+presentation*: an `OrderIso`{.AgdaRecord} between the respecting upper interval
+`[H , full]` of `Sub(𝒢)` and the meet order of the classical lattice
+`𝑳`{.AgdaBound} of [Classical.Small.Structures.Lattice][].  Order isomorphisms
+transport meets and joins, so this is exactly "`[H , G] ≅ 𝑳` as lattices" with no
+redundant clauses.  (`OrderIso`{.AgdaRecord} still lives in [FLRP.Problem][]; its
+planned migration to the `Order/` tree, foreseen there, is left to a dedicated
+change.)
+
+```agda
+IntervalIso :
+  (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
+  → Lattice → Type (lsuc 0ℓ)
+IntervalIso 𝒢 H H-sg 𝑳 =
+  OrderIso  (UpperInterval._≈ᵢ_ 𝒢 H H-sg) (UpperInterval._≤ᵢ_ 𝒢 H H-sg)
+            (Setoid._≈_ 𝔻[ proj₁ 𝑳 ]) (Lattice-Order._≤_ 𝑳)
+```
+
+Interval isomorphisms compose with order isomorphisms *between* two intervals: the
+mutually-inverse maps compose, and the round trips are repaired using that interval
+equality is mutual inclusion (so it maps into the target through monotonicity and
+the meet order's antisymmetry).  This small combinator is the engine of the
+fattening applications below.
+
+```agda
+compose-IntervalIso :
+  (𝒬 : Group 0ℓ 0ℓ) (J : Pred 𝕌[ proj₁ 𝒬 ] 0ℓ) (J-sg : IsSubgroup 𝒬 J)
+  (ℛ : Group 0ℓ 0ℓ) (B : Pred 𝕌[ proj₁ ℛ ] 0ℓ) (B-sg : IsSubgroup ℛ B)
+  (𝑳 : Lattice)
+  → OrderIso  (UpperInterval._≈ᵢ_ 𝒬 J J-sg) (UpperInterval._≤ᵢ_ 𝒬 J J-sg)
+              (UpperInterval._≈ᵢ_ ℛ B B-sg) (UpperInterval._≤ᵢ_ ℛ B B-sg)
+  → IntervalIso ℛ B B-sg 𝑳
+  → IntervalIso 𝒬 J J-sg 𝑳
+compose-IntervalIso 𝒬 J J-sg ℛ B B-sg 𝑳 F Iso = record
+  { to         = λ x → I2.to (F'.to x)
+  ; from       = λ u → F'.from (I2.from u)
+  ; to-mono    = λ le → I2.to-mono (F'.to-mono le)
+  ; from-mono  = λ le → F'.from-mono (I2.from-mono le)
+  ; to∘from    = λ u → ≈ᴸ-trans
+      (≤ᴸ-antisym  (I2.to-mono (proj₁ (F'.to∘from (I2.from u))))
+                   (I2.to-mono (proj₂ (F'.to∘from (I2.from u)))))
+      (I2.to∘from u)
+  ; from∘to    = λ x →
+      ( (λ z → proj₁ (F'.from∘to x) (F'.from-mono (proj₁ (I2.from∘to (F'.to x))) z))
+      , (λ z → F'.from-mono (proj₂ (I2.from∘to (F'.to x))) (proj₂ (F'.from∘to x) z)) )
+  }
+  where
+  module F' = OrderIso F
+  module I2 = OrderIso Iso
+  open Lattice-Order 𝑳 using () renaming ( ≤-antisym to ≤ᴸ-antisym )
+  open Setoid 𝔻[ proj₁ 𝑳 ] using () renaming ( trans to ≈ᴸ-trans )
+```
+
+#### Group representability
+
+A lattice is **group representable** when it occurs as an upper interval in the
+subgroup lattice of a group.  Per the vacuity discipline, this is a first-class
+record whose fields carry all witnesses — the group, the subgroup predicate, its
+subgroup proof, and the interval isomorphism — mirroring
+`Representable`{.AgdaRecord} of [FLRP.Problem][] on the algebra side.  (The note
+works with *finite* groups throughout; finiteness of the witness is deliberately not
+baked in here, since none of the lemmas of this module consume it — it will enter
+through `FiniteAlgebra`{.AgdaRecord} hypotheses exactly where a result needs it, as
+`minIE`{.AgdaFunction} already illustrates.)
+
+```agda
+record GroupRepresentable (𝑳 : Lattice) : Type (lsuc 0ℓ) where
+  field
+    grp           : Group 0ℓ 0ℓ
+    sub           : Pred 𝕌[ proj₁ grp ] 0ℓ
+    isSubgroup    : IsSubgroup grp sub
+    interval-iso  : IntervalIso grp sub isSubgroup 𝑳
+```
+
+#### Group properties and the enforceability classification
+
+A *group property* here is any predicate on groups (at a polymorphic level, per the
+level discipline above; isomorphism-invariance is not required, and none of the
+results below use it).
+
+```agda
+GroupProperty : (ℓP : Level) → Type (lsuc 0ℓ ⊔ lsuc ℓP)
+GroupProperty ℓP = Pred (Group 0ℓ 0ℓ) ℓP
+```
+
+`IE P 𝑳` is the note's display: every group with an upper interval isomorphic to
+`𝑳` has property `P`.
+
+```agda
+IE : {ℓP : Level} → GroupProperty ℓP → Lattice → Type (lsuc 0ℓ ⊔ ℓP)
+IE P 𝑳 =
+  ∀ (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
+  → IntervalIso 𝒢 H H-sg 𝑳
+  → P 𝒢
+```
+
+Core-freeness of a subgroup is expressed through WP-2's normal core: the core of
+`H` — the greatest normal subgroup below `H`, constructed in
+[Classical.Structures.Group.NormalCore][] as the meet of all conjugates — is
+contained in the trivial subgroup (the `≈`-class of the identity).  The converse
+containment always holds (the core is a subgroup, hence contains the identity's
+class), so this inclusion says exactly "the core *is* trivial".
+
+```agda
+CoreFree :
+  (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) → IsSubgroup 𝒢 H → Type 0ℓ
+CoreFree 𝒢 H H-sg = proj₁ (Core.core 𝒢 H H-sg) ⊆ proj₁ (trivialSubgroup 𝒢)
+```
+
+`cfIE P 𝑳` weakens `IE` by demanding the conclusion only for representations over a
+core-free subgroup; consequently every IE property is cf-IE (the note's "clearly").
+
+```agda
+cfIE : {ℓP : Level} → GroupProperty ℓP → Lattice → Type (lsuc 0ℓ ⊔ ℓP)
+cfIE P 𝑳 =
+  ∀ (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
+  → CoreFree 𝒢 H H-sg
+  → IntervalIso 𝒢 H H-sg 𝑳
+  → P 𝒢
+
+-- Interval enforceable implies core-free interval enforceable.
+IE→cfIE : {ℓP : Level} {P : GroupProperty ℓP} {𝑳 : Lattice} → IE P 𝑳 → cfIE P 𝑳
+IE→cfIE ie 𝒢 H H-sg _ iso = ie 𝒢 H H-sg iso
+```
+
+`minIE P 𝑳` asks for `P` only of *minimal* representations.  Minimality is measured
+through the `card`{.AgdaField} field of the `FiniteAlgebra`{.AgdaRecord} interface
+on the group's underlying algebra: the given representation's certified cardinality
+is at most that of every other finite representation of `𝑳`.  Since
+`card`{.AgdaField} bounds the carrier from above (the enumeration is surjective, not
+bijective), this is minimality of *certified* cardinalities; with exact enumerations
+it is the note's `|G|`-minimality.  The note has little to say about min-IE and
+neither do we — the definition is recorded because such properties arise in the
+literature (Lucchini's intervals, Pálfy's analysis of Feit's examples) and the
+catalog of RP-2 will want to state them.
+
+```agda
+minIE : {ℓP : Level} → GroupProperty ℓP → Lattice → Type (lsuc 0ℓ ⊔ ℓP)
+minIE P 𝑳 =
+  ∀ (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
+    (fin : FiniteAlgebra (proj₁ 𝒢))
+  → IntervalIso 𝒢 H H-sg 𝑳
+  → ( ∀ (𝒬 : Group 0ℓ 0ℓ) (J : Pred 𝕌[ proj₁ 𝒬 ] 0ℓ) (J-sg : IsSubgroup 𝒬 J)
+        (fin' : FiniteAlgebra (proj₁ 𝒬))
+      → IntervalIso 𝒬 J J-sg 𝑳
+      → FiniteAlgebra.card fin ≤ⁿ FiniteAlgebra.card fin' )
+  → P 𝒢
+```
+
+#### The fattening isomorphism
+
+The heart of this slice: for a subgroup `H` of `𝒢` and any group `𝒦`, the upper
+interval over the fattened subgroup `H ×ᶠ 𝒦` in `Sub(𝒢 ×ᵍ 𝒦)` is order-isomorphic
+to the upper interval over `H` in `Sub(𝒢)` — the note's `[H × K , G × K] ≅ [H , G]`.
+The two maps are restriction to the first coordinate, `M ↦ (λ g → M (g , ε))`, and
+pullback along the projection, `A ↦ (A ∘ proj₁)`; that they are well-defined,
+monotone, and mutually inverse is the content of the `Slice₁`{.AgdaModule} toolkit
+of [Classical.Structures.Group.Product][] — the pivot being that a respecting
+subgroup `M ⊇ H ×ᶠ 𝒦` satisfies `M (g , k) ⟺ M (g , ε)`, since
+`(g , k) ≈ (g , ε) ∙ (ε , k)` and `(ε , k)` lies in `H ×ᶠ 𝒦 ⊆ M`.  One round trip
+is even definitional: restricting a pulled-back subgroup gives back exactly the
+predicate one started from.
+
+`FattenSnd`{.AgdaModule} fattens by a full *second* factor (the note's displayed
+form); `FattenFst`{.AgdaModule} is the mirror with a full *first* factor.  Lemma 3.2
+needs both, one per witness.
+
+```agda
+module Fatten (𝒢 𝒦 : Group 0ℓ 0ℓ) where
+
+  private
+    𝒫 : Group 0ℓ 0ℓ
+    𝒫 = 𝒢 ×ᵍ 𝒦
+
+  open GroupProduct 𝒢 𝒦 using ( module Slice₁ ; module Slice₂
+                              ; ×ᶠ-isSubgroup ; ᶠ×-isSubgroup )
+
+  module FattenSnd (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H) where
+
+    -- The fattened subgroup of the product.
+    HP-sg : IsSubgroup 𝒫 (H ×ᶠ 𝒦)
+    HP-sg = ×ᶠ-isSubgroup H-sg
+
+    module IG = UpperInterval 𝒢 H H-sg
+    module IP = UpperInterval 𝒫 (H ×ᶠ 𝒦) HP-sg
+
+    -- Restriction: an interval element over H ×ᶠ 𝒦 restricts to one over H.
+    to-fatten : IP.Interval≈ → IG.Interval≈
+    to-fatten M = IG.mk S.restrict₁ S.restrict₁-isSubgroup S.restrict₁-⊇H
+      where
+      module S = Slice₁ H H-sg (IP.pred M) (IP.pred-isSubuniverse M)
+                        (IP.pred-respects M) (IP.above M)
+
+    -- Pullback: an interval element over H fattens to one over H ×ᶠ 𝒦.
+    from-fatten : IG.Interval≈ → IP.Interval≈
+    from-fatten A = IP.mk  (IG.pred A ×ᶠ 𝒦)
+                           (×ᶠ-isSubgroup (IG.element-isSubgroup A))
+                           (λ h → IG.above A h)
+
+    -- Both maps are monotone (they act by composition on the predicates).
+    to-fatten-mono : (M N : IP.Interval≈)
+      → IP._≤ᵢ_ M N → IG._≤ᵢ_ (to-fatten M) (to-fatten N)
+    to-fatten-mono M N M⊆N m = M⊆N m
+
+    from-fatten-mono : (A A' : IG.Interval≈)
+      → IG._≤ᵢ_ A A' → IP._≤ᵢ_ (from-fatten A) (from-fatten A')
+    from-fatten-mono A A' A⊆A' a = A⊆A' a
+
+    -- Restricting a pullback is the identity, definitionally.
+    to∘from-fatten : (A : IG.Interval≈) → IG._≈ᵢ_ (to-fatten (from-fatten A)) A
+    to∘from-fatten A = (λ z → z) , (λ z → z)
+
+    -- Pulling back a restriction recovers M, by the slice pivot.
+    from∘to-fatten : (M : IP.Interval≈) → IP._≈ᵢ_ (from-fatten (to-fatten M)) M
+    from∘to-fatten M = (λ z → S.slice-in z) , (λ z → S.slice-out z)
+      where
+      module S = Slice₁ H H-sg (IP.pred M) (IP.pred-isSubuniverse M)
+                        (IP.pred-respects M) (IP.above M)
+
+    -- The fattening isomorphism  [H ×ᶠ 𝒦 , full] ≅ [H , full].
+    -- (In from-mono the inclusion's element p is passed explicitly: the
+    -- fattened predicates factor through proj₁, so an implicit p would leave
+    -- its second component an unconstrained metavariable.)
+    fatten-iso : OrderIso IP._≈ᵢ_ IP._≤ᵢ_ IG._≈ᵢ_ IG._≤ᵢ_
+    fatten-iso = record
+      { to         = to-fatten
+      ; from       = from-fatten
+      ; to-mono    = λ {M} {N} le → to-fatten-mono M N le
+      ; from-mono  = λ {A} {A'} le {p} a → from-fatten-mono A A' le {p} a
+      ; to∘from    = to∘from-fatten
+      ; from∘to    = from∘to-fatten
+      }
+
+    -- Consequently any interval isomorphism [H , G] ≅ 𝑳 fattens to the product.
+    fatten-IntervalIso : (𝑳 : Lattice)
+      → IntervalIso 𝒢 H H-sg 𝑳 → IntervalIso 𝒫 (H ×ᶠ 𝒦) HP-sg 𝑳
+    fatten-IntervalIso 𝑳 iso =
+      compose-IntervalIso 𝒫 (H ×ᶠ 𝒦) HP-sg 𝒢 H H-sg 𝑳 fatten-iso iso
+
+  module FattenFst (J : Pred 𝕌[ proj₁ 𝒦 ] 0ℓ) (J-sg : IsSubgroup 𝒦 J) where
+
+    -- The mirrored fattened subgroup of the product.
+    JP-sg : IsSubgroup 𝒫 (𝒢 ᶠ× J)
+    JP-sg = ᶠ×-isSubgroup J-sg
+
+    module IK = UpperInterval 𝒦 J J-sg
+    module IP = UpperInterval 𝒫 (𝒢 ᶠ× J) JP-sg
+
+    -- Restriction to the second coordinate.
+    to-fatten : IP.Interval≈ → IK.Interval≈
+    to-fatten M = IK.mk S.restrict₂ S.restrict₂-isSubgroup S.restrict₂-⊇J
+      where
+      module S = Slice₂ J J-sg (IP.pred M) (IP.pred-isSubuniverse M)
+                        (IP.pred-respects M) (IP.above M)
+
+    -- Pullback along the second projection.
+    from-fatten : IK.Interval≈ → IP.Interval≈
+    from-fatten A = IP.mk  (𝒢 ᶠ× IK.pred A)
+                           (ᶠ×-isSubgroup (IK.element-isSubgroup A))
+                           (λ j → IK.above A j)
+
+    to-fatten-mono : (M N : IP.Interval≈)
+      → IP._≤ᵢ_ M N → IK._≤ᵢ_ (to-fatten M) (to-fatten N)
+    to-fatten-mono M N M⊆N m = M⊆N m
+
+    from-fatten-mono : (A A' : IK.Interval≈)
+      → IK._≤ᵢ_ A A' → IP._≤ᵢ_ (from-fatten A) (from-fatten A')
+    from-fatten-mono A A' A⊆A' a = A⊆A' a
+
+    to∘from-fatten : (A : IK.Interval≈) → IK._≈ᵢ_ (to-fatten (from-fatten A)) A
+    to∘from-fatten A = (λ z → z) , (λ z → z)
+
+    from∘to-fatten : (M : IP.Interval≈) → IP._≈ᵢ_ (from-fatten (to-fatten M)) M
+    from∘to-fatten M = (λ z → S.slice-in z) , (λ z → S.slice-out z)
+      where
+      module S = Slice₂ J J-sg (IP.pred M) (IP.pred-isSubuniverse M)
+                        (IP.pred-respects M) (IP.above M)
+
+    -- The mirrored fattening isomorphism  [𝒢 ᶠ× J , full] ≅ [J , full].
+    -- (Same explicit-p idiom as in FattenSnd, now factoring through proj₂.)
+    fatten-iso : OrderIso IP._≈ᵢ_ IP._≤ᵢ_ IK._≈ᵢ_ IK._≤ᵢ_
+    fatten-iso = record
+      { to         = to-fatten
+      ; from       = from-fatten
+      ; to-mono    = λ {M} {N} le → to-fatten-mono M N le
+      ; from-mono  = λ {A} {A'} le {p} a → from-fatten-mono A A' le {p} a
+      ; to∘from    = to∘from-fatten
+      ; from∘to    = from∘to-fatten
+      }
+
+    fatten-IntervalIso : (𝑳 : Lattice)
+      → IntervalIso 𝒦 J J-sg 𝑳 → IntervalIso 𝒫 (𝒢 ᶠ× J) JP-sg 𝑳
+    fatten-IntervalIso 𝑳 iso =
+      compose-IntervalIso 𝒫 (𝒢 ᶠ× J) JP-sg 𝒦 J J-sg 𝑳 fatten-iso iso
+```
+
+#### Lemma 3.2: no property and its negation are both IE via representable lattices
+
+The note's Lemma `lemma:ie-prop-and-neg`, in its two-line form: if `P` is IE via a
+group representable `𝑳₁` and `¬ P` is IE via a group representable `𝑳₂`, take the
+witnesses `[H₁ , G₁] ≅ 𝑳₁` and `[H₂ , G₂] ≅ 𝑳₂` and consider `G₁ × G₂`.  Fattening
+gives `𝑳₁ ≅ [H₁ × G₂ , G₁ × G₂]` and `𝑳₂ ≅ [G₁ × H₂ , G₁ × G₂]`, so the two
+enforceability assumptions make `G₁ × G₂` satisfy `P` and `¬ P` simultaneously.
+Note where representability enters: without the two witnesses there is no product
+group to build, which is precisely why the vacuity discipline refuses to quantify
+representability away.
+
+```agda
+no-contradictory-IE :
+  {ℓP : Level} (P : GroupProperty ℓP) (𝑳₁ 𝑳₂ : Lattice)
+  → GroupRepresentable 𝑳₁ → IE P 𝑳₁
+  → GroupRepresentable 𝑳₂ → IE (λ 𝒢 → ¬ P 𝒢) 𝑳₂
+  → ⊥
+no-contradictory-IE P 𝑳₁ 𝑳₂ rep₁ ie₁ rep₂ ie₂ = ¬P× P×
+  where
+  open GroupRepresentable rep₁
+    renaming ( grp to 𝒢₁ ; sub to H₁ ; isSubgroup to H₁-sg ; interval-iso to iso₁ )
+  open GroupRepresentable rep₂
+    renaming ( grp to 𝒢₂ ; sub to H₂ ; isSubgroup to H₂-sg ; interval-iso to iso₂ )
+
+  module F₂ = Fatten.FattenSnd 𝒢₁ 𝒢₂ H₁ H₁-sg
+  module F₁ = Fatten.FattenFst 𝒢₁ 𝒢₂ H₂ H₂-sg
+
+  P× : P (𝒢₁ ×ᵍ 𝒢₂)
+  P× = ie₁ (𝒢₁ ×ᵍ 𝒢₂) (H₁ ×ᶠ 𝒢₂) F₂.HP-sg (F₂.fatten-IntervalIso 𝑳₁ iso₁)
+
+  ¬P× : ¬ P (𝒢₁ ×ᵍ 𝒢₂)
+  ¬P× = ie₂ (𝒢₁ ×ᵍ 𝒢₂) (𝒢₁ ᶠ× H₂) F₁.JP-sg (F₁.fatten-IntervalIso 𝑳₂ iso₂)
+```
+
+The fattening remark that follows the lemma in the note: if `P` is IE via a group
+representable lattice, then `P` holds of the witness's product with *every* group —
+so no property that a direct factor can destroy (solvability, being alternating or
+symmetric, …) is IE via a representable lattice.
+
+```agda
+IE-fattens :
+  {ℓP : Level} (P : GroupProperty ℓP) (𝑳 : Lattice)
+  → IE P 𝑳 → (r : GroupRepresentable 𝑳)
+  → (𝒦 : Group 0ℓ 0ℓ) → P (GroupRepresentable.grp r ×ᵍ 𝒦)
+IE-fattens P 𝑳 ie r 𝒦 =
+  ie (grp ×ᵍ 𝒦) (sub ×ᶠ 𝒦) F.HP-sg (F.fatten-IntervalIso 𝑳 interval-iso)
+  where
+  open GroupRepresentable r
+  module F = Fatten.FattenSnd grp 𝒦 sub isSubgroup
+```
+
+Both arguments place the fattened subgroup *inside* a nontrivial normal subgroup of
+the product (`1 × K` lies in the core of `H × K`), so fattening destroys
+core-freeness and neither result transfers to the cf-IE level.  This is precisely
+why the note's program — and RP-3's hunt for contradictory families — lives at the
+core-free level, where an analog of Lemma 3.2 is not a theorem but the open
+dead-end question of RP-4.
+
+#### Lemma 3.1, stated with named hypotheses
+
+The note's Lemma `lemma-wjd-2` upgrades cf-IE to IE when the complementary class is
+closed under homomorphic images.  Its proof needs the **core-free reduction**: for
+`N = Core_G(H)` one has `[H , G] ≅ [H/N , G/N]` with `H/N` core-free in `G/N`, and
+`G/N` a homomorphic image of `G`.  Quotient groups are not yet in the library, so —
+per the `FLRP.Assumptions` discipline of the roadmap (§ 6): formal statements even
+for results whose proofs stay on paper, hypotheses as named records — the reduction
+enters as the hypothesis record `CoreFreeReduction`{.AgdaRecord}, and Lemma 3.1 is
+*stated* conditionally on it, its proof deferred to RP-1.
+
+```agda
+record CoreFreeReduction : Type (lsuc 0ℓ) where
+  field
+    reduce :
+      (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
+      → Σ[ 𝒬 ∈ Group 0ℓ 0ℓ ]
+        Σ[ J ∈ Pred 𝕌[ proj₁ 𝒬 ] 0ℓ ]
+        Σ[ J-sg ∈ IsSubgroup 𝒬 J ]
+          ( CoreFree 𝒬 J J-sg
+          × ((𝑳 : Lattice) → IntervalIso 𝒢 H H-sg 𝑳 → IntervalIso 𝒬 J J-sg 𝑳)
+          × ((proj₁ 𝒬) IsHomImageOf (proj₁ 𝒢)) )
+```
+
+The lemma's other hypothesis, H-closure of the complementary class: homomorphic
+images of groups without `P` are without `P`.  (A homomorphism of the underlying
+`Sig-Group` algebras is automatically a group homomorphism, so
+`_IsHomImageOf_`{.AgdaFunction} of [Setoid.Homomorphisms.HomomorphicImages][] is the
+right notion.)
+
+```agda
+ComplementHClosed : {ℓP : Level} → GroupProperty ℓP → Type (lsuc 0ℓ ⊔ ℓP)
+ComplementHClosed P =
+  ∀ (𝒢 𝒬 : Group 0ℓ 0ℓ) → (proj₁ 𝒬) IsHomImageOf (proj₁ 𝒢) → ¬ P 𝒢 → ¬ P 𝒬
+```
+
+One constructive gloss.  The note's argument is by contradiction: from a
+representation `[H , G] ≅ 𝑳`, reduce to the core-free `[H/N , G/N] ≅ 𝑳`, conclude
+`P (G/N)` by cf-IE, and note that `¬ P G` would propagate to `¬ P (G/N)` by
+H-closure — so the argument constructively establishes `¬ ¬ P G`, and reaching
+`P G` itself needs `P` stable under double negation.  We record stability as a
+third named hypothesis rather than silently classicizing; RP-1 will prove the
+`¬ ¬`-free variant outright and this one under stability.
+
+```agda
+PropertyStable : {ℓP : Level} → GroupProperty ℓP → Type (lsuc 0ℓ ⊔ ℓP)
+PropertyStable P = ∀ (𝒢 : Group 0ℓ 0ℓ) → ¬ ¬ P 𝒢 → P 𝒢
+
+-- Lemma 3.1 (lemma-wjd-2 of the note), as a statement: the type is defined,
+-- no inhabitant is claimed here; the proof is RP-1's first target.
+cfIE→IE-Statement : {ℓP : Level} → GroupProperty ℓP → Type (lsuc 0ℓ ⊔ ℓP)
+cfIE→IE-Statement P =
+    CoreFreeReduction
+  → ComplementHClosed P
+  → PropertyStable P
+  → (𝑳 : Lattice) → cfIE P 𝑳 → IE P 𝑳
+```
+
+#### The parachute meta-theorem, stated with named hypotheses
+
+Statement (B) of Pálfy–Pudlák, on the group side: every finite lattice is group
+representable.  This is the exact analog of `FLRP-Statement`{.AgdaFunction} of
+[FLRP.Problem][] — a type the library states but does not assert.
+
+```agda
+GroupFLRP-Statement : Type (lsuc 0ℓ)
+GroupFLRP-Statement = (𝑳 : FiniteLattice) → GroupRepresentable (toLattice 𝑳)
+```
+
+Theorem `thm-wjd-1` of the note proves (B) equivalent to a statement (C) about
+finite families of cf-IE classes.  Its hypotheses need two side conditions made
+formal: a lattice *has more than two elements* (three pairwise `≈`-distinct
+elements exist), and *at least two members* of the family do.
+
+```agda
+HasThreeDistinct : Lattice → Type 0ℓ
+HasThreeDistinct 𝑳 =
+  Σ[ x ∈ 𝕌[ proj₁ 𝑳 ] ] Σ[ y ∈ 𝕌[ proj₁ 𝑳 ] ] Σ[ z ∈ 𝕌[ proj₁ 𝑳 ] ]
+    ( (¬ (x ≈ y)) × (¬ (x ≈ z)) × (¬ (y ≈ z)) )
+  where open Setoid 𝔻[ proj₁ 𝑳 ] using ( _≈_ )
+
+TwoBigCanopies : {m : ℕ} → (Fin m → FiniteLattice) → Type 0ℓ
+TwoBigCanopies {m} 𝑳s =
+  Σ[ i ∈ Fin m ] Σ[ j ∈ Fin m ]
+    ( (¬ (i ≡ j))
+    × HasThreeDistinct (toLattice (𝑳s i))
+    × HasThreeDistinct (toLattice (𝑳s j)) )
+```
+
+Statement (C): for every family of at least two finite lattices, two of them big,
+and properties `Pᵢ` core-free enforceable by them, a *single* group satisfies every
+`Pᵢ` and realizes every `𝑳ᵢ` as an upper interval over a core-free subgroup.  (The
+note's § 3 statement strengthens core-freeness to every proper subgroup between
+`Hᵢ` and `G`; that refinement needs the proper-subgroup language and is deferred to
+RP-1 with the proof.)
+
+```agda
+Statement-C : (ℓP : Level) → Type (lsuc 0ℓ ⊔ lsuc ℓP)
+Statement-C ℓP =
+  ∀ (n : ℕ) (𝑳s : Fin (2 + n) → FiniteLattice) (Ps : Fin (2 + n) → GroupProperty ℓP)
+  → TwoBigCanopies 𝑳s
+  → (∀ i → cfIE (Ps i) (toLattice (𝑳s i)))
+  → Σ[ 𝒢 ∈ Group 0ℓ 0ℓ ]
+      ( (∀ i → Ps i 𝒢)
+      × (∀ i → Σ[ H ∈ Pred 𝕌[ proj₁ 𝒢 ] 0ℓ ] Σ[ H-sg ∈ IsSubgroup 𝒢 H ]
+                 ( CoreFree 𝒢 H H-sg
+                 × IntervalIso 𝒢 H H-sg (toLattice (𝑳s i)) )) )
+```
+
+The proof of (B) → (C) rests on the **parachute construction**
+`𝒫(L₁, …, Lₙ)` — a bottom element covered by `n` atoms with `Lᵢ` the interval from
+the `i`-th atom to the shared top — and on the Dedekind-rule argument that a
+core-free representation of a parachute makes every canopy's bottom subgroup
+core-free.  Both are RP-1 material (the construction needs finite-lattice surgery,
+the argument needs Dedekind's rule and the antichain corollary), so they enter as
+the named hypothesis record `ParachuteHypotheses`{.AgdaRecord}, and the meta-theorem
+is stated as a schema conditional on it and on the core-free reduction.
+
+```agda
+record ParachuteHypotheses : Type (lsuc 0ℓ) where
+  field
+    -- The parachute lattice of a finite family of finite lattices.
+    parachute : (n : ℕ) → (Fin (2 + n) → FiniteLattice) → FiniteLattice
+
+    -- Its defining property: a core-free group representation of the
+    -- parachute yields, for each canopy, a representation of that canopy
+    -- over a core-free subgroup of the same group.
+    canopy-intervals :
+      (n : ℕ) (𝑳s : Fin (2 + n) → FiniteLattice)
+      (r : GroupRepresentable (toLattice (parachute n 𝑳s)))
+      → CoreFree  (GroupRepresentable.grp r) (GroupRepresentable.sub r)
+                  (GroupRepresentable.isSubgroup r)
+      → TwoBigCanopies 𝑳s
+      → ∀ i → Σ[ H ∈ Pred 𝕌[ proj₁ (GroupRepresentable.grp r) ] 0ℓ ]
+              Σ[ H-sg ∈ IsSubgroup (GroupRepresentable.grp r) H ]
+                ( CoreFree (GroupRepresentable.grp r) H H-sg
+                × IntervalIso (GroupRepresentable.grp r) H H-sg (toLattice (𝑳s i)) )
+
+-- Theorem thm-wjd-1 of the note, as a statement.
+thm-wjd-1-Statement : (ℓP : Level) → Type (lsuc 0ℓ ⊔ lsuc ℓP)
+thm-wjd-1-Statement ℓP =
+  (GroupFLRP-Statement → Statement-C ℓP) × (Statement-C ℓP → GroupFLRP-Statement)
+
+-- The schema RP-1 will inhabit: the meta-theorem conditional on the
+-- parachute construction and the core-free reduction.
+thm-wjd-1-Schema : (ℓP : Level) → Type (lsuc 0ℓ ⊔ lsuc ℓP)
+thm-wjd-1-Schema ℓP =
+  ParachuteHypotheses → CoreFreeReduction → thm-wjd-1-Statement ℓP
+```
+
+By statement (C), exhibiting finitely many cf-IE classes with empty intersection
+would give the FLRP a negative answer; that hunt is RP-3, over the catalog RP-2
+builds on top of the definitions of this module.
+
+---
+
+[^1]: Sketch: take `𝒦` presented on a two-element carrier `{a , b}` with `a ≈ b`
+      and all operations returning `a` (a one-element group presented redundantly),
+      and `𝒢 = ℤ₂` on a propositional-equality carrier with `H` trivial.  The bare
+      predicate `{(e , a) , (e , b) , (g , a)}` is closed under the product
+      operations and lies between `H ×ᶠ 𝒦` and the full subuniverse, yet is neither
+      `≈`-saturated nor mutually included with a pulled-back subgroup of `𝒢`, so the
+      bare interval `[H ×ᶠ 𝒦 , full]` has three elements while `[H , full]` in
+      `Sub(ℤ₂)` has two.  Requiring `respects`{.AgdaField} removes exactly this
+      presentation junk.

--- a/src/FLRP/Enforceable.lagda.md
+++ b/src/FLRP/Enforceable.lagda.md
@@ -1,4 +1,4 @@
-n---
+---
 layout: default
 file: "src/FLRP/Enforceable.lagda.md"
 title: "FLRP.Enforceable module (The Agda Universal Algebra Library)"
@@ -23,7 +23,7 @@ The note's program is to combine interval-enforceable properties into a
 contradiction, which, by Pálfy–Pudlák, would answer the Finite Lattice Representation
 Problem negatively.
 
-#### Summary of the <span class="AgdaModule">FLRP.Enforceable</span> module
+#### Summary of the `FLRP.Enforceable`{.AgdaModule} module
 
 The module contents, keyed to the note, are as follows:
 
@@ -54,7 +54,7 @@ Two disciplines from the roadmap govern the definitions.
    groups and predicates, and Agda cannot quantify existentially over universe
    levels, so the levels must be pinned; `0ℓ` suffices for every finite (indeed
    every set-sized) instance.  Group *properties* appear only in universally
-   quantified positions, so they keep a polymorphic level `ℓP`.[^2]
+   quantified positions, so they keep a polymorphic level `ℓP`.
 
 <!--
 ```agda
@@ -116,7 +116,7 @@ sub*set* of the carrier, i.e. an `≈`-saturated predicate, and bare subuniverse
 distinguish `≈`-equal elements.  The distinction is not cosmetic — over a carrier
 with a redundant representative the bare interval `[H × K , G × K]` can be strictly
 larger than `[H , G]`, so the fattening isomorphism below is *false* at the bare
-level.[^3]
+level.[^2]
 
 We therefore take as interval elements the bare interval elements
 *paired with a proof that the predicate respects `≈`* — exactly the
@@ -267,7 +267,7 @@ record GroupRepresentable (𝑳 : Lattice) : Type (lsuc 0ℓ) where
 
 A *group property* here is any predicate on groups (at a polymorphic level, per the
 level discipline above; isomorphism-invariance is not required, and none of the
-results below use it).
+results below use it).[^3]
 
 ```agda
 GroupProperty : (ℓP : Level) → Type (lsuc 0ℓ ⊔ lsuc ℓP)

--- a/src/FLRP/Enforceable.lagda.md
+++ b/src/FLRP/Enforceable.lagda.md
@@ -69,7 +69,7 @@ open import Data.Empty                              using  ( ⊥ )
 open import Data.Fin.Base                           using  ( Fin )
 open import Data.Nat.Base renaming ( _≤_ to _≤ⁿ_ )  using  ( ℕ ; _+_ )
 open import Data.Product                            using  ( _,_ ; _×_ ; Σ-syntax
-                                                           ; proj₁ ; proj₂ )
+                                                           ; ∃-syntax ; proj₁ ; proj₂ )
 open import Data.Unit.Base                          using  ( tt )
 open import Level         renaming ( suc to lsuc )  using  ( Level ; 0ℓ ; _⊔_
                                                            ; Lift ; lift )
@@ -92,11 +92,6 @@ open import Setoid.Homomorphisms          using  ( _IsHomImageOf_ )
 open import Setoid.Subalgebras            using  ( Subuniverses )
 open import Order.Interval                        using ( module IntervalLattice )
 -- open import Setoid.Subalgebras.CompleteLattice using (module Sublattice)
-
-
-
-
-
 ```
 -->
 
@@ -201,8 +196,7 @@ Order isomorphisms transport meets and joins, so this is exactly
 "`[H , G] ≅ 𝑳` as lattices" with no redundant clauses.[^4]
 
 ```agda
-IntervalIso : (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
-  → Lattice → Type (lsuc 0ℓ)
+IntervalIso : ∀ 𝒢 H H-sg → Lattice → Type (lsuc 0ℓ)
 IntervalIso 𝒢 H H-sg 𝑳 = OrderIso _≈ᵢ_ _≤ᵢ_ (Setoid._≈_ 𝔻[ proj₁ 𝑳 ]) (Lattice-Order._≤_ 𝑳)
   where open UpperInterval 𝒢 H H-sg
 ```
@@ -280,7 +274,6 @@ GroupProperty ℓP = Pred (Group 0ℓ 0ℓ) ℓP
 ```agda
 IE : {ℓP : Level} → GroupProperty ℓP → Lattice → Type (lsuc 0ℓ ⊔ ℓP)
 IE P 𝑳 = ∀ 𝒢 H H-sg → IntervalIso 𝒢 H H-sg 𝑳 → P 𝒢
--- ^ here (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
 ```
 
 Core-freeness of a subgroup is expressed through the normal core:[^wp-2] the core of
@@ -325,7 +318,6 @@ exact enumerations it is the `|G|`-minimality of the note.  The note has little 
 say about min-IE and neither do we — the definition is recorded because such
 properties arise in the literature (Lucchini's intervals, Pálfy's analysis of Feit's
 examples) and the catalog of RP-2 will want to state them.
-
 
 ```agda
 open FiniteAlgebra using (card)
@@ -559,14 +551,10 @@ enters as the hypothesis record `CoreFreeReduction`{.AgdaRecord}, and Lemma 3.1 
 ```agda
 record CoreFreeReduction : Type (lsuc 0ℓ) where
   field
-    reduce :
-      (𝒢 : Group 0ℓ 0ℓ) (H : Pred 𝕌[ proj₁ 𝒢 ] 0ℓ) (H-sg : IsSubgroup 𝒢 H)
-      → Σ[ 𝒬 ∈ Group 0ℓ 0ℓ ]
-        Σ[ J ∈ Pred 𝕌[ proj₁ 𝒬 ] 0ℓ ]
-        Σ[ J-sg ∈ IsSubgroup 𝒬 J ]
-          ( CoreFree 𝒬 J J-sg
-          × ((𝑳 : Lattice) → IntervalIso 𝒢 H H-sg 𝑳 → IntervalIso 𝒬 J J-sg 𝑳)
-          × ((proj₁ 𝒬) IsHomImageOf (proj₁ 𝒢)) )
+    reduce : ∀ 𝒢 H H-sg → ∃[ 𝒬 ] ∃[ J ] ∃[ J-sg ]
+      ( CoreFree 𝒬 J J-sg
+      × (∀ 𝑳 → IntervalIso 𝒢 H H-sg 𝑳 → IntervalIso 𝒬 J J-sg 𝑳)
+      × (𝒬 .proj₁ IsHomImageOf 𝒢 .proj₁) )
 ```
 
 The lemma's other hypothesis, H-closure of the complementary class: homomorphic
@@ -577,8 +565,7 @@ right notion.)
 
 ```agda
 ComplementHClosed : {ℓP : Level} → GroupProperty ℓP → Type (lsuc 0ℓ ⊔ ℓP)
-ComplementHClosed P =
-  ∀ (𝒢 𝒬 : Group 0ℓ 0ℓ) → (proj₁ 𝒬) IsHomImageOf (proj₁ 𝒢) → ¬ P 𝒢 → ¬ P 𝒬
+ComplementHClosed P = ∀ 𝒢 𝒬  → 𝒬 .proj₁ IsHomImageOf 𝒢 .proj₁ → ¬ P 𝒢 → ¬ P 𝒬
 ```
 
 One constructive gloss.  The note's argument is by contradiction: from a
@@ -591,15 +578,13 @@ third named hypothesis rather than silently classicizing; RP-1 will prove the
 
 ```agda
 PropertyStable : {ℓP : Level} → GroupProperty ℓP → Type (lsuc 0ℓ ⊔ ℓP)
-PropertyStable P = ∀ (𝒢 : Group 0ℓ 0ℓ) → ¬ ¬ P 𝒢 → P 𝒢
+PropertyStable P = ∀ 𝒢 → ¬ ¬ P 𝒢 → P 𝒢
 
 -- Lemma 3.1 (lemma-wjd-2 of the note), as a statement: the type is defined,
 -- no inhabitant is claimed here; the proof is RP-1's first target.
 cfIE→IE-Statement : {ℓP : Level} → GroupProperty ℓP → Type (lsuc 0ℓ ⊔ ℓP)
 cfIE→IE-Statement P =
-    CoreFreeReduction
-  → ComplementHClosed P
-  → PropertyStable P
+  CoreFreeReduction → ComplementHClosed P → PropertyStable P
   → (𝑳 : Lattice) → cfIE P 𝑳 → IE P 𝑳
 ```
 
@@ -621,15 +606,13 @@ elements exist), and *at least two members* of the family do.
 
 ```agda
 HasThreeDistinct : Lattice → Type 0ℓ
-HasThreeDistinct 𝑳 =
-  Σ[ x ∈ 𝕌[ proj₁ 𝑳 ] ] Σ[ y ∈ 𝕌[ proj₁ 𝑳 ] ] Σ[ z ∈ 𝕌[ proj₁ 𝑳 ] ]
-    ( (¬ (x ≈ y)) × (¬ (x ≈ z)) × (¬ (y ≈ z)) )
-  where open Setoid 𝔻[ proj₁ 𝑳 ] using ( _≈_ )
+HasThreeDistinct (L , _) = let open Setoid 𝔻[ L ] in
+  ∃[ x ] ∃[ y ] ∃[ z ] ( ¬ (x ≈ y) × ¬ (x ≈ z) × ¬ (y ≈ z) )
 
 TwoBigCanopies : {m : ℕ} → (Fin m → FiniteLattice) → Type 0ℓ
 TwoBigCanopies {m} 𝑳s =
   Σ[ i ∈ Fin m ] Σ[ j ∈ Fin m ]
-    ( (¬ (i ≡ j))
+    ( ¬ (i ≡ j)
     × HasThreeDistinct (toLattice (𝑳s i))
     × HasThreeDistinct (toLattice (𝑳s j)) )
 ```
@@ -647,11 +630,10 @@ Statement-C ℓP =
   ∀ (n : ℕ) (𝑳s : Fin (2 + n) → FiniteLattice) (Ps : Fin (2 + n) → GroupProperty ℓP)
   → TwoBigCanopies 𝑳s
   → (∀ i → cfIE (Ps i) (toLattice (𝑳s i)))
-  → Σ[ 𝒢 ∈ Group 0ℓ 0ℓ ]
-      ( (∀ i → Ps i 𝒢)
-      × (∀ i → Σ[ H ∈ Pred 𝕌[ proj₁ 𝒢 ] 0ℓ ] Σ[ H-sg ∈ IsSubgroup 𝒢 H ]
-                 ( CoreFree 𝒢 H H-sg
-                 × IntervalIso 𝒢 H H-sg (toLattice (𝑳s i)) )) )
+  → ∃[ 𝒢 ] ( (∀ i → Ps i 𝒢)
+              × ( ∀ i →  ∃[ H ] ∃[ H-sg ]
+                         ( CoreFree 𝒢 H H-sg × IntervalIso 𝒢 H H-sg (toLattice (𝑳s i)) ))
+            )
 ```
 
 The proof of (B) → (C) rests on the **parachute construction**
@@ -664,6 +646,8 @@ the named hypothesis record `ParachuteHypotheses`{.AgdaRecord}, and the meta-the
 is stated as a schema conditional on it and on the core-free reduction.
 
 ```agda
+open GroupRepresentable
+
 record ParachuteHypotheses : Type (lsuc 0ℓ) where
   field
     -- The parachute lattice of a finite family of finite lattices.
@@ -675,13 +659,11 @@ record ParachuteHypotheses : Type (lsuc 0ℓ) where
     canopy-intervals :
       (n : ℕ) (𝑳s : Fin (2 + n) → FiniteLattice)
       (r : GroupRepresentable (toLattice (parachute n 𝑳s)))
-      → CoreFree  (GroupRepresentable.grp r) (GroupRepresentable.sub r)
-                  (GroupRepresentable.isSubgroup r)
+      → CoreFree (r .grp) (r .sub) (r .isSubgroup)
       → TwoBigCanopies 𝑳s
-      → ∀ i → Σ[ H ∈ Pred 𝕌[ proj₁ (GroupRepresentable.grp r) ] 0ℓ ]
-              Σ[ H-sg ∈ IsSubgroup (GroupRepresentable.grp r) H ]
-                ( CoreFree (GroupRepresentable.grp r) H H-sg
-                × IntervalIso (GroupRepresentable.grp r) H H-sg (toLattice (𝑳s i)) )
+      → ∀ i → ∃[ H ]    -- ∈ Pred 𝕌[ proj₁ (r .grp) ] 0ℓ
+              ∃[ H-sg ] -- ∈ IsSubgroup (r .grp) H
+                ( CoreFree (r .grp) H H-sg × IntervalIso (r .grp) H H-sg (toLattice (𝑳s i)) )
 
 -- Theorem thm-wjd-1 of the note, as a statement.
 thm-wjd-1-Statement : (ℓP : Level) → Type (lsuc 0ℓ ⊔ lsuc ℓP)
@@ -691,8 +673,7 @@ thm-wjd-1-Statement ℓP =
 -- The schema RP-1 will inhabit: the meta-theorem conditional on the
 -- parachute construction and the core-free reduction.
 thm-wjd-1-Schema : (ℓP : Level) → Type (lsuc 0ℓ ⊔ lsuc ℓP)
-thm-wjd-1-Schema ℓP =
-  ParachuteHypotheses → CoreFreeReduction → thm-wjd-1-Statement ℓP
+thm-wjd-1-Schema ℓP = ParachuteHypotheses → CoreFreeReduction → thm-wjd-1-Statement ℓP
 ```
 
 By statement (C), exhibiting finitely many cf-IE classes with empty intersection


### PR DESCRIPTION
## Summary

Implements WP-4, the enforceability framework of the vendored note's §§ 2–3 (`docs/papers/flrp/ieprops/`): `GroupRepresentable`, `GroupProperty`, `IE`, `cfIE` (core-freeness via WP-2's `Core`), and `minIE`, with explicit witness tracking per the vacuity discipline of ADR-008/roadmap § 4; binary direct products of groups as reusable `Classical/` infrastructure (`_×ᵍ_`, level-general, with a term-induction lemma discharging all group laws uniformly); the **fattening lemma** in both coordinates (`[H ×ᶠ 𝑲, ⊤] ≅ [H, ⊤]` as interval isomorphisms); and the machine-checked **Lemma 3.2** (`no-contradictory-IE`): no group property and its negation are both IE via group-representable lattices — the note's two-line product argument, formalized.  Lemma 3.1 and the parachute meta-theorem are stated with named hypotheses (proofs deferred to RP-1, #458).

## Related issues

Part of #455 and #451.  Deliberately **not** marked closing: the issue's task list includes Lemma 3.1 *proved*, and this PR delivers it conditionally (`cfIE→IE-Statement`, hypothesis-parameterized on `CoreFreeReduction` — the quotient-group iso `[H, G] ≅ [H/N, G/N]` — plus `ComplementHClosed` and `PropertyStable`), since quotient groups are not yet built and belong to RP-1's scope.  Reviewer's call whether to close #455 with the 3.1 discharge re-homed to #458, or leave it open on that one checkbox.

## Type of change

- [ ] Bug fix
- [x] New definition, theorem, or feature
- [ ] Refactor / cleanup (user-facing/API change)
- [ ] Refactor / cleanup (no user-facing change)
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop` (clean-slate protocol: affected `.agdai` deleted first, every new module visibly re-elaborated under the CI heap cap `+RTS -M6G -A128M`; `Enforceable` peaks at ~420 MB).
- [x] New public definitions have prose comment blocks.
- [x] Commits are coherent (products+fattening toolkit; the enforceability module) with explanatory messages referencing the note's lemma labels.
- [x] If this PR touches `src/`, it targets supported areas (`Classical/`, `FLRP/`); four files, purely additive, no overlap with the open #468.
- [x] If this PR introduces new notation, it doesn't conflict (`_×ᵍ_`, `_×ᶠ_`/`_ᶠ×_`, `IntervalIso`).

## Notes for reviewers

+  **A mathematical finding worth reading first**: the fattening isomorphism is *false* for intervals of bare subuniverses over general setoids — a concrete counterexample (redundant-representative carrier: the bare interval has three elements where the true one has two) is recorded as a footnote — so interval elements here carry a `Respects _≈_` proof (`Interval≈`).  Over `≡`-setoid groups (all Cayley-table groups) `respects` is free via `subst`, so nothing is lost; but WP-3 must make the same choice for its `Con (G ↷ G/H) ≅ [H, G]` interval side, and the module argues it must be the respecting one.
+  **Lemma 3.2's constructive content**: the proof never uses iso-invariance of the property `P` (the prose records this); the two `GroupRepresentable` hypotheses are exactly the witness-tracking that keeps the theorem non-vacuous.
+  **Lemma 3.1's constructive gap is now named**: beyond the quotient iso, the note's classical contradiction argument needs `¬¬`-stability of the property (`PropertyStable`).  Open question for RP-1: keep that packaging, or make the `¬¬`-conclusion variant primary.
+  **Elaboration idioms** (commented in-file): `fatten-IntervalIso` takes the lattice explicitly (uninferable through `Lattice-Order._≤_`), and `from-mono` passes its pair-typed element explicitly (second component otherwise an unconstrained meta).
+  **Open questions**: promote `UpperInterval`/`IntervalIso`/`OrderIso` to `Order/` now or when WP-3 lands; `minIE` is certified-cardinality minimality (via `FiniteAlgebra.card`, an upper bound under surjective enumeration) — acceptable, or should bijective cardinality land first; the mirrored fattening is proved directly rather than by a product-symmetry transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FjuJn2gfQEHExPzGef34J

---
_Generated by [Claude Code](https://claude.ai/code/session_014FjuJn2gfQEHExPzGef34J)_