### PR TITLE
Move Overture import inside module body post-signature-sweep (M4-19)

### DIFF
--- a/src/Setoid/Algebras.lagda.md
+++ b/src/Setoid/Algebras.lagda.md
@@ -11,8 +11,6 @@ author: "agda-algebras development team"
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Algebras where
 
 open import Setoid.Algebras.Basic public

--- a/src/Setoid/Algebras/Basic.lagda.md
+++ b/src/Setoid/Algebras/Basic.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Algebras.Basic][] module of the [Agda Universal Algebra Libr
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Algebras.Basic where
 
 -- Imports from the Agda and the Agda Standard Library --------------------
@@ -27,7 +25,7 @@ open import Relation.Binary  using ( Setoid )
 open import Relation.Binary.PropositionalEquality as ≡ using ( _≡_ ; refl )
 
 -- Imports from the Agda Universal Algebra Library ----------------------
-open import Overture             using ( OperationSymbolsOf ; ArityOf )
+open import Overture             using ( OperationSymbolsOf ; ArityOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Operations  using ( Op )
 open import Setoid.Signatures    using ( ⟨_⟩ )
 

--- a/src/Setoid/Algebras/Products.lagda.md
+++ b/src/Setoid/Algebras/Products.lagda.md
@@ -14,8 +14,6 @@ This is the [Setoid.Algebras.Products][] module of the [Agda Universal Algebra L
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Algebras.Products where
 
 -- Imports from Agda and the Agda Standard Library --------------------------------
@@ -33,7 +31,7 @@ open IsEquivalence  using () renaming ( refl to reflE ; sym to symE ; trans to t
 
 
 -- Imports from agda-algebras -----------------------------------------------------
-open import Overture  using ( proj₁; proj ; projIsOnto )
+open import Overture  using ( proj₁; proj ; projIsOnto ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
                       renaming ( IsSurjective to onto )
 
 open import Setoid.Algebras.Basic  using ( Algebra ; _^_ ; ov ; 𝔻[_] ; 𝕌[_])

--- a/src/Setoid/Algebras/Products.lagda.md
+++ b/src/Setoid/Algebras/Products.lagda.md
@@ -18,7 +18,7 @@ module Setoid.Algebras.Products where
 
 -- Imports from Agda and the Agda Standard Library --------------------------------
 open import Agda.Primitive    using () renaming ( Set to Type )
-open import Data.Product      using ( _,_ ; Σ-syntax )
+open import Data.Product      using ( _,_ ; Σ-syntax ; proj₁ )
 open import Function          using ( flip ; Func )
 open import Level             using( _⊔_ ; Level )
 open import Relation.Binary   using ( Setoid ;  IsEquivalence ; Decidable )
@@ -31,8 +31,8 @@ open IsEquivalence  using () renaming ( refl to reflE ; sym to symE ; trans to t
 
 
 -- Imports from agda-algebras -----------------------------------------------------
-open import Overture  using ( proj₁; proj ; projIsOnto ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-                      renaming ( IsSurjective to onto )
+open import Overture               using ( proj ; projIsOnto ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+                                   renaming ( IsSurjective to onto )
 
 open import Setoid.Algebras.Basic  using ( Algebra ; _^_ ; ov ; 𝔻[_] ; 𝕌[_])
 

--- a/src/Setoid/Categories/Algebra.lagda.md
+++ b/src/Setoid/Categories/Algebra.lagda.md
@@ -27,8 +27,6 @@ definitionally equal — `⊙-hom` is function composition, `𝒾𝒹` the ident
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Categories.Algebra where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -40,6 +38,7 @@ open import Level            using ( Level ; _⊔_ ) renaming ( suc to lsuc )
 open import Relation.Binary  using ( Setoid ; IsEquivalence )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic    using ( Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Homomorphisms.Basic       using ( hom ; 𝒾𝒹 )
 open import Setoid.Homomorphisms.Properties  using ( ⊙-hom )

--- a/src/Setoid/Categories/Algebra.lagda.md
+++ b/src/Setoid/Categories/Algebra.lagda.md
@@ -38,8 +38,8 @@ open import Level            using ( Level ; _⊔_ ) renaming ( suc to lsuc )
 open import Relation.Binary  using ( Setoid ; IsEquivalence )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic    using ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Overture                         using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic            using ( Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Homomorphisms.Basic       using ( hom ; 𝒾𝒹 )
 open import Setoid.Homomorphisms.Properties  using ( ⊙-hom )
 open import Setoid.Categories.Category       using ( Category )

--- a/src/Setoid/Congruences.lagda.md
+++ b/src/Setoid/Congruences.lagda.md
@@ -11,8 +11,6 @@ author: "agda-algebras development team"
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Congruences where
 
 open import Setoid.Congruences.Basic                    public

--- a/src/Setoid/Congruences/CompleteLattice.lagda.md
+++ b/src/Setoid/Congruences/CompleteLattice.lagda.md
@@ -38,8 +38,6 @@ complete with respect to `ℓ₀`-small families — the usual predicative readi
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Congruences.CompleteLattice where
 
 -- Imports from the Agda Standard Library ---------------------------------------
@@ -53,6 +51,7 @@ open import Relation.Binary.Lattice      using ( Supremum ; IsLattice
                                                ; BoundedLattice )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic  using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Order.CompleteLattice                using  ( CompleteLattice )
 open import Setoid.Congruences.Basic             using  ( Con ; mkcon ; _∣≈_ ; reflexive ; 𝟘[_]

--- a/src/Setoid/Congruences/Finite.lagda.md
+++ b/src/Setoid/Congruences/Finite.lagda.md
@@ -19,8 +19,6 @@ a finite list of `DecCon`{.AgdaFunction}s that is complete — every
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Congruences.Finite where
 
 open import Setoid.Congruences.Finite.Basic public

--- a/src/Setoid/Congruences/Finite/Basic.lagda.md
+++ b/src/Setoid/Congruences/Finite/Basic.lagda.md
@@ -57,8 +57,6 @@ from a `FiniteCongruences`{.AgdaRecord} witness.
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Congruences.Finite.Basic where
 
 open import Agda.Primitive  using  () renaming ( Set to Type )
@@ -79,6 +77,7 @@ open import Relation.Binary.PropositionalEquality  using  ( refl )
 open import Relation.Nullary                       using  ( Dec ; yes ; no )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic  using ( Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Algebras.Finite         using ( 𝟏 )
 open import Setoid.Congruences.Basic       using ( Con ; mkcon ; reflexive ; 𝟘[_] )

--- a/src/Setoid/Congruences/Finite/Basic.lagda.md
+++ b/src/Setoid/Congruences/Finite/Basic.lagda.md
@@ -59,7 +59,7 @@ from a `FiniteCongruences`{.AgdaRecord} witness.
 
 module Setoid.Congruences.Finite.Basic where
 
-open import Agda.Primitive  using  () renaming ( Set to Type )
+open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ----------------------------------------------
 open import Data.List.Base                         using  ( List ; [] ; _∷_ )
@@ -77,8 +77,8 @@ open import Relation.Binary.PropositionalEquality  using  ( refl )
 open import Relation.Nullary                       using  ( Dec ; yes ; no )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic  using ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Overture                       using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic          using ( Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Algebras.Finite         using ( 𝟏 )
 open import Setoid.Congruences.Basic       using ( Con ; mkcon ; reflexive ; 𝟘[_] )
 open import Setoid.Congruences.Lattice     using ( _≑_ )

--- a/src/Setoid/Congruences/Finite/Decidable.lagda.md
+++ b/src/Setoid/Congruences/Finite/Decidable.lagda.md
@@ -82,8 +82,6 @@ of L2 on the matrix-derived list rather than transport its theorem.[^4]
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Congruences.Finite.Decidable where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -119,6 +117,7 @@ open import Relation.Binary.PropositionalEquality          using  ( cong ; refl 
 open import Relation.Nullary.Decidable                     using  ( Dec ; does ; T? )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Algebras.Finite                    using  ( FiniteAlgebra )
 open import Setoid.Congruences.Basic                  using  ( Con )

--- a/src/Setoid/Congruences/Finite/Decidable.lagda.md
+++ b/src/Setoid/Congruences/Finite/Decidable.lagda.md
@@ -117,13 +117,13 @@ open import Relation.Binary.PropositionalEquality          using  ( cong ; refl 
 open import Relation.Nullary.Decidable                     using  ( Dec ; does ; T? )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Overture                                  using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic                     using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Algebras.Finite                    using  ( FiniteAlgebra )
 open import Setoid.Congruences.Basic                  using  ( Con )
-open import Setoid.Congruences.Finite.Basic  using  ( DecCon ; ConRel )
+open import Setoid.Congruences.Finite.Basic           using  ( DecCon ; ConRel )
 open import Setoid.Congruences.Generation             using  ( Cg ; Gen ; base ; Cg-least )
-open import Setoid.Congruences.Lattice  using  ( _≑_ )
+open import Setoid.Congruences.Lattice                using  ( _≑_ )
 open import Setoid.Congruences.Presented              using  ( fromPairs ; con-resp-≈
                                                              ; Cg-DecCon ; does-in ; does-out )
 open import Setoid.Signatures.Finite                  using  ( FiniteSignature )

--- a/src/Setoid/Congruences/Lattice.lagda.md
+++ b/src/Setoid/Congruences/Lattice.lagda.md
@@ -21,8 +21,6 @@ partially ordered set which, with the meet operation, forms a semilattice.
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Congruences.Lattice where
 
 -- Imports from the Agda Standard Library ---------------------------------------
@@ -36,6 +34,7 @@ open import Relation.Binary.Bundles  using ( Poset )
 open import Relation.Binary.Lattice  using ( Infimum ; IsMeetSemilattice ; MeetSemilattice )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic  using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Congruences.Basic           using  ( Con ; mkcon ; _∣≈_ ; reflexive
                                                       ; is-equivalence ; is-compatible

--- a/src/Setoid/Congruences/Lattice.lagda.md
+++ b/src/Setoid/Congruences/Lattice.lagda.md
@@ -34,11 +34,11 @@ open import Relation.Binary.Bundles  using ( Poset )
 open import Relation.Binary.Lattice  using ( Infimum ; IsMeetSemilattice ; MeetSemilattice )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic  using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Congruences.Basic           using  ( Con ; mkcon ; _∣≈_ ; reflexive
-                                                      ; is-equivalence ; is-compatible
-                                                      ; 𝟘[_] ; 𝟙[_] )
+open import Overture                  using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic     using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Congruences.Basic  using  ( Con ; mkcon ; _∣≈_ ; reflexive
+                                             ; is-equivalence ; is-compatible
+                                             ; 𝟘[_] ; 𝟙[_] )
 private variable α ρ ℓ : Level
 ```
 -->

--- a/src/Setoid/Congruences/Monolith.lagda.md
+++ b/src/Setoid/Congruences/Monolith.lagda.md
@@ -29,8 +29,6 @@ Birkhoff's subdirect representation theorem — is built on top of this in
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Congruences.Monolith where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
@@ -41,6 +39,7 @@ open import Relation.Binary   using ( Setoid ; IsEquivalence ; _⇒_ )
 open import Relation.Nullary  using ( ¬_ )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic  using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Congruences.Basic             using  ( Con ; mkcon ; _∣≈_ ; reflexive
                                                         ; is-equivalence ; is-compatible )

--- a/src/Setoid/Congruences/Monolith.lagda.md
+++ b/src/Setoid/Congruences/Monolith.lagda.md
@@ -39,10 +39,10 @@ open import Relation.Binary   using ( Setoid ; IsEquivalence ; _⇒_ )
 open import Relation.Nullary  using ( ¬_ )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic  using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Congruences.Basic             using  ( Con ; mkcon ; _∣≈_ ; reflexive
-                                                        ; is-equivalence ; is-compatible )
+open import Overture                    using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic       using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Congruences.Basic    using  ( Con ; mkcon ; _∣≈_ ; reflexive
+                                               ; is-equivalence ; is-compatible )
 open import Setoid.Congruences.Lattice  using  ( _⊆_ ; _≑_ ; _∧_ )
 
 private variable α ρ ℓ : Level

--- a/src/Setoid/Congruences/Permutability.lagda.md
+++ b/src/Setoid/Congruences/Permutability.lagda.md
@@ -43,9 +43,9 @@ open import Relation.Binary  using ( Setoid ; IsEquivalence )
                              renaming ( Rel to BinaryRel ; _⇒_ to _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic  using ( ov ; Algebra ; 𝕌[_] )
-open import Setoid.Congruences.Basic           using ( Con ; is-equivalence )
+open import Overture                  using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic     using ( ov ; Algebra ; 𝕌[_] )
+open import Setoid.Congruences.Basic  using ( Con ; is-equivalence )
 
 private variable α ρ ℓ : Level
 ```

--- a/src/Setoid/Congruences/Permutability.lagda.md
+++ b/src/Setoid/Congruences/Permutability.lagda.md
@@ -33,8 +33,6 @@ This module is pure congruence theory: it depends only on the congruence record 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Congruences.Permutability where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
@@ -45,6 +43,7 @@ open import Relation.Binary  using ( Setoid ; IsEquivalence )
                              renaming ( Rel to BinaryRel ; _⇒_ to _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic  using ( ov ; Algebra ; 𝕌[_] )
 open import Setoid.Congruences.Basic           using ( Con ; is-equivalence )
 

--- a/src/Setoid/Congruences/Properties.lagda.md
+++ b/src/Setoid/Congruences/Properties.lagda.md
@@ -32,11 +32,11 @@ open import Agda.Primitive  using () renaming ( Set to Type )
 open import Level           using ( Level ; _⊔_ ) renaming (suc to lsuc)
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic  using ( Algebra )
-open import Setoid.Congruences.Basic                using ( Con )
-open import Setoid.Congruences.Lattice  using ( _⊆_ ; _≑_ ; _∧_ )
-open import Setoid.Congruences.Generation           using ( _∨_ )
+open import Overture                       using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic          using ( Algebra )
+open import Setoid.Congruences.Basic       using ( Con )
+open import Setoid.Congruences.Lattice     using ( _⊆_ ; _≑_ ; _∧_ )
+open import Setoid.Congruences.Generation  using ( _∨_ )
 ```
 -->
 

--- a/src/Setoid/Congruences/Properties.lagda.md
+++ b/src/Setoid/Congruences/Properties.lagda.md
@@ -25,8 +25,6 @@ the meet `_∧_`, so both are operations on `Con 𝑨 (𝐋 ℓ₀)` and the equ
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Congruences.Properties where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
@@ -34,6 +32,7 @@ open import Agda.Primitive  using () renaming ( Set to Type )
 open import Level           using ( Level ; _⊔_ ) renaming (suc to lsuc)
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic  using ( Algebra )
 open import Setoid.Congruences.Basic                using ( Con )
 open import Setoid.Congruences.Lattice  using ( _⊆_ ; _≑_ ; _∧_ )

--- a/src/Setoid/Homomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms.lagda.md
@@ -12,8 +12,6 @@ This is the [Setoid.Homomorphisms][] module of the [Agda Universal Algebra Libra
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Homomorphisms where
 
 open import Setoid.Homomorphisms.Basic                       public

--- a/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
+++ b/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Homomorphisms.HomomorphicImages][] module of the [Agda Unive
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Homomorphisms.HomomorphicImages where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -31,7 +29,7 @@ open import Relation.Binary.PropositionalEquality using (refl)
 
 -- Imports from the Agda Universal Algebra Library ---------------------------------------------
 open import Overture                                    using  ( proj₁ ; proj₂
-                                                               ; ArityOf )
+                                                               ; ArityOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras  using  ( Algebra ; ov ; _^_ ; 𝔻[_]
                                                                ; Lift-Algˡ ; Lift-Alg ; 𝕌[_] )
 open import Setoid.Functions using (IsSurjective; Image_∋_ ; Ran ; range ; preimage ; image ; preimage≈image; Inv ; lift∼lower; InvIsInverseʳ; ⊙-IsSurjective)

--- a/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Homomorphisms.Factor][] module of the [Agda Universal Algebr
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Homomorphisms.Isomorphisms where
 
 -- Imports from Agda (builtin/primitive) and the Agda Standard Library ---------------------
@@ -29,7 +27,7 @@ open import Relation.Binary             using ( Setoid ; Reflexive ; Sym ; Trans
 open import Relation.Binary.PropositionalEquality using (refl)
 
 -- Imports from the Agda Universal Algebra Library -----------------------------------------
-open import Overture                         using  ( OperationSymbolsOf ; ArityOf )
+open import Overture                         using  ( OperationSymbolsOf ; ArityOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Operations              using  ( Op )
 open import Setoid.Functions                 using  ( eq ; IsInjective
                                                     ; IsSurjective ; SurjInv

--- a/src/Setoid/Homomorphisms/Properties.lagda.md
+++ b/src/Setoid/Homomorphisms/Properties.lagda.md
@@ -24,7 +24,7 @@ open import Relation.Binary                        using ( Setoid )
 open import Relation.Binary.PropositionalEquality  using ( refl)
 
 -- Imports from the Agda Universal Algebra Library ------------------------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature )
+open import Overture                       using  ( 𝓞 ; 𝓥 ; Signature )
 open import Setoid.Algebras                using  ( Algebra ; _^_; Lift-Algˡ ; Lift-Algʳ
                                                   ; Lift-Alg; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Congruences.Generation  using  ( Gen ; Cg-least )

--- a/src/Setoid/Homomorphisms/Properties.lagda.md
+++ b/src/Setoid/Homomorphisms/Properties.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Homomorphisms.Properties][] module of the [Agda Universal Al
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature)
-
 module Setoid.Homomorphisms.Properties  where
 
 -- Imports from Agda and the Agda Standard Library ------------------------------------------
@@ -26,6 +24,7 @@ open import Relation.Binary                        using ( Setoid )
 open import Relation.Binary.PropositionalEquality  using ( refl)
 
 -- Imports from the Agda Universal Algebra Library ------------------------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature )
 open import Setoid.Algebras                using  ( Algebra ; _^_; Lift-Algˡ ; Lift-Algʳ
                                                   ; Lift-Alg; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Congruences.Generation  using  ( Gen ; Cg-least )

--- a/src/Setoid/Subalgebras.lagda.md
+++ b/src/Setoid/Subalgebras.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Subalgebras][] module of the [Agda Universal Algebra Library
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Subalgebras where
 
 open import Setoid.Subalgebras.Basic public

--- a/src/Setoid/Subalgebras/Basic.lagda.md
+++ b/src/Setoid/Subalgebras/Basic.lagda.md
@@ -14,8 +14,6 @@ This is the [Setoid.Subalgebras.Basic][] module of the [Agda Universal Algebra L
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Subalgebras.Basic where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -27,7 +25,7 @@ open import Relation.Binary                using ( REL )
 open import Relation.Unary                 using ( Pred ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------------------
-open import Overture                       using ( proj₁ ; proj₂ )
+open import Overture                       using ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Functions               using ( IsInjective )
 
 open import Setoid.Algebras  using ( Algebra ; ov )

--- a/src/Setoid/Subalgebras/CompleteLattice.lagda.md
+++ b/src/Setoid/Subalgebras/CompleteLattice.lagda.md
@@ -31,8 +31,6 @@ a predicate on the carrier and does not mention the setoid equality.)
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Subalgebras.CompleteLattice where
 
 open import Agda.Primitive               using () renaming ( Set to Type )
@@ -51,6 +49,7 @@ open import Relation.Binary.Lattice      using  ( Supremum ; Infimum ; IsLattice
 open import Relation.Unary               using  ( Pred ; _∈_ ; _⊆_ ; _∩_ ; _∪_ ; ⋂ ; ⋃ )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic             using  ( ov ; Algebra ; 𝕌[_] )
 open import Order.CompleteLattice  using  ( CompleteLattice )
 open import Setoid.Subalgebras.Subuniverses

--- a/src/Setoid/Subalgebras/CompleteLattice.lagda.md
+++ b/src/Setoid/Subalgebras/CompleteLattice.lagda.md
@@ -49,11 +49,11 @@ open import Relation.Binary.Lattice      using  ( Supremum ; Infimum ; IsLattice
 open import Relation.Unary               using  ( Pred ; _∈_ ; _⊆_ ; _∩_ ; _∪_ ; ⋂ ; ⋃ )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic             using  ( ov ; Algebra ; 𝕌[_] )
-open import Order.CompleteLattice  using  ( CompleteLattice )
-open import Setoid.Subalgebras.Subuniverses
-  using ( Subuniverses ; Sg ; var ; sgIsSub ; sgIsSmallest ; ⋂s )
+open import Overture                         using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic            using  ( ov ; Algebra ; 𝕌[_] )
+open import Order.CompleteLattice            using  ( CompleteLattice )
+open import Setoid.Subalgebras.Subuniverses  using  ( Subuniverses ; Sg ; var
+                                                    ; sgIsSub ; sgIsSmallest ; ⋂s )
 
 private variable α ρᵃ : Level
 ```

--- a/src/Setoid/Subalgebras/Properties.lagda.md
+++ b/src/Setoid/Subalgebras/Properties.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Subalgebras.Properties][] module of the [Agda Universal Alge
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Subalgebras.Properties where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -30,7 +28,7 @@ import Relation.Binary.Structures as RelStructs
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library ----------------------------------
-open import Overture                          using  ( proj₁ ; proj₂ )
+open import Overture                          using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Functions                  using  ( id-is-injective ; IsInjective ; ⊙-injective )
 open import Setoid.Algebras  using  ( Algebra ; Lift-Algˡ ; Lift-Algʳ
                                                      ; Lift-Alg ; ov ; ⨅ ; 𝔻[_] )

--- a/src/Setoid/Subalgebras/Subdirect.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Subalgebras.Subdirect][] module of the [Agda Universal Algeb
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Subalgebras.Subdirect where
 
 open import Setoid.Subalgebras.Subdirect.Basic public

--- a/src/Setoid/Subalgebras/Subdirect/Basic.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Basic.lagda.md
@@ -22,8 +22,6 @@ algebras.
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Subalgebras.Subdirect.Basic where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
@@ -35,6 +33,7 @@ open import Relation.Binary  using ( Setoid )
 open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Functions                         using  ( IsInjective ; IsSurjective )
 
 open import Setoid.Algebras  using  ( Algebra ; ⨅ ; 𝔻[_] )

--- a/src/Setoid/Subalgebras/Subdirect/Basic.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Basic.lagda.md
@@ -24,23 +24,24 @@ algebras.
 
 module Setoid.Subalgebras.Subdirect.Basic where
 
--- Imports from Agda and the Agda Standard Library ----------------------------
-open import Agda.Primitive   using () renaming ( Set to Type )
-open import Data.Product     using ( _,_ ; Σ-syntax ; proj₁ ; proj₂ )
-open import Function         using ( id )
-open import Level            using ( Level ; _⊔_ )
-open import Relation.Binary  using ( Setoid )
-open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl )
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -------------------------------------
+open import Data.Product                           using  ( _,_ ; Σ-syntax
+                                                          ; proj₁ ; proj₂ )
+open import Function                               using  ( id )
+open import Level                                  using  ( Level ; _⊔_ )
+open import Relation.Binary                        using  ( Setoid )
+open import Relation.Binary.PropositionalEquality  using  ( _≡_ ; refl )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Functions                         using  ( IsInjective ; IsSurjective )
+open import Overture                  using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras           using  ( Algebra ; ⨅ ; 𝔻[_] )
+open import Setoid.Congruences        using  ( Con ; _╱_ )
+open import Setoid.Functions          using  ( IsInjective ; IsSurjective )
 
-open import Setoid.Algebras  using  ( Algebra ; ⨅ ; 𝔻[_] )
-open import Setoid.Congruences  using  ( Con ; _╱_ )
-open import Setoid.Homomorphisms  using  ( hom ; IsEpi
-                                                            ; 𝒾𝒹 ; ⊙-hom ; ⨅-hom-co
-                                                            ; πhom ; πepi ; ⨅-proj )
+open import Setoid.Homomorphisms      using  ( hom ; IsEpi ; 𝒾𝒹 ; ⊙-hom ; ⨅-hom-co
+                                             ; πhom ; πepi ; ⨅-proj )
 open import Setoid.Subalgebras.Basic  using  ( _≤_ )
 
 

--- a/src/Setoid/Subalgebras/Subdirect/BirkhoffSI.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/BirkhoffSI.lagda.md
@@ -37,8 +37,6 @@ proved *relative to* a precisely-stated assumption and nothing is postulated.[^1
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Subalgebras.Subdirect.BirkhoffSI where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -48,6 +46,7 @@ open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax )
 open import Level            using ( Level ; _⊔_ )  renaming ( suc to lsuc )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras  using  ( Algebra )
 open import Setoid.Congruences  using  ( Con ; _╱_ )
 open import Setoid.Congruences.Monolith using ( IsSubdirectlyIrreducible )

--- a/src/Setoid/Subalgebras/Subdirect/BirkhoffSI.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/BirkhoffSI.lagda.md
@@ -42,16 +42,16 @@ module Setoid.Subalgebras.Subdirect.BirkhoffSI where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
-open import Data.Product     using ( _×_ ; _,_ ; Σ-syntax )
-open import Level            using ( Level ; _⊔_ )  renaming ( suc to lsuc )
+open import Data.Product  using ( _×_ ; _,_ ; Σ-syntax )
+open import Level         using ( Level ; _⊔_ ) renaming ( suc to lsuc )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras  using  ( Algebra )
-open import Setoid.Congruences  using  ( Con ; _╱_ )
-open import Setoid.Congruences.Monolith using ( IsSubdirectlyIrreducible )
-open import Setoid.Subalgebras.Subdirect.Basic
-  using ( SubdirectEmbedding ; Separates ; separating→SubdirectEmbedding )
+open import Overture                            using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras                     using  ( Algebra )
+open import Setoid.Congruences                  using  ( Con ; _╱_ )
+open import Setoid.Congruences.Monolith         using  ( IsSubdirectlyIrreducible )
+open import Setoid.Subalgebras.Subdirect.Basic  using  ( SubdirectEmbedding ; Separates
+                                                       ; separating→SubdirectEmbedding )
 
 private variable α ρ ℓ ι : Level
 ```

--- a/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
@@ -55,8 +55,6 @@ the search go through under `--safe` Agda.
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Subalgebras.Subdirect.Finite where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
@@ -86,6 +84,7 @@ open import Data.List.Membership.Propositional.Properties
   using ( ∈-filter⁺ ; ∈-filter⁻ ; ∈-cartesianProduct⁺ ; ∈-allFin )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras.Basic  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Algebras.Finite                using  ( FiniteAlgebra ; 𝟏
                                                          ; 𝟏-FiniteAlgebra )

--- a/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Finite.lagda.md
@@ -84,24 +84,23 @@ open import Data.List.Membership.Propositional.Properties
   using ( ∈-filter⁺ ; ∈-filter⁻ ; ∈-cartesianProduct⁺ ; ∈-allFin )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras.Basic  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Algebras.Finite                using  ( FiniteAlgebra ; 𝟏
-                                                         ; 𝟏-FiniteAlgebra )
-open import Setoid.Congruences.Basic              using  ( Con ; mkcon ; is-equivalence ; _╱_
-                                                         ; reflexive ; is-compatible ; 𝟘[_] )
-open import Setoid.Congruences.Finite             using  ( ConRel ; 𝟏-FiniteCongruences
-                                                         ; FiniteCongruences ; DecCon )
+open import Overture                       using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras.Basic          using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite         using  ( FiniteAlgebra ; 𝟏
+                                                  ; 𝟏-FiniteAlgebra )
+open import Setoid.Congruences.Basic       using  ( Con ; mkcon ; is-equivalence ; _╱_
+                                                  ; reflexive ; is-compatible ; 𝟘[_] )
+open import Setoid.Congruences.Finite      using  ( ConRel ; 𝟏-FiniteCongruences
+                                                  ; FiniteCongruences ; DecCon )
+open import Setoid.Congruences.Generation  using  ( Cg ; Cg-least ; base )
+open import Setoid.Congruences.Lattice     using  ( _⊆_ ; ⊆-trans )
+open import Setoid.Congruences.Monolith    using  ( IsSubdirectlyIrreducible ; Nonzero
+                                                  ; mono-nonzero ; mono-least )
 
-open import Setoid.Congruences.Generation         using  ( Cg ; Cg-least ; base )
-open import Setoid.Congruences.Lattice  using  ( _⊆_ ; ⊆-trans )
-open import Setoid.Congruences.Monolith  using  ( IsSubdirectlyIrreducible ; Nonzero
-                                                         ; mono-nonzero ; mono-least )
-
-open import Setoid.Subalgebras.Subdirect.Basic  using ( Separates )
-open import Setoid.Subalgebras.Subdirect.BirkhoffSI
-  using (SubdirectSIRep; SubdirectlyRepresentable ; SIRep→Representable )
-
+open import Setoid.Subalgebras.Subdirect.Basic       using  ( Separates )
+open import Setoid.Subalgebras.Subdirect.BirkhoffSI  using  ( SubdirectSIRep
+                                                            ; SubdirectlyRepresentable
+                                                            ; SIRep→Representable )
 private variable α ρ : Level
 ```
 -->
@@ -117,7 +116,6 @@ whenever some listed element satisfies `Q` but not `P`.
 private variable ℓ₁ ℓ₂ ℓ₃ : Level
 
 private
-
   module _ {X : Type ℓ₁}{P : X → Type ℓ₂}{Q : X → Type ℓ₃}
            (P? : (x : X) → Dec (P x))(Q? : (x : X) → Dec (Q x))
            (sub : ∀ {x} → P x → Q x) where

--- a/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
@@ -50,16 +50,17 @@ open import Relation.Nullary                       using ( ¬_ ; Dec )
 open import Relation.Nullary.Decidable             using ( ¬? ; decidable-stable )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Functions                       using  ( IsInjective ; IsSurjective )
-open import Setoid.Algebras   using  ( Algebra ; ⨅ )
-open import Setoid.Congruences   using  ( Con )
-open import Setoid.Homomorphisms   using  ( hom ; kercon ; _≅_ ; Bijective→≅ )
-open import Setoid.Congruences.Monolith   using  ( HasMonolith ; Nonzero ; BelowDiagonal
-                                                          ; IsSubdirectlyIrreducible
-                                                          ; mono-nonzero ; mono-least ; ⋂ )
-open import Setoid.Subalgebras.Subdirect.Basic
-  using  ( coord ; SubdirectEmbedding ; Separates ; embed-inj ; proj-onto )
+open import Overture                            using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Functions                    using  ( IsInjective ; IsSurjective )
+open import Setoid.Algebras                     using  ( Algebra ; ⨅ )
+open import Setoid.Congruences                  using  ( Con )
+open import Setoid.Homomorphisms                using  ( hom ; kercon ; _≅_ ; Bijective→≅ )
+open import Setoid.Congruences.Monolith         using  ( HasMonolith ; Nonzero
+                                                       ; BelowDiagonal ; mono-nonzero
+                                                       ; IsSubdirectlyIrreducible
+                                                       ; mono-least ; ⋂ )
+open import Setoid.Subalgebras.Subdirect.Basic  using  ( coord ; SubdirectEmbedding
+                                                       ; Separates ; embed-inj ; proj-onto )
 
 private variable α ρ αᵃ ι : Level
 ```

--- a/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
+++ b/src/Setoid/Subalgebras/Subdirect/Irreducible.lagda.md
@@ -35,8 +35,6 @@ congruence-lattice statement about separating families, where the monolith argum
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Subalgebras.Subdirect.Irreducible where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
@@ -52,6 +50,7 @@ open import Relation.Nullary                       using ( ¬_ ; Dec )
 open import Relation.Nullary.Decidable             using ( ¬? ; decidable-stable )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Functions                       using  ( IsInjective ; IsSurjective )
 open import Setoid.Algebras   using  ( Algebra ; ⨅ )
 open import Setoid.Congruences   using  ( Con )

--- a/src/Setoid/Subalgebras/Subuniverses.lagda.md
+++ b/src/Setoid/Subalgebras/Subuniverses.lagda.md
@@ -14,8 +14,6 @@ This is the [Setoid.Subalgebras.Subuniverses][] module of the [Agda Universal Al
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Subalgebras.Subuniverses where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------------
@@ -31,7 +29,7 @@ open import Relation.Binary.PropositionalEquality using ( refl )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------------
 open import Overture                       using ( proj₁ ; proj₂ ; ArityOf ; Im_⊆_
-                                                 ; OperationSymbolsOf )
+                                                 ; OperationSymbolsOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Terms  using ( Term ; ℊ ; node )
 open import Setoid.Algebras  using ( Algebra ; 𝕌[_] ; _^_ ; ov )
 open import Setoid.Terms  using ( module Environment )

--- a/src/Setoid/Terms.lagda.md
+++ b/src/Setoid/Terms.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Terms][] module of the [Agda Universal Algebra Library][].
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Terms where
 
 open import Setoid.Terms.Basic  public

--- a/src/Setoid/Terms/Basic.lagda.md
+++ b/src/Setoid/Terms/Basic.lagda.md
@@ -26,9 +26,10 @@ open import Relation.Binary        using ( Setoid ; IsEquivalence )
 open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl ; sym ; trans )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture using ( ArityOf ; OperationSymbolsOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture         using ( 𝓞 ; 𝓥 ; Signature ; 𝑆
+                                   ; ArityOf ; OperationSymbolsOf )
 open import Setoid.Algebras  using ( Algebra ; ov ; _^_ ; 𝔻[_] ; 𝕌[_] )
-open import Overture.Terms using ( Term )
+open import Overture.Terms   using ( Term )
 
 open Func renaming ( to to _⟨$⟩_ )
 open Term

--- a/src/Setoid/Terms/Basic.lagda.md
+++ b/src/Setoid/Terms/Basic.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Terms.Basic][] module of the [Agda Universal Algebra Library
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Terms.Basic where
 
 -- imports from Agda and the Agda Standard Library -------------------------------
@@ -28,7 +26,7 @@ open import Relation.Binary        using ( Setoid ; IsEquivalence )
 open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl ; sym ; trans )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture using ( ArityOf ; OperationSymbolsOf )
+open import Overture using ( ArityOf ; OperationSymbolsOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras  using ( Algebra ; ov ; _^_ ; 𝔻[_] ; 𝕌[_] )
 open import Overture.Terms using ( Term )
 

--- a/src/Setoid/Terms/Monad.lagda.md
+++ b/src/Setoid/Terms/Monad.lagda.md
@@ -141,8 +141,6 @@ evaluation interacts with this monad structure.  It works as follows:
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Terms.Monad where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -152,6 +150,7 @@ open import Level                                  using ( Level ; suc )
 open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl ; cong-app )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Terms      using  ( Term ; ℊ ; node ; ov )
 open import Setoid.Categories.Category  using  ( Category )
 open import Setoid.Terms.Basic  using  ( Sub ; _[_] ; _≐_

--- a/src/Setoid/Terms/Monad.lagda.md
+++ b/src/Setoid/Terms/Monad.lagda.md
@@ -150,11 +150,11 @@ open import Level                                  using ( Level ; suc )
 open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl ; cong-app )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Overture.Terms      using  ( Term ; ℊ ; node ; ov )
+open import Overture                    using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture.Terms              using  ( Term ; ℊ ; node ; ov )
 open import Setoid.Categories.Category  using  ( Category )
-open import Setoid.Terms.Basic  using  ( Sub ; _[_] ; _≐_
-                                               ; ≐-isRefl ; ≐-isSym ; ≐-isTrans )
+open import Setoid.Terms.Basic          using  ( Sub ; _[_] ; _≐_ ; ≐-isRefl
+                                               ; ≐-isSym ; ≐-isTrans )
 open _≐_
 
 private variable

--- a/src/Setoid/Terms/Operations.lagda.md
+++ b/src/Setoid/Terms/Operations.lagda.md
@@ -20,7 +20,7 @@ module Setoid.Terms.Operations where
 
 -- Imports from Agda and the Agda Standard Library ---------------------
 open import Agda.Primitive    using ()  renaming ( Set to Type )
-open import Data.Product      using ( _,_ )
+open import Data.Product      using ( _,_ ; proj₁ ; proj₂ )
 open import Function.Base     using ( _∘_ )
 open import Function.Bundles  using ()         renaming ( Func to _⟶_ )
 open import Level             using ( Level )
@@ -31,13 +31,13 @@ open import Relation.Binary.PropositionalEquality as ≡ using ( _≡_ )
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from Agda Universal Algebra Library -----------------------------------
-open  import Overture                         using ( proj₁ ; proj₂ ; OperationSymbolsOf ; ArityOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open  import Overture.Terms using ( Term )
-open  import Setoid.Algebras using ( Algebra ; _^_ ; ov ; ⨅ )
-open  import Setoid.Homomorphisms using ( hom ; IsHom )
-open  import Setoid.Terms.Properties using ( free-lift )
-open  import Setoid.Terms.Basic
-      using ( module Environment ; 𝑻 ; _≐_ ; ≐-isRefl )
+open  import Overture                 using  ( OperationSymbolsOf ; ArityOf
+                                             ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open  import Overture.Terms           using  ( Term )
+open  import Setoid.Algebras          using  ( Algebra ; _^_ ; ov ; ⨅ )
+open  import Setoid.Homomorphisms     using  ( hom ; IsHom )
+open  import Setoid.Terms.Properties  using  ( free-lift )
+open  import Setoid.Terms.Basic       using  ( module Environment ; 𝑻 ; _≐_ ; ≐-isRefl )
 
 open Term
 open _⟶_ using ( cong ) renaming ( to to _⟨$⟩_ )

--- a/src/Setoid/Terms/Operations.lagda.md
+++ b/src/Setoid/Terms/Operations.lagda.md
@@ -16,8 +16,6 @@ Here we define *term operations* which are simply terms interpreted in a particu
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Terms.Operations where
 
 -- Imports from Agda and the Agda Standard Library ---------------------
@@ -33,7 +31,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using ( _≡_ )
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from Agda Universal Algebra Library -----------------------------------
-open  import Overture                         using ( proj₁ ; proj₂ ; OperationSymbolsOf ; ArityOf )
+open  import Overture                         using ( proj₁ ; proj₂ ; OperationSymbolsOf ; ArityOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open  import Overture.Terms using ( Term )
 open  import Setoid.Algebras using ( Algebra ; _^_ ; ov ; ⨅ )
 open  import Setoid.Homomorphisms using ( hom ; IsHom )

--- a/src/Setoid/Terms/Properties.lagda.md
+++ b/src/Setoid/Terms/Properties.lagda.md
@@ -14,8 +14,6 @@ This is the [Setoid.Terms.Properties][] module of the [Agda Universal Algebra Li
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Terms.Properties where
 
 open import Agda.Primitive   using () renaming ( Set to Type )
@@ -30,7 +28,7 @@ open import Relation.Binary.PropositionalEquality  using ( setoid; cong; refl)
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture                       using ( proj₁ ; proj₂ )
+open import Overture                       using ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Terms  using  ( Term )
 open import Setoid.Algebras  using  ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_ )
 open import Setoid.Functions               using  ( Img_∋_ ; eq ; isSurj ; IsSurjective

--- a/src/Setoid/Terms/Properties.lagda.md
+++ b/src/Setoid/Terms/Properties.lagda.md
@@ -28,16 +28,16 @@ open import Relation.Binary.PropositionalEquality  using ( setoid; cong; refl)
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture                       using ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Overture.Terms  using  ( Term )
-open import Setoid.Algebras  using  ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_ )
-open import Setoid.Functions               using  ( Img_∋_ ; eq ; isSurj ; IsSurjective
-                                                  ; isSurj→IsSurjective )
+open import Overture              using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture.Terms        using  ( Term )
+open import Setoid.Algebras       using  ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_ )
+open import Setoid.Functions      using  ( Img_∋_ ; eq ; isSurj ; IsSurjective
+                                         ; isSurj→IsSurjective )
 open import Setoid.Homomorphisms  using  ( hom ; compatible-map ; IsHom ; ⊙-hom )
-open import Setoid.Terms.Basic  using  ( 𝑻 ; _≐_  ; ≐-isRefl )
+open import Setoid.Terms.Basic    using  ( 𝑻 ; _≐_  ; ≐-isRefl )
 
 open Term
-open _⟶_ using ( ) renaming ( to to _⟨$⟩_ ; cong to ≈cong )
+open _⟶_ using () renaming ( to to _⟨$⟩_ ; cong to ≈cong )
 
 private variable
   α ρᵃ β ρᵇ ρ χ : Level
@@ -57,8 +57,8 @@ on the structure of the given term.
 
 ```agda
 module _ {𝑆 : Signature 𝓞 𝓥}{𝑨 : Algebra {𝑆 = 𝑆} α ρ}(h : X → 𝕌[ 𝑨 ]) where
-  open Algebra 𝑨      using ( Interp ) renaming ( Domain to A )
-  open Setoid A       using ( _≈_ ; reflexive )
+  open Algebra 𝑨              using ( Interp ) renaming ( Domain to A )
+  open Setoid A               using ( _≈_ ; reflexive )
   open Algebra (𝑻 {𝑆 = 𝑆} X)  using () renaming ( Domain to TX )
 
   free-lift : 𝕌[ 𝑻 {𝑆 = 𝑆} X ] → 𝕌[ 𝑨 ]
@@ -122,8 +122,8 @@ we can omit the `swelldef` hypothesis we needed previously to prove `free-unique
 
 ```agda
 module _ {𝑆 : Signature 𝓞 𝓥}{𝑨 : Algebra {𝑆 = 𝑆} α ρ}{gh hh : hom (𝑻 X) 𝑨} where
-  open Algebra 𝑨      using ( Interp )  renaming ( Domain to A )
-  open Setoid A       using ( _≈_ )
+  open Algebra 𝑨              using ( Interp )  renaming ( Domain to A )
+  open Setoid A               using ( _≈_ )
   open Algebra (𝑻 {𝑆 = 𝑆} X)  using ()          renaming ( Domain to TX )
   open SetoidReasoning A
   open _≐_

--- a/src/Setoid/Varieties.lagda.md
+++ b/src/Setoid/Varieties.lagda.md
@@ -13,8 +13,6 @@ This is the [Setoid.Varieties][] module of the [Agda Universal Algebra Library][
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Varieties where
 
 open import Setoid.Varieties.Closure  public

--- a/src/Setoid/Varieties/Closure.lagda.md
+++ b/src/Setoid/Varieties/Closure.lagda.md
@@ -17,8 +17,6 @@ Fix a signature 𝑆, let 𝒦 be a class of 𝑆-algebras, and define
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Varieties.Closure where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -33,6 +31,7 @@ open import Relation.Binary        using ( Setoid )
 open import Relation.Unary         using ( Pred ; _∈_ ; _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras using ( Algebra ; ov ; Lift-Alg ; ⨅ )
 open import Setoid.Homomorphisms
 open import Setoid.Subalgebras

--- a/src/Setoid/Varieties/Closure.lagda.md
+++ b/src/Setoid/Varieties/Closure.lagda.md
@@ -31,10 +31,11 @@ open import Relation.Binary        using ( Setoid )
 open import Relation.Unary         using ( Pred ; _∈_ ; _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras using ( Algebra ; ov ; Lift-Alg ; ⨅ )
+open import Overture               using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras        using  ( Algebra ; ov ; Lift-Alg ; ⨅ )
 open import Setoid.Homomorphisms
-open import Setoid.Subalgebras
+open import Setoid.Subalgebras     using  ( _≤_ ; ≤-trans ; ≤-reflexive
+                                          ; ≤-trans-≅ ; ≅-trans-≤ ; ≤-Lift )
 open _⟶_ renaming ( to to _⟨$⟩_ )
 ```
 -->

--- a/src/Setoid/Varieties/EquationalLogic.lagda.md
+++ b/src/Setoid/Varieties/EquationalLogic.lagda.md
@@ -17,8 +17,6 @@ Because a class of structures has a different type than a single structure, we m
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Varieties.EquationalLogic where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------
@@ -30,6 +28,7 @@ open import Relation.Binary  using ( Setoid )
 open import Relation.Unary   using ( Pred ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras using ( Algebra ; ov )
 open import Overture.Terms using ( Term )
 open import Setoid.Terms using ( module Environment )

--- a/src/Setoid/Varieties/EquationalLogic.lagda.md
+++ b/src/Setoid/Varieties/EquationalLogic.lagda.md
@@ -28,10 +28,10 @@ open import Relation.Binary  using ( Setoid )
 open import Relation.Unary   using ( Pred ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras using ( Algebra ; ov )
-open import Overture.Terms using ( Term )
-open import Setoid.Terms using ( module Environment )
+open import Overture         using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras  using ( Algebra ; ov )
+open import Overture.Terms   using ( Term )
+open import Setoid.Terms     using ( module Environment )
 
 private variable χ α ρᵃ ℓ ι : Level
 ```

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -16,7 +16,7 @@ module Setoid.Varieties.FreeAlgebras where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------
 open import Agda.Primitive   using ()                  renaming ( Set to Type )
-open import Data.Product     using ( Σ-syntax ; _,_ )
+open import Data.Product     using ( Σ-syntax ; _,_ ; proj₁ ; proj₂ )
 open import Function         using ( _∘_ ; id )        renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_)
 open import Relation.Binary  using ( Setoid )
@@ -27,21 +27,20 @@ open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                                    using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Overture.Terms  using  ( ℊ )
-open import Setoid.Algebras  using  ( Algebra ; ov ; Lift-Alg ; 𝔻[_] )
-open import Setoid.Functions                            using  ( eq ; IsSurjective )
-open import Setoid.Homomorphisms  using  ( epi ; IsEpi ; IsHom ; hom
-                                                               ; epi→hom ; ⊙-epi ; ToLift-epi )
-open import Setoid.Relations                            using  ( fkerPred )
-open import Setoid.Terms  using  ( 𝑻 ; _≐_ ; module Environment
-                                                               ; free-lift ; free-lift-interp )
-open import Setoid.Varieties.Closure  using  ( V ; S )
-
-open import Setoid.Varieties.Preservation  using  ( classIds-⊆-VIds ; S-id1 )
-open import Setoid.Varieties.SoundAndComplete  using  ( Eq ; _⊫_ ; ⊫-proof ; _≈̇_ ; _⊢_▹_≈_
-                                                               ; Th ; Mod ; module Soundness
-                                                               ; module FreeAlgebra )
+open import Overture                           using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture.Terms                     using  ( ℊ )
+open import Setoid.Algebras                    using  ( Algebra ; ov ; Lift-Alg ; 𝔻[_] )
+open import Setoid.Functions                   using  ( eq ; IsSurjective )
+open import Setoid.Homomorphisms               using  ( epi ; IsEpi ; IsHom ; hom
+                                                      ; epi→hom ; ⊙-epi ; ToLift-epi )
+open import Setoid.Relations                   using  ( fkerPred )
+open import Setoid.Terms                       using  ( 𝑻 ; _≐_ ; module Environment
+                                                      ; free-lift ; free-lift-interp )
+open import Setoid.Varieties.Closure           using  ( V ; S )
+open import Setoid.Varieties.Preservation      using  ( classIds-⊆-VIds ; S-id1 )
+open import Setoid.Varieties.SoundAndComplete  using  ( Eq ; _⊫_ ; ⊫-proof ; _≈̇_
+                                                      ; Th ; Mod ; module Soundness
+                                                      ; _⊢_▹_≈_ ; module FreeAlgebra )
 open _⟶_      using ( cong ) renaming ( to to _⟨$⟩_ )
 open Algebra  using ( Domain )
 ```

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -12,8 +12,6 @@ author: "agda-algebras development team"
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Varieties.FreeAlgebras where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------
@@ -29,7 +27,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                                    using  ( proj₁ ; proj₂ )
+open import Overture                                    using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Terms  using  ( ℊ )
 open import Setoid.Algebras  using  ( Algebra ; ov ; Lift-Alg ; 𝔻[_] )
 open import Setoid.Functions                            using  ( eq ; IsSurjective )

--- a/src/Setoid/Varieties/FreeSubstitution.lagda.md
+++ b/src/Setoid/Varieties/FreeSubstitution.lagda.md
@@ -70,8 +70,9 @@ The kit also has a *semantic* face, used by the converse Maltsev conditions:
 
 module Setoid.Varieties.FreeSubstitution where
 
--- Imports from Agda and the Agda Standard Library ----------------------------
-open import Agda.Primitive   using () renaming ( Set to Type )
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -------------------------------------
 open import Data.Product     using ( _,_ ; proj₁ )
 open import Data.Sum.Base    using ( inj₁ ; inj₂ )
 open import Function         using ( Func )
@@ -81,17 +82,17 @@ open import Relation.Binary  using () renaming ( _⇒_ to _⊆_ )
 import Relation.Binary.PropositionalEquality as ≡
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Overture.Terms  using  ( Term ; ℊ )
-open import Setoid.Algebras.Basic  using  ( 𝔻[_] )
-open import Setoid.Congruences.Generation    using  ( Gen ; Cg ; base ; symmetric
-                                                    ; _∨_ ; _∪ᵣ_ ; module principal )
-open import Setoid.Homomorphisms.Basic       using ( hom ; mkIsHom )
-open import Setoid.Homomorphisms.Kernels     using ( kercon )
-open import Setoid.Homomorphisms.Properties  using ( Cg⊆ker )
-open import Setoid.Terms.Basic  using ( _≐_ ; Sub ; _[_] )
-open import Setoid.Varieties.SoundAndComplete
-  using ( Eq ; _⊢_▹_≈_ ; module FreeAlgebra )
+open import Overture                           using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture.Terms                     using  ( Term ; ℊ )
+open import Setoid.Algebras.Basic              using  ( 𝔻[_] )
+open import Setoid.Congruences.Generation      using  ( Gen ; Cg ; base ; symmetric
+                                                      ; _∨_ ; _∪ᵣ_ ; module principal )
+open import Setoid.Homomorphisms.Basic         using  ( hom ; mkIsHom )
+open import Setoid.Homomorphisms.Kernels       using  ( kercon )
+open import Setoid.Homomorphisms.Properties    using  ( Cg⊆ker )
+open import Setoid.Terms.Basic                 using  ( _≐_ ; Sub ; _[_] )
+open import Setoid.Varieties.SoundAndComplete  using  ( Eq ; _⊢_▹_≈_
+                                                      ; module FreeAlgebra )
 
 open _≐_         using ( rfl ; gnl )
 open _⊢_▹_≈_     using ( app ; sub ; refl ; trans )

--- a/src/Setoid/Varieties/FreeSubstitution.lagda.md
+++ b/src/Setoid/Varieties/FreeSubstitution.lagda.md
@@ -68,8 +68,6 @@ The kit also has a *semantic* face, used by the converse Maltsev conditions:
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Varieties.FreeSubstitution where
 
 -- Imports from Agda and the Agda Standard Library ----------------------------
@@ -83,6 +81,7 @@ open import Relation.Binary  using () renaming ( _⇒_ to _⊆_ )
 import Relation.Binary.PropositionalEquality as ≡
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Terms  using  ( Term ; ℊ )
 open import Setoid.Algebras.Basic  using  ( 𝔻[_] )
 open import Setoid.Congruences.Generation    using  ( Gen ; Cg ; base ; symmetric

--- a/src/Setoid/Varieties/HSP.lagda.md
+++ b/src/Setoid/Varieties/HSP.lagda.md
@@ -17,8 +17,6 @@ Two other presentations of Birkhoff's theorem live in the source tree, and both 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Varieties.HSP where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------
@@ -30,7 +28,7 @@ open import Relation.Binary  using ( Setoid )
 open import Relation.Unary   using ( Pred ; _∈_ ; _⊆_ )
 
 -- -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture                                   using  ( proj₁ ; proj₂ )
+open import Overture                                   using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras                    using  ( Algebra ; ov ; Lift-Alg ; ⨅ )
 open import Setoid.Homomorphisms
 open import Setoid.Relations                           using  ( fkerPred )

--- a/src/Setoid/Varieties/HSP.lagda.md
+++ b/src/Setoid/Varieties/HSP.lagda.md
@@ -21,28 +21,27 @@ module Setoid.Varieties.HSP where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
-open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ )
+open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ ; proj₁ ; proj₂ )
 open import Function         using () renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_ )
 open import Relation.Binary  using ( Setoid )
 open import Relation.Unary   using ( Pred ; _∈_ ; _⊆_ )
 
 -- -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture                                   using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture                           using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras                    using  ( Algebra ; ov ; Lift-Alg ; ⨅ )
 open import Setoid.Homomorphisms
-open import Setoid.Relations                           using  ( fkerPred )
+open import Setoid.Relations                   using  ( fkerPred )
 open import Setoid.Subalgebras                 using  ( _≤_ ; mon→≤ )
 open import Setoid.Terms                       using  ( module Environment ; 𝑻
-                                                              ; lift-hom ; free-lift
-                                                              ; free-lift-interp )
-open import Setoid.Varieties.Closure           using  ( S ; P ; S-idem
-                                                              ; V ; V′ ; V-≅-lc )
+                                                      ; lift-hom ; free-lift
+                                                      ; free-lift-interp )
+open import Setoid.Varieties.Closure           using  ( S ; P ; S-idem ; V ; V′ ; V-≅-lc )
 open import Setoid.Varieties.FreeAlgebras      using  ( module FreeHom
-                                                              ; 𝔽-ModTh-epi-lift )
+                                                      ; 𝔽-ModTh-epi-lift )
 open import Setoid.Varieties.Preservation      using  ( S-id2 ; PS⊆SP )
 open import Setoid.Varieties.SoundAndComplete  using  ( module FreeAlgebra ; _⊫_ ; ⊫-proof
-                                                              ; _≈̇_ ; _⊢_▹_≈_ ; Mod ; Th )
+                                                      ; _≈̇_ ; _⊢_▹_≈_ ; Mod ; Th )
 
 open _⟶_          using () renaming ( to to _⟨$⟩_ )
 open Setoid       using ( Carrier )

--- a/src/Setoid/Varieties/Invariants.lagda.md
+++ b/src/Setoid/Varieties/Invariants.lagda.md
@@ -25,8 +25,8 @@ open import Level           using ( Level )
 open import Relation.Unary  using ( Pred )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras  using ( Algebra )
+open import Overture              using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Setoid.Algebras       using ( Algebra )
 open import Setoid.Homomorphisms  using ( _≅_ )
 
 private variable α ρᵃ ℓ : Level

--- a/src/Setoid/Varieties/Invariants.lagda.md
+++ b/src/Setoid/Varieties/Invariants.lagda.md
@@ -17,8 +17,6 @@ The canonical example available in this library is the modelling relation `𝑨 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
 module Setoid.Varieties.Invariants where
 
 -- Imports from Agda and the Agda Standard Library --------------------------------
@@ -27,6 +25,7 @@ open import Level           using ( Level )
 open import Relation.Unary  using ( Pred )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
+open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Setoid.Algebras  using ( Algebra )
 open import Setoid.Homomorphisms  using ( _≅_ )
 

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -21,7 +21,7 @@ module Setoid.Varieties.Preservation where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library -------------------------------
-open import Data.Product           using ( _,_ )
+open import Data.Product           using ( _,_ ; proj₁ ; proj₂ )
 open import Data.Unit.Polymorphic  using ( ⊤ )
 open import Function               using ()  renaming ( Func to _⟶_ )
 open import Level                  using ( Level ; _⊔_ )
@@ -29,22 +29,20 @@ open import Relation.Binary        using ( Setoid )
 open import Relation.Unary         using ( Pred ; _⊆_ ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                                    using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-
-open import Overture.Terms  using  ( Term )
-open import Setoid.Algebras  using  ( Algebra ; ov ; ⨅ )
-open import Setoid.Homomorphisms  using  ( ≅⨅⁺-refl ; ≅-refl
-                                                               ; IdHomImage ; ≅-sym )
-open import Setoid.Subalgebras  using  ( _≤_ ; ⨅-≤ ; ≅-trans-≤
-                                                               ; ≤-reflexive )
-open import Setoid.Terms  using  ( module Environment)
-open import Setoid.Varieties.Closure  using  ( H ; S ; P ; S-expa
-                                                               ; H-expa ; V ; P-expa
-                                                               ; V-expa ;Level-closure )
-open import Setoid.Varieties.Properties  using  ( ⊧-H-invar ; ⊧-S-invar
-                                                               ; ⊧-P-invar ; ⊧-I-invar )
+open import Overture                           using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture.Terms                     using  ( Term )
+open import Setoid.Algebras                    using  ( Algebra ; ov ; ⨅ )
+open import Setoid.Homomorphisms               using  ( ≅⨅⁺-refl ; ≅-refl
+                                                      ; IdHomImage ; ≅-sym )
+open import Setoid.Subalgebras                 using  ( _≤_ ; ⨅-≤ ; ≅-trans-≤
+                                                      ; ≤-reflexive )
+open import Setoid.Terms                       using  ( module Environment)
+open import Setoid.Varieties.Closure           using  ( H ; S ; P ; V ; S-expa ; H-expa
+                                                      ; P-expa ; V-expa ; Level-closure )
+open import Setoid.Varieties.Properties        using  ( ⊧-H-invar ; ⊧-S-invar
+                                                      ; ⊧-P-invar ; ⊧-I-invar )
 open import Setoid.Varieties.SoundAndComplete  using  ( _⊧_ ; _⊫_ ; ⊫-proof
-                                                               ; _≈̇_ ; _⊢_▹_≈_ ; Th)
+                                                      ; _≈̇_ ; _⊢_▹_≈_ ; Th)
 open _⟶_      using () renaming ( to to _⟨$⟩_ )
 open Algebra  using ( Domain )
 ```

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -16,8 +16,6 @@ same identities.
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Varieties.Preservation where
 
 open import Agda.Primitive using () renaming ( Set to Type )
@@ -31,7 +29,7 @@ open import Relation.Binary        using ( Setoid )
 open import Relation.Unary         using ( Pred ; _⊆_ ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                                    using  ( proj₁ ; proj₂ )
+open import Overture                                    using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 
 open import Overture.Terms  using  ( Term )
 open import Setoid.Algebras  using  ( Algebra ; ov ; ⨅ )

--- a/src/Setoid/Varieties/Properties.lagda.md
+++ b/src/Setoid/Varieties/Properties.lagda.md
@@ -21,8 +21,6 @@ We prove some closure and invariance properties of the relation `⊧`.  In parti
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Varieties.Properties where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------------------
@@ -36,7 +34,7 @@ open import Relation.Unary   using ( Pred ; _∈_ )
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library ---------------------------------------------
-open  import Overture                       using  ( proj₁ ; proj₂ )
+open  import Overture                       using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open  import Setoid.Functions               using  ( InvIsInverseʳ ; SurjInv )
 open  import Overture.Terms  using  ( Term ; ℊ )
 open  import Setoid.Algebras

--- a/src/Setoid/Varieties/Properties.lagda.md
+++ b/src/Setoid/Varieties/Properties.lagda.md
@@ -25,7 +25,7 @@ module Setoid.Varieties.Properties where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------------------
 open import Agda.Primitive   using () renaming ( Set to Type )
-open import Data.Product     using ( _,_ )
+open import Data.Product     using ( _,_ ; proj₁ ; proj₂ )
 open import Function         using ( _∘_ ; Func ; _$_ )
 open import Level            using ( Level )
 open import Relation.Binary  using ( Setoid )
@@ -34,18 +34,19 @@ open import Relation.Unary   using ( Pred ; _∈_ )
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library ---------------------------------------------
-open  import Overture                       using  ( proj₁ ; proj₂ ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open  import Setoid.Functions               using  ( InvIsInverseʳ ; SurjInv )
-open  import Overture.Terms  using  ( Term ; ℊ )
-open  import Setoid.Algebras
-      using  ( Algebra ; Lift-Algˡ ; ov ; 𝕌[_] ; 𝔻[_] ; ⨅ )
-open  import Setoid.Homomorphisms
-      using  ( hom ; _≅_ ; mkiso ; Lift-≅ˡ ; ≅-sym ; _IsHomImageOf_ )
-open  import Setoid.Terms
-      using  ( 𝑻 ; module Environment ; comm-hom-term ; interp-prod ; term-agreement )
-open  import Setoid.Subalgebras  using  ( _≤_ ; SubalgebrasOfClass )
-open  import Setoid.Varieties.SoundAndComplete
-      using ( _⊧_ ; _⊫_ ; ⊫-proof ; _≈̇_ ; _⊢_▹_≈_ )
+open  import Overture                           using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open  import Overture.Terms                     using  ( Term ; ℊ )
+open  import Setoid.Algebras                    using  ( Algebra ; Lift-Algˡ ; ov
+                                                       ; 𝕌[_] ; 𝔻[_] ; ⨅ )
+open  import Setoid.Functions                   using  ( InvIsInverseʳ ; SurjInv )
+open  import Setoid.Homomorphisms               using  ( hom ; _≅_ ; mkiso ; Lift-≅ˡ
+                                                       ; ≅-sym ; _IsHomImageOf_ )
+open  import Setoid.Subalgebras                 using  ( _≤_ ; SubalgebrasOfClass )
+open  import Setoid.Terms                       using  ( 𝑻 ; module Environment
+                                                       ; comm-hom-term ; interp-prod
+                                                       ; term-agreement )
+open  import Setoid.Varieties.SoundAndComplete  using  ( _⊧_ ; _⊫_ ; ⊫-proof ; _≈̇_
+                                                       ; _⊢_▹_≈_ )
 
 private variable α ρᵃ β ρᵇ χ ℓ : Level
 

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -17,10 +17,10 @@ This module is based on [Andreas Abel's Agda formalization of Birkhoff's complet
 
 module Setoid.Varieties.SoundAndComplete where
 
-open import Agda.Primitive   using () renaming ( Set to Type )
+open import Agda.Primitive using () renaming ( Set to Type )
 
 -- imports from the Agda Standard Library ---------------------------------------
-open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ )
+open import Data.Product     using ( _,_ ; Σ-syntax ; _×_ ; proj₁ ; proj₂ )
 open import Function         using ( _∘_ ; flip ) renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_ )
 open import Relation.Binary  using ( Setoid ; IsEquivalence )
@@ -31,11 +31,11 @@ open import Relation.Binary.PropositionalEquality using ( refl )
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                  using ( proj₁ ; proj₂ ; OperationSymbolsOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Overture.Terms  using ( Term )
-open import Setoid.Algebras  using ( Algebra ; ov ; 𝔻[_] )
-open import Setoid.Signatures         using ( ⟨_⟩ )
-open import Setoid.Terms  using ( module Environment ; Sub ; _[_] )
+open import Overture           using ( OperationSymbolsOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture.Terms     using ( Term )
+open import Setoid.Algebras    using ( Algebra ; ov ; 𝔻[_] )
+open import Setoid.Signatures  using ( ⟨_⟩ )
+open import Setoid.Terms       using ( module Environment ; Sub ; _[_] )
 
 open Setoid  using ( Carrier ; _≈_ ; isEquivalence )
 open _⟶_     renaming ( to to _⟨$⟩_ )

--- a/src/Setoid/Varieties/SoundAndComplete.lagda.md
+++ b/src/Setoid/Varieties/SoundAndComplete.lagda.md
@@ -15,8 +15,6 @@ This module is based on [Andreas Abel's Agda formalization of Birkhoff's complet
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
-open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆)
-
 module Setoid.Varieties.SoundAndComplete where
 
 open import Agda.Primitive   using () renaming ( Set to Type )
@@ -33,7 +31,7 @@ open import Relation.Binary.PropositionalEquality using ( refl )
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                  using ( proj₁ ; proj₂ ; OperationSymbolsOf )
+open import Overture                  using ( proj₁ ; proj₂ ; OperationSymbolsOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Terms  using ( Term )
 open import Setoid.Algebras  using ( Algebra ; ov ; 𝔻[_] )
 open import Setoid.Signatures         using ( ⟨_⟩ )


### PR DESCRIPTION
## Summary

The signature-parameter sweep left `open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )` stranded above the module declaration in 42 `Setoid/` modules, where it is no longer needed now that those modules take no top-level `{𝑆}` parameter.  This PR relocates each import inside the module body (or drops it where it is dead), so that nothing but the options pragma precedes `module … where`, consistent with the repo-wide convention.

## Related issues

Closes #477.

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [ ] Refactor / cleanup (user-facing/API change)
- [x] Refactor / cleanup (no user-facing change)
- [ ] Documentation
- [ ] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop` (full library: 243 + 68 modules, exit 0).
- [x] New public definitions have prose comment blocks.  (n/a — no definitions added or changed; imports only.)
- [x] Commits are coherent and have explanatory messages.
- [x] This PR touches `src/` in a supported area (`Setoid/`).
- [x] This PR introduces no new notation.

## Notes for reviewers

The change is purely a relocation of import lines; no definition, signature, or exported name is touched, and the module public interfaces are unchanged (the moved imports are not `public`).  It comes in three mechanical shapes:

+  **8 pure re-export barrels** (`Setoid.Algebras`, `Setoid.Subalgebras`, `Setoid.Congruences`, `Setoid.Terms`, `Setoid.Varieties`, `Setoid.Homomorphisms`, `Setoid.Subalgebras.Subdirect`, `Setoid.Congruences.Finite`): the import is **dropped entirely**.  Their bodies are only `open import … public` re-exports that never mention `𝓞 / 𝓥 / Signature / 𝑆`, and every barrel already clean in the tree (e.g. `Setoid.lagda.md`, `Setoid.Categories`, `Setoid.Functions`) carries no `Overture` import — so removing keeps them consistent rather than moving a dead import inside.
+  **15 modules** that already `open import Overture using (…)` inside: `𝓞 ; 𝓥 ; Signature ; 𝑆` is appended to that line, keeping a single consolidated `Overture` import (matching e.g. `Setoid.Homomorphisms.Basic`).
+  **19 modules** with no inside `Overture` import: a consolidated `open import Overture using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )` is added as the first line under the "Imports from the Agda Universal Algebra Library" heading.  (`Setoid.Homomorphisms.Properties` keeps the `𝑆`-free form it already had.)

One related item left out of scope on purpose: `Setoid/Functions/Injective.lagda.md` has the same shape but a **different** import — `open import Relation.Binary using ( Setoid )` above a parameter-less module (`Setoid` is used in the body, so it would move inside rather than be dropped).  It is not an `Overture` line and is unrelated to the signature-parameter sweep this issue describes, so it is not included here; happy to fold it in if you'd like the cleanup to cover it too.  Its sibling `Setoid/Functions/Bijective.lagda.md` legitimately keeps the import, since its module parameter `{𝑨 : Setoid α ρᵃ}` needs `Setoid` in scope before the declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015H9msYynYoE7iqXy5zzJr3)_