### PR TITLE
FLRP WP-7 slice iii: assumptions registry and the Representable ↔ Representableᵈ bridge

### DIFF
--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -2909,11 +2909,25 @@ Apply new style conventions uniformly across the Setoid tree.
 
 ---
 
-### Issue M4-18: Move Demos under Examples (#436)
+### Issue M4-18: Move Demos under Examples (#436, closed)
 
 **Labels**: `milestone-4-style`
 
 _(no description on GitHub)_
+
+---
+
+### Issue M4-19: Clean up imports post-sweep (#477, closed)
+
+**Labels**: 
+
+After the sweep that removed the signature parameter from many module definitions, the line
+
+```agda
+open import Overture using (𝓞 ; 𝓥 ; Signature ; 𝑆 )
+```
+
+still appears outside the start of the module, which is unnecessary when there's no top-level module parameter.  We can now move the import of Overture inside with the other imports, consistent with the repo-wide style convention.
 
 <!-- END GENERATED: milestone-4 -->
 
@@ -3589,7 +3603,7 @@ Per the ratified two-layer congruence discipline (`docs/adr/008-two-layer-congru
 
 ---
 
-### Issue M6-13d: FLRP WP-4: FLRP.Enforceable — IE, cf-IE, min-IE, and the no-go lemmas (#455)
+### Issue M6-13d: FLRP WP-4: FLRP.Enforceable — IE, cf-IE, min-IE, and the no-go lemmas (#455, closed)
 
 **Labels**: `research-exploratory`, `flrp-research`
 
@@ -3755,15 +3769,31 @@ Part of #451.
 
 ## Tasks (three PR-sized slices)
 
-- [ ] Slice (i) — L1 + L2: `Cg` of a finite pair list on a finite finitary algebra has decidable membership (congruence-closure computation), and every `DecCon` is `≑` to `Cg` of its related-pairs list; includes fixing the Agda packaging of finite finitary signatures (audit A3).
-- [ ] Slice (ii) — L3 + audits: constructive completeness for `DecCon` via enumeration of Bool-valued tables; the `FiniteCongruencesᵈ` interface; audit A1 (which m6-8 consumers, in particular finite Birkhoff, survive on `FiniteAlgebra` + `FiniteCongruencesᵈ` alone) and audit A2 (WP-2 group modules are Layer-D ready).
-- [ ] Slice (iii) — L4 + L5: the `FLRP.Assumptions` registry with the classical bridge (`complete` of `FiniteCongruences`) as its first entry, strength documented (between WLEM and LEM at the working level); the `DecCon` poset as a finite lattice with decidable order; `Representableᵈ` and `FLRP-Statementᵈ`; the constructive `chain₂` instance; and, under the bridge, `Representable 𝑳 ↔ Representableᵈ 𝑳`.
+- [x] Slice (i) — L1 + L2: `Cg` of a finite pair list on a finite finitary algebra has decidable membership (congruence-closure computation), and every `DecCon` is `≑` to `Cg` of its related-pairs list; includes fixing the Agda packaging of finite finitary signatures (audit A3).  *(merged #467)*
+- [x] Slice (ii) — L3 + audits: constructive completeness for `DecCon` via enumeration of Bool-valued tables; the `FiniteCongruencesᵈ` interface; audit A1 (which m6-8 consumers, in particular finite Birkhoff, survive on `FiniteAlgebra` + `FiniteCongruencesᵈ` alone) and audit A2 (WP-2 group modules are Layer-D ready).  *(merged #468)*
+- [ ] Slice (iii) — L4 + L5.  **Constructive core merged in #479; the classical-bridge parts remain** — see the status update below.
+  - [x] `Representableᵈ`, `FLRP-Statementᵈ`, the decidable-congruence poset order (`_⊆ᵈ_`, `_≑ᵈ_`, `ConIsoᵈ`), and the constructive `chain₂` instance `chain₂-Representableᵈ`, all `--safe` with no postulates (`src/FLRP/Representable.lagda.md`, #479).
+  - [ ] `FLRP.Assumptions` registry with the classical bridge (`complete` of `FiniteCongruences`) as its first entry, strength documented (between WLEM and LEM at the working level).
+  - [ ] Under that bridge, `Representable 𝑳 ↔ Representableᵈ 𝑳`.
+  - [ ] The `DecCon` poset as a finite lattice with decidable order (meets, joins) — deferred to WP-6 (#457) certificate tooling; #479 provides only the `OrderIso` target that representability needs.
+
+## Status update — 2026-07-20 (slice iii core merged)
+
+Slices (i) and (ii) merged in #467 and #468.  The **constructive core of slice (iii)** merged in #479 (`src/FLRP/Representable.lagda.md`): `Representableᵈ`, `FLRP-Statementᵈ`, the decidable-congruence poset order (`ConIsoᵈ`), and the postulate-free two-element-chain representation `chain₂-Representableᵈ` — the object the WP-1 no-go theorem forbids at Layer S, now attained constructively at Layer D.
+
+Remaining to close this issue (narrowed scope):
+
++  `src/FLRP/Assumptions.lagda.md` — the `--safe` registry naming the classical bridge (`FiniteCongruences.complete : ∀ φ → Σ[ d ∈ DecCon 𝑨 _ ] (d ∈ cons) × (φ ≑ proj₁ d)`) as an explicit hypothesis, never a postulate; strength documented between WLEM and LEM (ADR-008 L4).
++  Under that bridge, the cross-layer equivalence `Representable 𝑳 ↔ Representableᵈ 𝑳` — the `Con` and `DecCon` posets of a finite finitary algebra coincide once `complete` holds; `Representable`/`Representableᵈ` differ exactly by `ConIso` vs `ConIsoᵈ` plus the `finsig` field.
++  Wiring the now-unblocked Layer-D corollary of WP-3 (#454): `FLRP.Bridge.interval-Con-representable` can target `Representableᵈ` (may land here or as a sibling PR).
+
+Coordination: WP-5 (#456) also plans `FLRP.Assumptions` with the Kurzweil–Netter duality as "its first entry."  This issue **creates** the module with the classical `complete` bridge as entry 1; WP-5 appends the duality entry.
 
 ## Acceptance criteria
 
-- [ ] All new modules type-check under `--cubical-compatible --exact-split --safe`; no postulates; the bridge appears only as an explicit hypothesis.
-- [ ] `Representableᵈ (toLattice chain₂)` is inhabited with no classical assumptions.
-- [ ] The m6-8 note gains an addendum recording the A1 audit outcome.
+- [ ] All new modules type-check under `--cubical-compatible --exact-split --safe`; no postulates; the bridge appears only as an explicit hypothesis.  *(FLRP.Representable satisfies this in #479; completes when FLRP.Assumptions lands.)*
+- [x] `Representableᵈ (toLattice chain₂)` is inhabited with no classical assumptions.  *(`chain₂-Representableᵈ`, #479.)*
+- [x] The m6-8 note gains an addendum recording the A1 audit outcome.  *(`docs/notes/m6-8-finite-birkhoff.md` § "Update (WP-7 A1)"; full findings in `docs/notes/flrp-wp7-audits.md`.)*
 
 <!-- END GENERATED: milestone-6 -->
 

--- a/docs/_links.md
+++ b/docs/_links.md
@@ -322,6 +322,11 @@
 
 [FLRP]: /FLRP/
 [FLRP.Problem]: /FLRP/Problem/
+[FLRP.Enforceable]: /FLRP/Enforceable/
+[FLRP.Bridge]: /FLRP/Bridge/
+[FLRP.Representable]: /FLRP/Representable/
+[FLRP.Assumptions]: /FLRP/Assumptions/
+[FLRP.LayerBridge]: /FLRP/LayerBridge/
 
 <!-- ===== Module sources on GitHub ===== -->
 [Overture.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Overture.lagda.md
@@ -638,6 +643,11 @@
 
 [FLRP.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP.lagda.md
 [FLRP/Problem.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Problem.lagda.md
+[FLRP/Enforceable.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Enforceable.lagda.md
+[FLRP/Bridge.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Bridge.lagda.md
+[FLRP/Representable.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Representable.lagda.md
+[FLRP/Assumptions.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Assumptions.lagda.md
+[FLRP/LayerBridge.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/LayerBridge.lagda.md
 
 <!-- ===== External links ===== -->
 [A Machine-checked proof of Birkhoff's Variety Theorem in Martin-Löf Type Theory]: https://arxiv.org/abs/2101.10166

--- a/src/Classical/Properties/Lattice.lagda.md
+++ b/src/Classical/Properties/Lattice.lagda.md
@@ -51,9 +51,8 @@ open import Relation.Nullary.Decidable.Core          using ( Dec ; ¬? ; _×-dec
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library --------------------------------
-open import Classical.Signatures.Lattice             using ( Sig-Lattice )
-open import Classical.Structures.Lattice             using ( Lattice ; module Lattice-Op )
-open import Setoid.Algebras.Basic  using ( 𝔻[_] ; 𝕌[_] )
+open import Classical.Structures.Lattice   using ( Lattice ; module Lattice-Op )
+open import Setoid.Algebras.Basic          using ( 𝔻[_] ; 𝕌[_] )
 
 private variable α ρ : Level
 ```

--- a/src/Classical/Structures/Group/Product.lagda.md
+++ b/src/Classical/Structures/Group/Product.lagda.md
@@ -66,23 +66,20 @@ open import Relation.Unary                using ( Pred ; _∈_ ; _⊆_ )
 import Algebra.Properties.Group as GroupProperties
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Bundles.Group           using ( ⟨_⟩ᵍᵖ )
-open import Classical.Signatures.Group        using ( Sig-Group ; ∙-Op ; ε-Op ; ⁻¹-Op )
-open import Classical.Structures.Group.Basic  using ( Group ; module Group-Op ; _⊨ᵍᵖ_ )
-open import Classical.Structures.Group.Subgroups
-                                              using ( IsSubgroup ; mkIsSubgroup
-                                                    ; sub-∙-closed ; sub-⁻¹-closed )
-open import Classical.Structures.Interpret    using ( interp-cong )
-open import Classical.Theories.Group          using ( Th-Group )
-open import Overture.Signatures               using ( OperationSymbolsOf ; ArityOf )
-open import Overture.Operations               using ( Op )
-open import Overture.Terms                    using ( Term ; ℊ ; node )
-
-open import Setoid.Algebras.Basic
-                                              using ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_
-                                                    ; mkAlgebra )
-open import Setoid.Subalgebras.Subuniverses using ( Subuniverses )
-open import Setoid.Terms                      using ( module Environment )
+open import Classical.Bundles.Group               using  ( ⟨_⟩ᵍᵖ )
+open import Classical.Signatures.Group            using  ( Sig-Group ; ∙-Op ; ε-Op ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic      using  ( Group ; module Group-Op ; _⊨ᵍᵖ_ )
+open import Classical.Structures.Group.Subgroups  using  ( IsSubgroup ; mkIsSubgroup
+                                                         ; sub-∙-closed ; sub-⁻¹-closed )
+open import Classical.Structures.Interpret        using  ( interp-cong )
+open import Classical.Theories.Group              using  ( Th-Group )
+open import Overture.Signatures                   using  ( OperationSymbolsOf ; ArityOf )
+open import Overture.Operations                   using  ( Op )
+open import Overture.Terms                        using  ( Term ; ℊ ; node )
+open import Setoid.Algebras.Basic                 using  ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_
+                                                         ; mkAlgebra )
+open import Setoid.Subalgebras.Subuniverses       using  ( Subuniverses )
+open import Setoid.Terms                          using  ( module Environment )
 
 open Func renaming ( to to _⟨$⟩_ )
 
@@ -149,7 +146,7 @@ for the Cubical port.
     }
 
   open Setoid G×K using ()
-    renaming ( _≈_ to _≈ₓ_ ; refl to reflₓ ; sym to symₓ ; trans to transₓ )
+    renaming ( _≈_ to _≈ₓ_ ; trans to transₓ )
 ```
 
 Each operation symbol acts componentwise: the interpretation of `f` at a tuple of
@@ -223,7 +220,7 @@ indexed tuples lack η under `--cubical-compatible`; each bridge is one
 ```agda
   open Group-Op 𝒢 using ()
     renaming ( _∙_ to _∙₁_ ; ε to ε₁ ; _⁻¹ to _⁻¹₁
-             ; idˡ-law to idˡ-law₁ ; idʳ-law to idʳ-law₁ ; invʳ-law to invʳ-law₁ )
+             ; idʳ-law to idʳ-law₁ ; invʳ-law to invʳ-law₁ )
   open Group-Op 𝒦 using ()
     renaming ( _∙_ to _∙₂_ ; ε to ε₂ ; _⁻¹ to _⁻¹₂
              ; idˡ-law to idˡ-law₂ ; idʳ-law to idʳ-law₂ ; invʳ-law to invʳ-law₂ )

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -45,7 +45,9 @@ Two standing warnings apply to everything under this namespace.
    `Con (𝒢 ↷ 𝒢/H) ≅ [H, 𝒢]` between the *semantic* congruence lattice of the
    transitive G-set of cosets and the respecting upper interval in the subgroup
    lattice, with the representability corollary.  The Layer D (`DecCon`) restatement
-   (required by issue #454's updated criteria) lands with the WP-7 decidable layer.
+   required by issue #454's updated criteria is now provided here as well
+   (`bridgeᵈ` / `interval-DecCon-representable`), by composing with the cross-layer
+   isomorphism of [FLRP.LayerBridge][].
 +  [FLRP.Representable][] — the Layer-D reformulation of the problem:
    decidable representability `Representableᵈ`, the statement
    `FLRP-Statementᵈ`, and the constructive two-element-chain representation

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -12,19 +12,21 @@ This is the [FLRP][] module of the [Agda Universal Algebra Library][].
 
 This top-level `FLRP/` tree hosts the library's research program on the
 **Finite Lattice Representation Problem**: is every finite lattice isomorphic to the
-congruence lattice of a *finite* algebra?  The program's plan (the state of the art,
-the primary avenue of attack via interval-enforceable properties, and the breakdown
-into work packages) lives in `docs/notes/flrp-research-roadmap.md`; this tree holds
-only problem-specific formal content, while reusable mathematics developed along the
-way (group actions, subgroup lattices, closure combinatorics) lands in the `Setoid/`,
-`Classical/`, and `Order/` trees proper.
+congruence lattice of a *finite* algebra?
+
+The program's plan (the state of the art, the primary avenue of attack via
+interval-enforceable properties, and the breakdown into work packages) lives in
+[`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md).
+
+The `FLRP/` tree holds only problem-specific formal content, while reusable
+mathematics developed along the way (group actions, subgroup lattices, closure
+combinatorics) lives in the `Setoid/`, `Classical/`, and `Order/` trees.
 
 Two standing warnings apply to everything under this namespace.
 
 +  **Research-track separation**.  The FLRP is distinct from the algebraic-complexity
    / finite-CSP track and from the Maltsev and interpretability infrastructure, even
-   where they share modules; do not conflate them (see `CLAUDE.md` and
-   `docs/GITHUB_PROJECT.md`).
+   where they share modules.
 +  **Experimental status**.  FLRP modules are research material and are exempt from
    the stable-API deprecation discipline until their results stabilize.
 
@@ -36,14 +38,14 @@ Two standing warnings apply to everything under this namespace.
 +  [FLRP.Enforceable][] — group representability of a lattice, the
    interval-enforceability classification (IE, cf-IE, min-IE), the fattening
    isomorphism `[H × K, G × K] ≅ [H, G]`, the no-contradictory-IE theorem
-   (the note's Lemma 3.2), and hypothesis-parameterized statements of Lemma 3.1
-   and the parachute meta-theorem.
+   (the research note's Lemma 3.2), and hypothesis-parameterized statements of
+   Lemma 3.1 and the parachute meta-theorem.
 +  [FLRP.Bridge][] — the easy (constructive) direction of the Pálfy–Pudlák
-   correspondence at **Layer S**: the order isomorphism `Con (𝒢 ↷ 𝒢/H) ≅ [H, 𝒢]`
-   between the *semantic* congruence lattice of the transitive coset G-set and the
-   respecting upper interval in the subgroup lattice, with the representability
-   corollary.  The Layer D (`DecCon`) restatement required by issue #454's updated
-   criteria lands with the WP-7 decidable layer.
+   correspondence at the semantic layer (*Layer S*): the order isomorphism
+   `Con (𝒢 ↷ 𝒢/H) ≅ [H, 𝒢]` between the *semantic* congruence lattice of the
+   transitive G-set of cosets and the respecting upper interval in the subgroup
+   lattice, with the representability corollary.  The Layer D (`DecCon`) restatement
+   (required by issue #454's updated criteria) lands with the WP-7 decidable layer.
 +  [FLRP.Representable][] — the Layer-D reformulation of the problem:
    decidable representability `Representableᵈ`, the statement
    `FLRP-Statementᵈ`, and the constructive two-element-chain representation

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -49,15 +49,20 @@ Two standing warnings apply to everything under this namespace.
    `FLRP-Statementᵈ`, and the constructive two-element-chain representation
    `chain₂-Representableᵈ` (the object the no-go theorem forbids at Layer S,
    attained here with no postulate).
++  [FLRP.Assumptions][] — the registry of classical theorems imported as
+   explicit hypotheses (never postulates), keeping the tree honest under
+   `--safe`; its first entry is the congruence-completeness bridge
+   `CongruenceCompleteness`, the single Layer-S→Layer-D assumption of ADR-008.
++  [FLRP.LayerBridge][] — the cross-layer bridge: under the congruence-completeness
+   assumption, the semantic and decidable congruence posets are order-isomorphic
+   (`conDecIso`), whence `Representable 𝑳 ↔ Representableᵈ 𝑳`.
 
 **Planned submodules** (per § 6 of the roadmap).
 
 +  `FLRP.Closure` (closure properties of the representable class);
 +  `FLRP.Intervals` (intervals in subgroup lattices and core-free normalization);
 +  `FLRP.Reductions` (the catalog of reduction theorems);
-+  `FLRP.Certificates` (machine-checked representation certificates);
-+  `FLRP.Assumptions` (the registry of classical theorems imported as explicit
-   hypotheses, keeping the tree honest under `--safe`).
++  `FLRP.Certificates` (machine-checked representation certificates).
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
@@ -68,4 +73,6 @@ open import FLRP.Problem public
 open import FLRP.Enforceable public
 open import FLRP.Bridge public
 open import FLRP.Representable public
+open import FLRP.Assumptions public
+open import FLRP.LayerBridge public
 ```

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -1,0 +1,171 @@
+---
+layout: default
+file: "src/FLRP/Assumptions.lagda.md"
+title: "FLRP.Assumptions module (The Agda Universal Algebra Library)"
+date: "2026-07-20"
+author: "the agda-algebras development team"
+---
+
+### The registry of classical assumptions of the FLRP program
+
+This is the [FLRP.Assumptions][] module of the [Agda Universal Algebra Library][].
+
+The FLRP tree is `--safe` and postulate-free.  Where a result genuinely depends on
+a classical theorem, that theorem is never introduced as a `postulate`; it is stated
+as an **explicit hypothesis** and threaded through the results that consume it.  This
+module is the single place those hypotheses are *named, documented, and given their
+logical strength*, so that the classical content of the program is auditable at one
+site rather than smeared across the development.  It implements the assumption-registry
+discipline of [ADR-008][] (`docs/adr/008-two-layer-congruence-discipline.md`, L4) and
+the FLRP roadmap.
+
+**Entry 1 — the congruence-completeness bridge**.  This is the *single* classical
+assumption of the two-layer discipline: the one place a result may cross from the
+semantic congruence layer (Layer S, `Con`{.AgdaFunction}) to the decidable layer
+(Layer D, `DecCon`{.AgdaFunction}).  It is registered here as
+`CongruenceCompleteness`{.AgdaFunction} `𝑨`.
+
++  **Meaning**.  Every *semantic* congruence of `𝑨`{.AgdaBound} is `≑`{.AgdaFunction}
+   (mutual containment) to a *decidable* one.
++  **Source**.  It is exactly the `complete`{.AgdaField} field of
+   `FiniteCongruences`{.AgdaRecord} of [Setoid.Congruences.Finite.Basic][], with the
+   finite list and its membership proof forgotten (the list side is *constructive* —
+   see below), so `fromFiniteCongruences`{.AgdaFunction} extracts it from the canonical
+   record.
++  **Strength**.  It sits strictly *between weak excluded middle and excluded middle*
+   at the working relation level.  The lower bound is the no-go theorem
+   `chain₂-ConIso→WLEM`{.AgdaFunction} / `chain₂-Representable→WLEM`{.AgdaFunction} of
+   [FLRP.Problem][]: on a nontrivial algebra the bridge lets an oracle congruence be
+   decided, yielding weak excluded middle.  The upper bound is that full excluded
+   middle at the working level supplies it (design note § 2.1).  Pinning the exact
+   strength is a side question the program does not need (`docs/notes/flrp-two-layer-congruences.md`
+   § 2.1, L4).
+
+The constructive *complement* of this assumption is already discharged with no axiom:
+the finite list of decidable congruences and its completeness *for the decidable layer*
+is `FiniteCongruencesᵈ`{.AgdaRecord} of [Setoid.Congruences.Finite.Decidable][], built
+from carrier- and signature-finiteness alone.  `toFiniteCongruences`{.AgdaFunction}
+below makes this precise: adjoining `CongruenceCompleteness`{.AgdaFunction} to that free
+constructive data reconstitutes the full semantic `FiniteCongruences`{.AgdaRecord}, so
+the assumption is *neither more nor less* than the classical delta between the two
+layers.
+
+**Coordination note (WP-5, issue #456)**.  Work package WP-5 also plans to register
+its Kurzweil–Netter duality in this module.  The module is structured as *per-assumption
+statement definitions* (rather than one monolithic record) precisely so that a second
+entry can be appended without disturbing the first: WP-5 should add its duality as
+"Entry 2" alongside `CongruenceCompleteness`{.AgdaFunction}, and downstream results take
+whichever entry they need as an ordinary argument.
+
+The standing FLRP research-track separation warning of [FLRP.Problem][] applies here
+too: this is problem-specific formal content, not to be conflated with the
+algebraic-complexity / finite-CSP work elsewhere in the library.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.Assumptions where
+
+-- Imports from Agda and the Agda Standard Library -----------------------------
+open import Agda.Primitive                       using () renaming ( Set to Type )
+open import Data.List.Membership.Propositional    using ( _∈_ )
+open import Data.Product                          using ( _×_ ; _,_ ; Σ-syntax
+                                                        ; proj₁ ; proj₂ )
+open import Level                                 using ( Level ; _⊔_ )
+                                                  renaming ( suc to lsuc )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Overture                              using ( 𝓞 ; 𝓥 ; Signature )
+open import Setoid.Algebras.Basic                 using ( Algebra )
+open import Setoid.Algebras.Finite                using ( FiniteAlgebra )
+open import Setoid.Signatures.Finite              using ( FiniteSignature )
+open import Setoid.Congruences.Basic              using ( Con )
+open import Setoid.Congruences.Lattice            using ( _≑_ ; ≑-trans )
+open import Setoid.Congruences.Finite.Basic       using ( DecCon ; FiniteCongruences )
+open import Setoid.Congruences.Finite.Decidable   using ( FiniteCongruencesᵈ
+                                                        ; FiniteAlgebra→FiniteCongruencesᵈ )
+
+private variable α ρ : Level
+```
+-->
+
+#### Entry 1: the congruence-completeness bridge
+
+Throughout we fix an algebra `𝑨`{.AgdaBound} and work at its **working congruence
+level** `ℓ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ` — the absorbing level at which the decidable-layer
+machinery of [Setoid.Congruences.Finite.Basic][] and
+[Setoid.Congruences.Finite.Decidable][] lives, and the level at which the `complete`
+field of `FiniteCongruences`{.AgdaRecord} quantifies.
+
+```agda
+module _ {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = 𝑆} α ρ) where
+  private
+    ℓ : Level
+    ℓ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ
+```
+
+`CongruenceCompleteness`{.AgdaFunction} `𝑨` is the assumption itself: a function that,
+given *any* semantic congruence `φ`{.AgdaBound}, produces a decidable congruence
+`≑`{.AgdaFunction} to it.  This is the `complete`{.AgdaField} field of
+`FiniteCongruences`{.AgdaRecord} with the list `cons`{.AgdaField} and the membership
+proof `d ∈ cons`{.AgdaFunction} dropped: those record the *finiteness* of the
+collection of decidable congruences, which is constructive
+(`FiniteCongruencesᵈ`{.AgdaRecord}), whereas the classical content is precisely the
+existence of a decidable `≑`-representative for a congruence that need carry no
+decision procedure of its own.
+
+```agda
+  CongruenceCompleteness : Type (lsuc ℓ)
+  CongruenceCompleteness = (φ : Con 𝑨 ℓ) → Σ[ d ∈ DecCon 𝑨 ℓ ] (φ ≑ proj₁ d)
+```
+
+**The source.**  A `FiniteCongruences`{.AgdaRecord} witness — the canonical form of the
+assumption in the library — yields the bridge by forgetting the list and its membership
+proof.  This is the direction any consumer that already has the full record uses.
+
+```agda
+  fromFiniteCongruences : FiniteCongruences 𝑨 → CongruenceCompleteness
+  fromFiniteCongruences 𝑪 φ = proj₁ (complete φ) , proj₂ (proj₂ (complete φ))
+    where open FiniteCongruences 𝑪 using ( complete )
+```
+
+**Exactly the classical delta.**  Conversely, adjoining the bridge to the *free
+constructive* data of a finite finitary algebra — its carrier finiteness
+(`FiniteAlgebra`{.AgdaRecord}) and signature finiteness
+(`FiniteSignature`{.AgdaRecord}), from which
+`FiniteAlgebra→FiniteCongruencesᵈ`{.AgdaFunction} builds a complete list of *decidable*
+congruences with no axiom — reconstitutes the full semantic
+`FiniteCongruences`{.AgdaRecord}.  So `CongruenceCompleteness`{.AgdaFunction} is neither
+more nor less than the classical content of "finite" for congruence-lattice purposes:
+it is the whole gap between Layer D and Layer S, and nothing else.
+
+The list is the constructive `consᵈ`{.AgdaField}; completeness chains the bridge's
+`≑`{.AgdaFunction} into the decidable-layer completeness `completeᵈ`{.AgdaField} by
+transitivity.
+
+```agda
+  toFiniteCongruences : CongruenceCompleteness
+    → FiniteAlgebra 𝑨 → FiniteSignature 𝑆 → FiniteCongruences 𝑨
+  toFiniteCongruences cc 𝑭 𝑺 = record { cons = consᵈ ; complete = comp }
+    where
+    open FiniteCongruencesᵈ (FiniteAlgebra→FiniteCongruencesᵈ 𝑭 𝑺) using ( consᵈ ; completeᵈ )
+    comp : (φ : Con 𝑨 ℓ) → Σ[ e ∈ DecCon 𝑨 ℓ ] (e ∈ consᵈ) × (φ ≑ proj₁ e)
+    comp φ = e , e∈ , φ≑e
+      where
+      d : DecCon 𝑨 ℓ
+      d = proj₁ (cc φ)
+      φ≑d : φ ≑ proj₁ d
+      φ≑d = proj₂ (cc φ)
+      e : DecCon 𝑨 ℓ
+      e = proj₁ (completeᵈ d)
+      e∈ : e ∈ consᵈ
+      e∈ = proj₁ (proj₂ (completeᵈ d))
+      d≑e : proj₁ d ≑ proj₁ e
+      d≑e = proj₂ (proj₂ (completeᵈ d))
+      φ≑e : φ ≑ proj₁ e
+      φ≑e = (λ p → proj₁ d≑e (proj₁ φ≑d p))
+          , (λ p → proj₂ φ≑d (proj₂ d≑e p))
+```
+
+--------------------------------------

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -10,56 +10,53 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.Assumptions][] module of the [Agda Universal Algebra Library][].
 
-The FLRP tree is `--safe` and postulate-free.  Where a result genuinely depends on
-a classical theorem, that theorem is never introduced as a `postulate`; it is stated
-as an **explicit hypothesis** and threaded through the results that consume it.  This
-module is the single place those hypotheses are *named, documented, and given their
-logical strength*, so that the classical content of the program is auditable at one
-site rather than smeared across the development.  It implements the assumption-registry
-discipline of [ADR-008][] (`docs/adr/008-two-layer-congruence-discipline.md`, L4) and
-the FLRP roadmap.
+The [Agda Universal Algebra Library][] is postulate-free, confined to
+[*Safe Agda*](https://agda.readthedocs.io/en/v2.8.0-r3/language/safe-agda.html#safe-agda),
+and the FLRP tree is no execption.  Where a result genuinely depends on a classical
+theorem, that theorem is never introduced as a `postulate`; it is stated as an
+*explicit hypothesis* and threaded through the results that consume it.
 
-**Entry 1 — the congruence-completeness bridge**.  This is the *single* classical
+The present module is the single place these hypotheses are *named, documented, and
+given their logical strength*, so that the classical content of the FLRP research
+program is auditable at one site rather than smeared across the development.[^1]
+
+**Entry 1**: the congruence-completeness bridge.  This is the *single* classical
 assumption of the two-layer discipline: the one place a result may cross from the
 semantic congruence layer (Layer S, `Con`{.AgdaFunction}) to the decidable layer
 (Layer D, `DecCon`{.AgdaFunction}).  It is registered here as
 `CongruenceCompleteness`{.AgdaFunction} `𝑨`.
 
 +  **Meaning**.  Every *semantic* congruence of `𝑨`{.AgdaBound} is `≑`{.AgdaFunction}
-   (mutual containment) to a *decidable* one.
+   to a *decidable* one.  (`≑`{.AgdaFunction} is mutual containment.)
+
 +  **Source**.  It is exactly the `complete`{.AgdaField} field of
    `FiniteCongruences`{.AgdaRecord} of [Setoid.Congruences.Finite.Basic][], with the
    finite list and its membership proof forgotten (the list side is *constructive* —
    see below), so `fromFiniteCongruences`{.AgdaFunction} extracts it from the canonical
    record.
+
 +  **Strength**.  It sits strictly *between weak excluded middle and excluded middle*
    at the working relation level.  The lower bound is the no-go theorem
    `chain₂-ConIso→WLEM`{.AgdaFunction} / `chain₂-Representable→WLEM`{.AgdaFunction} of
    [FLRP.Problem][]: on a nontrivial algebra the bridge lets an oracle congruence be
    decided, yielding weak excluded middle.  The upper bound is that full excluded
-   middle at the working level supplies it (design note § 2.1).  Pinning the exact
-   strength is a side question the program does not need (`docs/notes/flrp-two-layer-congruences.md`
-   § 2.1, L4).
+   middle at the working level supplies it.[^2]
 
 The constructive *complement* of this assumption is already discharged with no axiom:
 the finite list of decidable congruences and its completeness *for the decidable layer*
 is `FiniteCongruencesᵈ`{.AgdaRecord} of [Setoid.Congruences.Finite.Decidable][], built
 from carrier- and signature-finiteness alone.  `toFiniteCongruences`{.AgdaFunction}
-below makes this precise: adjoining `CongruenceCompleteness`{.AgdaFunction} to that free
-constructive data reconstitutes the full semantic `FiniteCongruences`{.AgdaRecord}, so
-the assumption is *neither more nor less* than the classical delta between the two
-layers.
+below makes this precise: adjoining `CongruenceCompleteness`{.AgdaFunction} to that
+free constructive data reconstitutes the full semantic
+`FiniteCongruences`{.AgdaRecord}, so the assumption is exactly the classical delta
+between the two layers, no more, no less.
 
-**Coordination note (WP-5, issue #456)**.  Work package WP-5 also plans to register
-its Kurzweil–Netter duality in this module.  The module is structured as *per-assumption
-statement definitions* (rather than one monolithic record) precisely so that a second
-entry can be appended without disturbing the first: WP-5 should add its duality as
-"Entry 2" alongside `CongruenceCompleteness`{.AgdaFunction}, and downstream results take
-whichever entry they need as an ordinary argument.
-
-The standing FLRP research-track separation warning of [FLRP.Problem][] applies here
-too: this is problem-specific formal content, not to be conflated with the
-algebraic-complexity / finite-CSP work elsewhere in the library.
+**Coordination note**.  Work package 5 (WP-5) also plans to register
+its Kurzweil–Netter duality in this module.[^3]  The module is structured as
+*per-assumption statement definitions* (rather than one monolithic record) precisely
+so that a second entry can be appended without disturbing the first: WP-5 should add
+its duality as "Entry 2" alongside `CongruenceCompleteness`{.AgdaFunction}, and
+downstream results take whichever entry they need as an ordinary argument.[^4]
 
 <!--
 ```agda
@@ -67,24 +64,26 @@ algebraic-complexity / finite-CSP work elsewhere in the library.
 
 module FLRP.Assumptions where
 
--- Imports from Agda and the Agda Standard Library -----------------------------
-open import Agda.Primitive                       using () renaming ( Set to Type )
-open import Data.List.Membership.Propositional    using ( _∈_ )
-open import Data.Product                          using ( _×_ ; _,_ ; Σ-syntax
-                                                        ; proj₁ ; proj₂ )
-open import Level                                 using ( Level ; _⊔_ )
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.List.Membership.Propositional    using  ( _∈_ )
+open import Data.Product                          using  ( _×_ ; _,_ ; Σ-syntax
+                                                         ; proj₁ ; proj₂ )
+open import Function                              using  (_∘_)
+open import Level                                 using  ( Level ; _⊔_ )
                                                   renaming ( suc to lsuc )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Overture                              using ( 𝓞 ; 𝓥 ; Signature )
-open import Setoid.Algebras.Basic                 using ( Algebra )
-open import Setoid.Algebras.Finite                using ( FiniteAlgebra )
-open import Setoid.Signatures.Finite              using ( FiniteSignature )
-open import Setoid.Congruences.Basic              using ( Con )
-open import Setoid.Congruences.Lattice            using ( _≑_ ; ≑-trans )
-open import Setoid.Congruences.Finite.Basic       using ( DecCon ; FiniteCongruences )
-open import Setoid.Congruences.Finite.Decidable   using ( FiniteCongruencesᵈ
-                                                        ; FiniteAlgebra→FiniteCongruencesᵈ )
+open import Overture                              using  ( 𝓞 ; 𝓥 ; Signature )
+open import Setoid.Algebras.Basic                 using  ( Algebra )
+open import Setoid.Algebras.Finite                using  ( FiniteAlgebra )
+open import Setoid.Signatures.Finite              using  ( FiniteSignature )
+open import Setoid.Congruences.Basic              using  ( Con )
+open import Setoid.Congruences.Lattice            using  ( _≑_ ; ≑-trans )
+open import Setoid.Congruences.Finite.Basic       using  ( DecCon ; FiniteCongruences )
+open import Setoid.Congruences.Finite.Decidable   using  ( FiniteCongruencesᵈ
+                                                         ; FiniteAlgebra→FiniteCongruencesᵈ )
 
 private variable α ρ : Level
 ```
@@ -92,9 +91,9 @@ private variable α ρ : Level
 
 #### Entry 1: the congruence-completeness bridge
 
-Throughout we fix an algebra `𝑨`{.AgdaBound} and work at its **working congruence
-level** `ℓ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ` — the absorbing level at which the decidable-layer
-machinery of [Setoid.Congruences.Finite.Basic][] and
+Throughout we fix an algebra `𝑨`{.AgdaBound} and work at its
+**working congruence level** `ℓ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ` — the absorbing level at which the
+decidable-layer machinery of [Setoid.Congruences.Finite.Basic][] and
 [Setoid.Congruences.Finite.Decidable][] lives, and the level at which the `complete`
 field of `FiniteCongruences`{.AgdaRecord} quantifies.
 
@@ -105,40 +104,46 @@ module _ {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = 𝑆} α ρ) where
     ℓ = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ
 ```
 
-`CongruenceCompleteness`{.AgdaFunction} `𝑨` is the assumption itself: a function that,
-given *any* semantic congruence `φ`{.AgdaBound}, produces a decidable congruence
-`≑`{.AgdaFunction} to it.  This is the `complete`{.AgdaField} field of
-`FiniteCongruences`{.AgdaRecord} with the list `cons`{.AgdaField} and the membership
-proof `d ∈ cons`{.AgdaFunction} dropped: those record the *finiteness* of the
-collection of decidable congruences, which is constructive
-(`FiniteCongruencesᵈ`{.AgdaRecord}), whereas the classical content is precisely the
-existence of a decidable `≑`-representative for a congruence that need carry no
-decision procedure of its own.
+`CongruenceCompleteness`{.AgdaFunction} `𝑨` is the assumption itself; it is a
+function that, given *any* semantic congruence `φ`{.AgdaBound}, produces a decidable
+congruence `≑`{.AgdaFunction} to it.
+
+This is the `complete`{.AgdaField} field of `FiniteCongruences`{.AgdaRecord} with the
+list `cons`{.AgdaField} and the membership proof `d ∈ cons`{.AgdaFunction} dropped;
+those record the *finiteness* of the collection of decidable congruences, which is
+constructive (`FiniteCongruencesᵈ`{.AgdaRecord}), whereas the classical content is
+precisely the existence of a decidable `≑`-representative for a congruence that need
+carry no decision procedure of its own.
 
 ```agda
+  -- For each semantic congruence φ, there exists a decidable congruence d such that φ ≑ d.
   CongruenceCompleteness : Type (lsuc ℓ)
-  CongruenceCompleteness = (φ : Con 𝑨 ℓ) → Σ[ d ∈ DecCon 𝑨 ℓ ] (φ ≑ proj₁ d)
+  CongruenceCompleteness = (φ : Con 𝑨 ℓ) → Σ[ (d , _) ∈ DecCon 𝑨 ℓ ] φ ≑ d
 ```
 
-**The source.**  A `FiniteCongruences`{.AgdaRecord} witness — the canonical form of the
-assumption in the library — yields the bridge by forgetting the list and its membership
-proof.  This is the direction any consumer that already has the full record uses.
+**The source**.  A `FiniteCongruences`{.AgdaRecord} witness — the canonical form of
+the assumption in the library — yields the bridge by forgetting the list and its
+membership proof.  This is the direction a consumer already in posession of the full
+record would use.
 
 ```agda
   fromFiniteCongruences : FiniteCongruences 𝑨 → CongruenceCompleteness
-  fromFiniteCongruences 𝑪 φ = proj₁ (complete φ) , proj₂ (proj₂ (complete φ))
-    where open FiniteCongruences 𝑪 using ( complete )
+  fromFiniteCongruences 𝑪 φ = witness φ , witness≑ φ
+    where open FiniteCongruences 𝑪 using ( witness ; witness≑ )
+  -- Recall, `witness φ` is d and `witness≑ φ` is the proof of `φ ≑ proj₁ d`
+
 ```
 
-**Exactly the classical delta.**  Conversely, adjoining the bridge to the *free
-constructive* data of a finite finitary algebra — its carrier finiteness
-(`FiniteAlgebra`{.AgdaRecord}) and signature finiteness
-(`FiniteSignature`{.AgdaRecord}), from which
-`FiniteAlgebra→FiniteCongruencesᵈ`{.AgdaFunction} builds a complete list of *decidable*
-congruences with no axiom — reconstitutes the full semantic
-`FiniteCongruences`{.AgdaRecord}.  So `CongruenceCompleteness`{.AgdaFunction} is neither
-more nor less than the classical content of "finite" for congruence-lattice purposes:
-it is the whole gap between Layer D and Layer S, and nothing else.
+**The classical delta**.  Conversely, adjoining the bridge to the *free constructive*
+data of a finite finitary algebra — its carrier finiteness
+(`FiniteAlgebra`{.AgdaRecord}) and signature finiteness (`FiniteSignature`{.AgdaRecord}),
+from which `FiniteAlgebra→FiniteCongruencesᵈ`{.AgdaFunction} builds a complete list of
+*decidable* congruences with no axiom — reconstitutes the full semantic
+`FiniteCongruences`{.AgdaRecord}.
+
+So `CongruenceCompleteness`{.AgdaFunction} is neither more nor less than the
+classical content of "finite" for congruence-lattice purposes: it is the gap
+between Layer D and Layer S, and nothing else.
 
 The list is the constructive `consᵈ`{.AgdaField}; completeness chains the bridge's
 `≑`{.AgdaFunction} into the decidable-layer completeness `completeᵈ`{.AgdaField} by
@@ -149,23 +154,40 @@ transitivity.
     → FiniteAlgebra 𝑨 → FiniteSignature 𝑆 → FiniteCongruences 𝑨
   toFiniteCongruences cc 𝑭 𝑺 = record { cons = consᵈ ; complete = comp }
     where
-    open FiniteCongruencesᵈ (FiniteAlgebra→FiniteCongruencesᵈ 𝑭 𝑺) using ( consᵈ ; completeᵈ )
-    comp : (φ : Con 𝑨 ℓ) → Σ[ e ∈ DecCon 𝑨 ℓ ] (e ∈ consᵈ) × (φ ≑ proj₁ e)
-    comp φ = e , e∈ , φ≑e
+    open FiniteCongruencesᵈ (FiniteAlgebra→FiniteCongruencesᵈ 𝑭 𝑺)
+      using ( consᵈ ; witnessᵈ ; witnessᵈ∈ ; witnessᵈ≑ )
+
+    comp : (φ : Con 𝑨 ℓ) → Σ[ e ∈ DecCon 𝑨 ℓ ] e ∈ consᵈ × φ ≑ proj₁ e
+    comp φ = e , witnessᵈ∈ d , φ≑e
       where
       d : DecCon 𝑨 ℓ
-      d = proj₁ (cc φ)
-      φ≑d : φ ≑ proj₁ d
-      φ≑d = proj₂ (cc φ)
+      d = cc φ .proj₁
+
+      φ≑d : φ ≑ d .proj₁
+      φ≑d = cc φ .proj₂
+
       e : DecCon 𝑨 ℓ
-      e = proj₁ (completeᵈ d)
-      e∈ : e ∈ consᵈ
-      e∈ = proj₁ (proj₂ (completeᵈ d))
-      d≑e : proj₁ d ≑ proj₁ e
-      d≑e = proj₂ (proj₂ (completeᵈ d))
-      φ≑e : φ ≑ proj₁ e
-      φ≑e = (λ p → proj₁ d≑e (proj₁ φ≑d p))
-          , (λ p → proj₂ φ≑d (proj₂ d≑e p))
+      e = witnessᵈ d
+
+      d≑e : d .proj₁ ≑ e .proj₁
+      d≑e = witnessᵈ≑ d
+
+      φ≑e : φ ≑ e .proj₁
+      φ≑e = d≑e .proj₁ ∘ φ≑d .proj₁ , φ≑d .proj₂ ∘ d≑e .proj₂
 ```
 
 --------------------------------------
+
+[^1]: This is the assumption-registry discipline of [ADR-008][] and the FLRP roadmap.
+
+[^2]: Pinning the exact strength is a side question the program does not need
+      (see `docs/notes/flrp-two-layer-congruences.md` § 2.1, L4).
+
+[^3]: **WP-5: closure toolkit** formalizes product and ordinal-sum closure of
+      representability (see
+      [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7
+      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456).
+
+[^4]: The standing FLRP research-track separation warning of [FLRP.Problem][] applies
+      here too: this is problem-specific formal content, not to be conflated with the
+      algebraic-complexity / finite-CSP work elsewhere in the library.

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -80,7 +80,7 @@ open import Setoid.Algebras.Basic                 using  ( Algebra )
 open import Setoid.Algebras.Finite                using  ( FiniteAlgebra )
 open import Setoid.Signatures.Finite              using  ( FiniteSignature )
 open import Setoid.Congruences.Basic              using  ( Con )
-open import Setoid.Congruences.Lattice            using  ( _≑_ ; ≑-trans )
+open import Setoid.Congruences.Lattice            using  ( _≑_ )
 open import Setoid.Congruences.Finite.Basic       using  ( DecCon ; FiniteCongruences )
 open import Setoid.Congruences.Finite.Decidable   using  ( FiniteCongruencesᵈ
                                                          ; FiniteAlgebra→FiniteCongruencesᵈ )

--- a/src/FLRP/Bridge.lagda.md
+++ b/src/FLRP/Bridge.lagda.md
@@ -72,7 +72,7 @@ open import Agda.Primitive using () renaming ( Set to Type )
 open import Data.Fin.Patterns             using ( 0F )
 open import Data.Product                  using ( _,_ ; _×_ ; Σ-syntax ; proj₁ ; proj₂ )
 open import Function                      using ( _∘_ )
-open import Level                         using ( Level ; 0ℓ ) renaming ( suc to lsuc )
+open import Level                         using ( 0ℓ ) renaming ( suc to lsuc )
 open import Relation.Binary               using ( Setoid ; IsEquivalence )
                                           renaming ( Rel to BinaryRel )
 open import Relation.Binary.Definitions   using ( _Respects_ )
@@ -85,22 +85,23 @@ open import Classical.Bundles.Group               using  ( ⟨_⟩ᵍᵖ )
 open import Classical.Signatures.Unary            using  ( Sig-Unary )
 open import Classical.Structures.Group.Basic      using  ( Group ; module Group-Op )
 open import Classical.Structures.Group.Subgroups  using  ( IsSubgroup ; mkIsSubgroup )
-open import Classical.Structures.Group.SubgroupLattice using (module GroupSublattice)
+open import Classical.Structures.Group.SubgroupLattice
+                                                  using  (module GroupSublattice)
 open import Classical.Structures.Group.Cosets     using  ( module Coset )
 open import Classical.Structures.Group.GSet       using  ( module CosetAction )
 open import FLRP.Enforceable                      using  ( module UpperInterval )
 open import FLRP.Problem                          using  ( OrderIso )
-open import Setoid.Algebras.Basic                 using  ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_ )
+open import Setoid.Algebras.Basic                 using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Algebras.Finite                using  ( FiniteAlgebra )
 open import Setoid.Congruences.Basic              using  ( Con ; IsCongruence ; mkcon
                                                          ; _∣≈_ ; is-compatible
                                                          ; is-equivalence ; reflexive )
-open import Setoid.Congruences.Lattice            using ( _≑_ )
+open import Setoid.Congruences.Lattice            using  ( _≑_ )
                                                   renaming ( _⊆_ to _⊑_ )
-open import Setoid.Congruences.Finite.Basic       using ( DecCon )
-open import FLRP.Representable                     using ( _⊆ᵈ_ ; _≑ᵈ_ )
-open import FLRP.Assumptions                       using ( CongruenceCompleteness )
-open import FLRP.LayerBridge                       using ( conDecIso ; wit )
+open import Setoid.Congruences.Finite.Basic       using  ( DecCon )
+open import FLRP.Representable                    using  ( _⊆ᵈ_ ; _≑ᵈ_ )
+open import FLRP.Assumptions                      using  ( CongruenceCompleteness )
+open import FLRP.LayerBridge                      using  ( conDecIso ; wit )
 ```
 -->
 
@@ -122,13 +123,14 @@ module Bridge (𝒢    : Group 0ℓ 0ℓ)
   G : Type 0ℓ
   G = 𝕌[ 𝑮 ]
 
-  open Setoid 𝔻[ 𝑮 ]  using ( _≈_ )
-                      renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
-  open Group-Op 𝒢     using ( _∙_ ; ε ; _⁻¹ ; ∙-cong ; idˡ-law ; idʳ-law ; invˡ-law )
-  open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ  using ( ε⁻¹≈ε ; \\-leftDividesˡ )
-  open IsSubgroup H-sg          using ( respects )
-  open Coset 𝒢 H H-sg           using ( _∼_ ; ≈⇒∼ )
-  open CosetAction 𝒢 H H-sg     using ( cosetAlgebra )
+  open Setoid 𝔻[ 𝑮 ]            renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+                                using ( _≈_ )
+  open Group-Op 𝒢               using  ( _∙_ ; ε ; _⁻¹ ; ∙-cong ; idˡ-law
+                                       ; idʳ-law ; invˡ-law )
+  open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ  using  ( ε⁻¹≈ε ; \\-leftDividesˡ )
+  open IsSubgroup H-sg          using  ( respects )
+  open Coset 𝒢 H H-sg           using  ( _∼_ ; ≈⇒∼ )
+  open CosetAction 𝒢 H H-sg     using  ( cosetAlgebra )
   open UpperInterval 𝒢 H H-sg
 ```
 

--- a/src/FLRP/Bridge.lagda.md
+++ b/src/FLRP/Bridge.lagda.md
@@ -44,18 +44,17 @@ elements carry a `Respects`{.AgdaFunction} proof.  Over a redundant presentation
 bare interval can be strictly larger than the respecting one, so the isomorphism is
 *false* at the bare level (see the counterexample in [FLRP.Enforceable][]).
 
-This is the **Layer S** formulation: `bridge`{.AgdaFunction} relates the *semantic*
-congruence lattice `Con`{.AgdaFunction} to the interval, and the whole isomorphism is
-proved constructively with no classical or deferred hypotheses.  The correspondence
-itself is layer-agnostic (ADR-008), so the **Layer D** restatement called for by the
-updated acceptance criteria of issue #454 — the same isomorphism with the
-decidable-congruence poset `DecCon`{.AgdaFunction} in place of `Con`{.AgdaFunction},
-over the interval's decidable order — is a thin follow-up that this module does *not*
-yet provide; it lands with the decidable coset algebra of WP-7 slice iii.  The
-representability corollary (`interval-Con-representable`{.AgdaFunction}) is likewise
-stated conditionally on a finiteness witness for the coset algebra, whose hookup to
-`Representableᵈ`{.AgdaRecord} of the decidable layer is that same WP-7 work and is
-deliberately not imported here.
+The core isomorphism `bridge`{.AgdaFunction} is the **Layer S** formulation: it relates
+the *semantic* congruence lattice `Con`{.AgdaFunction} to the interval, proved
+constructively with no classical or deferred hypotheses.  The correspondence itself is
+layer-agnostic (ADR-008), so the **Layer D** restatement called for by the updated
+acceptance criteria of issue #454 — the same isomorphism with the decidable-congruence
+poset `DecCon`{.AgdaFunction} in place of `Con`{.AgdaFunction} — follows by composing
+`bridge`{.AgdaFunction} with the cross-layer poset isomorphism `Con 𝑨 ≅ DecCon 𝑨` of
+[FLRP.LayerBridge][].  That restatement is now provided at the end of this module
+(`bridgeᵈ`{.AgdaFunction}, `interval-DecCon-representable`{.AgdaFunction}), taking the
+coset algebra's congruence-completeness bridge (`CongruenceCompleteness`{.AgdaFunction}
+of [FLRP.Assumptions][]) and its carrier-finiteness witness as explicit hypotheses.
 
 <!--
 ```agda
@@ -90,7 +89,12 @@ open import Setoid.Algebras.Finite                using  ( FiniteAlgebra )
 open import Setoid.Congruences.Basic              using  ( Con ; IsCongruence ; mkcon
                                                          ; _∣≈_ ; is-compatible
                                                          ; is-equivalence ; reflexive )
-open import Setoid.Congruences.Lattice            using ( _≑_ ) renaming ( _⊆_ to _⊑_ )
+open import Setoid.Congruences.Lattice            using ( _≑_ )
+                                                  renaming ( _⊆_ to _⊑_ )
+open import Setoid.Congruences.Finite.Basic       using ( DecCon )
+open import FLRP.Representable                     using ( _⊆ᵈ_ ; _≑ᵈ_ )
+open import FLRP.Assumptions                       using ( CongruenceCompleteness )
+open import FLRP.LayerBridge                       using ( conDecIso )
 ```
 -->
 
@@ -370,9 +374,9 @@ Finiteness of the coset algebra enters as an explicit hypothesis rather than bei
 derived: constructing `FiniteAlgebra cosetAlgebra`{.AgdaRecord} from finiteness of
 `𝒢`{.AgdaBound} needs a decision procedure for `∼_H`{.AgdaFunction} and a surjective
 enumeration of cosets, which is a separate concern.  This is exactly the datum the
-decidable layer supplies: on the eventual hookup this corollary meets
-`Representableᵈ`{.AgdaRecord} of the two-layer discipline (ADR-008), developed on the
-concurrent WP-7 branch and deliberately *not* imported here.
+decidable layer supplies: the Layer-D restatement below (`bridgeᵈ`{.AgdaFunction}) meets
+`Representableᵈ`{.AgdaRecord} of the two-layer discipline (ADR-008) through this same
+finiteness witness together with the congruence-completeness bridge.
 
 ```agda
   -- Corollary: a finite coset algebra realizes the interval [H , 𝒢] as its Con.
@@ -380,4 +384,74 @@ concurrent WP-7 branch and deliberately *not* imported here.
     FiniteAlgebra cosetAlgebra
     → Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Unary G} 0ℓ 0ℓ ] ( FiniteAlgebra 𝑨 × RepIso 𝑨 )
   interval-Con-representable fin = cosetAlgebra , fin , bridge⁻¹
+```
+
+#### The Layer-D restatement
+
+The updated acceptance criteria of issue #454 call for the correspondence at **Layer
+D**: the same isomorphism with the *decidable* congruence poset
+`DecCon`{.AgdaFunction} in place of the semantic `Con`{.AgdaFunction}.  The cross-layer
+bridge of [FLRP.LayerBridge][] — the order isomorphism `Con 𝑨 ≅ DecCon 𝑨` under the
+congruence-completeness assumption `CongruenceCompleteness`{.AgdaFunction} of
+[FLRP.Assumptions][] — supplies exactly the missing half: composing it with
+`bridge⁻¹`{.AgdaFunction} turns `[H , 𝒢] ≅ Con (𝒢 ↷ 𝒢/H)` into
+`[H , 𝒢] ≅ DecCon (𝒢 ↷ 𝒢/H)`.
+
+`RepIsoᵈ`{.AgdaFunction} is the decidable-layer analogue of `RepIso`{.AgdaFunction}:
+the interval, order-isomorphic to the `DecCon`{.AgdaFunction} poset.  Its assembly
+needs no antisymmetry: both round trips land in a mutual-inclusion equivalence
+(`≈ᵢ`{.AgdaFunction}, `≑ᵈ`{.AgdaFunction}), so each is built directly from the two
+monotone maps — the same product construction as `compose-IntervalIso`{.AgdaFunction}
+of [FLRP.Enforceable][].
+
+```agda
+  RepIsoᵈ : (𝑨 : Algebra {𝑆 = Sig-Unary G} 0ℓ 0ℓ) → Type (lsuc 0ℓ)
+  RepIsoᵈ 𝑨 = OrderIso _≈ᵢ_ _≤ᵢ_ (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) (_⊆ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ})
+
+  -- bridge⁻¹ (interval ≅ Con) composed with the cross-layer poset iso
+  -- (Con ≅ DecCon, under the coset algebra's congruence-completeness bridge).
+  -- Endpoint implicits of the monotone maps are forwarded explicitly, and each
+  -- round trip is assembled directly on a related pair — the implicit congruence
+  -- arguments of the named ⊆-trans are not inferable through the non-injective
+  -- containment relations (the discipline of Setoid.Congruences.Lattice).
+  bridgeᵈ : CongruenceCompleteness cosetAlgebra → RepIsoᵈ cosetAlgebra
+  bridgeᵈ cc = record
+    { to         = λ M → CD.to (BI.to M)
+    ; from       = λ d → BI.from (CD.from d)
+    ; to-mono    = λ {M}{N} M≤N →
+        CD.to-mono {BI.to M} {BI.to N} (BI.to-mono {M} {N} M≤N)
+    ; from-mono  = λ {d}{e} d⊆e →
+        BI.from-mono {CD.from d} {CD.from e} (CD.from-mono {d} {e} d⊆e)
+    ; to∘from    = λ d →
+          (λ p → proj₁ (CD.to∘from d)
+                   (CD.to-mono {BI.to (BI.from (CD.from d))} {CD.from d}
+                               (proj₁ (BI.to∘from (CD.from d))) p))
+        , (λ p → CD.to-mono {CD.from d} {BI.to (BI.from (CD.from d))}
+                            (proj₂ (BI.to∘from (CD.from d))) (proj₂ (CD.to∘from d) p))
+    ; from∘to    = λ M →
+          (λ z → proj₁ (BI.from∘to M)
+                   (BI.from-mono {CD.from (CD.to (BI.to M))} {BI.to M}
+                                 (proj₁ (CD.from∘to (BI.to M))) z))
+        , (λ z → BI.from-mono {BI.to M} {CD.from (CD.to (BI.to M))}
+                             (proj₂ (CD.from∘to (BI.to M))) (proj₂ (BI.from∘to M) z))
+    }
+    where
+    module CD = OrderIso (conDecIso cc)
+    module BI = OrderIso bridge⁻¹
+```
+
+**Corollary (Layer D, near-closing #454).**  A finite coset algebra whose semantic
+congruences are all `≑`{.AgdaFunction} to decidable ones (the congruence-completeness
+bridge for the coset algebra) realizes the interval `[H , 𝒢]` as its *decidable*
+congruence poset.  This is the `Representableᵈ`{.AgdaRecord}-side target of the two-layer
+discipline: the algebra, its carrier-finiteness witness, and the decidable-layer
+isomorphism are exactly the data `Representableᵈ`{.AgdaRecord} of [FLRP.Representable][]
+consumes (there over a classical `Lattice`{.AgdaRecord} presentation of the interval).
+
+```agda
+  interval-DecCon-representable :
+    FiniteAlgebra cosetAlgebra
+    → CongruenceCompleteness cosetAlgebra
+    → Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Unary G} 0ℓ 0ℓ ] ( FiniteAlgebra 𝑨 × RepIsoᵈ 𝑨 )
+  interval-DecCon-representable fin cc = cosetAlgebra , fin , bridgeᵈ cc
 ```

--- a/src/FLRP/Bridge.lagda.md
+++ b/src/FLRP/Bridge.lagda.md
@@ -10,48 +10,52 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.Bridge][] module of the [Agda Universal Algebra Library][].
 
-For a group `𝒢`{.AgdaBound} and a subgroup `H`{.AgdaBound}, the congruence lattice of
-the transitive coset G-set `𝒢 ↷ 𝒢/H` is order-isomorphic to the interval `[H , 𝒢]`
-in the subgroup lattice `Sub(𝒢)`.  This module formalizes the **easy (constructive)
-direction** of the Pálfy–Pudlák correspondence — work package WP-3 of the FLRP
-research program (see `docs/notes/flrp-research-roadmap.md` § 7).  Classical
-references: McKenzie–McNulty–Taylor Lemma 4.20, Dixon–Mortimer Theorem 1.5A, and the
-introduction of the vendored note `docs/papers/flrp/ieprops/IEProps-1205.1927v4.tex`.
+For a group `G`{.AgdaBound} and a subgroup `H`{.AgdaBound}, the congruence lattice of
+the transitive coset G-set `G ↷ G/H` is order-isomorphic to the interval `[H , G]`
+in the subgroup lattice `Sub G`.
+
+This module formalizes the **easy** (constructive) **direction** of the Pálfy–Pudlák
+correspondence.[^1]
 
 The correspondence has two mutually inverse, order-preserving maps.
 
 +  **`θ ↦ K_θ`** (`to`{.AgdaFunction}).  A congruence `θ`{.AgdaBound} of the coset
    algebra — a `G`-invariant equivalence on cosets — maps to the subgroup
-   `K_θ = { g ∈ 𝒢 : H·ε ∼_θ H·g }`, the `θ`-class of the base coset viewed as a
+   `K_θ = { g ∈ G : H·ε ∼_θ H·g }`, the `θ`-class of the base coset viewed as a
    predicate on the carrier.  We prove `K_θ`{.AgdaFunction} is an equality-respecting
    subgroup containing `H`{.AgdaBound}, i.e. an element of the respecting interval
-   `[H , 𝒢]`.
+   `[H , G]`.
+
 +  **`K ↦ θ_K`** (`from`{.AgdaFunction}).  A subgroup `K`{.AgdaBound} with
-   `H ≤ K ≤ 𝒢` maps to the relation `H·x ∼ H·y ⟺ x ⁻¹ ∙ y ∈ K` on cosets — which is
-   exactly the coset relation of `K`{.AgdaBound} from
-   [Classical.Structures.Group.Cosets][].  We prove it is a congruence of the coset
-   algebra (an equivalence, reflexive over `∼_H`, compatible with every unary
-   translate).
+   `H ≤ K ≤ G` maps to the relation `θ_K` on cosets defined by
+   `H·x θ_K H·y ⟺ x ⁻¹ ∙ y ∈ K` — which is exactly the coset relation of
+   `K`{.AgdaBound} from [Classical.Structures.Group.Cosets][].  We prove it is a
+   congruence of the coset algebra (an equivalence, reflexive over `∼_H`, compatible
+   with every unary translate).
 
 The two maps are mutually inverse and monotone, giving the order isomorphism
 `bridge`{.AgdaFunction}.
 
-**On the interval side we use the respecting `UpperInterval`{.AgdaModule} of
-[FLRP.Enforceable][], not the bare `SubInterval`{.AgdaModule}.**  This honors the
-WP-4 finding: the round trip `to (from M) ≈ M`{.AgdaFunction} moves membership
-across the setoid equality `ε ⁻¹ ∙ g ≈ g`, which is sound only because interval
-elements carry a `Respects`{.AgdaFunction} proof.  Over a redundant presentation the
-bare interval can be strictly larger than the respecting one, so the isomorphism is
-*false* at the bare level (see the counterexample in [FLRP.Enforceable][]).
+*On the interval side we use the respecting `UpperInterval`{.AgdaModule} of
+[FLRP.Enforceable][], not the bare `SubInterval`{.AgdaModule}.*
 
-The core isomorphism `bridge`{.AgdaFunction} is the **Layer S** formulation: it relates
+This honors the WP-4 finding: the round trip `to (from M) ≈ M` moves
+membership across the setoid equality `ε ⁻¹ ∙ g ≈ g`, which is sound only because
+interval elements carry a `Respects`{.AgdaFunction} proof.
+
+Over a redundant presentation the bare interval can be strictly larger than the
+respecting one, so the isomorphism is *false* at the bare level (see the
+counterexample in [FLRP.Enforceable][]).
+
+The core isomorphism `bridge`{.AgdaFunction} is the *Layer S* formulation: it relates
 the *semantic* congruence lattice `Con`{.AgdaFunction} to the interval, proved
-constructively with no classical or deferred hypotheses.  The correspondence itself is
-layer-agnostic (ADR-008), so the **Layer D** restatement called for by the updated
-acceptance criteria of issue #454 — the same isomorphism with the decidable-congruence
-poset `DecCon`{.AgdaFunction} in place of `Con`{.AgdaFunction} — follows by composing
-`bridge`{.AgdaFunction} with the cross-layer poset isomorphism `Con 𝑨 ≅ DecCon 𝑨` of
-[FLRP.LayerBridge][].  That restatement is now provided at the end of this module
+constructively with no classical or deferred hypotheses.
+
+The correspondence itself is layer-agnostic, so the *Layer D* restatement follows by
+composing `bridge`{.AgdaFunction} with the cross-layer poset isomorphism `Con 𝑨 ≅
+DecCon 𝑨` of [FLRP.LayerBridge][].[^2]
+
+ That restatement is now provided at the end of this module
 (`bridgeᵈ`{.AgdaFunction}, `interval-DecCon-representable`{.AgdaFunction}), taking the
 coset algebra's congruence-completeness bridge (`CongruenceCompleteness`{.AgdaFunction}
 of [FLRP.Assumptions][]) and its carrier-finiteness witness as explicit hypotheses.
@@ -67,6 +71,7 @@ open import Agda.Primitive using () renaming ( Set to Type )
 -- Imports from the Agda Standard Library ---------------------------------------
 open import Data.Fin.Patterns             using ( 0F )
 open import Data.Product                  using ( _,_ ; _×_ ; Σ-syntax ; proj₁ ; proj₂ )
+open import Function                      using ( _∘_ )
 open import Level                         using ( Level ; 0ℓ ) renaming ( suc to lsuc )
 open import Relation.Binary               using ( Setoid ; IsEquivalence )
                                           renaming ( Rel to BinaryRel )
@@ -80,6 +85,7 @@ open import Classical.Bundles.Group               using  ( ⟨_⟩ᵍᵖ )
 open import Classical.Signatures.Unary            using  ( Sig-Unary )
 open import Classical.Structures.Group.Basic      using  ( Group ; module Group-Op )
 open import Classical.Structures.Group.Subgroups  using  ( IsSubgroup ; mkIsSubgroup )
+open import Classical.Structures.Group.SubgroupLattice using (module GroupSublattice)
 open import Classical.Structures.Group.Cosets     using  ( module Coset )
 open import Classical.Structures.Group.GSet       using  ( module CosetAction )
 open import FLRP.Enforceable                      using  ( module UpperInterval )
@@ -94,7 +100,7 @@ open import Setoid.Congruences.Lattice            using ( _≑_ )
 open import Setoid.Congruences.Finite.Basic       using ( DecCon )
 open import FLRP.Representable                     using ( _⊆ᵈ_ ; _≑ᵈ_ )
 open import FLRP.Assumptions                       using ( CongruenceCompleteness )
-open import FLRP.LayerBridge                       using ( conDecIso )
+open import FLRP.LayerBridge                       using ( conDecIso ; wit )
 ```
 -->
 
@@ -111,9 +117,10 @@ module Bridge (𝒢    : Group 0ℓ 0ℓ)
               (H-sg : IsSubgroup 𝒢 H)
   where
 
-  private
-    𝑮 = proj₁ 𝒢
-    G = 𝕌[ 𝑮 ]
+  𝑮 : Algebra 0ℓ 0ℓ
+  𝑮 = proj₁ 𝒢
+  G : Type 0ℓ
+  G = 𝕌[ 𝑮 ]
 
   open Setoid 𝔻[ 𝑮 ]  using ( _≈_ )
                       renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
@@ -128,31 +135,32 @@ module Bridge (𝒢    : Group 0ℓ 0ℓ)
 #### Elementary facts about a congruence of the coset algebra
 
 The coset algebra's setoid equality is the coset relation `_∼_`{.AgdaFunction} of
-`H`{.AgdaBound} (that is `𝔻[ cosetAlgebra ]`'s `_≈_`{.AgdaFunction}), so a congruence
-`θ`{.AgdaBound} is reflexive over `_∼_`{.AgdaFunction}, and — being an equivalence
-compatible with every operation symbol `g`{.AgdaBound} — it is symmetric, transitive,
-and invariant under left translation `x ↦ g ∙ x`{.AgdaFunction} (the action).  These
-four facts are the only structure of `θ`{.AgdaBound} the correspondence consumes.
+`H`{.AgdaBound} (that is `_≈_`{.AgdaFunction} of `𝔻[ cosetAlgebra ]`), so a
+congruence `θ`{.AgdaBound} is reflexive over `_∼_`{.AgdaFunction}, and — being an
+equivalence compatible with every operation symbol `g`{.AgdaBound} — it is symmetric,
+transitive, and invariant under left translation `x ↦ g ∙ x`{.AgdaFunction} (the
+action).  These four facts are the only structure of `θ`{.AgdaBound} the
+correspondence consumes.
 
 ```agda
-  -- A congruence relates ∼-equal (coset-equal) elements: reflexivity over ∼_H.
-  θ-refl : (θ : Con cosetAlgebra 0ℓ) {a b : G} → a ∼ b → proj₁ θ a b
-  θ-refl θ = reflexive (proj₂ θ)
+  module _ ((_θ_ , θcon) : Con cosetAlgebra 0ℓ) where
 
-  -- Symmetry of the congruence.
-  θ-sym : (θ : Con cosetAlgebra 0ℓ) {a b : G} → proj₁ θ a b → proj₁ θ b a
-  θ-sym θ = IsEquivalence.sym (is-equivalence (proj₂ θ))
+    -- A congruence relates ∼-equal (coset-equal) elements: reflexivity over ∼_H.
+    θ-refl : {a b : G} → a ∼ b → a θ b
+    θ-refl = reflexive θcon
 
-  -- Transitivity of the congruence.
-  θ-trans : (θ : Con cosetAlgebra 0ℓ) {a b c : G}
-    → proj₁ θ a b → proj₁ θ b c → proj₁ θ a c
-  θ-trans θ = IsEquivalence.trans (is-equivalence (proj₂ θ))
+    -- Symmetry of the congruence.
+    θ-sym : {a b : G} → a θ b → b θ a
+    θ-sym = IsEquivalence.sym (is-equivalence θcon)
 
-  -- G-invariance: the congruence is preserved by left translation (the action of g).
-  -- This is compatibility of θ with the unary operation symbol g of the coset algebra.
-  θ-transl : (θ : Con cosetAlgebra 0ℓ) (g : G) {a b : G}
-    → proj₁ θ a b → proj₁ θ (g ∙ a) (g ∙ b)
-  θ-transl θ g {a} {b} p = is-compatible (proj₂ θ) g {λ _ → a} {λ _ → b} (λ _ → p)
+    -- Transitivity of the congruence.
+    θ-trans : {a b c : G} → a θ b → b θ c → a θ c
+    θ-trans = IsEquivalence.trans (is-equivalence θcon)
+
+    -- G-invariance: the congruence is preserved by left translation (the action of g).
+    -- This is compatibility of θ with the unary operation symbol g of the coset algebra.
+    θ-transl : (g : G) {a b : G} → a θ b → (g ∙ a) θ (g ∙ b)
+    θ-transl g {a} {b} p = is-compatible θcon g {λ _ → a} {λ _ → b} (λ _ → p)
 
   -- A single group-arithmetic fact used for the interval-side round trip.
   ε⁻¹∙ : (a : G) → ε ⁻¹ ∙ a ≈ a
@@ -163,12 +171,12 @@ four facts are the only structure of `θ`{.AgdaBound} the correspondence consume
 
 `K_θ`{.AgdaFunction} is the `θ`-class of the base coset, read as a predicate on the
 group carrier: `g ∈ K_θ` exactly when the identity coset `H·ε` is `θ`-related to the
-coset `H·g` (in the setoid presentation, `proj₁ θ ε g`).
+coset `H·g` (in the setoid presentation, `ε θ g`).
 
 ```agda
   -- The forward map on predicates: K_θ g  =  H·ε ∼_θ H·g.
   Kθ : (θ : Con cosetAlgebra 0ℓ) → Pred G 0ℓ
-  Kθ θ g = proj₁ θ ε g
+  Kθ (_θ_ , _) g = ε θ g
 ```
 
 `K_θ`{.AgdaFunction} is a subgroup.  Each closure property is one short congruence
@@ -182,23 +190,22 @@ transitivity against a `∼`-step.
   private
     -- ε ∈ K_θ (the identity coset is θ-related to itself).
     Kθ-ε : (θ : Con cosetAlgebra 0ℓ) → ε ∈ Kθ θ
-    Kθ-ε θ = IsEquivalence.refl (is-equivalence (proj₂ θ))
+    Kθ-ε (_ , θcon) = IsEquivalence.refl (is-equivalence θcon)
 
     -- K_θ is closed under the group multiplication.
-    Kθ-∙ : (θ : Con cosetAlgebra 0ℓ) {x y : G}
-      → x ∈ Kθ θ → y ∈ Kθ θ → (x ∙ y) ∈ Kθ θ
+    Kθ-∙ : (θ : Con cosetAlgebra 0ℓ) {x y : G} → x ∈ Kθ θ → y ∈ Kθ θ → x ∙ y ∈ Kθ θ
     Kθ-∙ θ {x} {y} εx εy =
       θ-trans θ εx (θ-trans θ (θ-refl θ (≈⇒∼ (≈sym (idʳ-law x)))) (θ-transl θ x εy))
 
     -- K_θ is closed under inverses.
-    Kθ-⁻¹ : (θ : Con cosetAlgebra 0ℓ) {x : G} → x ∈ Kθ θ → (x ⁻¹) ∈ Kθ θ
+    Kθ-⁻¹ : (θ : Con cosetAlgebra 0ℓ) {x : G} → x ∈ Kθ θ → x ⁻¹ ∈ Kθ θ
     Kθ-⁻¹ θ {x} εx = θ-sym θ
       (θ-trans θ (θ-refl θ (≈⇒∼ (≈sym (idʳ-law (x ⁻¹)))))
                  (θ-trans θ (θ-transl θ (x ⁻¹) εx) (θ-refl θ (≈⇒∼ (invˡ-law x)))))
 
     -- K_θ respects the setoid equality of the group.
     Kθ-resp : (θ : Con cosetAlgebra 0ℓ) → Kθ θ Respects _≈_
-    Kθ-resp θ {x} {y} x≈y εx = θ-trans θ εx (θ-refl θ (≈⇒∼ x≈y))
+    Kθ-resp θ x≈y εx = θ-trans θ εx (θ-refl θ (≈⇒∼ x≈y))
 
   -- Well-definedness of the forward map (part 1): K_θ is a subgroup.
   Kθ-isSubgroup : (θ : Con cosetAlgebra 0ℓ) → IsSubgroup 𝒢 (Kθ θ)
@@ -225,7 +232,7 @@ translation lemmas come for free.
 ```agda
   -- The backward map's relation: the coset relation of K = pred M.
   θK-rel : (M : Interval≈) → BinaryRel G 0ℓ
-  θK-rel M = Coset._∼_ 𝒢 (pred M) (element-isSubgroup M)
+  θK-rel M = Coset._∼_ 𝒢 (set M) (element-isSubgroup M)
 ```
 
 `θ_K`{.AgdaFunction} is a congruence of the coset algebra of `H`{.AgdaBound}.
@@ -237,23 +244,24 @@ translate) are the corresponding `Coset`{.AgdaModule} lemmas at `K`{.AgdaBound}.
 
 ```agda
   -- Well-definedness of the backward map: θ_K is a congruence of the coset algebra.
-  θK-isCongruence : (M : Interval≈) → IsCongruence cosetAlgebra (θK-rel M)
-  θK-isCongruence M = mkcon reflx equivx compatx
+  θK-isCongruence : (𝑴 : Interval≈) → IsCongruence cosetAlgebra (θK-rel 𝑴)
+  θK-isCongruence 𝑴@(((M , _) , H≤M , _) , _) = mkcon reflx equivx compatx
     where
-    K   = pred M
-    Ksg = element-isSubgroup M
+
+    Ksg : IsSubgroup 𝒢 M
+    Ksg = element-isSubgroup 𝑴
 
     -- Reflexivity over ∼_H: ∼_H ⊆ ∼_K pointwise, because H ⊆ K (above M).
-    reflx : {a b : G} → a ∼ b → θK-rel M a b
-    reflx p = above M p
+    reflx : {a b : G} → a ∼ b → θK-rel 𝑴 a b
+    reflx = H≤M
 
     -- θ_K is an equivalence (the Coset equivalence at K).
-    equivx : IsEquivalence (θK-rel M)
-    equivx = Coset.∼-isEquivalence 𝒢 K Ksg
+    equivx : IsEquivalence (θK-rel 𝑴)
+    equivx = Coset.∼-isEquivalence 𝒢 M Ksg
 
     -- θ_K is compatible with every unary translate (left congruence at K).
-    compatx : cosetAlgebra ∣≈ θK-rel M
-    compatx g h = Coset.∼-congˡ 𝒢 K Ksg g (h 0F)
+    compatx : cosetAlgebra ∣≈ θK-rel 𝑴
+    compatx g h = Coset.∼-congˡ 𝒢 M Ksg g (h 0F)
 
   -- The backward map: an interval element goes to the coset congruence θ_K.
   from : Interval≈ → Con cosetAlgebra 0ℓ
@@ -313,12 +321,12 @@ over the bare `SubInterval`{.AgdaModule}.
   to∘from M = fwd , bwd
     where
     -- K_{θ_K} ⊆ K:  ε ⁻¹ ∙ g ∈ K  and  ε ⁻¹ ∙ g ≈ g  give  g ∈ K.
-    fwd : Kθ (from M) ⊆ pred M
-    fwd {g} p = pred-respects M (ε⁻¹∙ g) p
+    fwd : Kθ (from M) ⊆ set M
+    fwd {g} p = set-respects M (ε⁻¹∙ g) p
 
     -- K ⊆ K_{θ_K}:  g ∈ K  and  g ≈ ε ⁻¹ ∙ g  give  ε ⁻¹ ∙ g ∈ K.
-    bwd : pred M ⊆ Kθ (from M)
-    bwd {g} p = pred-respects M (≈sym (ε⁻¹∙ g)) p
+    bwd : set M ⊆ Kθ (from M)
+    bwd {g} p = set-respects M (≈sym (ε⁻¹∙ g)) p
 ```
 
 #### The order isomorphism
@@ -416,37 +424,47 @@ of [FLRP.Enforceable][].
   -- containment relations (the discipline of Setoid.Congruences.Lattice).
   bridgeᵈ : CongruenceCompleteness cosetAlgebra → RepIsoᵈ cosetAlgebra
   bridgeᵈ cc = record
-    { to         = λ M → CD.to (BI.to M)
-    ; from       = λ d → BI.from (CD.from d)
-    ; to-mono    = λ {M}{N} M≤N →
-        CD.to-mono {BI.to M} {BI.to N} (BI.to-mono {M} {N} M≤N)
-    ; from-mono  = λ {d}{e} d⊆e →
-        BI.from-mono {CD.from d} {CD.from e} (CD.from-mono {d} {e} d⊆e)
-    ; to∘from    = λ d →
-          (λ p → proj₁ (CD.to∘from d)
-                   (CD.to-mono {BI.to (BI.from (CD.from d))} {CD.from d}
-                               (proj₁ (BI.to∘from (CD.from d))) p))
-        , (λ p → CD.to-mono {CD.from d} {BI.to (BI.from (CD.from d))}
-                            (proj₂ (BI.to∘from (CD.from d))) (proj₂ (CD.to∘from d) p))
-    ; from∘to    = λ M →
-          (λ z → proj₁ (BI.from∘to M)
-                   (BI.from-mono {CD.from (CD.to (BI.to M))} {BI.to M}
-                                 (proj₁ (CD.from∘to (BI.to M))) z))
-        , (λ z → BI.from-mono {BI.to M} {CD.from (CD.to (BI.to M))}
-                             (proj₂ (CD.from∘to (BI.to M))) (proj₂ (BI.from∘to M) z))
+    { to         = to'
+    ; from       = from'
+    ; to-mono    = λ {M}{N} → CD.to-mono ∘ BI.to-mono {M} {N}
+    ; from-mono  = λ {d}{e} → BI.from-mono {CD.from d} {CD.from e} ∘ CD.from-mono {d} {e}
+    ; to∘from    = λ d → to-from-⊑ d , ⊑-from-to d
+    ; from∘to    = λ 𝑴 → from∘to-≤ 𝑴 , ≤-from∘to 𝑴
     }
     where
+    open GroupSublattice 𝒢 0ℓ
     module CD = OrderIso (conDecIso cc)
     module BI = OrderIso bridge⁻¹
+
+    to' : Interval≈ → DecCon cosetAlgebra 0ℓ
+    to' = CD.to ∘ BI.to
+
+    from' : DecCon cosetAlgebra 0ℓ → Interval≈
+    from' = BI.from ∘ CD.from
+
+    to-from-⊑ : ((d , _) : DecCon cosetAlgebra 0ℓ) → wit cc (from (to d)) .proj₁ ⊑ d
+    to-from-⊑ d = CD.to∘from d .proj₁ ∘ CD.to-mono (BI.to∘from (CD.from d) .proj₁)
+
+    ⊑-from-to : ((d , _) : DecCon cosetAlgebra 0ℓ) →  d ⊑ wit cc (from (to d)) .proj₁
+    ⊑-from-to d = CD.to-mono (BI.to∘from (CD.from d) .proj₂) ∘ CD.to∘from d .proj₂
+
+    from∘to-≤ : (𝑴 : Interval≈) → sublat (from' (to' 𝑴)) ≤ sublat 𝑴
+    from∘to-≤ 𝑴 = BI.from∘to 𝑴 .proj₁ ∘
+                    BI.from-mono {CD.from (to' 𝑴)} {BI.to 𝑴} (CD.from∘to (BI.to 𝑴) .proj₁)
+    ≤-from∘to : (𝑴 : Interval≈) → sublat 𝑴 ≤ sublat (from' (to' 𝑴))
+    ≤-from∘to M = BI.from-mono {BI.to M} {CD.from (to' M)}
+                    (CD.from∘to (BI.to M) .proj₂) ∘ BI.from∘to M .proj₂
+
 ```
 
-**Corollary (Layer D, near-closing #454).**  A finite coset algebra whose semantic
-congruences are all `≑`{.AgdaFunction} to decidable ones (the congruence-completeness
-bridge for the coset algebra) realizes the interval `[H , 𝒢]` as its *decidable*
-congruence poset.  This is the `Representableᵈ`{.AgdaRecord}-side target of the two-layer
-discipline: the algebra, its carrier-finiteness witness, and the decidable-layer
-isomorphism are exactly the data `Representableᵈ`{.AgdaRecord} of [FLRP.Representable][]
-consumes (there over a classical `Lattice`{.AgdaRecord} presentation of the interval).
+**Corollary** (Layer D).[^3]  A finite coset algebra whose semantic congruences are
+all `≑`{.AgdaFunction} to decidable ones (the congruence-completeness bridge for the
+coset algebra) realizes the interval `[H , 𝒢]` as its *decidable* congruence poset.
+
+This is the `Representableᵈ`{.AgdaRecord}-side target of the two-layer discipline:
+the algebra, its carrier-finiteness witness, and the decidable-layer isomorphism are
+exactly the data `Representableᵈ`{.AgdaRecord} of [FLRP.Representable][] consumes
+(there over a classical `Lattice`{.AgdaRecord} presentation of the interval).
 
 ```agda
   interval-DecCon-representable :
@@ -455,3 +473,18 @@ consumes (there over a classical `Lattice`{.AgdaRecord} presentation of the inte
     → Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Unary G} 0ℓ 0ℓ ] ( FiniteAlgebra 𝑨 × RepIsoᵈ 𝑨 )
   interval-DecCon-representable fin cc = cosetAlgebra , fin , bridgeᵈ cc
 ```
+
+---
+
+[^1]: This is the main deliverable of work package WP-3;
+      see [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7.
+      Classical references include McKenzie–McNulty–Taylor Lemma 4.20, Dixon–Mortimer
+      Theorem 1.5A, and the introduction of the research note
+      [`docs/papers/flrp/ieprops/IEProps-1205.1927v4.tex`](docs/papers/flrp/ieprops/IEProps-1205.1927v4.tex).
+
+[^2]: The Layer D restatement referenced here is the one called for by the updated
+      acceptance criteria of Issue #454 — the same isomorphism with the
+      decidable-congruence poset `DecCon`{.AgdaFunction} in place of
+      `Con`{.AgdaFunction}.
+
+[^3]: This Corollary nearly closes [Issue #454](https://github.com/ualib/agda-algebras/issues/454).

--- a/src/FLRP/Enforceable.lagda.md
+++ b/src/FLRP/Enforceable.lagda.md
@@ -73,7 +73,7 @@ open import Data.Product                            using  ( _,_ ; _×_ ; Σ-syn
 open import Data.Unit.Base                          using  ( tt )
 open import Function                                using  ( _∘_ )
 open import Level         renaming ( suc to lsuc )  using  ( Level ; 0ℓ ; _⊔_
-                                                           ; Lift ; lift )
+                                                           ; lift )
 open import Relation.Binary                         using  ( Setoid )
 open import Relation.Binary.Definitions             using  ( _Respects_ )
 open import Relation.Binary.PropositionalEquality   using  ( _≡_ )
@@ -136,7 +136,7 @@ module UpperInterval
 
   open Setoid 𝔻[ proj₁ 𝒢 ] using ( _≈_ )
   open GroupSublattice 𝒢 0ℓ  using  ( Subᴸ ; 1ˢ ; 1ˢ-maximum ; subgroup→Subᴸ
-                                    ; module SubInterval ; Sub-Lattice )
+                                    ; Sub-Lattice )
 
   -- The bottom of the interval: H as an element of the subuniverse lattice.
   H↑ : Subᴸ

--- a/src/FLRP/Enforceable.lagda.md
+++ b/src/FLRP/Enforceable.lagda.md
@@ -71,6 +71,7 @@ open import Data.Nat.Base renaming ( _≤_ to _≤ⁿ_ )  using  ( ℕ ; _+_ )
 open import Data.Product                            using  ( _,_ ; _×_ ; Σ-syntax
                                                            ; ∃-syntax ; proj₁ ; proj₂ )
 open import Data.Unit.Base                          using  ( tt )
+open import Function                                using  ( _∘_ )
 open import Level         renaming ( suc to lsuc )  using  ( Level ; 0ℓ ; _⊔_
                                                            ; Lift ; lift )
 open import Relation.Binary                         using  ( Setoid )
@@ -90,8 +91,8 @@ open import FLRP.Problem                  using  ( OrderIso ; FiniteLattice ; to
 open import Setoid.Algebras               using  ( 𝔻[_] ; 𝕌[_] ; FiniteAlgebra )
 open import Setoid.Homomorphisms          using  ( _IsHomImageOf_ )
 open import Setoid.Subalgebras            using  ( Subuniverses )
-open import Order.Interval                        using ( module IntervalLattice )
--- open import Setoid.Subalgebras.CompleteLattice using (module Sublattice)
+open import Order.Interval                using  ( module IntervalLattice )
+-- open import Setoid.Subalgebras.CompleteLattice using
 ```
 -->
 
@@ -147,26 +148,29 @@ module UpperInterval
 
   -- An interval element: a bare element whose predicate respects ≈.
   Interval≈ : Type (lsuc 0ℓ)
-  Interval≈ = Σ[ ((M , _) , _) ∈ Interval ] (M Respects _≈_)
+  Interval≈ = Σ[ ((M , M∈Subs) , H≤M , M≤G) ∈ Interval ] (M Respects _≈_)
 
-  -- Accessors: the underlying predicate and its three certificates.
-  pred : Interval≈ → Pred 𝕌[ proj₁ 𝒢 ] 0ℓ
-  pred (((M , _) , _) , _) = M
+  -- Accessors: the underlying predicate and its four certificates.
+  sublat : Interval≈ → Subᴸ
+  sublat (((M , M∈Subs) , H≤M , M≤G) , Mresp≈ ) = (M , M∈Subs)
 
-  pred-isSubuniverse : (M : Interval≈) → pred M ∈ Subuniverses (proj₁ 𝒢)
-  pred-isSubuniverse (((_ , Mp) , _) , _) = Mp
+  set : Interval≈ → Pred 𝕌[ proj₁ 𝒢 ] 0ℓ
+  set = proj₁ ∘ sublat
 
-  pred-respects : (M : Interval≈) → pred M Respects _≈_
-  pred-respects (_ , Mresp) = Mresp
+  set-isSubuniverse : (𝑴 : Interval≈) → set 𝑴 ∈ Subuniverses (proj₁ 𝒢)
+  set-isSubuniverse = proj₂ ∘ sublat
 
-  above : (M : Interval≈) → H ⊆ pred M
-  above ((_ , H⊆ , _) , _) = H⊆
+  set-respects : (𝑴 : Interval≈) → set 𝑴 Respects _≈_
+  set-respects (((M , M∈Subs) , H≤M , M≤G) , Mresp≈ ) = Mresp≈
+
+  above : (𝑴 : Interval≈) → H ⊆ set 𝑴
+  above (((M , M∈Subs) , H≤M , M≤G) , Mresp≈ ) = H≤M
 
   open IsSubgroup
   -- An interval element is a respecting subgroup.
-  element-isSubgroup : (M : Interval≈) → IsSubgroup 𝒢 (pred M)
-  element-isSubgroup M .respects       = pred-respects M
-  element-isSubgroup M .isSubuniverse  = pred-isSubuniverse M
+  element-isSubgroup : (M : Interval≈) → IsSubgroup 𝒢 (set M)
+  element-isSubgroup M .respects       = set-respects M
+  element-isSubgroup M .isSubuniverse  = set-isSubuniverse M
 
   -- Conversely, a respecting subgroup above H is an interval element
   -- (the top bound against the full subuniverse is trivial).
@@ -373,12 +377,12 @@ module Fatten (𝒢 𝒦 : Group 0ℓ 0ℓ) where
     to-fatten : IP.Interval≈ → IG.Interval≈
     to-fatten M = IG.mk S.restrict₁ S.restrict₁-isSubgroup S.restrict₁-⊇H
       where
-      module S = Slice₁ H H-sg (IP.pred M) (IP.pred-isSubuniverse M)
-                        (IP.pred-respects M) (IP.above M)
+      module S = Slice₁ H H-sg (IP.set M) (IP.set-isSubuniverse M)
+                        (IP.set-respects M) (IP.above M)
 
     -- Pullback: an interval element over H fattens to one over H ×ᶠ 𝒦.
     from-fatten : IG.Interval≈ → IP.Interval≈
-    from-fatten A = IP.mk  (IG.pred A ×ᶠ 𝒦)
+    from-fatten A = IP.mk  (IG.set A ×ᶠ 𝒦)
                            (×ᶠ-isSubgroup (IG.element-isSubgroup A))
                            (λ h → IG.above A h)
 
@@ -399,8 +403,8 @@ module Fatten (𝒢 𝒦 : Group 0ℓ 0ℓ) where
     from∘to-fatten : (M : IP.Interval≈) → IP._≈ᵢ_ (from-fatten (to-fatten M)) M
     from∘to-fatten M = (λ z → S.slice-in z) , (λ z → S.slice-out z)
       where
-      module S = Slice₁ H H-sg (IP.pred M) (IP.pred-isSubuniverse M)
-                        (IP.pred-respects M) (IP.above M)
+      module S = Slice₁ H H-sg (IP.set M) (IP.set-isSubuniverse M)
+                        (IP.set-respects M) (IP.above M)
 
     -- The fattening isomorphism  [H ×ᶠ 𝒦 , full] ≅ [H , full].
     -- (In from-mono the inclusion's element p is passed explicitly: the
@@ -435,12 +439,12 @@ module Fatten (𝒢 𝒦 : Group 0ℓ 0ℓ) where
     to-fatten : IP.Interval≈ → IK.Interval≈
     to-fatten M = IK.mk S.restrict₂ S.restrict₂-isSubgroup S.restrict₂-⊇J
       where
-      module S = Slice₂ J J-sg (IP.pred M) (IP.pred-isSubuniverse M)
-                        (IP.pred-respects M) (IP.above M)
+      module S = Slice₂ J J-sg (IP.set M) (IP.set-isSubuniverse M)
+                        (IP.set-respects M) (IP.above M)
 
     -- Pullback along the second projection.
     from-fatten : IK.Interval≈ → IP.Interval≈
-    from-fatten A = IP.mk  (𝒢 ᶠ× IK.pred A)
+    from-fatten A = IP.mk  (𝒢 ᶠ× IK.set A)
                            (ᶠ×-isSubgroup (IK.element-isSubgroup A))
                            (λ j → IK.above A j)
 
@@ -458,8 +462,8 @@ module Fatten (𝒢 𝒦 : Group 0ℓ 0ℓ) where
     from∘to-fatten : (M : IP.Interval≈) → IP._≈ᵢ_ (from-fatten (to-fatten M)) M
     from∘to-fatten M = (λ z → S.slice-in z) , (λ z → S.slice-out z)
       where
-      module S = Slice₂ J J-sg (IP.pred M) (IP.pred-isSubuniverse M)
-                        (IP.pred-respects M) (IP.above M)
+      module S = Slice₂ J J-sg (IP.set M) (IP.set-isSubuniverse M)
+                        (IP.set-respects M) (IP.above M)
 
     -- The mirrored fattening isomorphism  [𝒢 ᶠ× J , full] ≅ [J , full].
     -- (Same explicit-p idiom as in FattenSnd, now factoring through proj₂.)

--- a/src/FLRP/LayerBridge.lagda.md
+++ b/src/FLRP/LayerBridge.lagda.md
@@ -17,41 +17,43 @@ through exactly one registered classical assumption, the congruence-completeness
 `CongruenceCompleteness`{.AgdaFunction} of [FLRP.Assumptions][].  This module discharges
 that meeting.
 
-Under the bridge as an *explicit hypothesis* — never a postulate — we prove:
+Under the bridge as an *explicit hypothesis* we prove:
 
-+  `conDecIso`{.AgdaFunction}: the semantic congruence poset `(Con 𝑨, ≑, ⊆)` and the
-   decidable congruence poset `(DecCon 𝑨, ≑ᵈ, ⊆ᵈ)` of an algebra are
-   **order-isomorphic**.  The forgetful map `DecCon → Con` (take the underlying
-   congruence, `proj₁`{.AgdaFunction}) is free; its inverse `Con → DecCon` is where the
-   bridge is spent — it sends a semantic congruence to a decidable representative
++  **`conDecIso`{.AgdaFunction}**.  The semantic congruence poset `(Con 𝑨, ≑, ⊆)` and
+   the decidable congruence poset `(DecCon 𝑨, ≑ᵈ, ⊆ᵈ)` of an algebra are
+   **order-isomorphic**.
+
+   The forgetful map `DecCon → Con` (take the underlying congruence,
+   `proj₁`{.AgdaFunction}) is free; its inverse `Con → DecCon` is where the bridge is
+   spent; it sends a semantic congruence to a decidable representative
    `≑`{.AgdaFunction} to it.
 
-+  `ConIsoᵈ→ConIso`{.AgdaFunction} and `ConIso→ConIsoᵈ`{.AgdaFunction}: transporting a
-   lattice order-isomorphism across the layers, by composing with
-   `conDecIso`{.AgdaFunction}.  The only non-formal ingredient is that a map *into* a
-   classical lattice respects the source `≑`{.AgdaFunction} — because the lattice meet
-   order is antisymmetric (`≤-antisym`{.AgdaFunction} of [Classical.Properties.Lattice][]),
-   the same one-line fact the no-go theorem of [FLRP.Problem][] uses.
++  **`ConIsoᵈ→ConIso`{.AgdaFunction}** / **`ConIso→ConIsoᵈ`{.AgdaFunction}**.
+   A lattice order-isomorphism is transported across the layers, by composing with
+   `conDecIso`{.AgdaFunction}.
 
-+  `Representableᵈ→Representable`{.AgdaFunction} and
-   `Representable→Representableᵈ`{.AgdaFunction}: the representability notions of the two
-   layers are equivalent.  `Representable`{.AgdaRecord} and `Representableᵈ`{.AgdaRecord}
-   differ by exactly `ConIso`{.AgdaFunction} versus `ConIsoᵈ`{.AgdaFunction} plus the
+   The only non-formal ingredient is that a map *into* a
+   classical lattice respects the source `≑`{.AgdaFunction}.[^1]
+
++  **`Representableᵈ→Representable`{.AgdaFunction}** / **`Representable→Representableᵈ`{.AgdaFunction}**.
+   The representability notions of the two layers are equivalent.
+
+   `Representable`{.AgdaRecord} and `Representableᵈ`{.AgdaRecord} differ by exactly
+   `ConIso`{.AgdaFunction} versus `ConIsoᵈ`{.AgdaFunction} plus the
    `finsig : FiniteSignature`{.AgdaField} datum, so each direction is an
    `OrderIso`{.AgdaRecord} transport, and the `Representable → Representableᵈ` direction
    additionally consumes the finite-signature witness (which `Representable`{.AgdaRecord}
-   does not carry).  **Both** directions consume the bridge: passing between the layers
-   in either direction requires the poset isomorphism, whose `Con → DecCon` half is the
+   does not carry).
+
+   *Both* directions consume the bridge: passing between the layers in either
+   direction requires the poset isomorphism, whose `Con → DecCon` half is the
    classical step.
 
 The `OrderIso`{.AgdaRecord} composition here is done by hand at each of the two
-transports rather than through a general transitivity combinator: the round trips need
-the middle lattice map to respect `≑`{.AgdaFunction} (antisymmetry), which a fully
-generic `OrderIso`-transitivity cannot supply without extra hypotheses, so the direct
-assembly from small named lemmas is clearer.
-
-The standing FLRP research-track separation warning of [FLRP.Problem][] applies here
-too.
+transports rather than through a general transitivity combinator: the round trips
+need the middle lattice map to respect `≑`{.AgdaFunction} (antisymmetry), which a
+fully generic `OrderIso`-transitivity cannot supply without extra hypotheses, so the
+direct assembly from small named lemmas is clearer.[^2]
 
 <!--
 ```agda
@@ -65,18 +67,19 @@ open import Level                 using ( Level ; 0ℓ ; _⊔_ )
 open import Relation.Binary       using ( Setoid )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Overture                             using ( 𝓞 ; 𝓥 ; Signature )
-open import Classical.Small.Structures.Lattice   using ( Lattice )
-open import Classical.Properties.Lattice         using ( module Lattice-Order )
-open import Setoid.Algebras.Basic                using ( Algebra ; 𝔻[_] )
-open import Setoid.Signatures.Finite             using ( FiniteSignature )
-open import Setoid.Congruences.Basic             using ( Con )
-open import Setoid.Congruences.Lattice           using ( _⊆_ ; _≑_ )
-open import Setoid.Congruences.Finite.Basic      using ( DecCon )
-open import FLRP.Problem                          using ( OrderIso ; Representable ; ConIso )
-open import FLRP.Representable                    using ( Representableᵈ ; ConIsoᵈ
+open import Overture                             using  ( 𝓞 ; 𝓥 ; Signature )
+open import Classical.Small.Structures.Lattice   using  ( Lattice )
+open import Classical.Properties.Lattice         using  ( module Lattice-Order )
+open import Setoid.Algebras.Basic                using  ( Algebra ; 𝔻[_] )
+open import Setoid.Signatures.Finite             using  ( FiniteSignature )
+open import Setoid.Congruences.Basic             using  ( Con )
+open import Setoid.Congruences.Lattice           using  ( _⊆_ ; _≑_ )
+open import Setoid.Congruences.Finite.Basic      using  ( DecCon )
+open import FLRP.Problem                         using  ( OrderIso ; Representable
+                                                        ; ConIso )
+open import FLRP.Representable                   using  ( Representableᵈ ; ConIsoᵈ
                                                         ; _⊆ᵈ_ ; _≑ᵈ_ )
-open import FLRP.Assumptions                      using ( CongruenceCompleteness )
+open import FLRP.Assumptions                     using  ( CongruenceCompleteness )
 
 private variable α ρ : Level
 ```
@@ -92,18 +95,23 @@ for each semantic congruence `φ`{.AgdaBound}, a decidable congruence
 is `≑`{.AgdaFunction} to it.
 
 ```agda
-module _ {𝑆 : Signature 𝓞 𝓥}{𝑨 : Algebra {𝑆 = 𝑆} α ρ}(cc : CongruenceCompleteness 𝑨) where
+module _
+  {𝑆  : Signature 𝓞 𝓥}
+  {𝑨  : Algebra {𝑆 = 𝑆} α ρ}
+  (cc : CongruenceCompleteness 𝑨)
+  where
+
   private
     ℓw : Level
     ℓw = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ
 
-    -- The decidable representative of a semantic congruence (the bridge's map) ...
-    wit : Con 𝑨 ℓw → DecCon 𝑨 ℓw
-    wit φ = proj₁ (cc φ)
+  -- The decidable representative of a semantic congruence (the bridge's map) ...
+  wit : Con 𝑨 ℓw → DecCon 𝑨 ℓw
+  wit φ = proj₁ (cc φ)
 
-    -- ... and the ≑-witness that it represents φ.
-    wit≑ : (φ : Con 𝑨 ℓw) → φ ≑ proj₁ (wit φ)
-    wit≑ φ = proj₂ (cc φ)
+  -- ... and the ≑-witness that it represents φ.
+  wit≑ : (φ : Con 𝑨 ℓw) → φ ≑ proj₁ (wit φ)
+  wit≑ φ = proj₂ (cc φ)
 ```
 
 `wit`{.AgdaFunction} is monotone: a containment `θ ⊆ φ`{.AgdaFunction} forwards to a
@@ -154,7 +162,7 @@ module _ {𝑆 : Signature 0ℓ 0ℓ}{𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ}
   open Lattice-Order 𝑳       using ( _≤_ ; ≤-antisym )
 ```
 
-**Layer D to Layer S.**  Given a decidable-layer isomorphism `isoᵈ : DecCon 𝑨 ≅ 𝑳`,
+**Layer D to Layer S**.  Given a decidable-layer isomorphism `isoᵈ : DecCon 𝑨 ≅ 𝑳`,
 compose `Con → DecCon` (the `to`{.AgdaFunction} of `P`{.AgdaBound}) with it to land a
 semantic-layer isomorphism `Con 𝑨 ≅ 𝑳`.  `to-cong`{.AgdaFunction} is the fact that
 `isoᵈ`{.AgdaBound}'s forward map respects `≑ᵈ`{.AgdaFunction} (both images sit below one
@@ -189,7 +197,7 @@ trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{
          , (λ p → proj₂ (D.from∘to (P.to φ)) (proj₂ (P.from∘to φ) p))
 ```
 
-**Layer S to Layer D.**  Dually, given a semantic-layer isomorphism
+**Layer S to Layer D**.  Dually, given a semantic-layer isomorphism
 `iso : Con 𝑨 ≅ 𝑳`, compose the forgetful `DecCon → Con` (the `from`{.AgdaFunction} of
 `P`{.AgdaBound}) with it.  Here `to-congᵈ`{.AgdaFunction} — that `wit`{.AgdaFunction}
 (the `to`{.AgdaFunction} of `P`{.AgdaBound}) respects `≑`{.AgdaFunction} — is what the
@@ -256,3 +264,10 @@ module _ {𝑳 : Lattice} where
 ```
 
 --------------------------------------
+
+[^1]: because the lattice meet order is antisymmetric
+      (`≤-antisym`{.AgdaFunction} of [Classical.Properties.Lattice][]
+      — the same one-line fact the no-go theorem of [FLRP.Problem][] uses).
+
+[^2]: The standing FLRP research-track separation warning of [FLRP.Problem][] applies
+      here too.

--- a/src/FLRP/LayerBridge.lagda.md
+++ b/src/FLRP/LayerBridge.lagda.md
@@ -1,0 +1,258 @@
+---
+layout: default
+file: "src/FLRP/LayerBridge.lagda.md"
+title: "FLRP.LayerBridge module (The Agda Universal Algebra Library)"
+date: "2026-07-20"
+author: "the agda-algebras development team"
+---
+
+### The cross-layer bridge: `Con ≅ DecCon` and `Representable ↔ Representableᵈ`
+
+This is the [FLRP.LayerBridge][] module of the [Agda Universal Algebra Library][].
+
+[FLRP.Problem][] states representability at the *semantic* congruence layer (Layer S,
+`Con`{.AgdaFunction}) and [FLRP.Representable][] restates it at the *decidable* layer
+(Layer D, `DecCon`{.AgdaFunction}); [ADR-008][] mandates that the two layers meet
+through exactly one registered classical assumption, the congruence-completeness bridge
+`CongruenceCompleteness`{.AgdaFunction} of [FLRP.Assumptions][].  This module discharges
+that meeting.
+
+Under the bridge as an *explicit hypothesis* — never a postulate — we prove:
+
++  `conDecIso`{.AgdaFunction}: the semantic congruence poset `(Con 𝑨, ≑, ⊆)` and the
+   decidable congruence poset `(DecCon 𝑨, ≑ᵈ, ⊆ᵈ)` of an algebra are
+   **order-isomorphic**.  The forgetful map `DecCon → Con` (take the underlying
+   congruence, `proj₁`{.AgdaFunction}) is free; its inverse `Con → DecCon` is where the
+   bridge is spent — it sends a semantic congruence to a decidable representative
+   `≑`{.AgdaFunction} to it.
+
++  `ConIsoᵈ→ConIso`{.AgdaFunction} and `ConIso→ConIsoᵈ`{.AgdaFunction}: transporting a
+   lattice order-isomorphism across the layers, by composing with
+   `conDecIso`{.AgdaFunction}.  The only non-formal ingredient is that a map *into* a
+   classical lattice respects the source `≑`{.AgdaFunction} — because the lattice meet
+   order is antisymmetric (`≤-antisym`{.AgdaFunction} of [Classical.Properties.Lattice][]),
+   the same one-line fact the no-go theorem of [FLRP.Problem][] uses.
+
++  `Representableᵈ→Representable`{.AgdaFunction} and
+   `Representable→Representableᵈ`{.AgdaFunction}: the representability notions of the two
+   layers are equivalent.  `Representable`{.AgdaRecord} and `Representableᵈ`{.AgdaRecord}
+   differ by exactly `ConIso`{.AgdaFunction} versus `ConIsoᵈ`{.AgdaFunction} plus the
+   `finsig : FiniteSignature`{.AgdaField} datum, so each direction is an
+   `OrderIso`{.AgdaRecord} transport, and the `Representable → Representableᵈ` direction
+   additionally consumes the finite-signature witness (which `Representable`{.AgdaRecord}
+   does not carry).  **Both** directions consume the bridge: passing between the layers
+   in either direction requires the poset isomorphism, whose `Con → DecCon` half is the
+   classical step.
+
+The `OrderIso`{.AgdaRecord} composition here is done by hand at each of the two
+transports rather than through a general transitivity combinator: the round trips need
+the middle lattice map to respect `≑`{.AgdaFunction} (antisymmetry), which a fully
+generic `OrderIso`-transitivity cannot supply without extra hypotheses, so the direct
+assembly from small named lemmas is clearer.
+
+The standing FLRP research-track separation warning of [FLRP.Problem][] applies here
+too.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.LayerBridge where
+
+-- Imports from Agda and the Agda Standard Library -----------------------------
+open import Data.Product          using ( _,_ ; proj₁ ; proj₂ )
+open import Level                 using ( Level ; 0ℓ ; _⊔_ )
+open import Relation.Binary       using ( Setoid )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Overture                             using ( 𝓞 ; 𝓥 ; Signature )
+open import Classical.Small.Structures.Lattice   using ( Lattice )
+open import Classical.Properties.Lattice         using ( module Lattice-Order )
+open import Setoid.Algebras.Basic                using ( Algebra ; 𝔻[_] )
+open import Setoid.Signatures.Finite             using ( FiniteSignature )
+open import Setoid.Congruences.Basic             using ( Con )
+open import Setoid.Congruences.Lattice           using ( _⊆_ ; _≑_ )
+open import Setoid.Congruences.Finite.Basic      using ( DecCon )
+open import FLRP.Problem                          using ( OrderIso ; Representable ; ConIso )
+open import FLRP.Representable                    using ( Representableᵈ ; ConIsoᵈ
+                                                        ; _⊆ᵈ_ ; _≑ᵈ_ )
+open import FLRP.Assumptions                      using ( CongruenceCompleteness )
+
+private variable α ρ : Level
+```
+-->
+
+#### The poset isomorphism `Con 𝑨 ≅ DecCon 𝑨`
+
+Fix an algebra `𝑨`{.AgdaBound} and the bridge hypothesis `cc`{.AgdaBound}.  Working at
+the absorbing congruence level `ℓw = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ` (the level at which
+`CongruenceCompleteness`{.AgdaFunction} and the decidable layer live), the bridge gives,
+for each semantic congruence `φ`{.AgdaBound}, a decidable congruence
+`wit φ`{.AgdaFunction} together with a proof `wit≑`{.AgdaFunction} that `φ`{.AgdaBound}
+is `≑`{.AgdaFunction} to it.
+
+```agda
+module _ {𝑆 : Signature 𝓞 𝓥}{𝑨 : Algebra {𝑆 = 𝑆} α ρ}(cc : CongruenceCompleteness 𝑨) where
+  private
+    ℓw : Level
+    ℓw = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ
+
+    -- The decidable representative of a semantic congruence (the bridge's map) ...
+    wit : Con 𝑨 ℓw → DecCon 𝑨 ℓw
+    wit φ = proj₁ (cc φ)
+
+    -- ... and the ≑-witness that it represents φ.
+    wit≑ : (φ : Con 𝑨 ℓw) → φ ≑ proj₁ (wit φ)
+    wit≑ φ = proj₂ (cc φ)
+```
+
+`wit`{.AgdaFunction} is monotone: a containment `θ ⊆ φ`{.AgdaFunction} forwards to a
+containment of the representatives, because each representative is `≑`{.AgdaFunction} to
+its source, so the two `≑`-witnesses bracket the given containment.
+
+```agda
+  -- wit is monotone for the containment order.  Inlined as a direct ⇒-composition
+  -- (applied to the underlying related pair p): the two ≑-witnesses of wit≑ bracket
+  -- the given containment.  A named ⊆-trans cannot be used here — its implicit
+  -- congruence arguments are not inferable through the non-injective `_⊆_`.
+  wit-mono : {θ φ : Con 𝑨 ℓw} → θ ⊆ φ → wit θ ⊆ᵈ wit φ
+  wit-mono {θ}{φ} θ⊆φ p = proj₁ (wit≑ φ) (θ⊆φ (proj₂ (wit≑ θ) p))
+```
+
+The order isomorphism: `to`{.AgdaFunction} is `wit`{.AgdaFunction} (the classical step),
+`from`{.AgdaFunction} is `proj₁`{.AgdaFunction} (forget the decision procedure).
+Forgetfulness makes `from-mono`{.AgdaFunction} the identity, since `⊆ᵈ`{.AgdaFunction} is
+by definition `⊆`{.AgdaFunction} on the underlying congruences; and both round trips are
+just the `≑`-witness `wit≑`{.AgdaFunction}, read in the appropriate direction.
+
+```agda
+  conDecIso : OrderIso  (_≑_ {𝑨 = 𝑨}{ℓ = ℓw}) (_⊆_ {𝑨 = 𝑨}{ℓ = ℓw})
+                        (_≑ᵈ_ {𝑨 = 𝑨}{ℓ = ℓw}) (_⊆ᵈ_ {𝑨 = 𝑨}{ℓ = ℓw})
+  conDecIso = record
+    { to         = wit
+    ; from       = proj₁
+    ; to-mono    = λ {θ}{φ} → wit-mono {θ}{φ}
+    ; from-mono  = λ p → p
+    ; to∘from    = λ d → proj₂ (wit≑ (proj₁ d)) , proj₁ (wit≑ (proj₁ d))
+    ; from∘to    = λ φ → proj₂ (wit≑ φ) , proj₁ (wit≑ φ)
+    }
+```
+
+#### Transporting a lattice isomorphism across the layers
+
+Fix a classical lattice `𝑳`{.AgdaBound} and the bridge `cc`{.AgdaBound}, now at the FLRP
+level discipline (`0ℓ`{.AgdaBound}).  `P`{.AgdaBound} is the poset isomorphism of the
+previous section; `≈`{.AgdaFunction} is the lattice's setoid equality and `≤`{.AgdaFunction}
+its meet order, whose antisymmetry `≤-antisym`{.AgdaFunction} discharges the one
+`≑`-congruence obligation of each transport.
+
+```agda
+module _ {𝑆 : Signature 0ℓ 0ℓ}{𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ}
+         (𝑳 : Lattice)(cc : CongruenceCompleteness 𝑨) where
+  private module P = OrderIso (conDecIso cc)
+  open Setoid 𝔻[ proj₁ 𝑳 ]  using ( _≈_ ) renaming ( sym to ≈sym ; trans to ≈trans )
+  open Lattice-Order 𝑳       using ( _≤_ ; ≤-antisym )
+```
+
+**Layer D to Layer S.**  Given a decidable-layer isomorphism `isoᵈ : DecCon 𝑨 ≅ 𝑳`,
+compose `Con → DecCon` (the `to`{.AgdaFunction} of `P`{.AgdaBound}) with it to land a
+semantic-layer isomorphism `Con 𝑨 ≅ 𝑳`.  `to-cong`{.AgdaFunction} is the fact that
+`isoᵈ`{.AgdaBound}'s forward map respects `≑ᵈ`{.AgdaFunction} (both images sit below one
+another, and `≤`{.AgdaFunction} is antisymmetric); the round trips then chain a round
+trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{.AgdaBound}.
+
+```agda
+  ConIsoᵈ→ConIso : ConIsoᵈ 𝑨 𝑳 → ConIso 𝑨 𝑳
+  ConIsoᵈ→ConIso isoᵈ = record
+    { to         = λ θ → D.to (P.to θ)
+    ; from       = λ u → P.from (D.from u)
+    ; to-mono    = λ {θ}{φ} θ⊆φ → D.to-mono {P.to θ} {P.to φ} (P.to-mono {θ} {φ} θ⊆φ)
+    ; from-mono  = λ {u}{v} u≤v → P.from-mono {D.from u} {D.from v} (D.from-mono {u} {v} u≤v)
+    ; to∘from    = tf
+    ; from∘to    = ft
+    }
+    where
+    module D = OrderIso isoᵈ
+    -- isoᵈ's forward map respects ≑ᵈ, since the meet order is antisymmetric.
+    -- (Endpoint implicits of the monotone maps are forwarded explicitly: they are
+    -- not inferable through the non-injective containment relations.)
+    to-cong : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → D.to d ≈ D.to e
+    to-cong {d}{e} deq = ≤-antisym (D.to-mono {d} {e} (proj₁ deq)) (D.to-mono {e} {d} (proj₂ deq))
+    -- Con → DecCon → Con → 𝑳 collapses to 𝑳 via a P round trip then an isoᵈ one.
+    tf : ∀ u → D.to (P.to (P.from (D.from u))) ≈ u
+    tf u = ≈trans (to-cong {P.to (P.from (D.from u))} {D.from u} (P.to∘from (D.from u))) (D.to∘from u)
+    -- 𝑳 → DecCon → Con → DecCon collapses via an isoᵈ round trip then a P one.
+    -- The ≑ round trip is assembled directly (≑-trans's congruence implicits are
+    -- likewise uninferable), composing the two ⇒-directions on a related pair p.
+    ft : ∀ φ → P.from (D.from (D.to (P.to φ))) ≑ φ
+    ft φ = (λ p → proj₁ (P.from∘to φ) (proj₁ (D.from∘to (P.to φ)) p))
+         , (λ p → proj₂ (D.from∘to (P.to φ)) (proj₂ (P.from∘to φ) p))
+```
+
+**Layer S to Layer D.**  Dually, given a semantic-layer isomorphism
+`iso : Con 𝑨 ≅ 𝑳`, compose the forgetful `DecCon → Con` (the `from`{.AgdaFunction} of
+`P`{.AgdaBound}) with it.  Here `to-congᵈ`{.AgdaFunction} — that `wit`{.AgdaFunction}
+(the `to`{.AgdaFunction} of `P`{.AgdaBound}) respects `≑`{.AgdaFunction} — is what the
+`≑ᵈ`-valued round trip needs, and it is `wit-mono`{.AgdaFunction} in both directions.
+
+```agda
+  ConIso→ConIsoᵈ : ConIso 𝑨 𝑳 → ConIsoᵈ 𝑨 𝑳
+  ConIso→ConIsoᵈ iso = record
+    { to         = λ d → C.to (P.from d)
+    ; from       = λ u → P.to (C.from u)
+    ; to-mono    = λ {d}{e} d⊆ᵈe → C.to-mono {P.from d} {P.from e} (P.from-mono {d} {e} d⊆ᵈe)
+    ; from-mono  = λ {u}{v} u≤v → P.to-mono {C.from u} {C.from v} (C.from-mono {u} {v} u≤v)
+    ; to∘from    = tf
+    ; from∘to    = ft
+    }
+    where
+    module C = OrderIso iso
+    -- iso's forward map respects ≑, by antisymmetry of the meet order.
+    to-cong : {θ φ : Con 𝑨 0ℓ} → θ ≑ φ → C.to θ ≈ C.to φ
+    to-cong {θ}{φ} eq = ≤-antisym (C.to-mono {θ} {φ} (proj₁ eq)) (C.to-mono {φ} {θ} (proj₂ eq))
+    -- wit respects ≑ (needed to push an iso round trip through the ≑ᵈ side); it is
+    -- P.to-mono in both directions, endpoints forwarded explicitly.
+    to-congᵈ : {θ φ : Con 𝑨 0ℓ} → θ ≑ φ → P.to θ ≑ᵈ P.to φ
+    to-congᵈ {θ}{φ} eq = P.to-mono {θ} {φ} (proj₁ eq) , P.to-mono {φ} {θ} (proj₂ eq)
+    tf : ∀ u → C.to (P.from (P.to (C.from u))) ≈ u
+    tf u = ≈trans (to-cong {P.from (P.to (C.from u))} {C.from u} (P.from∘to (C.from u))) (C.to∘from u)
+    ft : ∀ d → P.to (C.from (C.to (P.from d))) ≑ᵈ d
+    ft d = (λ p → proj₁ (P.to∘from d) (proj₁ (to-congᵈ {C.from (C.to (P.from d))} {P.from d} (C.from∘to (P.from d))) p))
+         , (λ p → proj₂ (to-congᵈ {C.from (C.to (P.from d))} {P.from d} (C.from∘to (P.from d))) (proj₂ (P.to∘from d) p))
+```
+
+#### The representability equivalence
+
+The two layer-transports assemble the equivalence of the representability notions.  The
+finiteness and carrier data carry over unchanged; only the isomorphism field is
+transported, and `Representable → Representableᵈ`{.AgdaFunction} additionally supplies the
+finite-signature witness that `Representableᵈ`{.AgdaRecord} carries and
+`Representable`{.AgdaRecord} does not.
+
+```agda
+module _ {𝑳 : Lattice} where
+
+  -- Layer D ⇒ Layer S: transport the ConIsoᵈ to a ConIso.
+  Representableᵈ→Representable : (r : Representableᵈ 𝑳)
+    → CongruenceCompleteness (Representableᵈ.alg r) → Representable 𝑳
+  Representableᵈ→Representable r cc = record
+    { sig      = Representableᵈ.sig r
+    ; alg      = Representableᵈ.alg r
+    ; finite   = Representableᵈ.finite r
+    ; con-iso  = ConIsoᵈ→ConIso 𝑳 cc (Representableᵈ.con-isoᵈ r)
+    }
+
+  -- Layer S ⇒ Layer D: transport the ConIso to a ConIsoᵈ, given a FiniteSignature.
+  Representable→Representableᵈ : (r : Representable 𝑳)
+    → FiniteSignature (Representable.sig r)
+    → CongruenceCompleteness (Representable.alg r) → Representableᵈ 𝑳
+  Representable→Representableᵈ r fs cc = record
+    { sig       = Representable.sig r
+    ; alg       = Representable.alg r
+    ; finite    = Representable.finite r
+    ; finsig    = fs
+    ; con-isoᵈ  = ConIso→ConIsoᵈ 𝑳 cc (Representable.con-iso r)
+    }
+```
+
+--------------------------------------

--- a/src/FLRP/LayerBridge.lagda.md
+++ b/src/FLRP/LayerBridge.lagda.md
@@ -63,6 +63,7 @@ module FLRP.LayerBridge where
 
 -- Imports from Agda and the Agda Standard Library -----------------------------
 open import Data.Product          using ( _,_ ; proj₁ ; proj₂ )
+open import Function              using ( _∘_ )
 open import Level                 using ( Level ; 0ℓ ; _⊔_ )
 open import Relation.Binary       using ( Setoid )
 
@@ -119,12 +120,11 @@ containment of the representatives, because each representative is `≑`{.AgdaFu
 its source, so the two `≑`-witnesses bracket the given containment.
 
 ```agda
-  -- wit is monotone for the containment order.  Inlined as a direct ⇒-composition
-  -- (applied to the underlying related pair p): the two ≑-witnesses of wit≑ bracket
-  -- the given containment.  A named ⊆-trans cannot be used here — its implicit
-  -- congruence arguments are not inferable through the non-injective `_⊆_`.
+  -- wit is monotone for the containment order: the two ≑-witnesses of wit≑ bracket
+  -- the given containment.  Composed with `_∘_` rather than a named ⊆-trans, whose
+  -- implicit congruence arguments are not inferable through the non-injective `_⊆_`.
   wit-mono : {θ φ : Con 𝑨 ℓw} → θ ⊆ φ → wit θ ⊆ᵈ wit φ
-  wit-mono {θ}{φ} θ⊆φ p = proj₁ (wit≑ φ) (θ⊆φ (proj₂ (wit≑ θ) p))
+  wit-mono {θ}{φ} θ⊆φ = wit≑ φ .proj₁ ∘ θ⊆φ ∘ wit≑ θ .proj₂
 ```
 
 The order isomorphism: `to`{.AgdaFunction} is `wit`{.AgdaFunction} (the classical step),
@@ -141,8 +141,8 @@ just the `≑`-witness `wit≑`{.AgdaFunction}, read in the appropriate directio
     ; from       = proj₁
     ; to-mono    = λ {θ}{φ} → wit-mono {θ}{φ}
     ; from-mono  = λ p → p
-    ; to∘from    = λ d → proj₂ (wit≑ (proj₁ d)) , proj₁ (wit≑ (proj₁ d))
-    ; from∘to    = λ φ → proj₂ (wit≑ φ) , proj₁ (wit≑ φ)
+    ; to∘from    = λ d → wit≑ (d .proj₁) .proj₂ , wit≑ (d .proj₁) .proj₁
+    ; from∘to    = λ φ → wit≑ φ .proj₂ , wit≑ φ .proj₁
     }
 ```
 
@@ -172,29 +172,27 @@ trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{
 ```agda
   ConIsoᵈ→ConIso : ConIsoᵈ 𝑨 𝑳 → ConIso 𝑨 𝑳
   ConIsoᵈ→ConIso isoᵈ = record
-    { to         = λ θ → D.to (P.to θ)
-    ; from       = λ u → P.from (D.from u)
-    ; to-mono    = λ {θ}{φ} θ⊆φ → D.to-mono {P.to θ} {P.to φ} (P.to-mono {θ} {φ} θ⊆φ)
-    ; from-mono  = λ {u}{v} u≤v → P.from-mono {D.from u} {D.from v} (D.from-mono {u} {v} u≤v)
+    { to         = D.to ∘ P.to
+    ; from       = P.from ∘ D.from
+    ; to-mono    = λ {θ}{φ} → D.to-mono ∘ P.to-mono {θ} {φ}
+    ; from-mono  = λ {u}{v} → P.from-mono {D.from u} {D.from v} ∘ D.from-mono {u} {v}
     ; to∘from    = tf
     ; from∘to    = ft
     }
     where
     module D = OrderIso isoᵈ
-    -- isoᵈ's forward map respects ≑ᵈ, since the meet order is antisymmetric.
-    -- (Endpoint implicits of the monotone maps are forwarded explicitly: they are
-    -- not inferable through the non-injective containment relations.)
+    -- isoᵈ's forward map respects ≑ᵈ, since the meet order is antisymmetric.  (The
+    -- monotone maps' endpoint implicits are forwarded only where a composition or the
+    -- goal type does not already pin them — the containment relations are non-injective.)
     to-cong : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → D.to d ≈ D.to e
-    to-cong {d}{e} deq = ≤-antisym (D.to-mono {d} {e} (proj₁ deq)) (D.to-mono {e} {d} (proj₂ deq))
-    -- Con → DecCon → Con → 𝑳 collapses to 𝑳 via a P round trip then an isoᵈ one.
+    to-cong {d}{e} deq = ≤-antisym (D.to-mono {d} {e} (deq .proj₁)) (D.to-mono {e} {d} (deq .proj₂))
+    -- Con → DecCon → Con → 𝑳 collapses to 𝑳 via a P round trip (through to-cong) then an isoᵈ one.
     tf : ∀ u → D.to (P.to (P.from (D.from u))) ≈ u
     tf u = ≈trans (to-cong {P.to (P.from (D.from u))} {D.from u} (P.to∘from (D.from u))) (D.to∘from u)
-    -- 𝑳 → DecCon → Con → DecCon collapses via an isoᵈ round trip then a P one.
-    -- The ≑ round trip is assembled directly (≑-trans's congruence implicits are
-    -- likewise uninferable), composing the two ⇒-directions on a related pair p.
+    -- 𝑳 → DecCon → Con → DecCon: the ≑ round trip, composed on each ⇒-direction.
     ft : ∀ φ → P.from (D.from (D.to (P.to φ))) ≑ φ
-    ft φ = (λ p → proj₁ (P.from∘to φ) (proj₁ (D.from∘to (P.to φ)) p))
-         , (λ p → proj₂ (D.from∘to (P.to φ)) (proj₂ (P.from∘to φ) p))
+    ft φ = P.from∘to φ .proj₁ ∘ D.from∘to (P.to φ) .proj₁
+         , D.from∘to (P.to φ) .proj₂ ∘ P.from∘to φ .proj₂
 ```
 
 **Layer S to Layer D**.  Dually, given a semantic-layer isomorphism
@@ -206,10 +204,10 @@ trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{
 ```agda
   ConIso→ConIsoᵈ : ConIso 𝑨 𝑳 → ConIsoᵈ 𝑨 𝑳
   ConIso→ConIsoᵈ iso = record
-    { to         = λ d → C.to (P.from d)
-    ; from       = λ u → P.to (C.from u)
-    ; to-mono    = λ {d}{e} d⊆ᵈe → C.to-mono {P.from d} {P.from e} (P.from-mono {d} {e} d⊆ᵈe)
-    ; from-mono  = λ {u}{v} u≤v → P.to-mono {C.from u} {C.from v} (C.from-mono {u} {v} u≤v)
+    { to         = C.to ∘ P.from
+    ; from       = P.to ∘ C.from
+    ; to-mono    = λ {d}{e} → C.to-mono ∘ P.from-mono {d} {e}
+    ; from-mono  = λ {u}{v} → P.to-mono {C.from u} {C.from v} ∘ C.from-mono {u} {v}
     ; to∘from    = tf
     ; from∘to    = ft
     }
@@ -217,16 +215,17 @@ trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{
     module C = OrderIso iso
     -- iso's forward map respects ≑, by antisymmetry of the meet order.
     to-cong : {θ φ : Con 𝑨 0ℓ} → θ ≑ φ → C.to θ ≈ C.to φ
-    to-cong {θ}{φ} eq = ≤-antisym (C.to-mono {θ} {φ} (proj₁ eq)) (C.to-mono {φ} {θ} (proj₂ eq))
+    to-cong {θ}{φ} eq = ≤-antisym (C.to-mono {θ} {φ} (eq .proj₁)) (C.to-mono {φ} {θ} (eq .proj₂))
     -- wit respects ≑ (needed to push an iso round trip through the ≑ᵈ side); it is
-    -- P.to-mono in both directions, endpoints forwarded explicitly.
+    -- P.to-mono in both directions.
     to-congᵈ : {θ φ : Con 𝑨 0ℓ} → θ ≑ φ → P.to θ ≑ᵈ P.to φ
-    to-congᵈ {θ}{φ} eq = P.to-mono {θ} {φ} (proj₁ eq) , P.to-mono {φ} {θ} (proj₂ eq)
+    to-congᵈ {θ}{φ} eq = P.to-mono {θ} {φ} (eq .proj₁) , P.to-mono {φ} {θ} (eq .proj₂)
     tf : ∀ u → C.to (P.from (P.to (C.from u))) ≈ u
     tf u = ≈trans (to-cong {P.from (P.to (C.from u))} {C.from u} (P.from∘to (C.from u))) (C.to∘from u)
+    -- The ≑ᵈ round trip, composed on each ⇒-direction; `cd` names the ≑ᵈ from to-congᵈ.
     ft : ∀ d → P.to (C.from (C.to (P.from d))) ≑ᵈ d
-    ft d = (λ p → proj₁ (P.to∘from d) (proj₁ (to-congᵈ {C.from (C.to (P.from d))} {P.from d} (C.from∘to (P.from d))) p))
-         , (λ p → proj₂ (to-congᵈ {C.from (C.to (P.from d))} {P.from d} (C.from∘to (P.from d))) (proj₂ (P.to∘from d) p))
+    ft d = P.to∘from d .proj₁ ∘ cd .proj₁ , cd .proj₂ ∘ P.to∘from d .proj₂
+      where cd = to-congᵈ {C.from (C.to (P.from d))} {P.from d} (C.from∘to (P.from d))
 ```
 
 #### The representability equivalence

--- a/src/FLRP/LayerBridge.lagda.md
+++ b/src/FLRP/LayerBridge.lagda.md
@@ -68,19 +68,19 @@ open import Level                 using ( Level ; 0ℓ ; _⊔_ )
 open import Relation.Binary       using ( Setoid )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Overture                             using  ( 𝓞 ; 𝓥 ; Signature )
-open import Classical.Small.Structures.Lattice   using  ( Lattice )
-open import Classical.Properties.Lattice         using  ( module Lattice-Order )
-open import Setoid.Algebras.Basic                using  ( Algebra ; 𝔻[_] ; 𝕌[_] )
-open import Setoid.Signatures.Finite             using  ( FiniteSignature )
-open import Setoid.Congruences.Basic             using  ( Con )
-open import Setoid.Congruences.Lattice           using  ( _⊆_ ; _≑_ )
-open import Setoid.Congruences.Finite.Basic      using  ( DecCon )
-open import FLRP.Problem                         using  ( OrderIso ; Representable
-                                                        ; ConIso )
-open import FLRP.Representable                   using  ( Representableᵈ ; ConIsoᵈ
-                                                        ; _⊆ᵈ_ ; _≑ᵈ_ )
-open import FLRP.Assumptions                     using  ( CongruenceCompleteness )
+open import Classical.Properties.Lattice        using  ( module Lattice-Order )
+open import Classical.Small.Structures.Lattice  using  ( Lattice )
+open import FLRP.Assumptions                    using  ( CongruenceCompleteness )
+open import FLRP.Problem                        using  ( OrderIso ; Representable
+                                                       ; ConIso )
+open import FLRP.Representable                  using  ( Representableᵈ ; ConIsoᵈ
+                                                       ; _⊆ᵈ_ ; _≑ᵈ_ )
+open import Overture                            using  ( 𝓞 ; 𝓥 ; Signature )
+open import Setoid.Algebras.Basic               using  ( Algebra ; 𝔻[_] ; 𝕌[_] )
+open import Setoid.Congruences.Basic            using  ( Con )
+open import Setoid.Congruences.Finite.Basic     using  ( DecCon )
+open import Setoid.Congruences.Lattice          using  ( _⊆_ ; _≑_ )
+open import Setoid.Signatures.Finite            using  ( FiniteSignature )
 
 private variable α ρ : Level
 ```
@@ -162,8 +162,8 @@ module _
   (cc : CongruenceCompleteness 𝑨)
   where
   private module P = OrderIso (conDecIso cc)
-  open Setoid 𝔻[ proj₁ 𝑳 ]  using ( _≈_ ) renaming ( sym to ≈sym ; trans to ≈trans )
-  open Lattice-Order 𝑳       using ( _≤_ ; ≤-antisym )
+  open Setoid 𝔻[ proj₁ 𝑳 ]  using ( _≈_ ) renaming ( trans to ≈trans )
+  open Lattice-Order 𝑳       using ( ≤-antisym )
 ```
 
 **Layer D to Layer S**.  Given a decidable-layer isomorphism `isoᵈ : DecCon 𝑨 ≅ 𝑳`,

--- a/src/FLRP/LayerBridge.lagda.md
+++ b/src/FLRP/LayerBridge.lagda.md
@@ -63,7 +63,7 @@ module FLRP.LayerBridge where
 
 -- Imports from Agda and the Agda Standard Library -----------------------------
 open import Data.Product          using ( _,_ ; proj₁ ; proj₂ )
-open import Function              using ( _∘_ )
+open import Function              using ( _∘_ ; id )
 open import Level                 using ( Level ; 0ℓ ; _⊔_ )
 open import Relation.Binary       using ( Setoid )
 
@@ -71,7 +71,7 @@ open import Relation.Binary       using ( Setoid )
 open import Overture                             using  ( 𝓞 ; 𝓥 ; Signature )
 open import Classical.Small.Structures.Lattice   using  ( Lattice )
 open import Classical.Properties.Lattice         using  ( module Lattice-Order )
-open import Setoid.Algebras.Basic                using  ( Algebra ; 𝔻[_] )
+open import Setoid.Algebras.Basic                using  ( Algebra ; 𝔻[_] ; 𝕌[_] )
 open import Setoid.Signatures.Finite             using  ( FiniteSignature )
 open import Setoid.Congruences.Basic             using  ( Con )
 open import Setoid.Congruences.Lattice           using  ( _⊆_ ; _≑_ )
@@ -108,11 +108,11 @@ module _
 
   -- The decidable representative of a semantic congruence (the bridge's map) ...
   wit : Con 𝑨 ℓw → DecCon 𝑨 ℓw
-  wit φ = proj₁ (cc φ)
+  wit φ = cc φ .proj₁
 
   -- ... and the ≑-witness that it represents φ.
   wit≑ : (φ : Con 𝑨 ℓw) → φ ≑ proj₁ (wit φ)
-  wit≑ φ = proj₂ (cc φ)
+  wit≑ φ = cc φ .proj₂
 ```
 
 `wit`{.AgdaFunction} is monotone: a containment `θ ⊆ φ`{.AgdaFunction} forwards to a
@@ -140,8 +140,8 @@ just the `≑`-witness `wit≑`{.AgdaFunction}, read in the appropriate directio
     { to         = wit
     ; from       = proj₁
     ; to-mono    = λ {θ}{φ} → wit-mono {θ}{φ}
-    ; from-mono  = λ p → p
-    ; to∘from    = λ d → wit≑ (d .proj₁) .proj₂ , wit≑ (d .proj₁) .proj₁
+    ; from-mono  = id
+    ; to∘from    = λ (d , _) → wit≑ d .proj₂ , wit≑ d .proj₁
     ; from∘to    = λ φ → wit≑ φ .proj₂ , wit≑ φ .proj₁
     }
 ```
@@ -155,8 +155,12 @@ its meet order, whose antisymmetry `≤-antisym`{.AgdaFunction} discharges the o
 `≑`-congruence obligation of each transport.
 
 ```agda
-module _ {𝑆 : Signature 0ℓ 0ℓ}{𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ}
-         (𝑳 : Lattice)(cc : CongruenceCompleteness 𝑨) where
+module _
+  {𝑆 : Signature 0ℓ 0ℓ}
+  {𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ}
+  (𝑳 : Lattice)
+  (cc : CongruenceCompleteness 𝑨)
+  where
   private module P = OrderIso (conDecIso cc)
   open Setoid 𝔻[ proj₁ 𝑳 ]  using ( _≈_ ) renaming ( sym to ≈sym ; trans to ≈trans )
   open Lattice-Order 𝑳       using ( _≤_ ; ≤-antisym )
@@ -172,8 +176,8 @@ trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{
 ```agda
   ConIsoᵈ→ConIso : ConIsoᵈ 𝑨 𝑳 → ConIso 𝑨 𝑳
   ConIsoᵈ→ConIso isoᵈ = record
-    { to         = D.to ∘ P.to
-    ; from       = P.from ∘ D.from
+    { to         = to'
+    ; from       = from'
     ; to-mono    = λ {θ}{φ} → D.to-mono ∘ P.to-mono {θ} {φ}
     ; from-mono  = λ {u}{v} → P.from-mono {D.from u} {D.from v} ∘ D.from-mono {u} {v}
     ; to∘from    = tf
@@ -185,12 +189,20 @@ trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{
     -- monotone maps' endpoint implicits are forwarded only where a composition or the
     -- goal type does not already pin them — the containment relations are non-injective.)
     to-cong : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → D.to d ≈ D.to e
-    to-cong {d}{e} deq = ≤-antisym (D.to-mono {d} {e} (deq .proj₁)) (D.to-mono {e} {d} (deq .proj₂))
+    to-cong deq = ≤-antisym (D.to-mono (deq .proj₁)) (D.to-mono (deq .proj₂))
+
+    to' : Con 𝑨 0ℓ → 𝕌[ proj₁ 𝑳 ]
+    to' =  D.to ∘ P.to
+
+    from' : 𝕌[ proj₁ 𝑳 ] → Con 𝑨 0ℓ
+    from' = P.from ∘ D.from
+
     -- Con → DecCon → Con → 𝑳 collapses to 𝑳 via a P round trip (through to-cong) then an isoᵈ one.
-    tf : ∀ u → D.to (P.to (P.from (D.from u))) ≈ u
-    tf u = ≈trans (to-cong {P.to (P.from (D.from u))} {D.from u} (P.to∘from (D.from u))) (D.to∘from u)
+    tf : ∀ u → to' (from' u) ≈ u
+    tf u = ≈trans (to-cong (P.to∘from (D.from u))) (D.to∘from u)
+
     -- 𝑳 → DecCon → Con → DecCon: the ≑ round trip, composed on each ⇒-direction.
-    ft : ∀ φ → P.from (D.from (D.to (P.to φ))) ≑ φ
+    ft : ∀ φ → from' (to' φ) ≑ φ
     ft φ = P.from∘to φ .proj₁ ∘ D.from∘to (P.to φ) .proj₁
          , D.from∘to (P.to φ) .proj₂ ∘ P.from∘to φ .proj₂
 ```
@@ -204,8 +216,8 @@ trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{
 ```agda
   ConIso→ConIsoᵈ : ConIso 𝑨 𝑳 → ConIsoᵈ 𝑨 𝑳
   ConIso→ConIsoᵈ iso = record
-    { to         = C.to ∘ P.from
-    ; from       = P.to ∘ C.from
+    { to         = to'
+    ; from       = from'
     ; to-mono    = λ {d}{e} → C.to-mono ∘ P.from-mono {d} {e}
     ; from-mono  = λ {u}{v} → P.to-mono {C.from u} {C.from v} ∘ C.from-mono {u} {v}
     ; to∘from    = tf
@@ -215,51 +227,64 @@ trip of `P`{.AgdaBound} (through `to-cong`{.AgdaFunction}) with one of `isoᵈ`{
     module C = OrderIso iso
     -- iso's forward map respects ≑, by antisymmetry of the meet order.
     to-cong : {θ φ : Con 𝑨 0ℓ} → θ ≑ φ → C.to θ ≈ C.to φ
-    to-cong {θ}{φ} eq = ≤-antisym (C.to-mono {θ} {φ} (eq .proj₁)) (C.to-mono {φ} {θ} (eq .proj₂))
+    to-cong eq = ≤-antisym (C.to-mono (eq .proj₁)) (C.to-mono (eq .proj₂))
+
     -- wit respects ≑ (needed to push an iso round trip through the ≑ᵈ side); it is
     -- P.to-mono in both directions.
     to-congᵈ : {θ φ : Con 𝑨 0ℓ} → θ ≑ φ → P.to θ ≑ᵈ P.to φ
-    to-congᵈ {θ}{φ} eq = P.to-mono {θ} {φ} (eq .proj₁) , P.to-mono {φ} {θ} (eq .proj₂)
-    tf : ∀ u → C.to (P.from (P.to (C.from u))) ≈ u
-    tf u = ≈trans (to-cong {P.from (P.to (C.from u))} {C.from u} (P.from∘to (C.from u))) (C.to∘from u)
+    to-congᵈ eq = P.to-mono (eq .proj₁) , P.to-mono (eq .proj₂)
+
+    to' : DecCon 𝑨 0ℓ → 𝕌[ proj₁ 𝑳 ]
+    to' = C.to ∘ P.from
+
+    from' : 𝕌[ proj₁ 𝑳 ] → DecCon 𝑨 0ℓ
+    from' = P.to ∘ C.from
+
+    tf : ∀ u → to' (from' u) ≈ u
+    tf u = ≈trans (to-cong (P.from∘to (C.from u))) (C.to∘from u)
+
     -- The ≑ᵈ round trip, composed on each ⇒-direction; `cd` names the ≑ᵈ from to-congᵈ.
-    ft : ∀ d → P.to (C.from (C.to (P.from d))) ≑ᵈ d
+    ft : ∀ d → from' (to' d) ≑ᵈ d
     ft d = P.to∘from d .proj₁ ∘ cd .proj₁ , cd .proj₂ ∘ P.to∘from d .proj₂
-      where cd = to-congᵈ {C.from (C.to (P.from d))} {P.from d} (C.from∘to (P.from d))
+      where
+      cd : from' (to' d) ≑ᵈ P.to (P.from d)
+      cd = to-congᵈ (C.from∘to (P.from d))
 ```
 
 #### The representability equivalence
 
-The two layer-transports assemble the equivalence of the representability notions.  The
-finiteness and carrier data carry over unchanged; only the isomorphism field is
-transported, and `Representable → Representableᵈ`{.AgdaFunction} additionally supplies the
-finite-signature witness that `Representableᵈ`{.AgdaRecord} carries and
+The two layer-transports assemble the equivalence of the representability notions.
+The finiteness and carrier data carry over unchanged; only the isomorphism field is
+transported, and `Representable → Representableᵈ`{.AgdaFunction} additionally
+supplies the finite-signature witness that `Representableᵈ`{.AgdaRecord} carries and
 `Representable`{.AgdaRecord} does not.
 
 ```agda
 module _ {𝑳 : Lattice} where
-
+  open Representableᵈ
+  open Representable
   -- Layer D ⇒ Layer S: transport the ConIsoᵈ to a ConIso.
   Representableᵈ→Representable : (r : Representableᵈ 𝑳)
-    → CongruenceCompleteness (Representableᵈ.alg r) → Representable 𝑳
-  Representableᵈ→Representable r cc = record
-    { sig      = Representableᵈ.sig r
-    ; alg      = Representableᵈ.alg r
-    ; finite   = Representableᵈ.finite r
-    ; con-iso  = ConIsoᵈ→ConIso 𝑳 cc (Representableᵈ.con-isoᵈ r)
-    }
+    → CongruenceCompleteness (r .algᵈ) → Representable 𝑳
+  Representableᵈ→Representable r cc =
+    record
+      { sig      = r .sigᵈ
+      ; alg      = r .algᵈ
+      ; finite   = r .finiteᵈ
+      ; con-iso  = ConIsoᵈ→ConIso 𝑳 cc (r .con-isoᵈ)
+      }
 
   -- Layer S ⇒ Layer D: transport the ConIso to a ConIsoᵈ, given a FiniteSignature.
   Representable→Representableᵈ : (r : Representable 𝑳)
-    → FiniteSignature (Representable.sig r)
-    → CongruenceCompleteness (Representable.alg r) → Representableᵈ 𝑳
-  Representable→Representableᵈ r fs cc = record
-    { sig       = Representable.sig r
-    ; alg       = Representable.alg r
-    ; finite    = Representable.finite r
-    ; finsig    = fs
-    ; con-isoᵈ  = ConIso→ConIsoᵈ 𝑳 cc (Representable.con-iso r)
-    }
+    → FiniteSignature (r .sig) → CongruenceCompleteness (r .alg) → Representableᵈ 𝑳
+  Representable→Representableᵈ r fs cc =
+    record
+      { sigᵈ       = r .sig
+      ; algᵈ       = r .alg
+      ; finiteᵈ    = r .finite
+      ; finsigᵈ    = fs
+      ; con-isoᵈ  = ConIso→ConIsoᵈ 𝑳 cc (r .con-iso)
+      }
 ```
 
 --------------------------------------

--- a/src/FLRP/Representable.lagda.md
+++ b/src/FLRP/Representable.lagda.md
@@ -146,11 +146,11 @@ than semantic `Con`{.AgdaFunction}.
 ```agda
 record Representableᵈ (𝑳 : Lattice) : Type (lsuc 0ℓ) where
   field
-    sig       : Signature 0ℓ 0ℓ
-    alg       : Algebra {𝑆 = sig} 0ℓ 0ℓ
-    finite    : FiniteAlgebra {𝑆 = sig} alg
-    finsig    : FiniteSignature sig
-    con-isoᵈ  : ConIsoᵈ {𝑆 = sig} alg 𝑳
+    sigᵈ      : Signature 0ℓ 0ℓ
+    algᵈ      : Algebra {𝑆 = sigᵈ} 0ℓ 0ℓ
+    finiteᵈ   : FiniteAlgebra {𝑆 = sigᵈ} algᵈ
+    finsigᵈ   : FiniteSignature sigᵈ
+    con-isoᵈ  : ConIsoᵈ {𝑆 = sigᵈ} algᵈ 𝑳
 ```
 
 The Finite Lattice Representation Problem, reformulated at Layer D: every finite
@@ -427,10 +427,10 @@ unattainable at Layer S is thus attained, constructively, at Layer D.
 ```agda
 chain₂-Representableᵈ : Representableᵈ chain₂-lattice
 chain₂-Representableᵈ = record
-  { sig       = 𝑆∅
-  ; alg       = 𝟚
-  ; finite    = 𝟚-FiniteAlgebra
-  ; finsig    = 𝑆∅-FiniteSignature
+  { sigᵈ       = 𝑆∅
+  ; algᵈ       = 𝟚
+  ; finiteᵈ    = 𝟚-FiniteAlgebra
+  ; finsigᵈ    = 𝑆∅-FiniteSignature
   ; con-isoᵈ  = 𝟚-ConIsoᵈ
   }
 ```

--- a/src/FLRP/Representable.lagda.md
+++ b/src/FLRP/Representable.lagda.md
@@ -143,6 +143,19 @@ exact input from which [Setoid.Congruences.Finite.Decidable][] builds a complete
 of decidable congruences — and the isomorphism is over `DecCon`{.AgdaFunction} rather
 than semantic `Con`{.AgdaFunction}.
 
+A note on the field superscripts.  The `ᵈ`{.AgdaBound} on `sigᵈ`{.AgdaField},
+`algᵈ`{.AgdaField}, `finiteᵈ`{.AgdaField}, and `finsigᵈ`{.AgdaField} is *namespacing*,
+not a claim of decidability: those fields hold the very same interfaces
+`Representable`{.AgdaRecord} uses (`Signature`{.AgdaRecord}, `Algebra`{.AgdaRecord},
+`FiniteAlgebra`{.AgdaRecord}, `FiniteSignature`{.AgdaRecord}), and `finiteᵈ`{.AgdaField}
+in particular is carrier-finiteness, which is constructive.  Only
+`con-isoᵈ`{.AgdaField} (`: ConIsoᵈ`{.AgdaFunction}) is a genuinely decidable-layer
+datum.  The superscripts are carried on every field so that `Representable`{.AgdaRecord}
+and `Representableᵈ`{.AgdaRecord} can be `open`ed together without their field names
+clashing — which is what keeps the cross-layer transports of [FLRP.LayerBridge][]
+legible — matching the all-superscripted convention of the sibling record
+`FiniteCongruencesᵈ`{.AgdaRecord}.
+
 ```agda
 record Representableᵈ (𝑳 : Lattice) : Type (lsuc 0ℓ) where
   field

--- a/src/FLRP/Representable.lagda.md
+++ b/src/FLRP/Representable.lagda.md
@@ -58,28 +58,25 @@ open import Data.Unit.Base       using ( tt )
 open import Level                using ( Level ; 0ℓ ; _⊔_ ; Lift ; lift ; lower )
                                  renaming ( suc to lsuc )
 open import Relation.Binary      using ( Setoid ; IsEquivalence )
-                                 renaming ( Rel to BinaryRel )
-open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl ; sym ; subst )
+open import Relation.Binary.PropositionalEquality
+                                 using ( _≡_ ; refl ; sym ; subst )
 open import Relation.Nullary     using ( ¬_ ; Dec ; yes ; no )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Overture                             using  ( 𝓞 ; 𝓥 ; Signature )
-open import Classical.Small.Structures.Lattice   using  ( Lattice )
 open import Classical.Properties.Lattice         using  ( module Lattice-Order )
+open import Classical.Small.Structures.Lattice   using  ( Lattice )
+open import FLRP.Problem                         using  ( OrderIso ; FiniteLattice
+                                                        ; toLattice ; 𝑆∅ ; chain₂-lattice )
+open import Overture                             using  ( 𝓞 ; 𝓥 ; Signature )
 open import Setoid.Algebras.Basic                using  ( Algebra ; 𝔻[_] ; mkAlgebraₚ )
 open import Setoid.Algebras.Finite               using  ( FiniteAlgebra )
-open import Setoid.Signatures.Finite             using  ( FiniteSignature )
-open import Setoid.Congruences.Basic             using  ( Con ; reflexive ; 𝟘[_]
+open import Setoid.Congruences.Basic             using  ( reflexive ; 𝟘[_]
                                                         ; is-equivalence ; 𝟙[_] )
-open import Setoid.Congruences.Lattice           using  ( _⊆_ ; _≑_ ; ≑-sym
-                                                        ; 𝟘-min ; 𝟙-max )
 open import Setoid.Congruences.Finite.Basic      using  ( DecCon ; ConRel )
 open import Setoid.Congruences.Finite.Decidable  using  ( FiniteCongruencesᵈ
                                                         ; FiniteAlgebra→FiniteCongruencesᵈ )
-open import Setoid.Congruences.ChainJoin         using  ( Finitary )
-open import FLRP.Problem                         using  ( OrderIso ; FiniteLattice
-                                                        ; toLattice ; 𝑆∅ ; chain₂
-                                                        ; chain₂-lattice )
+open import Setoid.Congruences.Lattice           using  ( _⊆_ ; _≑_ ; 𝟘-min ; 𝟙-max )
+open import Setoid.Signatures.Finite             using  ( FiniteSignature )
 
 private variable α ρ ℓ : Level
 ```

--- a/src/Setoid/Congruences/Finite/Basic.lagda.md
+++ b/src/Setoid/Congruences/Finite/Basic.lagda.md
@@ -118,7 +118,7 @@ record FiniteCongruences {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = �
     -- a finite list of decidable congruences of 𝑨 ...
     cons      : List (DecCon 𝑨 (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ))
     -- ... exhausting the congruence lattice of 𝑨, up to ≑
-    complete  : ∀ φ → Σ[ d ∈ DecCon 𝑨 _ ] (d ∈ cons) × (φ ≑ proj₁ d)
+    complete  : ∀ φ → Σ[ d ∈ DecCon 𝑨 _ ] d ∈ cons × φ ≑ proj₁ d
 
   witness : ∀ φ → DecCon 𝑨 (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ)
   witness = proj₁ ∘ complete

--- a/src/Setoid/Congruences/Lattice.lagda.md
+++ b/src/Setoid/Congruences/Lattice.lagda.md
@@ -34,7 +34,7 @@ open import Relation.Binary.Bundles  using ( Poset )
 open import Relation.Binary.Lattice  using ( Infimum ; IsMeetSemilattice ; MeetSemilattice )
 
 -- Imports from the Agda Universal Algebras Library ------------------------------
-open import Overture                  using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture                  using  ( 𝑆 )
 open import Setoid.Algebras.Basic     using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Congruences.Basic  using  ( Con ; mkcon ; _∣≈_ ; reflexive
                                              ; is-equivalence ; is-compatible

--- a/src/Setoid/Congruences/Monolith.lagda.md
+++ b/src/Setoid/Congruences/Monolith.lagda.md
@@ -39,7 +39,7 @@ open import Relation.Binary   using ( Setoid ; IsEquivalence ; _⇒_ )
 open import Relation.Nullary  using ( ¬_ )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture                    using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture                    using  ( 𝑆 )
 open import Setoid.Algebras.Basic       using  ( ov ; Algebra ; 𝕌[_] ; 𝔻[_] )
 open import Setoid.Congruences.Basic    using  ( Con ; mkcon ; _∣≈_ ; reflexive
                                                ; is-equivalence ; is-compatible )

--- a/src/Setoid/Congruences/Permutability.lagda.md
+++ b/src/Setoid/Congruences/Permutability.lagda.md
@@ -43,7 +43,7 @@ open import Relation.Binary  using ( Setoid ; IsEquivalence )
                              renaming ( Rel to BinaryRel ; _⇒_ to _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture                  using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture                  using ( 𝑆 )
 open import Setoid.Algebras.Basic     using ( ov ; Algebra ; 𝕌[_] )
 open import Setoid.Congruences.Basic  using ( Con ; is-equivalence )
 

--- a/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
+++ b/src/Setoid/Homomorphisms/HomomorphicImages.lagda.md
@@ -18,26 +18,26 @@ module Setoid.Homomorphisms.HomomorphicImages where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ----------------------------------------------------
-open import Data.Product     using ( _,_ ; Σ-syntax )
-                             renaming ( _×_ to _∧_ )
-open import Function         using ( Func ; _∘_ )
-open import Level            using ( Level ; _⊔_ ; suc )
-open import Relation.Binary  using ( Setoid )
-open import Relation.Unary   using ( Pred ; _∈_ )
-
-open import Relation.Binary.PropositionalEquality using (refl)
+open import Data.Product  renaming ( _×_ to _∧_ )  using ( _,_ ; Σ-syntax )
+open import Function                               using ( Func ; _∘_ )
+open import Level                                  using ( Level ; _⊔_ ; suc )
+open import Relation.Binary                        using ( Setoid )
+open import Relation.Unary                         using ( Pred ; _∈_ )
+open import Relation.Binary.PropositionalEquality  using (refl)
 
 -- Imports from the Agda Universal Algebra Library ---------------------------------------------
-open import Overture                                    using  ( proj₁ ; proj₂
-                                                               ; ArityOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras  using  ( Algebra ; ov ; _^_ ; 𝔻[_]
-                                                               ; Lift-Algˡ ; Lift-Alg ; 𝕌[_] )
-open import Setoid.Functions using (IsSurjective; Image_∋_ ; Ran ; range ; preimage ; image ; preimage≈image; Inv ; lift∼lower; InvIsInverseʳ; ⊙-IsSurjective)
-open import Setoid.Signatures                           using  ( ⟨_⟩ )
-open import Setoid.Homomorphisms.Basic                  using  ( hom ; IsHom ; 𝒾𝒹 )
+open import Overture                           using  ( proj₁ ; proj₂ ; ArityOf ; 𝑆 )
+open import Setoid.Algebras                    using  ( Algebra ; ov ; _^_ ; 𝔻[_]
+                                                      ; Lift-Algˡ ; Lift-Alg ; 𝕌[_] )
+open import Setoid.Functions                   using  (IsSurjective; Image_∋_ ; Ran
+                                                      ; range ; preimage ; image ; Inv
+                                                      ; preimage≈image ; lift∼lower
+                                                      ; InvIsInverseʳ ; ⊙-IsSurjective)
+open import Setoid.Homomorphisms.Basic         using  ( hom ; IsHom ; 𝒾𝒹 )
 open import Setoid.Homomorphisms.Isomorphisms  using  ( _≅_ ; Lift-≅ )
-open  import Setoid.Homomorphisms.Properties            using  ( Lift-homˡ ; ToLiftˡ
-                                                               ; lift-hom-lemma ; ⊙-hom )
+open import Setoid.Homomorphisms.Properties    using  ( Lift-homˡ ; ToLiftˡ
+                                                      ; lift-hom-lemma ; ⊙-hom )
+open import Setoid.Signatures                  using  ( ⟨_⟩ )
 
 open Algebra
 

--- a/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
+++ b/src/Setoid/Homomorphisms/Isomorphisms.lagda.md
@@ -22,20 +22,20 @@ open import Data.Unit.Polymorphic.Base  using ()      renaming ( ⊤ to 𝟙 ; t
 open import Data.Unit.Base              using ( ⊤ ; tt )
 open import Function                    using ()  renaming ( Func to _⟶_ )
 open import Level                       using ( Level ; Lift ; lift ; lower ; _⊔_ )
-open import Relation.Binary             using ( Setoid ; Reflexive ; Sym ; Trans )
+open import Relation.Binary             using ( Setoid )
 
 open import Relation.Binary.PropositionalEquality using (refl)
 
 -- Imports from the Agda Universal Algebra Library -----------------------------------------
-open import Overture                         using  ( OperationSymbolsOf ; ArityOf ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture                         using  ( OperationSymbolsOf ; ArityOf
+                                                    ; 𝓞 ; 𝓥 ; Signature ; 𝑆 )
 open import Overture.Operations              using  ( Op )
-open import Setoid.Functions                 using  ( eq ; IsInjective
-                                                    ; IsSurjective ; SurjInv
-                                                    ; SurjInvIsInverseʳ )
-open import Setoid.Algebras          using  ( Algebra ; Lift-Alg ; _^_ ; 𝔻[_]
+open import Setoid.Algebras                  using  ( Algebra ; Lift-Alg ; _^_ ; 𝔻[_]
                                                     ; 𝕌[_] ; mkAlgebra ; Lift-Algˡ
                                                     ; Lift-Algʳ ; ⨅ )
 
+open import Setoid.Functions                 using  ( eq ; IsInjective ; IsSurjective
+                                                    ; SurjInv ; SurjInvIsInverseʳ )
 open import Setoid.Homomorphisms.Basic       using  ( hom ; IsHom ; 𝒾𝒹 ; mkIsHom )
 open import Setoid.Homomorphisms.Properties  using  ( ⊙-hom ; ToLiftˡ ; FromLiftˡ
                                                     ; ToFromLiftˡ ; FromToLiftˡ

--- a/src/Setoid/Varieties/EquationalLogic.lagda.md
+++ b/src/Setoid/Varieties/EquationalLogic.lagda.md
@@ -28,9 +28,9 @@ open import Relation.Binary  using ( Setoid )
 open import Relation.Unary   using ( Pred ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture         using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
-open import Setoid.Algebras  using ( Algebra ; ov )
+open import Overture         using ( 𝑆 )
 open import Overture.Terms   using ( Term )
+open import Setoid.Algebras  using ( Algebra ; ov )
 open import Setoid.Terms     using ( module Environment )
 
 private variable χ α ρᵃ ℓ ι : Level

--- a/src/Setoid/Varieties/FreeAlgebras.lagda.md
+++ b/src/Setoid/Varieties/FreeAlgebras.lagda.md
@@ -15,9 +15,9 @@ author: "agda-algebras development team"
 module Setoid.Varieties.FreeAlgebras where
 
 -- Imports from Agda and the Agda Standard Library -------------------------------
-open import Agda.Primitive   using ()                  renaming ( Set to Type )
+open import Agda.Primitive   using () renaming ( Set to Type )
 open import Data.Product     using ( Σ-syntax ; _,_ ; proj₁ ; proj₂ )
-open import Function         using ( _∘_ ; id )        renaming ( Func to _⟶_ )
+open import Function         using ( _∘_ ; id ) renaming ( Func to _⟶_ )
 open import Level            using ( Level ; _⊔_)
 open import Relation.Binary  using ( Setoid )
 open import Relation.Unary   using ( Pred ; _∈_ ; _⊆_ )
@@ -27,7 +27,7 @@ open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                           using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture                           using  ( 𝑆 )
 open import Overture.Terms                     using  ( ℊ )
 open import Setoid.Algebras                    using  ( Algebra ; ov ; Lift-Alg ; 𝔻[_] )
 open import Setoid.Functions                   using  ( eq ; IsSurjective )

--- a/src/Setoid/Varieties/HSP.lagda.md
+++ b/src/Setoid/Varieties/HSP.lagda.md
@@ -28,20 +28,19 @@ open import Relation.Binary  using ( Setoid )
 open import Relation.Unary   using ( Pred ; _∈_ ; _⊆_ )
 
 -- -- Imports from the Agda Universal Algebra Library ----------------------------
-open import Overture                           using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture                           using  ( 𝑆 )
 open import Setoid.Algebras                    using  ( Algebra ; ov ; Lift-Alg ; ⨅ )
 open import Setoid.Homomorphisms
 open import Setoid.Relations                   using  ( fkerPred )
 open import Setoid.Subalgebras                 using  ( _≤_ ; mon→≤ )
-open import Setoid.Terms                       using  ( module Environment ; 𝑻
-                                                      ; lift-hom ; free-lift
-                                                      ; free-lift-interp )
+open import Setoid.Terms                       using  ( module Environment ; lift-hom
+                                                      ; 𝑻 ; free-lift ; free-lift-interp )
 open import Setoid.Varieties.Closure           using  ( S ; P ; S-idem ; V ; V′ ; V-≅-lc )
 open import Setoid.Varieties.FreeAlgebras      using  ( module FreeHom
                                                       ; 𝔽-ModTh-epi-lift )
 open import Setoid.Varieties.Preservation      using  ( S-id2 ; PS⊆SP )
-open import Setoid.Varieties.SoundAndComplete  using  ( module FreeAlgebra ; _⊫_ ; ⊫-proof
-                                                      ; _≈̇_ ; _⊢_▹_≈_ ; Mod ; Th )
+open import Setoid.Varieties.SoundAndComplete  using  ( module FreeAlgebra ; ⊫-proof
+                                                      ; _≈̇_ ; _⊢_▹_≈_ ; Mod ; Th ; _⊫_ )
 
 open _⟶_          using () renaming ( to to _⟨$⟩_ )
 open Setoid       using ( Carrier )

--- a/src/Setoid/Varieties/Invariants.lagda.md
+++ b/src/Setoid/Varieties/Invariants.lagda.md
@@ -25,7 +25,7 @@ open import Level           using ( Level )
 open import Relation.Unary  using ( Pred )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture              using ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture              using ( 𝑆 )
 open import Setoid.Algebras       using ( Algebra )
 open import Setoid.Homomorphisms  using ( _≅_ )
 

--- a/src/Setoid/Varieties/Preservation.lagda.md
+++ b/src/Setoid/Varieties/Preservation.lagda.md
@@ -29,7 +29,7 @@ open import Relation.Binary        using ( Setoid )
 open import Relation.Unary         using ( Pred ; _⊆_ ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library -------------------------------
-open import Overture                           using  ( 𝓞 ; 𝓥 ; Signature ; 𝑆 )
+open import Overture                           using  ( 𝑆 )
 open import Overture.Terms                     using  ( Term )
 open import Setoid.Algebras                    using  ( Algebra ; ov ; ⨅ )
 open import Setoid.Homomorphisms               using  ( ≅⨅⁺-refl ; ≅-refl


### PR DESCRIPTION
## Summary

Completes the remaining slice (iii) of FLRP WP-7 (part of #466): the `FLRP.Assumptions` registry and the cross-layer bridge `Representable ↔ Representableᵈ`.  The constructive core of slice (iii) — `Representableᵈ`, `FLRP-Statementᵈ`, `ConIsoᵈ`, and the postulate-free `chain₂-Representableᵈ` — already merged in #479; this PR adds the two things that were still missing, plus the WP-3 Layer-D hookup.

+  **`src/FLRP/Assumptions.lagda.md`** — the registry of the program's classical theorems, imported as *explicit hypotheses*, never postulates.  Its first (and, for now, only) entry is the congruence-completeness bridge `CongruenceCompleteness 𝑨`: every semantic congruence of `𝑨` is `≑` to a decidable one.  This is exactly the `complete` field of `FiniteCongruences` (`src/Setoid/Congruences/Finite/Basic.lagda.md`) with the finite list forgotten — the list side is the *constructive* `FiniteCongruencesᵈ`, so what remains is precisely the classical delta.  `fromFiniteCongruences` extracts it from the canonical record; `toFiniteCongruences` shows the converse (adjoining it to the free constructive data reconstitutes the full `FiniteCongruences`), certifying it is neither more nor less than the classical content.  Its strength (between WLEM and LEM at the working level) is documented against ADR-008 and `docs/notes/flrp-two-layer-congruences.md` § 2.1 / L4.

+  **`src/FLRP/LayerBridge.lagda.md`** — under that hypothesis, the semantic congruence poset `(Con 𝑨, ≑, ⊆)` and the decidable poset `(DecCon 𝑨, ≑ᵈ, ⊆ᵈ)` are order-isomorphic (`conDecIso`: the forgetful `DecCon → Con` is free, its inverse `Con → DecCon` is where the bridge is spent).  Transporting `ConIso`/`ConIsoᵈ` across it gives `Representableᵈ→Representable` and `Representable→Representableᵈ`.

+  **`src/FLRP/Bridge.lagda.md`** — the WP-3 deferred Layer-D corollary is now wired: composing the merged Layer-S bridge `bridge⁻¹` with `conDecIso` yields `bridgeᵈ` / `interval-DecCon-representable`, realizing the interval `[H, 𝒢]` as the `DecCon` poset of a finite coset algebra.  This near-closes #454 (its updated criteria asked for the correspondence stated over `DecCon`).

## Did the bridge go through under just the single `complete` hypothesis?

Yes.  The whole cross-layer equivalence needs *only* `CongruenceCompleteness` (the `complete` bridge), and nothing more of classical strength.

+  Both directions of `Representable ↔ Representableᵈ` consume it — they factor through the one poset isomorphism `conDecIso`, whose `Con → DecCon` half is the classical step (used in the `to` field of the D→S transport and the `from` field of the S→D transport).
+  The `Representable → Representableᵈ` direction additionally takes a `FiniteSignature` witness, but that is a *finiteness datum* (`Representableᵈ` structurally carries it, `Representable` does not), not a classical assumption.
+  The `interval-DecCon-representable` corollary needs the bridge *for the coset algebra* plus its carrier-finiteness witness — exactly the data `Representableᵈ` consumes.

One implementation note worth recording: composing `OrderIso`s over `Con`/`DecCon` cannot use the named `⊆-trans`/`≑-trans`/`≑-sym` or `.to-mono` on congruence *proofs*, because `_⊆_`/`_≑_` are non-injective defined relations and their implicit congruence endpoints are then unsolvable (the discipline documented in `Setoid.Congruences.Lattice`).  The proofs are therefore inlined as eta-expanded `⇒`-compositions with the monotone maps' endpoints forwarded explicitly.

## WP-5 coordination

WP-5 (#456) also plans a `FLRP.Assumptions` module with the Kurzweil–Netter duality as "its first entry".  To avoid a collision, this PR creates the module with the classical congruence-completeness bridge as **Entry 1** and structures it as *per-assumption statement definitions* (not a monolithic record) so WP-5 can append its duality as **Entry 2** without disturbing the first; the module prose says so explicitly.

## Acceptance

+  Clean-slate `nix develop --command make check` (`.agdai` purged, `+RTS -M6G`) is green; the `Checking FLRP.Assumptions` / `FLRP.Representable` / `FLRP.LayerBridge` lines appear and 317 modules compile from source with no errors (only the pre-existing Legacy `∥_∥` deprecation UserWarnings).
+  All new modules type-check `--cubical-compatible --exact-split --safe` with **no postulates**; the bridge appears only as an explicit hypothesis.
+  `chain₂-Representableᵈ` (`toLattice chain₂`) stays inhabited with no assumptions (unchanged from #479).
+  The m6-8 note's A1 addendum is present (`docs/notes/flrp-wp7-audits.md` and `docs/notes/m6-8-finite-birkhoff.md`).

Closes #466.  This is WP-7 slice (iii), the final slice — slices (i) and (ii) merged in #467 and #468, and the constructive core of slice (iii) in #479; the remaining items on the issue (the `FLRP.Assumptions` registry, the `Representable ↔ Representableᵈ` equivalence, and the WP-3 Layer-D corollary) are all delivered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

