### PR TITLE
FLRP WP-5: closure toolkit — product and ordinal-sum closure of Representableᵈ; Kurzweil–Netter duality as Assumptions Entry 2 (#456)

### DIFF
--- a/docs/GITHUB_PROJECT.md
+++ b/docs/GITHUB_PROJECT.md
@@ -3503,7 +3503,7 @@ This is separated from #373 because it is a sizeable undertaking on its own:
 
 ### Issue M6-13: FLRP research program — tracking issue (#451)
 
-**Labels**: `research-exploratory`, `flrp-research`
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
 
 ## Description
 
@@ -3577,7 +3577,7 @@ Scope note: this is the largest WP; splitting into WP-2a (subgroups/core) and WP
 
 ---
 
-### Issue M6-13c: FLRP WP-3: Pálfy–Pudlák bridge, easy direction — Con(G ↷ G/H) ≅ [H, G] (#454)
+### Issue M6-13c: FLRP WP-3: Pálfy–Pudlák bridge, easy direction — Con(G ↷ G/H) ≅ [H, G] (#454, closed)
 
 **Labels**: `research-exploratory`, `flrp-research`
 
@@ -3628,7 +3628,7 @@ Depends on WP-2 (WP-3 is helpful but not required).  Part of #451.
 
 ### Issue M6-13e: FLRP WP-5: closure toolkit — products, ordinal sums, Kurzweil–Netter duality (#456)
 
-**Labels**: `research-exploratory`, `flrp-research`
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
 
 ## Description
 
@@ -3649,7 +3649,7 @@ Depends on WP-1.  Part of #451.
 
 ---
 
-### Issue M6-13f: FLRP WP-6: certificate pipeline — schema, Agda checker, GAP/SAT emitters (#457)
+### Issue M6-13f: FLRP WP-6: certificate pipeline — schema, Agda checker, GAP/SAT emitters (#457, closed)
 
 **Labels**: `research-exploratory`, `flrp-research`
 
@@ -3686,7 +3686,7 @@ Full design: `docs/notes/flrp-wp6-freese-certificates.md`.  Guiding principle: *
 
 ### Issue M6-13g: FLRP RP-1: formalize the IE framework end-to-end (parachute theorems) (#458)
 
-**Labels**: `research-exploratory`, `flrp-research`
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
 
 ## Description
 
@@ -3703,7 +3703,7 @@ Depends on WP-2 and WP-4.  Part of #451; roadmap § 4.
 
 ### Issue M6-13h: FLRP RP-2: the enforcement catalog (#459)
 
-**Labels**: `research-exploratory`, `flrp-research`
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
 
 ## Description
 
@@ -3720,7 +3720,7 @@ Depends on WP-4; grows alongside RP-1.  Part of #451.
 
 ### Issue M6-13i: FLRP RP-3: hunt for an empty intersection of cf-IE classes (#460)
 
-**Labels**: `research-exploratory`, `flrp-research`
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
 
 ## Description
 
@@ -3739,7 +3739,7 @@ Depends on RP-1 and RP-2.  Part of #451; success/kill criteria in roadmap § 4.
 
 ### Issue M6-13j: FLRP RP-4: dead-end branch — can a property and its negation both be cf-IE? (#461)
 
-**Labels**: `research-exploratory`, `flrp-research`
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
 
 ## Description
 
@@ -3755,7 +3755,7 @@ Depends on RP-1 (wreath products, Kurzweil construction).  Part of #451; roadmap
 
 ---
 
-### Issue M6-13k: FLRP WP-7: the decidable layer — presented congruences, FiniteAlgebraᵈ, Representableᵈ (#466)
+### Issue M6-13k: FLRP WP-7: the decidable layer — presented congruences, FiniteAlgebraᵈ, Representableᵈ (#466, closed)
 
 **Labels**: `flrp-research`
 
@@ -3794,6 +3794,325 @@ Coordination: WP-5 (#456) also plans `FLRP.Assumptions` with the Kurzweil–Nett
 - [ ] All new modules type-check under `--cubical-compatible --exact-split --safe`; no postulates; the bridge appears only as an explicit hypothesis.  *(FLRP.Representable satisfies this in #479; completes when FLRP.Assumptions lands.)*
 - [x] `Representableᵈ (toLattice chain₂)` is inhabited with no classical assumptions.  *(`chain₂-Representableᵈ`, #479.)*
 - [x] The m6-8 note gains an addendum recording the A1 audit outcome.  *(`docs/notes/m6-8-finite-birkhoff.md` § "Update (WP-7 A1)"; full findings in `docs/notes/flrp-wp7-audits.md`.)*
+
+---
+
+### Issue M6-14: FLRP computational campaign: small-lattice certificates and the L7 hunt — tracking issue (#483)
+
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
+
+## Description
+
+This tracking issue registers the computational campaign of roadmap § 5, Avenue A (`docs/notes/flrp-research-roadmap.md`): systematic small-lattice representation work under the certificate discipline, now that the WP-6 pipeline (#457, PR #482) provides the certificate schema, the search-free Agda checker, and the `cg2` emitter.  Three inputs converge here.
+
++  The WP-6 certificate pipeline (PR #482): external engines emit Freese-trace certificates and Agda re-checks them into `Representableᵈ` witnesses; nothing enters `src/` on the authority of an external tool.
++  The DeMeo–Freese–Jipsen manuscript *Representing Finite Lattices as Congruence Lattices of Finite Algebras* (`article/SmallLatticeReps.tex` in https://github.com/UniversalAlgebra/fin-lat-rep), whose § 6 catalogs 35 nondistributive, non-ordinal-sum lattices `L1`–`L35` of size ≤ 7 together with explicit minimal unary algebras `B1`–`B35` for most of them, and whose lone open case `L10` is this library's `L7`.
++  A 2026-07-22 working session on `L7` that produced its minimal sublattice-of-`Eq(6)` representation and machine-checked closure obstructions on 6 and 7 points (recorded in #484).
+
+**Naming**.  The lattice this library calls `L7` (`Examples.Classical.Lattices.L7`) is `L10` in the manuscript's numbering, and the manuscript's `L7` is a different lattice.  Every module, note, and issue in this family must state which numbering it uses; #485 includes a dictionary task.
+
+## Sub-issues
+
++  #484
++  #485
++  #486
++  #487
++  #494
++  #499
+
+## Dependency sketch
+
++  #486 is infrastructure for #484 (the Eq(8) sweep) and produces candidate algebras that the #485 pipeline certifies.
++  #487 feeds both #484 (minimal representations must be transitive, by the manuscript's § 5 theorem, so transitive-degree scans settle the frontier degree by degree) and #485 (the group-representation entries `L11`, `L14`, `L16`, `L20`); its Agda import route is the WP-3 bridge (#454).
++  Everything follows roadmap § 6: search scripts and raw logs live outside `src/`, and external results enter only as re-checked certificates.
+
+## Acceptance criteria
+
+- [ ] Each sub-issue is closed or explicitly re-scoped, with its artifacts (scripts, certificates, notes) merged.
+- [ ] A census status note in `docs/notes/` records, for all 35 catalog entries plus `L7`, whether an Agda-checked certificate exists and by which route.
+
+---
+
+### Issue M6-14a: L7 (= L10 of SmallLatticeReps): Eq(6) sublattice representation, closure obstructions on ≤ 7 points, and the Eq(8) frontier (#484, closed)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+`L7` (this library's name; `L10` in the SmallLatticeReps manuscript — see the naming note on #483) is the smallest lattice not known to be representable as the congruence lattice of a finite algebra (`Examples.Classical.Lattices.L7`, roadmap § 5.A.1).  A 2026-07-22 working session established the results below by exhaustive machine search; this issue records them and drives the next steps.  Part of #483.
+
+## Session results (2026-07-22)
+
+Element names follow the module's grid labeling: carrier `⊥, (1,0), (0,1), x, (1,1), (0,2), ⊤`, with `x` the doubly irreducible atom-and-coatom.  Partitions are written in bar notation on `{0,…,5}` with singleton blocks suppressed.
+
++  **Minimal sublattice representation**.  `L7` embeds in `Eq(6)` and in no `Eq(n)` with `n ≤ 5` (bounds normalize to `Δ`/`∇`: quotient by the bottom partition; simplicity of `L7` handles the top).  An explicit embedding:  `⊥ ↦ Δ`,  `x ↦ |0,4|1,3|2,5|`,  `(1,0) ↦ |0,2|3,4|`,  `(0,1) ↦ |0,1|4,5|`,  `(1,1) ↦ |0,1,2|3,4,5|`,  `(0,2) ↦ |0,1|2,3|4,5|`,  `⊤ ↦ ∇`.
++  **Classification**.  `Eq(6)` contains 1080 labelled copies of `L7`, and exactly two up to relabeling of the six points: the copy above, which is invariant under the involution `(0 4)(1 5)(2 3)`, and a rigid copy obtained from it by replacing `x ↦ |0,3|1,4|2,5|`.
++  **Closure fails on 6 points**.  For both classes, the monoid of unary maps preserving the five nontrivial relations consists of the stabilizer group plus the constants — there is no non-bijective non-constant preserving map — so `Inv(M)` has 31 (symmetric class) resp. 203 (rigid class) members instead of 7.  Since the congruence lattice of an arbitrary algebra is determined by its unary polynomials, no algebra on 6 elements has `Con ≅ L7`.
++  **Closure fails on 7 points**.  `Eq(7)` contains 55,440 labelled copies in 12 classes (2 with a `ℤ₂` stabilizer, 10 rigid); again no class admits any non-bijective non-constant preserving map, and `Inv(M)` has 59 resp. 877 members.  Hence **no algebra on at most 7 elements has congruence lattice `L7`**.
++  Combined with the manuscript's § 5 theorem that a minimal representation of `L10 = L7` must come from a transitive permutation group: a minimal representation, if one exists, is a transitive `G`-set on at least 8 points.
+
+## Tasks
+
+- [ ] Record the session computation as a docs note (proposed: `docs/notes/flrp-l7-eq6.md`) with the partitions, the two-class classification, the closure data, and reproduction instructions via the #486 tooling.
+- [ ] Formalize the positive fact in Agda: the seven listed partitions form a sublattice of `Eq(6)` isomorphic to `L7`, verified by decision over the finite carrier in the style of `Examples.Classical.Lattices.L7`; this is the library's explicit Pudlák–Tůma witness for `L7`, on a base set of provably minimal size.
+- [ ] Eq(8) closure sweep with the vectorized #486 tooling: enumerate the relabeling classes of copies of `L7` in `Eq(8)` (bounds at `Δ`/`∇`) and closure-test each.  A closed class yields a finite algebra with `Con ≅ L7` — feed it directly to the PR #482 emitter for a certificate; if all classes fail, the negative census extends to `|A| ≤ 8`.
+- [ ] Group-side cross-check with #487: for each `TransitiveGroup(n, k)` with point stabilizer `H`, starting at degree `n = 8`, test `[H, G] ≅ L7`; by the transitivity theorem this settles existence of minimal representations degree by degree and cross-validates the Eq(8) sweep.
+- [ ] Decide how much of the negative sweep is certifiable in Agda (the per-class `Inv(M)` computations are plain finite checks; exhaustiveness of the embedding enumeration is the hard part) and record the decision in the docs note.
+
+## Acceptance criteria
+
+- [ ] The Eq(6) representation and its classification are stated in a committed note and reproducible from committed scripts.
+- [ ] The Agda module with the Eq(6) sublattice witness type-checks under the standard pragma set.
+- [ ] The 8-point frontier is resolved: either a closed class is found and certified, or the census extends to `|A| ≤ 8` with the transitive-degree-8 cross-check recorded.
+
+---
+
+### Issue M6-14b: Certificates of representability for the SmallLatticeReps catalog (L1–L35) (#485, closed)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Run the WP-6 pipeline (#457, PR #482) over the small-lattice catalog of the SmallLatticeReps manuscript (DeMeo–Freese–Jipsen, `article/SmallLatticeReps.tex` in https://github.com/UniversalAlgebra/fin-lat-rep; orientation here is from the 2016-06-10 draft).  Manuscript § 6 lists 35 nondistributive, non-ordinal-sum lattices `L1`–`L35` of size ≤ 7, most with explicit minimal unary algebras `B1`–`B35` given as value tables on `{0,…,n−1}` — exactly the input format of `scripts/flrp/cg2.py`, and all unary, matching the v1 renderer.  Target: each catalog entry becomes a generated module under `src/FLRP/Certificates/SmallLatticeReps/` proving `Representableᵈ`, with no manual editing beyond file placement, plus a census note recording status.  This also machine-audits every `Con(Bᵢ) ≅ Lᵢ` claim in the manuscript, so discrepancies feed back as errata.  Part of #483.
+
+**Naming**.  The manuscript numbering clashes with ours: manuscript `L10` is this library's `L7`, and manuscript `L7` is a different lattice.  Certificate modules use the manuscript numbering, with the dictionary task below resolving the clash explicitly.
+
+## Coverage plan
+
++  **Immediately emittable** (unary, carrier ≤ 10, inside the v1 renderer's `0F`–`9F` limit): `B1`–`B4`, `B6`–`B8`, `B12`, `B15`, `B19`, `B21`, `B23`–`B26`, `B29`–`B32`, `B34`, `B35` — about 21 entries.  Note `B2` is the regular `V4` action, so manuscript `L2 = M3` is already certified by the pilot `FLRP.Certificates.Pilot.V4RegularM3` up to naming and placement.
++  **Needs the renderer extension** (carrier > 10): `B5` (12), `B9` (16), `B13` (19), `B17` (12), `B33` (16); the engine is size-agnostic, only `Fin`-literal rendering must grow past `9F`.
++  **Group-representation entries**: `L11` (108-element coset algebra from `SmallGroup(216,153)`), `L14` (upper interval in `Sub(A6)`, size 90), `L16` (`Sub(C2.A6)`, size 180), `L20` (filter-ideal in `SmallGroup(216,153)`).  Route: the WP-3 bridge (#454) when available, or direct big-carrier certificates if checking cost stays acceptable; concrete group data comes from #487.
++  **Duals without explicit algebras**: `L18` (dual of `L19`) and `L22` (dual of `L23`) carry no explicit small algebra in the manuscript; they follow from Kurzweil–Netter duality, which is a registered assumption per WP-5 (#456).  Either find explicit algebras (searches via #486/#487, or the mechanized overalgebra route of roadmap § 5.C) or record them as assumption-conditional.
++  **The open case**: manuscript `L10` (our `L7`) is #484's subject and is excluded here.
+
+## Tasks
+
+- [ ] Naming dictionary: a docs note mapping manuscript `L1`–`L35` to existing agda-algebras names (`M3`, `N5`, the hexagon, our `L7`, …), linked from every certificate module header.
+- [ ] Batch-emit the ~21 immediately emittable entries; commit engine inputs (`scripts/flrp/inputs/`), audit JSONs, and the generated modules; wire them into the barrels and `make check`.
+- [ ] Extend the renderer past `9F` (carriers up to at least 19) and emit `B5`, `B9`, `B13`, `B17`, `B33`.
+- [ ] Decide and implement the route for `L11`, `L14`, `L16`, `L20` (WP-3 bridge vs direct big-carrier certificates), coordinating with #454 and #487.
+- [ ] Resolve `L18` and `L22`: explicit algebras found by search, or assumption-conditional statements through the WP-5 duality registration.
+- [ ] Census note in `docs/notes/` (entry ↦ certified / pending renderer / pending bridge / assumption-conditional / open), updated as batches land; consider feeding the table back to the manuscript repo.
+- [ ] Report any discrepancy the pipeline finds in a manuscript table as an erratum to https://github.com/UniversalAlgebra/fin-lat-rep.
+
+## Acceptance criteria
+
+- [ ] Every unary catalog entry with carrier ≤ 19 has a type-checked certificate module produced by the emitter with no manual editing beyond file placement.
+- [ ] The census note states the status of all 35 entries and is regenerable from committed artifacts.
+
+---
+
+### Issue M6-14c: FLRP search tooling: generalized Eq(n) sublattice search and Snow closure tests in scripts/flrp (#486, closed)
+
+**Labels**: `research-exploratory`, `flrp-research`
+
+## Description
+
+Fold the 2026-07-22 session's search programs into `scripts/flrp/` (the directory established by PR #482) as first-class, generalized tools.  The session versions live outside the repository and are hard-coded to `L7`; the campaign needs them for arbitrary finite target lattices.  Part of #483.
+
+## What exists and how it fits together
+
++  **From PR #482** (`scripts/flrp/`): `cg2.py` (Freese worklist with trace recording), `lattice.py`, `emit_agda.py`, `test_flrp.py`, and the JSON conventions of `README.md`.  Direction: given an algebra, compute its congruence lattice with traces and emit an Agda certificate.
++  **From the session** (currently outside the repo): exhaustive `Eq(n)` sublattice search for a target lattice with bounds at `Δ`/`∇` (restricted-growth-string partitions, precomputed meet/join tables), `Sₙ`-orbit classification of the copies, and the Snow-style closure test — backtracking enumeration of the monoid `M` of relation-preserving unary maps, then progressive filtering to `Inv(M)`.  Direction: given a lattice, find candidate representations and decide whether each is a congruence lattice on that base set.
++  The two directions are complementary, with a small overlap in partition utilities.  When a closure test succeeds, the unary algebra `⟨X, M⟩` is exactly a `cg2.py` input, closing the loop: lattice ⇒ search ⇒ algebra ⇒ certificate ⇒ `Representableᵈ`.
+
+## Tasks
+
+- [ ] Generalize the search from the hard-coded `L7` constraint schedule to an arbitrary finite target lattice (input: covers or meet/join tables in a JSON format shared with `lattice.py`; derive the generator-driven pruning order automatically).
+- [ ] Unify partition representations: adopt the Freese normal-form parent vectors already used by `cg2.py` as the shared type, in one utilities module, so union-find and canonical forms are not duplicated.
+- [ ] Vectorize for `Eq(8)`: numpy `int16` meet/join tables (2 × 4140² entries ≈ 69 MB), mask-based candidate enumeration, and an invariant-bucketed orbit sweep, so the #484 Eq(8) run completes in minutes to hours rather than days.
+- [ ] Port the session's checks into the test suite: Bell-number counts, `M3` in `Eq(4)`, the `Eq(6)` results (1080 copies, 2 classes, closure verdicts), and the `Eq(7)` results (55,440 copies, 12 classes, closure verdicts).
+- [ ] Output discipline: deterministic JSON artifacts under the `inputs/` and `out/` conventions of PR #482, so sweeps are citable and re-runs are byte-identical no-ops.
+- [ ] SAT/model-finder encoder, first step per roadmap § 5.A.3: encode `Con(𝑨) ≅ L` for operation tables on ≤ n elements; a small working prototype that documents the encoding suffices at this stage.
+
+## Acceptance criteria
+
+- [ ] `scripts/flrp/` contains the generalized search and closure tools, tests are green, and the README documents the formats and workflows.
+- [ ] The `Eq(6)` and `Eq(7)` session results are reproduced by the committed tools from a clean checkout.
+- [ ] An end-to-end demo exists: the search finds a closed class for some small lattice (for instance `N5` on 4 points), and its `⟨X, M⟩` flows through `cg2.py` and `emit_agda.py` to a type-checked certificate with no manual editing.
+
+---
+
+### Issue M6-14d: GAP subgroup-interval search: Hulpke intermediate-subgroup routines over the small-groups libraries (#487, closed)
+
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
+
+## Description
+
+Build GAP scripts that hunt for a given finite lattice as an upper interval `[H, G]` in subgroup lattices across the GAP group libraries — SmallGroups first, then the perfect- and primitive-groups libraries per roadmap § 5.A.1 — using A. Hulpke's intermediate-subgroup machinery (`IntermediateSubgroups` and his latest interval routines).  The SmallLatticeReps manuscript already ran such searches by hand (`SmallGroup(216,153)` for the minimal pentagonal upper interval and for the `L11`/`L20` constructions); this issue makes them systematic, scripted, and repo-resident, with outputs both the certificate pipeline and the manuscript can consume.  Part of #483.
+
+## Tasks
+
+- [ ] Scripted search: given a target lattice (JSON format shared with #486), scan a configurable slice of the SmallGroups library for upper intervals `[H, G]` isomorphic to it, with core-free normalization of `H` and lattice-isomorphism testing on the interval; record `(G, H, interval, isomorphism witness)` as JSON artifacts under the `scripts/flrp/` conventions, raw logs outside `src/` per roadmap § 6.
+- [ ] Transitive-degree scan for `L7` (with #484): for each `TransitiveGroup(n, k)` with point stabilizer `H`, starting at degree `n = 8`, test `[H, G] ≅ L7`; by the manuscript's § 5 transitivity theorem, a degree-by-degree exhaustion settles existence of minimal representations of that size.
+- [ ] Reproduce and script the manuscript's concrete claims: `SmallGroup(216,153)` as the smallest group with a pentagonal upper interval (the manuscript's TODO appendix), the `L11` filter-ideal construction, and the interval data behind `L14`, `L16`, `L20` for #485.
+- [ ] Import route into Agda: coordinate with the WP-3 bridge (#454) so a found interval becomes `Representableᵈ` via `Con(G ↷ G/H) ≅ [H, G]`; for small indices, alternatively dump the coset algebra's operation tables into `cg2.py` for a direct certificate.
+- [ ] Environment: GAP is not in the flake; document a pinned GAP setup, and provide it by specifying a new nix devshell in flake.nix that provides GAP and the SmallGroups library, so runs are reproducible; note the library versions in every emitted artifact.
+
+## Acceptance criteria
+
+- [ ] A clean-checkout run reproduces the `SmallGroup(216,153)` pentagon-minimality claim and emits its JSON artifact.
+- [ ] The degree-8 transitive scan for `L7` is complete with a recorded verdict.
+- [ ] At least one found interval flows into an Agda-checked `Representableᵈ` witness, by the bridge or by direct certificate.
+
+---
+
+### Issue M6-14e: eqsearch --group-rep: restrict the Eq(n) sweep to uniform (coset-block) copies (#494, closed)
+
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
+
+## Description
+
+Extend the #486 search tooling (`eqsearch.py` / `eqfast.py`, PR #493) with a `--group-rep` flag that restricts the sublattice sweep to copies all of whose members are **uniform** partitions: for each relation `r` in the copy there is a `k` (necessarily dividing `n`) such that every block of `r` has exactly `k` elements.  This mechanizes remark iv of the manuscript's closure-algorithm discussion (SmallLatticeReps § 6.1): "If it can be shown that the algebra of a minimal representation of `L` has a transitive permutation group for its nonconstant unary polynomials, then we can restrict our search in `Eq(k)` to uniform equivalence relations."  Congruences of a transitive `G`-set are its systems of imprimitivity — the blocks are cosets of intermediate subgroups, hence all of equal size — so every congruence lattice of a transitive group action occurs among uniform copies.
+
+**Naming** (per #483): the library's `L7` (`Examples.Classical.Lattices.L7`) is the manuscript's `L10`; the dictionary is `docs/notes/flrp-slr-naming.md`.
+
+## Why this is the right restriction for the `L7` hunt
+
++  By the manuscript's § 5 analysis of intransitive group actions (its Theorem on the orbit congruence `τ` and the intervals it pins) a minimal representation of library `L7` cannot come from an intransitive action, and the machine-checked closure obstructions through eight points (#484, `docs/notes/flrp-l7-eq6.md` § 6) push the frontier to nine; so a minimal representation, if one exists, is the congruence lattice of a transitive `G`-set on at least nine points — and every congruence of such an algebra is a uniform partition.
++  Positive verdicts keep exactly their current meaning: the Snow closure test (the preserving monoid `M` over *all* unary maps, and `Inv(M)`) is unchanged, so a closed uniform class still yields the honest witness algebra `⟨X, M⟩` and a ready-made claim file for the WP-6 certificate pipeline.
++  Negative verdicts weaken, and the README must say so explicitly: "no closed uniform class on `n` points" rules out algebras whose congruence lattices consist of uniform partitions — in particular every transitive group action — rather than all algebras; for library `L7` at the minimal frontier that is exactly the statement needed.
+
+## Why this is fast
+
+Nontrivial uniform partitions are vanishingly rare among all partitions:
+
+| `n` | Bell(`n`) | nontrivial uniform | by block size |
+|---|---|---|---|
+| 6 | 203 | 25 | 15 of shape `2³`, 10 of shape `3²` |
+| 7 | 877 | 0 | (7 is prime) |
+| 8 | 4,140 | 140 | 105 of shape `2⁴`, 35 of shape `4²` |
+| 9 | 21,147 | 280 | 280 of shape `3³` |
+| 10 | 115,975 | 1,071 | 945 of shape `2⁵`, 126 of shape `5²` |
+| 12 | 4,213,597 | 32,032 | 10,395 + 15,400 + 5,775 + 462 (shapes `2⁶`, `3⁴`, `4³`, `6²`) |
+
++  At nine points the candidate pool collapses from 21,145 nontrivial partitions to **280**, and the ~1.8 GB `Eq(9)` meet/join tables that currently block the unrestricted sweep (#486 follow-up) shrink to a `282 × 282` table — the table problem disappears entirely rather than needing the blocked build.
++  The prefix ballooning that made the committed unrestricted `Eq(8)` run take about three hours acts on a pool two orders of magnitude smaller; a uniform `Eq(9)` sweep should take minutes even in the pure engine, and `Eq(10)` and `Eq(12)` come into range — sizes the unrestricted table-driven design cannot touch at all.
++  Prime degrees degenerate gracefully and correctly: `Eq(7)` and `Eq(11)` have no nontrivial uniform partitions, matching the group fact that a transitive action of prime degree is primitive, so its congruence lattice is the two-element chain; the sweep can skip prime `n` and the enumerator's empty pool there is a wired-correctly cross-check.
+
+## Implementation sketch
+
++  Enumerate the uniform pool directly, one divisor `k` of `n` at a time (never through the full `Bell(n)` enumeration), in the engines' canonical min-rooted parent-vector order.
++  A copy is closed under the target's meets and joins by definition, so the assignment plan only ever needs meet/join of pool members followed by a **membership test in the pool**: compute them on the fly with the existing pure kernels or precompute pool² tables — both trivial at these pool sizes.  A meet or join of two uniform partitions need not be uniform; that case simply fails the placement, which is the pruning doing its work.
++  Classification and orbit generation are unchanged: relabeling points preserves uniformity, so class representatives, stabilizers, and orbit sizes work exactly as today.
++  The closure test is unchanged (the full unary-map monoid).  Remark iv's second sentence — restricting the *polymorph* search to permutations — is a separable optimization with different verdict semantics (`Inv` of the permutation group alone) and should stay out of this flag, or land later as its own flag with its own documentation.
++  Reports keep the `flrp-eqsearch v1` format with a field recording the restriction, so uniform censuses are never mistaken for full ones.
+
+## Tests
+
++  Parity with the unrestricted engine: for `n ≤ 7`, filter the full census's classes to those whose members are all uniform and require the `--group-rep` sweep to produce exactly those classes; behind `FLRP_EQSEARCH_SLOW=1`, apply the same filter to the committed `Eq(8)` report (`out/l7_eq8_report.json`).  For `L7`/`Eq(6)` both known classes contain non-uniform members (the grid element `(1,0)` is `|0,2|3,4|` with singleton blocks), so the uniform census there is empty — pin it.
++  Pool pins: the uniform counts in the table above for `n = 6, 8, 9, 10` as unit tests of the enumerator.
++  Fast/pure backend parity, as for the existing `--fast` tests.
+
+## The headline runs
+
++  The `--group-rep` sweep of `Eq(9)` for library `L7` (manuscript `L10`), with the verdict — a closed class and hence a witness algebra flowing into the certificate pipeline, or a machine-checked "no transitive representation on nine points" — recorded in `docs/notes/flrp-l7-eq6.md` and #484.
++  Then `Eq(10)` and `Eq(12)` as budget permits (`Eq(11)` is prime and skips itself).
++  Cross-validation with #487's transitive-degree scan: the GAP side enumerates transitive groups of degree `n` and tests intermediate-subgroup intervals `[H, G] ≅ L7`; a closed uniform class found here must be visible there and vice versa, so disagreement in either direction is a bug or a discovery.
+
+## Acceptance criteria
+
+- [ ] `--group-rep` lands in both engines with byte-identical reports, a recorded restriction field, and documented negative-verdict semantics in the README.
+- [ ] The pool enumerator's counts and the filter-parity tests (including the empty `L7`/`Eq(6)` uniform census) are pinned in `make flrp-test`.
+- [ ] The `Eq(9)` uniform sweep for library `L7` is run and its outcome recorded in the `L7` note and #484.
+
+Part of #483; extends #486 (search tooling); serves #484 (the `L7` hunt) and cross-validates #487 (the GAP transitive-degree scan).
+
+---
+
+### Issue M6-14f: eqsearch --group-rep: bring the Eq(12) uniform sweep within reach (orbit–stabilizer classification, blocked pool tables) (#499, closed)
+
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
+
+## Description
+
+Extend the #494 uniform restriction (`--group-rep`, PR #498) so the `Eq(12)` sweep runs to a verdict.  Twelve is now the frontier: the `Eq(9)` and `Eq(10)` uniform censuses are empty and eleven is prime (`docs/notes/flrp-l7-eq6.md` § 8), so a minimal representation of library `L7` (manuscript `L10`; dictionary `docs/notes/flrp-slr-naming.md`), if one exists, has at least twelve elements — and `n = 12` is the first ground-set size whose uniform pool contains comparable nontrivial partitions (divisor chains `2 | 4`, `2 | 6`, `3 | 6`), hence the first where a uniform copy of `L7` is even conceivable.
+
+## Why Eq(12) is decisive
+
++  A closed uniform class at twelve is a candidate minimal representation of the open lattice, flowing directly into the WP-6 certificate pipeline (carrier 12 is well inside the renderer's literal cap of 32).
++  An empty or unclosed census pushes the frontier from twelve to **sixteen** in one step: thirteen is prime, and fourteen (`2 ∤ 7`) and fifteen (`3 ∤ 5`) have antichain pools by the divisor argument of the `L7` note § 8, so with the manuscript's § 5 transitivity theorem the next size where a uniform copy is conceivable is `16 = 2⁴` (chains `2 | 4 | 8`).
++  Cross-validation with #487 (the GAP transitive-degree scan, `scripts/gap/flrp/`): degree 12 is the first degree where both attacks probe genuinely new ground; a closed class found here must be visible there and vice versa, so disagreement in either direction is a bug or a discovery.
+
+## What breaks at twelve, and the known fixes
+
+The #494 engines were sized for pools of a few hundred to a thousand; at twelve the nontrivial pool is 32,032 (shapes `2⁶`: 10,395, `3⁴`: 15,400, `4³`: 5,775, `6²`: 462).
+
++  **Tables**.  Eager pool² meet/join at `int16` is ~4.1 GB; replace with a blocked (row-band) build or with on-the-fly membership — per-prefix `meet_rows`/`join_rows` against the pool matrix plus binary search over the sorted pool codes, memoized by prefix index.  The 2026-07-24 `Eq(10)` measurements (pure 6 m 59 s versus fast 24 m 12 s: the constant per-prefix mask cost dominates at narrow pools) say to benchmark both engines rather than assume vectorization wins.
++  **Classification**.  Materialized orbits are `12! ≈ 4.79 × 10⁸` relabelings per class — hours apiece even with #494's chunking.  Replace with orbit–stabilizer: backtrack for the stabilizer of the relation set, report orbit size `12!/|stab|`, keep the first-found-representative order, and keep a conservation cross-check (`Σ 12!/|stab|` equals the number of distinct relation sets) so reports stay byte-identical wherever the materialized classifier also runs.
++  **Closure universe**.  `Inv(M)` must still range over all of `Eq(12)` (`Bell(12) = 4,213,597`): the tuple-of-tuples universe costs on the order of a gigabyte and a progressive filter pass is seconds per map, so either accept that, pack the universe as an `int8` matrix with a vectorized invariance filter, or stream the filter — decided by measurement, without changing `invariant_partitions` semantics.
++  **Sweep order**.  The prefix ballooning of the generic height-ordered assignment plan (#486's known follow-up) may finally bite once the pool has real chains; the constraint-density-guided order is the fix if it does.
+
+## Tests
+
++  Pool pins at twelve: 32,032 nontrivial members with the shape split 10,395 + 15,400 + 5,775 + 462, plus the structural facts at 13, 14, 15 (empty or antichain pools) as cheap cross-checks.
++  Byte-parity of the orbit–stabilizer classifier against the materialized one on every existing census (`M3` on 4 and 6 points, the uniform `L7` censuses through ten, and the committed unrestricted reports).
++  The committed `Eq(12)` report re-derived under `FLRP_EQSEARCH_SLOW=1`, with fast/pure cross-validation of whatever engine variants land.
+
+## The headline run
+
++  The `--group-rep` sweep of `Eq(12)` for library `L7`, with the verdict — a closed class and hence a witness algebra flowing into the certificate pipeline, or a machine-checked "no transitive representation on twelve points", which by the chaining above moves the frontier to sixteen — recorded in `docs/notes/flrp-l7-eq6.md` and #484.
+
+## Acceptance criteria
+
+- [ ] The `Eq(12)` uniform sweep completes on one core with recorded wall-clock, byte-deterministic output, and a committed report.
+- [ ] The classification and table costs are brought down as sketched, with parity pinned against the existing engines on all committed censuses in `make flrp-test`.
+- [ ] The verdict is recorded in the `L7` note and #484; if a class closes, the witness flows through `claim_input`/`emit_agda.py` to an Agda-checked certificate.
+
+Part of #483; extends #494 (PR #498) and #486; serves #484 (the `L7` hunt); cross-validates #487 (the GAP transitive-degree scan).
+
+---
+
+### Issue M6-15: FLRP: formalize the unary-reduction theorem Con 𝑨 = Con ⟨A, Pol₁(𝑨)⟩ (#501)
+
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
+
+## Description
+
+Formalize the **unary-reduction theorem** for congruence lattices: the congruences of an algebra are exactly the equivalence relations compatible with its unary polynomial operations, so `Con 𝑨 = Con ⟨A, Pol₁(𝑨)⟩` (McKenzie–McNulty–Taylor, *Algebras, Lattices, Varieties* I, Theorem 4.18).  The manuscript `docs/papers/fin-lat-rep/SmallLatticeReps.tex` invokes this reduction at the start of its Kurzweil–Netter duality proof ("we can assume that F consists of unary operations"), and the closure method of its § Concrete Representations (the `λ(L)` operator, the filter–ideal lemma) lives entirely in the unary world, so this theorem is the bridge from the library's general signatures to those arguments.
+
+Context: the WP-5 closure toolkit (#456) deliberately avoided this reduction — the product and ordinal-sum witness constructions carry general signatures directly — but the planned formal proof of Kurzweil–Netter duality (#502) needs it, and it is independently useful infrastructure for the FLRP program (#451).
+
+## Tasks
+
+- [ ] Unary polynomial operations of a setoid algebra: terms in one variable with constants from the carrier, or the inductive closure of the basic operations under composition and point substitution; pick one canonical presentation and prove it closed under composition.
+- [ ] The reduction theorem at Layer S: an equivalence relation is a congruence of `𝑨` iff it is compatible with every unary polynomial; hence `Con 𝑨` and `Con` of the unary reduct are equal as posets (mutual `≑`, order preserved).
+- [ ] The Layer-D corollary for finite finitary algebras: the unary reduct is again finite finitary (unary polynomials of a finite algebra are finitely many up to extensional equality, which is decidable on a finite carrier), and `DecCon` transports across the reduction.
+- [ ] Placement per roadmap § 6: the polynomial machinery is reusable mathematics and belongs in the `Setoid/` tree (e.g. beside `Setoid.Terms`), not under `FLRP/`.
+
+## Acceptance criteria
+
+- [ ] Type-checks under `--safe` with no postulates; the reduction is stated and proved at Layer S with the Layer-D transport for finite finitary algebras.
+
+---
+
+### Issue M6-16: FLRP WP-5 stretch: formal Kurzweil–Netter duality proof, retiring Assumptions Entry 2 (#502)
+
+**Labels**: `milestone-6-flrp`, `research-exploratory`, `flrp-research`
+
+## Description
+
+Prove **Kurzweil–Netter duality closure** formally, retiring Entry 2 of `FLRP.Assumptions`: if a finite lattice is decidably representable then so is its dual, with no hypothesis.  This is the stretch goal of WP-5 (#456), split out so the closure-toolkit PR could land without it; roadmap § 7 flags the payoff explicitly — the content is finite and combinatorial, and Netter's 1986 proof may never have been published, so a machine-checked reproof is independently valuable (a standalone paper).
+
+The target argument is the one presented in `docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals: the theorem of Kurzweil and Netter" (after Pálfy's 2009 lectures): the idempotent-contraction lattice `IC(n) ≅ Eq(n)`; the dual isomorphism `f ↦ f̂[Sⁿ]` from `Eq(n)` onto the interval `[D, Sⁿ]` of the subgroup lattice of a power of a finite nonabelian simple group `S` (Lemma lem:latt-duals); the transitive-G-set bridge `Con ⟨Sⁿ/D, Sⁿ⟩ ≅ [D, Sⁿ]`; and the expansion of the coset algebra by the lifted operations `F̂`, cutting the congruences down to the `F`-invariant partitions.
+
+On completion, `KurzweilNetterDuality` becomes a proved theorem, `dual-Representableᵈ` of `FLRP.Closure` drops its hypothesis, and the census's assumption-conditional entries `L18`/`L22` (#485) become unconditional.
+
+## Prerequisites
+
++  The WP-3 bridge `Con (G ↷ G/H) ≅ [H, G]` at Layer D on the needed scale (#454), plus WP-2 group infrastructure for the power `Sⁿ`, its diagonal subgroup `D`, and the interval `[D, Sⁿ]`.
++  The unary-reduction theorem `Con 𝑨 = Con ⟨A, Pol₁(𝑨)⟩` (#501), or a reworked argument that lifts general-arity operations through the construction directly.
++  A finite nonabelian simple group in the library to instantiate `S`: either formalize simplicity of `A₅` (a substantial task in itself), or state the closure theorem parameterized by such an `S` and track the `A₅` instantiation separately.
+
+## Tasks
+
+- [ ] `Eq(n) ≅ IC(n)` and the dual isomorphism onto `[D, Sⁿ]` (the manuscript's Lemma lem:latt-duals).
+- [ ] The expansion step: congruences of the expanded coset algebra correspond to `F`-invariant partitions, i.e. to the congruences of the original algebra, dually ordered.
+- [ ] Assemble `(𝑳 : Lattice) → Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)` and retire Entry 2 per the registry's documented retirement path (deprecate the assumption, rewire `dual-Representableᵈ`).
+
+## Acceptance criteria
+
+- [ ] Type-checks under `--safe` with no postulates and no registry hypothesis; `FLRP.Assumptions` Entry 2 is retired with its documentation updated to point at the theorem.
 
 <!-- END GENERATED: milestone-6 -->
 

--- a/docs/_links.md
+++ b/docs/_links.md
@@ -367,6 +367,7 @@
 [FLRP.Certificates.SmallLatticeReps.SLR34]: /FLRP/Certificates/SmallLatticeReps/SLR34/
 [FLRP.Certificates.SmallLatticeReps.SLR35]: /FLRP/Certificates/SmallLatticeReps/SLR35/
 [FLRP.Closure]: /FLRP/Closure/
+[FLRP.Closure.Basic]: /FLRP/Closure/Basic/
 [FLRP.Closure.OrdinalSum]: /FLRP/Closure/OrdinalSum/
 [FLRP.Closure.Product]: /FLRP/Closure/Product/
 [FLRP.Enforceable]: /FLRP/Enforceable/
@@ -734,6 +735,7 @@
 [FLRP/Certificates/SmallLatticeReps/SLR34.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Certificates/SmallLatticeReps/SLR34.lagda.md
 [FLRP/Certificates/SmallLatticeReps/SLR35.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Certificates/SmallLatticeReps/SLR35.lagda.md
 [FLRP/Closure.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure.lagda.md
+[FLRP/Closure/Basic.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/Basic.lagda.md
 [FLRP/Closure/OrdinalSum.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/OrdinalSum.lagda.md
 [FLRP/Closure/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/Product.lagda.md
 [FLRP/Enforceable.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Enforceable.lagda.md

--- a/docs/_links.md
+++ b/docs/_links.md
@@ -190,6 +190,9 @@
 [Classical.Structures.Group.Subgroups]: /Classical/Structures/Group/Subgroups/
 [Classical.Structures.Interpret]: /Classical/Structures/Interpret/
 [Classical.Structures.Lattice]: /Classical/Structures/Lattice/
+[Classical.Structures.Lattice.Dual]: /Classical/Structures/Lattice/Dual/
+[Classical.Structures.Lattice.OrdinalSum]: /Classical/Structures/Lattice/OrdinalSum/
+[Classical.Structures.Lattice.Product]: /Classical/Structures/Lattice/Product/
 [Classical.Structures.Magma]: /Classical/Structures/Magma/
 [Classical.Structures.Monoid]: /Classical/Structures/Monoid/
 [Classical.Structures.Ring]: /Classical/Structures/Ring/
@@ -363,6 +366,9 @@
 [FLRP.Certificates.SmallLatticeReps.SLR33]: /FLRP/Certificates/SmallLatticeReps/SLR33/
 [FLRP.Certificates.SmallLatticeReps.SLR34]: /FLRP/Certificates/SmallLatticeReps/SLR34/
 [FLRP.Certificates.SmallLatticeReps.SLR35]: /FLRP/Certificates/SmallLatticeReps/SLR35/
+[FLRP.Closure]: /FLRP/Closure/
+[FLRP.Closure.OrdinalSum]: /FLRP/Closure/OrdinalSum/
+[FLRP.Closure.Product]: /FLRP/Closure/Product/
 [FLRP.Enforceable]: /FLRP/Enforceable/
 [FLRP.L7EqSix]: /FLRP/L7EqSix/
 [FLRP.LayerBridge]: /FLRP/LayerBridge/
@@ -551,6 +557,9 @@
 [Classical/Structures/Group/Subgroups.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Subgroups.lagda.md
 [Classical/Structures/Interpret.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Interpret.lagda.md
 [Classical/Structures/Lattice.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice.lagda.md
+[Classical/Structures/Lattice/Dual.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice/Dual.lagda.md
+[Classical/Structures/Lattice/OrdinalSum.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
+[Classical/Structures/Lattice/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice/Product.lagda.md
 [Classical/Structures/Magma.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Magma.lagda.md
 [Classical/Structures/Monoid.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Monoid.lagda.md
 [Classical/Structures/Ring.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Ring.lagda.md
@@ -724,6 +733,9 @@
 [FLRP/Certificates/SmallLatticeReps/SLR33.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Certificates/SmallLatticeReps/SLR33.lagda.md
 [FLRP/Certificates/SmallLatticeReps/SLR34.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Certificates/SmallLatticeReps/SLR34.lagda.md
 [FLRP/Certificates/SmallLatticeReps/SLR35.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Certificates/SmallLatticeReps/SLR35.lagda.md
+[FLRP/Closure.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure.lagda.md
+[FLRP/Closure/OrdinalSum.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/OrdinalSum.lagda.md
+[FLRP/Closure/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/Product.lagda.md
 [FLRP/Enforceable.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Enforceable.lagda.md
 [FLRP/L7EqSix.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/L7EqSix.lagda.md
 [FLRP/LayerBridge.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/LayerBridge.lagda.md

--- a/src/Classical/Bundles/DistributiveLattice.lagda.md
+++ b/src/Classical/Bundles/DistributiveLattice.lagda.md
@@ -69,16 +69,16 @@ private variable α ρ : Level
   ; isDistributiveLattice = record
       { isLattice = record
           { isEquivalence = isEquivalence
-          ; ∨-comm        = ∨-comm-law
-          ; ∨-assoc       = ∨-assoc-law
+          ; ∨-comm        = λ x y → ∨-comm-law {x}{y}
+          ; ∨-assoc       = λ x y z → ∨-assoc-law {x}{y}{z}
           ; ∨-cong        = ∨-cong
-          ; ∧-comm        = ∧-comm-law
-          ; ∧-assoc       = ∧-assoc-law
+          ; ∧-comm        = λ x y → ∧-comm-law {x}{y}
+          ; ∧-assoc       = λ x y z → ∧-assoc-law {x}{y}{z}
           ; ∧-cong        = ∧-cong
-          ; absorptive    = ∨-absorbs-∧ , absorbˡ-law
+          ; absorptive    = ∨-absorbs-∧ , λ x y → absorbˡ-law {x}{y}
           }
-      ; ∨-distrib-∧ = ∨-distribˡ-law , ∨-distribʳ-law
-      ; ∧-distrib-∨ = ∧-distribˡ-law , ∧-distribʳ-law
+      ; ∨-distrib-∧ = (λ x y z → ∨-distribˡ-law {x}{y}{z}) , λ x y z → ∨-distribʳ-law {x}{y}{z}
+      ; ∧-distrib-∨ = (λ x y z → ∧-distribˡ-law {x}{y}{z}) , λ x y z → ∧-distribʳ-law {x}{y}{z}
       }
   }
   where
@@ -87,7 +87,7 @@ private variable α ρ : Level
 
   -- stdlib's first absorption is x ∨ (x ∧ y) ≈ x; our absorbʳ-law is (x ∧ y) ∨ x ≈ x.
   ∨-absorbs-∧ : ∀ x y → x ∨ (x ∧ y) ≈ x
-  ∨-absorbs-∧ x y = ≈trans (∨-comm-law x (x ∧ y)) (absorbʳ-law x y)
+  ∨-absorbs-∧ x y = ≈trans ∨-comm-law absorbʳ-law
 
 ⟪_⟫ᵈˡ : stdlib-DistributiveLattice α ρ → DistributiveLattice α ρ
 ⟪ L ⟫ᵈˡ = 𝑨 , λ { ∧-assoc    ρ → L-∧-assoc (ρ 0F) (ρ 1F) (ρ 2F)

--- a/src/Classical/Bundles/Lattice.lagda.md
+++ b/src/Classical/Bundles/Lattice.lagda.md
@@ -61,13 +61,13 @@ private variable α ρ : Level
   ; _∧_     = _∧_
   ; isLattice = record
       { isEquivalence = isEquivalence
-      ; ∨-comm        = ∨-comm-law
-      ; ∨-assoc       = ∨-assoc-law
+      ; ∨-comm        = λ x y → ∨-comm-law {x}{y}
+      ; ∨-assoc       = λ x y z → ∨-assoc-law {x}{y}{z}
       ; ∨-cong        = ∨-cong
-      ; ∧-comm        = ∧-comm-law
-      ; ∧-assoc       = ∧-assoc-law
+      ; ∧-comm        = λ x y → ∧-comm-law {x}{y}
+      ; ∧-assoc       = λ x y z → ∧-assoc-law {x}{y}{z}
       ; ∧-cong        = ∧-cong
-      ; absorptive    = ∨-absorbs-∧ , absorbˡ-law
+      ; absorptive    = (λ x y → ∨-absorbs-∧ {x}{y}) , λ x y → absorbˡ-law {x}{y}
       }
   }
   where
@@ -75,8 +75,8 @@ private variable α ρ : Level
   open Setoid 𝔻[ proj₁ 𝑳 ]
 
   -- stdlib's first absorption is x ∨ (x ∧ y) ≈ x; our absorbʳ-law is (x ∧ y) ∨ x ≈ x.
-  ∨-absorbs-∧ : ∀ x y → (x ∨ (x ∧ y)) ≈ x
-  ∨-absorbs-∧ x y = trans (∨-comm-law x (x ∧ y)) (absorbʳ-law x y)
+  ∨-absorbs-∧ : ∀ {x y} → (x ∨ (x ∧ y)) ≈ x
+  ∨-absorbs-∧ = trans ∨-comm-law absorbʳ-law
 
 ⟪_⟫ˡᵃ : stdlib-Lattice α ρ → Lattice α ρ
 ⟪ L ⟫ˡᵃ = 𝑨 , λ { ∧-assoc ρ → L-∧-assoc (ρ 0F) (ρ 1F) (ρ 2F)

--- a/src/Classical/Properties/Lattice.lagda.md
+++ b/src/Classical/Properties/Lattice.lagda.md
@@ -41,9 +41,9 @@ open import Agda.Primitive                           using () renaming ( Set to 
 open import Data.Fin.Base                            using ( Fin )
 open import Data.Fin.Properties                      using ( _≟_ ; all? )
 open import Data.Nat.Base                            using ( ℕ )
-open import Data.Product                             using ( proj₁ ; _×_ )
+open import Data.Product                             using ( proj₁ ; _×_ ; Σ-syntax )
 open import Data.Sum.Base                            using ( _⊎_ )
-open import Level                                    using ( Level )
+open import Level                                    using ( Level ; _⊔_ )
 open import Relation.Binary                          using ( Setoid )
 open import Relation.Binary.PropositionalEquality    using ( _≡_ ; _≢_ )
 open import Relation.Nullary.Decidable.Core          using ( Dec ; ¬? ; _×-dec_ ; _→-dec_ ; _⊎-dec_ )
@@ -133,6 +133,13 @@ binary congruence.
     x ∧ y'   ≈⟨ ∧-cong refl (sym y≈y') ⟩
     x ∧ y    ≈⟨ x≤y ⟩
     x        ∎
+
+  -- ≈-equal elements are ≤-comparable (the `reflexive` field of the preorder).
+  ≤-reflexive : ∀ {x y} → x ≈ y → x ≤ y
+  ≤-reflexive {x} {y} x≈y = begin
+    x ∧ y   ≈⟨ ∧-cong refl (sym x≈y) ⟩
+    x ∧ x   ≈⟨ ∧-idem-law x ⟩
+    x       ∎
 ```
 
 **`_∧_` is the binary meet.**  The two lower-bound clauses and the universal
@@ -182,6 +189,45 @@ through absorption twice.
     x ∨ (y ∨ z)   ≈⟨ ∨-cong refl (≤-via-∨ y≤z) ⟩
     x ∨ z         ≈⟨ ≤-via-∨ x≤z ⟩
     z             ∎)
+```
+
+**Extrema.**  `IsTop t` says `t` is a greatest element of the meet order, and
+`IsBot b` that `b` is a least one.  An arbitrary lattice need not have either; the
+predicates state the universal property of a *chosen* extremum, and by antisymmetry
+any two choices are `≈`-equal.  Constructions that glue lattices at their ends — the
+ordinal sum of [Classical.Structures.Lattice.OrdinalSum][] — consume exactly this
+data.
+
+```agda
+  -- t is a top (greatest) element of the meet order.
+  IsTop : 𝕌[ 𝑨 ] → Type (α ⊔ ρ)
+  IsTop t = ∀ x → x ≤ t
+
+  -- b is a bottom (least) element of the meet order.
+  IsBot : 𝕌[ 𝑨 ] → Type (α ⊔ ρ)
+  IsBot b = ∀ x → b ≤ x
+
+  -- Tops are unique up to ≈, by antisymmetry; likewise bottoms.
+  top-unique : ∀ {t t'} → IsTop t → IsTop t' → t ≈ t'
+  top-unique {t} {t'} pt pt' = ≤-antisym (pt' t) (pt t')
+
+  bot-unique : ∀ {b b'} → IsBot b → IsBot b' → b ≈ b'
+  bot-unique {b} {b'} pb pb' = ≤-antisym (pb b') (pb' b)
+```
+
+#### Chosen extrema, packaged
+
+`TopOf 𝑳` is the type of chosen tops of `𝑳`: an element paired with its
+universal property; `BotOf 𝑳` likewise for bottoms.  These are the arguments a
+construction takes when it needs a *specific* extremum (again, see the ordinal sum),
+packaged as Σ-types per the library's Σ-first discipline.
+
+```agda
+TopOf : Lattice α ρ → Type (α ⊔ ρ)
+TopOf 𝑳 = Σ[ t ∈ 𝕌[ proj₁ 𝑳 ] ] Lattice-Order.IsTop 𝑳 t
+
+BotOf : Lattice α ρ → Type (α ⊔ ρ)
+BotOf 𝑳 = Σ[ b ∈ 𝕌[ proj₁ 𝑳 ] ] Lattice-Order.IsBot 𝑳 b
 ```
 
 #### The decidable meet order and its atoms {#finite-order}

--- a/src/Classical/Properties/Lattice.lagda.md
+++ b/src/Classical/Properties/Lattice.lagda.md
@@ -16,18 +16,12 @@ a `Lattice α ρ` — that is, the algebraic data of meet, join, and the eight
 equations — we construct the partial order `x ≤ y := x ∧ y ≈ x` and show that
 `_∧_` and `_∨_` are the binary meet and join with respect to it.
 
-The dual order characterization `x ≤ y ⇔ x ∨ y ≈ y` is proved as the connecting
-lemma.  The partial-order properties and the GLB properties use only
-associativity, commutativity, and idempotency; the join upper-bound clauses use
-absorption directly, and the join leastness proof routes through the connecting
-lemma.
-
-This is the first module in `Classical/Properties/`.  The directory is a
-by-concern parallel of `Classical/Structures/`, `Classical/Bundles/`, etc., for
-*derived* results about classical structures — results that are theorems
-*about* a fixed inhabitant of one of those structures, not part of its
-definition.  Future inhabitants include, for example, uniqueness of inverses in
-Group and `0 · x ≈ 0` in Ring.
+This is the first module in `Classical/Properties/`.  The directory is a by-concern
+parallel of `Classical/Structures/`, `Classical/Bundles/`, etc., for *derived*
+results about classical structures — results that are theorems *about* a fixed
+inhabitant of one of those structures, not part of its definition.  Future
+inhabitants include, for example, uniqueness of inverses in Group and `0 · x ≈ 0`
+in Ring.
 
 <!--
 ```agda
@@ -68,7 +62,9 @@ module Lattice-Order {α ρ : Level} (𝑳 : Lattice α ρ) where
   open SetoidReasoning 𝔻[ 𝑨 ]
 ```
 
-**The induced order.**  `x ≤ y` is `x ∧ y ≈ x` (the meet-form characterization).
+**The induced order**.
+
+`x ≤ y` is `x ∧ y ≈ x` (the meet-form characterization).
 The join-form `x ∨ y ≈ y` is proved iff-equivalent below.
 
 ```agda
@@ -77,92 +73,100 @@ The join-form `x ∨ y ≈ y` is proved iff-equivalent below.
   x ≤ y = x ∧ y ≈ x
 ```
 
-**Connecting lemma: meet-form and join-form agree.**  Forward direction uses
-the second absorption law (in its `absorbʳ-law` shape: `(y ∧ x) ∨ y ≈ y`);
-backward direction uses the first.  The partial-order and GLB results below need
-only associativity, commutativity, and idempotency; the join upper-bound clauses
-use absorption directly.
+The dual order characterization `x ≤ y ⇔ x ∨ y ≈ y` is proved as the connecting
+lemma.  The partial-order properties and the GLB properties use only associativity,
+commutativity, and idempotency; the join upper-bound clauses use absorption directly,
+and the join leastness proof routes through the connecting lemma.
+
+**Connecting lemma: meet-form and join-form agree**.
+
+Forward direction uses the second absorption law (in its `absorbʳ-law` shape:
+`(y ∧ x) ∨ y ≈ y`); backward direction uses the first.
+
 
 ```agda
   ≤-via-∨ : ∀ {x y} → x ≤ y → x ∨ y ≈ y
   ≤-via-∨ {x} {y} x≤y = begin
-    x ∨ y         ≈⟨ ∨-cong (sym x≤y) refl ⟩
-    (x ∧ y) ∨ y   ≈⟨ ∨-cong (∧-comm-law x y) refl ⟩
-    (y ∧ x) ∨ y   ≈⟨ absorbʳ-law y x ⟩
+    x ∨ y         ≈˘⟨ ∨-cong x≤y refl ⟩
+    (x ∧ y) ∨ y   ≈⟨ ∨-cong ∧-comm-law refl ⟩
+    (y ∧ x) ∨ y   ≈⟨ absorbʳ-law ⟩
     y             ∎
 
   ≤-from-∨ : ∀ {x y} → x ∨ y ≈ y → x ≤ y
   ≤-from-∨ {x} {y} x∨y≈y = begin
-    x ∧ y         ≈⟨ ∧-cong refl (sym x∨y≈y) ⟩
-    x ∧ (x ∨ y)   ≈⟨ absorbˡ-law x y ⟩
+    x ∧ y         ≈˘⟨ ∧-cong refl x∨y≈y ⟩
+    x ∧ (x ∨ y)   ≈⟨ absorbˡ-law ⟩
     x             ∎
 ```
 
-**Partial order modulo `≈`.**  Reflexivity is idempotency, transitivity uses
-associativity, antisymmetry uses commutativity, and the `≈`-respect lemmas use
-binary congruence.
+**Partial order modulo `≈`**.
+
+Reflexivity is idempotency, transitivity uses associativity, antisymmetry uses
+commutativity, and the `≈`-respect lemmas use binary congruence.
 
 ```agda
   ≤-refl : ∀ {x} → x ≤ x
-  ≤-refl {x} = ∧-idem-law x
+  ≤-refl = ∧-idem-law
 
   ≤-trans : ∀ {x y z} → x ≤ y → y ≤ z → x ≤ z
   ≤-trans {x} {y} {z} x≤y y≤z = begin
-    x ∧ z         ≈⟨ ∧-cong (sym x≤y) refl ⟩
-    (x ∧ y) ∧ z   ≈⟨ ∧-assoc-law x y z ⟩
+    x ∧ z         ≈˘⟨ ∧-cong x≤y refl ⟩
+    (x ∧ y) ∧ z   ≈⟨ ∧-assoc-law ⟩
     x ∧ (y ∧ z)   ≈⟨ ∧-cong refl y≤z ⟩
     x ∧ y         ≈⟨ x≤y ⟩
     x             ∎
 
   ≤-antisym : ∀ {x y} → x ≤ y → y ≤ x → x ≈ y
   ≤-antisym {x} {y} x≤y y≤x = begin
-    x       ≈⟨ sym x≤y ⟩
-    x ∧ y   ≈⟨ ∧-comm-law x y ⟩
+    x       ≈˘⟨ x≤y ⟩
+    x ∧ y   ≈⟨ ∧-comm-law ⟩
     y ∧ x   ≈⟨ y≤x ⟩
     y       ∎
 
   ≤-respˡ-≈ : ∀ {x x' y} → x ≈ x' → x ≤ y → x' ≤ y
   ≤-respˡ-≈ {x} {x'} {y} x≈x' x≤y = begin
-    x' ∧ y   ≈⟨ ∧-cong (sym x≈x') refl ⟩
+    x' ∧ y   ≈˘⟨ ∧-cong x≈x' refl ⟩
     x ∧ y    ≈⟨ x≤y ⟩
     x        ≈⟨ x≈x' ⟩
     x'       ∎
 
   ≤-respʳ-≈ : ∀ {x y y'} → y ≈ y' → x ≤ y → x ≤ y'
   ≤-respʳ-≈ {x} {y} {y'} y≈y' x≤y = begin
-    x ∧ y'   ≈⟨ ∧-cong refl (sym y≈y') ⟩
+    x ∧ y'   ≈˘⟨ ∧-cong refl y≈y' ⟩
     x ∧ y    ≈⟨ x≤y ⟩
     x        ∎
 
   -- ≈-equal elements are ≤-comparable (the `reflexive` field of the preorder).
   ≤-reflexive : ∀ {x y} → x ≈ y → x ≤ y
   ≤-reflexive {x} {y} x≈y = begin
-    x ∧ y   ≈⟨ ∧-cong refl (sym x≈y) ⟩
-    x ∧ x   ≈⟨ ∧-idem-law x ⟩
+    x ∧ y   ≈˘⟨ ∧-cong refl x≈y ⟩
+    x ∧ x   ≈⟨ ∧-idem-law ⟩
     x       ∎
 ```
 
-**`_∧_` is the binary meet.**  The two lower-bound clauses and the universal
-property — together with the partial-order facts above — say that `x ∧ y` is
-the greatest lower bound of `x` and `y` with respect to `_≤_`.
+**`_∧_` is the binary meet**.
+
+The two lower-bound clauses and the universal property, together with the
+partial-order facts above, say that `x ∧ y` is the greatest lower bound of `x` and
+`y` with respect to `_≤_`.
 
 ```agda
-  ∧-lowerˡ : ∀ x y → (x ∧ y) ≤ x
-  ∧-lowerˡ x y = begin
-    (x ∧ y) ∧ x   ≈⟨ ∧-comm-law (x ∧ y) x ⟩
-    x ∧ (x ∧ y)   ≈⟨ sym (∧-assoc-law x x y) ⟩
-    (x ∧ x) ∧ y   ≈⟨ ∧-cong (∧-idem-law x) refl ⟩
+  ∧-lowerˡ : ∀ {x y} → (x ∧ y) ≤ x
+  ∧-lowerˡ {x} {y} = begin
+    (x ∧ y) ∧ x   ≈⟨ ∧-comm-law ⟩
+    x ∧ (x ∧ y)   ≈˘⟨ ∧-assoc-law ⟩
+    (x ∧ x) ∧ y   ≈⟨ ∧-cong ∧-idem-law refl ⟩
     x ∧ y         ∎
 
-  ∧-lowerʳ : ∀ x y → (x ∧ y) ≤ y
-  ∧-lowerʳ x y = begin
-    (x ∧ y) ∧ y   ≈⟨ ∧-assoc-law x y y ⟩
-    x ∧ (y ∧ y)   ≈⟨ ∧-cong refl (∧-idem-law y) ⟩
+  ∧-lowerʳ : ∀ {x y} → (x ∧ y) ≤ y
+  ∧-lowerʳ {x} {y} = begin
+    (x ∧ y) ∧ y   ≈⟨ ∧-assoc-law ⟩
+    x ∧ (y ∧ y)   ≈⟨ ∧-cong refl ∧-idem-law ⟩
     x ∧ y         ∎
 
   ∧-greatest : ∀ {x y z} → z ≤ x → z ≤ y → z ≤ (x ∧ y)
   ∧-greatest {x} {y} {z} z≤x z≤y = begin
-    z ∧ (x ∧ y)   ≈⟨ sym (∧-assoc-law z x y) ⟩
+    z ∧ (x ∧ y)   ≈˘⟨ ∧-assoc-law ⟩
     (z ∧ x) ∧ y   ≈⟨ ∧-cong z≤x refl ⟩
     z ∧ y         ≈⟨ z≤y ⟩
     z             ∎
@@ -174,18 +178,18 @@ property is proved through the join-form characterization to avoid going
 through absorption twice.
 
 ```agda
-  ∨-upperˡ : ∀ x y → x ≤ (x ∨ y)
-  ∨-upperˡ x y = absorbˡ-law x y
+  ∨-upperˡ : ∀ {x y} → x ≤ (x ∨ y)
+  ∨-upperˡ = absorbˡ-law
 
-  ∨-upperʳ : ∀ x y → y ≤ (x ∨ y)
-  ∨-upperʳ x y = begin
-    y ∧ (x ∨ y)   ≈⟨ ∧-cong refl (∨-comm-law x y) ⟩
-    y ∧ (y ∨ x)   ≈⟨ absorbˡ-law y x ⟩
+  ∨-upperʳ : ∀ {x y} → y ≤ (x ∨ y)
+  ∨-upperʳ {x} {y} = begin
+    y ∧ (x ∨ y)   ≈⟨ ∧-cong refl ∨-comm-law ⟩
+    y ∧ (y ∨ x)   ≈⟨ absorbˡ-law ⟩
     y             ∎
 
   ∨-least : ∀ {x y z} → x ≤ z → y ≤ z → (x ∨ y) ≤ z
   ∨-least {x} {y} {z} x≤z y≤z = ≤-from-∨ (begin
-    (x ∨ y) ∨ z   ≈⟨ ∨-assoc-law x y z ⟩
+    (x ∨ y) ∨ z   ≈⟨ ∨-assoc-law ⟩
     x ∨ (y ∨ z)   ≈⟨ ∨-cong refl (≤-via-∨ y≤z) ⟩
     x ∨ z         ≈⟨ ≤-via-∨ x≤z ⟩
     z             ∎)

--- a/src/Classical/Structures.lagda.md
+++ b/src/Classical/Structures.lagda.md
@@ -46,6 +46,9 @@ open import Classical.Structures.DistributiveLattice public
 open import Classical.Structures.Group public
 open import Classical.Structures.Interpret public
 open import Classical.Structures.Lattice public
+open import Classical.Structures.Lattice.Dual public
+open import Classical.Structures.Lattice.OrdinalSum public
+open import Classical.Structures.Lattice.Product public
 open import Classical.Structures.Magma public
 open import Classical.Structures.Monoid public
 open import Classical.Structures.Ring public

--- a/src/Classical/Structures.lagda.md
+++ b/src/Classical/Structures.lagda.md
@@ -39,20 +39,20 @@ submodules are the initial, pattern-setting structures.
 
 module Classical.Structures where
 
-open import Classical.Structures.CommutativeMonoid public
-open import Classical.Structures.CommutativeSemigroup public
-open import Classical.Structures.CommutativeRing public
-open import Classical.Structures.DistributiveLattice public
-open import Classical.Structures.Group public
-open import Classical.Structures.Interpret public
-open import Classical.Structures.Lattice public
-open import Classical.Structures.Lattice.Dual public
-open import Classical.Structures.Lattice.OrdinalSum public
-open import Classical.Structures.Lattice.Product public
-open import Classical.Structures.Magma public
-open import Classical.Structures.Monoid public
-open import Classical.Structures.Ring public
-open import Classical.Structures.Semigroup public
-open import Classical.Structures.Semilattice public
-open import Classical.Structures.Unary public
+open import Classical.Structures.CommutativeMonoid     public
+open import Classical.Structures.CommutativeSemigroup  public
+open import Classical.Structures.CommutativeRing       public
+open import Classical.Structures.DistributiveLattice   public
+open import Classical.Structures.Group                 public
+open import Classical.Structures.Interpret             public
+open import Classical.Structures.Lattice               public
+open import Classical.Structures.Lattice.Dual          public
+open import Classical.Structures.Lattice.OrdinalSum    public
+open import Classical.Structures.Lattice.Product       public
+open import Classical.Structures.Magma                 public
+open import Classical.Structures.Monoid                public
+open import Classical.Structures.Ring                  public
+open import Classical.Structures.Semigroup             public
+open import Classical.Structures.Semilattice           public
+open import Classical.Structures.Unary                 public
 ```

--- a/src/Classical/Structures/DistributiveLattice.lagda.md
+++ b/src/Classical/Structures/DistributiveLattice.lagda.md
@@ -122,10 +122,10 @@ module DistributiveLattice-Op {α ρ : Level} (𝑫 : DistributiveLattice α ρ)
   equations = proj₂ 𝑫
 
   -- x ∧ (y ∨ z) ≈ (x ∧ y) ∨ (x ∧ z)   (meet distributes over join, on the left)
-  ∧-distribˡ-law : ∀ x y z → x ∧ (y ∨ z) ≈ (x ∧ y) ∨ (x ∧ z)
-  ∧-distribˡ-law x y z = begin
+  ∧-distribˡ-law : ∀ {x y z} → x ∧ (y ∨ z) ≈ (x ∧ y) ∨ (x ∧ z)
+  ∧-distribˡ-law {x} {y} {z} = begin
     x ∧ (y ∨ z)                   ≈⟨ ∧-cong refl (sym (interp-node-∨ (ℊ 1F) (ℊ 2F) {η})) ⟩
-    x ∧ ⟦ y∨z ⟧ ⟨$⟩ η             ≈⟨ sym (interp-node-∧ (ℊ 0F) y∨z {η}) ⟩
+    x ∧ ⟦ y∨z ⟧ ⟨$⟩ η             ≈˘⟨ interp-node-∧ (ℊ 0F) y∨z {η} ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η                ≈⟨ equations ∧-distribˡ η ⟩
     ⟦ rhsT ⟧ ⟨$⟩ η                ≈⟨ interp-node-∨ xy xz {η} ⟩
     ⟦ xy ⟧ ⟨$⟩ η ∨ ⟦ xz ⟧ ⟨$⟩ η   ≈⟨ ∨-cong (interp-node-∧ (ℊ 0F) (ℊ 1F) {η}) (interp-node-∧ (ℊ 0F) (ℊ 2F) {η}) ⟩
@@ -141,10 +141,10 @@ module DistributiveLattice-Op {α ρ : Level} (𝑫 : DistributiveLattice α ρ)
     rhsT = node ∨-Op (pair xy xz)
 
   -- x ∨ (y ∧ z) ≈ (x ∨ y) ∧ (x ∨ z)   (join distributes over meet, on the left)
-  ∨-distribˡ-law : ∀ x y z → x ∨ (y ∧ z) ≈ (x ∨ y) ∧ (x ∨ z)
-  ∨-distribˡ-law x y z = begin
+  ∨-distribˡ-law : ∀ {x y z} → x ∨ (y ∧ z) ≈ (x ∨ y) ∧ (x ∨ z)
+  ∨-distribˡ-law {x} {y} {z} = begin
     x ∨ (y ∧ z)                   ≈⟨ ∨-cong refl (sym (interp-node-∧ (ℊ 1F) (ℊ 2F) {η})) ⟩
-    x ∨ ⟦ y∧z ⟧ ⟨$⟩ η             ≈⟨ sym (interp-node-∨ (ℊ 0F) y∧z {η}) ⟩
+    x ∨ ⟦ y∧z ⟧ ⟨$⟩ η             ≈˘⟨ interp-node-∨ (ℊ 0F) y∧z {η} ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η                ≈⟨ equations ∨-distribˡ η ⟩
     ⟦ rhsT ⟧ ⟨$⟩ η                ≈⟨ interp-node-∧ xy xz {η} ⟩
     ⟦ xy ⟧ ⟨$⟩ η ∧ ⟦ xz ⟧ ⟨$⟩ η   ≈⟨ ∧-cong (interp-node-∨ (ℊ 0F) (ℊ 1F) {η}) (interp-node-∨ (ℊ 0F) (ℊ 2F) {η}) ⟩
@@ -160,19 +160,19 @@ module DistributiveLattice-Op {α ρ : Level} (𝑫 : DistributiveLattice α ρ)
     rhsT = node ∧-Op (pair xy xz)
 
   -- (y ∨ z) ∧ x ≈ (y ∧ x) ∨ (z ∧ x)   (right form, by ∧-commutativity)
-  ∧-distribʳ-law : ∀ x y z → (y ∨ z) ∧ x ≈ (y ∧ x) ∨ (z ∧ x)
-  ∧-distribʳ-law x y z = begin
-    (y ∨ z) ∧ x        ≈⟨ ∧-comm-law (y ∨ z) x ⟩
-    x ∧ (y ∨ z)        ≈⟨ ∧-distribˡ-law x y z ⟩
-    (x ∧ y) ∨ (x ∧ z)  ≈⟨ ∨-cong (∧-comm-law x y) (∧-comm-law x z) ⟩
+  ∧-distribʳ-law : ∀ {x y z} → (y ∨ z) ∧ x ≈ (y ∧ x) ∨ (z ∧ x)
+  ∧-distribʳ-law {x} {y} {z} = begin
+    (y ∨ z) ∧ x        ≈⟨ ∧-comm-law ⟩
+    x ∧ (y ∨ z)        ≈⟨ ∧-distribˡ-law ⟩
+    (x ∧ y) ∨ (x ∧ z)  ≈⟨ ∨-cong ∧-comm-law ∧-comm-law ⟩
     (y ∧ x) ∨ (z ∧ x)  ∎
 
   -- (y ∧ z) ∨ x ≈ (y ∨ x) ∧ (z ∨ x)   (right form, by ∨-commutativity)
-  ∨-distribʳ-law : ∀ x y z → (y ∧ z) ∨ x ≈ (y ∨ x) ∧ (z ∨ x)
-  ∨-distribʳ-law x y z = begin
-    (y ∧ z) ∨ x        ≈⟨ ∨-comm-law (y ∧ z) x ⟩
-    x ∨ (y ∧ z)        ≈⟨ ∨-distribˡ-law x y z ⟩
-    (x ∨ y) ∧ (x ∨ z)  ≈⟨ ∧-cong (∨-comm-law x y) (∨-comm-law x z) ⟩
+  ∨-distribʳ-law : ∀ {x y z} → (y ∧ z) ∨ x ≈ (y ∨ x) ∧ (z ∨ x)
+  ∨-distribʳ-law {x} {y} {z} = begin
+    (y ∧ z) ∨ x        ≈⟨ ∨-comm-law ⟩
+    x ∨ (y ∧ z)        ≈⟨ ∨-distribˡ-law ⟩
+    (x ∨ y) ∧ (x ∨ z)  ≈⟨ ∧-cong ∨-comm-law ∨-comm-law ⟩
     (y ∨ x) ∧ (z ∨ x)  ∎
 ```
 

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -89,9 +89,11 @@ open import Classical.Theories.Lattice        using  ( Eq-Lattice ; Th-Lattice ;
 open import Classical.Theories.Semilattice    using  ( Th-Semilattice )
                                               renaming  ( assoc to assocˢˡ ; comm  to commˢˡ
                                                         ; idem  to idemˢˡ )
+open import Overture.Operations               using  ( Op )
 open import Overture.Terms                    using  ( Term ; ℊ ; node )
 open import Overture.Signatures               using  ( ArityOf ; OperationSymbolsOf )
-open import Setoid.Algebras.Basic             using  ( Algebra ; _^_ ; 𝔻[_] ; 𝕌[_] )
+open import Setoid.Algebras.Basic             using  ( Algebra ; _^_ ; 𝔻[_] ; 𝕌[_]
+                                                     ; mkAlgebra )
 open import Setoid.Algebras.Reduct            using  ( reductBy )
 open import Setoid.Signatures                 using  ( ⟨_⟩ )
 open import Setoid.Terms                      using  ( module Environment )
@@ -462,4 +464,69 @@ eqsToLattice A _∧'_ _∨'_ ∧-assoc-≡ ∧-comm-≡ ∧-idem-≡ ∨-assoc-�
   proof ∨-idem  ρ = ∨-idem-≡  (ρ 0F)
   proof absorbˡ ρ = absorbˡ-≡ (ρ 0F) (ρ 1F)
   proof absorbʳ ρ = absorbʳ-≡ (ρ 0F) (ρ 1F)
+```
+
+#### Setoid-level lattice builders
+
+`eqsToLattice`{.AgdaFunction} covers carriers with propositional equality; the
+constructions that build one lattice out of others — the binary product, the dual,
+and the ordinal sum of [Classical.Structures.Lattice.Product][],
+[Classical.Structures.Lattice.Dual][], and [Classical.Structures.Lattice.OrdinalSum][]
+— produce *setoid* carriers, so they need the general form.
+`setoidOpsToBareLattice`{.AgdaFunction} assembles the `Sig-Lattice` algebra from a
+carrier setoid, two binary operations, and their congruence proofs (which the
+propositional case got for free from `cong₂`{.AgdaFunction});
+`setoidEqsToLattice`{.AgdaFunction} adds the eight equations, now stated over the
+setoid equality `≈`.
+
+The interpretation clauses *apply* the argument tuple (`a 0F ∧' a 1F` rather than
+routing through `pair`{.AgdaFunction}), so each equation of `Th-Lattice`
+evaluates definitionally to its curried form, and the satisfaction proof consumes the
+curried hypotheses directly — the same reduction discipline that makes
+`eqsToLattice`{.AgdaFunction}'s proof clauses one-liners.
+
+```agda
+module _ (𝐷 : Setoid α ρ) where
+  open Setoid 𝐷 using ( _≈_ ) renaming ( Carrier to D )
+
+  setoidOpsToBareLattice : (_∧'_ _∨'_ : D → D → D)
+    → (∀ {x y u v} → x ≈ y → u ≈ v → (x ∧' u) ≈ (y ∧' v))
+    → (∀ {x y u v} → x ≈ y → u ≈ v → (x ∨' u) ≈ (y ∨' v))
+    → Algebra {𝑆 = Sig-Lattice} α ρ
+  setoidOpsToBareLattice _∧'_ _∨'_ ∧'-cong ∨'-cong = mkAlgebra 𝐷 interp interp-congruence
+    where
+    interp : (o : OperationSymbolsOf Sig-Lattice) → Op (ArityOf Sig-Lattice o) D
+    interp ∧-Op a = a 0F ∧' a 1F
+    interp ∨-Op a = a 0F ∨' a 1F
+
+    interp-congruence : ∀ o {u v : ArityOf Sig-Lattice o → D}
+      → (∀ i → u i ≈ v i) → interp o u ≈ interp o v
+    interp-congruence ∧-Op e = ∧'-cong (e 0F) (e 1F)
+    interp-congruence ∨-Op e = ∨'-cong (e 0F) (e 1F)
+
+  setoidEqsToLattice : (_∧'_ _∨'_ : D → D → D)
+    → (∧'-cong    : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∧' u) ≈ (y ∧' v))
+    → (∨'-cong    : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∨' u) ≈ (y ∨' v))
+    → (∧'-assoc-≈ : ∀ a b c → ((a ∧' b) ∧' c) ≈ (a ∧' (b ∧' c)))
+    → (∧'-comm-≈  : ∀ a b → (a ∧' b) ≈ (b ∧' a))
+    → (∧'-idem-≈  : ∀ a → (a ∧' a) ≈ a)
+    → (∨'-assoc-≈ : ∀ a b c → ((a ∨' b) ∨' c) ≈ (a ∨' (b ∨' c)))
+    → (∨'-comm-≈  : ∀ a b → (a ∨' b) ≈ (b ∨' a))
+    → (∨'-idem-≈  : ∀ a → (a ∨' a) ≈ a)
+    → (absorbˡ-≈  : ∀ a b → (a ∧' (a ∨' b)) ≈ a)
+    → (absorbʳ-≈  : ∀ a b → ((a ∧' b) ∨' a) ≈ a)
+    → Lattice α ρ
+  setoidEqsToLattice _∧'_ _∨'_ ∧'-cong ∨'-cong
+    ∧'-assoc-≈ ∧'-comm-≈ ∧'-idem-≈ ∨'-assoc-≈ ∨'-comm-≈ ∨'-idem-≈ absorbˡ-≈ absorbʳ-≈ =
+    setoidOpsToBareLattice _∧'_ _∨'_ ∧'-cong ∨'-cong , proof
+    where
+    proof : setoidOpsToBareLattice _∧'_ _∨'_ ∧'-cong ∨'-cong ⊨ˡᵃ Th-Lattice
+    proof ∧-assoc η = ∧'-assoc-≈ (η 0F) (η 1F) (η 2F)
+    proof ∧-comm  η = ∧'-comm-≈  (η 0F) (η 1F)
+    proof ∧-idem  η = ∧'-idem-≈  (η 0F)
+    proof ∨-assoc η = ∨'-assoc-≈ (η 0F) (η 1F) (η 2F)
+    proof ∨-comm  η = ∨'-comm-≈  (η 0F) (η 1F)
+    proof ∨-idem  η = ∨'-idem-≈  (η 0F)
+    proof absorbˡ η = absorbˡ-≈  (η 0F) (η 1F)
+    proof absorbʳ η = absorbʳ-≈  (η 0F) (η 1F)
 ```

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -509,26 +509,26 @@ module _ (𝐷 : Setoid α ρ) where
   setoidEqsToLattice : (_∧'_ _∨'_ : D → D → D)
     → (∧'-cong    : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∧' u) ≈ (y ∧' v))
     → (∨'-cong    : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∨' u) ≈ (y ∨' v))
-    → (∧'-assoc-≈ : ∀ a b c → ((a ∧' b) ∧' c) ≈ (a ∧' (b ∧' c)))
-    → (∧'-comm-≈  : ∀ a b → (a ∧' b) ≈ (b ∧' a))
-    → (∧'-idem-≈  : ∀ a → (a ∧' a) ≈ a)
-    → (∨'-assoc-≈ : ∀ a b c → ((a ∨' b) ∨' c) ≈ (a ∨' (b ∨' c)))
-    → (∨'-comm-≈  : ∀ a b → (a ∨' b) ≈ (b ∨' a))
-    → (∨'-idem-≈  : ∀ a → (a ∨' a) ≈ a)
-    → (absorbˡ-≈  : ∀ a b → (a ∧' (a ∨' b)) ≈ a)
-    → (absorbʳ-≈  : ∀ a b → ((a ∧' b) ∨' a) ≈ a)
+    → (∧'-assoc-≈ : ∀ {a b c} → ((a ∧' b) ∧' c) ≈ (a ∧' (b ∧' c)))
+    → (∧'-comm-≈  : ∀ {a b} → (a ∧' b) ≈ (b ∧' a))
+    → (∧'-idem-≈  : ∀ {a} → (a ∧' a) ≈ a)
+    → (∨'-assoc-≈ : ∀ {a b c} → ((a ∨' b) ∨' c) ≈ (a ∨' (b ∨' c)))
+    → (∨'-comm-≈  : ∀ {a b} → (a ∨' b) ≈ (b ∨' a))
+    → (∨'-idem-≈  : ∀ {a} → (a ∨' a) ≈ a)
+    → (absorbˡ-≈  : ∀ {a b} → (a ∧' (a ∨' b)) ≈ a)
+    → (absorbʳ-≈  : ∀ {a b} → ((a ∧' b) ∨' a) ≈ a)
     → Lattice α ρ
   setoidEqsToLattice _∧'_ _∨'_ ∧'-cong ∨'-cong
     ∧'-assoc-≈ ∧'-comm-≈ ∧'-idem-≈ ∨'-assoc-≈ ∨'-comm-≈ ∨'-idem-≈ absorbˡ-≈ absorbʳ-≈ =
     setoidOpsToBareLattice _∧'_ _∨'_ ∧'-cong ∨'-cong , proof
     where
     proof : setoidOpsToBareLattice _∧'_ _∨'_ ∧'-cong ∨'-cong ⊨ˡᵃ Th-Lattice
-    proof ∧-assoc η = ∧'-assoc-≈ (η 0F) (η 1F) (η 2F)
-    proof ∧-comm  η = ∧'-comm-≈  (η 0F) (η 1F)
-    proof ∧-idem  η = ∧'-idem-≈  (η 0F)
-    proof ∨-assoc η = ∨'-assoc-≈ (η 0F) (η 1F) (η 2F)
-    proof ∨-comm  η = ∨'-comm-≈  (η 0F) (η 1F)
-    proof ∨-idem  η = ∨'-idem-≈  (η 0F)
-    proof absorbˡ η = absorbˡ-≈  (η 0F) (η 1F)
-    proof absorbʳ η = absorbʳ-≈  (η 0F) (η 1F)
+    proof ∧-assoc η = ∧'-assoc-≈ -- (η 0F) (η 1F) (η 2F)
+    proof ∧-comm  η = ∧'-comm-≈  -- (η 0F) (η 1F)
+    proof ∧-idem  η = ∧'-idem-≈  -- (η 0F)
+    proof ∨-assoc η = ∨'-assoc-≈ -- (η 0F) (η 1F) (η 2F)
+    proof ∨-comm  η = ∨'-comm-≈  -- (η 0F) (η 1F)
+    proof ∨-idem  η = ∨'-idem-≈  -- (η 0F)
+    proof absorbˡ η = absorbˡ-≈  -- (η 0F) (η 1F)
+    proof absorbʳ η = absorbʳ-≈  -- (η 0F) (η 1F)
 ```

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -186,8 +186,8 @@ module _ (𝑳 : Lattice α ρ) where
     ∨-cong : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∨ u) ≈ (y ∨ v)
     ∨-cong x≈y u≈v = interp-cong 𝑨 ∨-Op (λ { 0F → x≈y ; 1F → u≈v })
 
-  lt-∧-assoc : ∀ x y z → (x ∧ y) ∧ z ≈ x ∧ (y ∧ z)
-  lt-∧-assoc x y z = begin
+  lt-∧-assoc : ∀ {x y z} → (x ∧ y) ∧ z ≈ x ∧ (y ∧ z)
+  lt-∧-assoc {x} {y} {z} = begin
     (x ∧ y) ∧ z       ≈⟨ ∧-cong (≈sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η)) ≈refl ⟩
     ⟦ xy ⟧ ⟨$⟩ η ∧ z  ≈⟨ ≈sym (interp-node-∧ xy (ℊ 2F) η) ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η    ≈⟨ proj₂ 𝑳 ∧-assoc η ⟩
@@ -203,19 +203,20 @@ module _ (𝑳 : Lattice α ρ) where
     lhsT = node ∧-Op (pair xy (ℊ 2F))
     rhsT = node ∧-Op (pair (ℊ 0F) yz)
 
-  lt-∧-comm : ∀ x y → x ∧ y ≈ y ∧ x
-  lt-∧-comm x y = ≈trans  (≈sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η))
-                          (≈trans (proj₂ 𝑳 ∧-comm η) (interp-node-∧ (ℊ 1F) (ℊ 0F) η))
+  lt-∧-comm : ∀ {x y} → x ∧ y ≈ y ∧ x
+  lt-∧-comm {x} {y} =
+    ≈trans  (≈sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η))
+            (≈trans (proj₂ 𝑳 ∧-comm η) (interp-node-∧ (ℊ 1F) (ℊ 0F) η))
     where η : Fin 3 → 𝕌[ 𝑨 ]
           η = λ { 0F → x ; 1F → y ; 2F → x }
 
-  lt-∧-idem : ∀ x → x ∧ x ≈ x
-  lt-∧-idem x = ≈trans (≈sym (interp-node-∧ (ℊ 0F) (ℊ 0F) η)) (proj₂ 𝑳 ∧-idem η)
+  lt-∧-idem : ∀ {x} → x ∧ x ≈ x
+  lt-∧-idem {x} = ≈trans (≈sym (interp-node-∧ (ℊ 0F) (ℊ 0F) η)) (proj₂ 𝑳 ∧-idem η)
     where η : Fin 3 → 𝕌[ 𝑨 ]
           η = λ { 0F → x ; 1F → x ; 2F → x }
 
-  lt-∨-assoc : ∀ x y z → (x ∨ y) ∨ z ≈ x ∨ (y ∨ z)
-  lt-∨-assoc x y z = begin
+  lt-∨-assoc : ∀ {x y z} → (x ∨ y) ∨ z ≈ x ∨ (y ∨ z)
+  lt-∨-assoc {x} {y} {z} = begin
     (x ∨ y) ∨ z       ≈⟨ ∨-cong (≈sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η)) ≈refl ⟩
     ⟦ xy ⟧ ⟨$⟩ η ∨ z  ≈⟨ ≈sym (interp-node-∨ xy (ℊ 2F) η) ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η    ≈⟨ proj₂ 𝑳 ∨-assoc η ⟩
@@ -231,20 +232,21 @@ module _ (𝑳 : Lattice α ρ) where
     lhsT = node ∨-Op (pair xy (ℊ 2F))
     rhsT = node ∨-Op (pair (ℊ 0F) yz)
 
-  lt-∨-comm : ∀ x y → x ∨ y ≈ y ∨ x
-  lt-∨-comm x y = ≈trans  (≈sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η))
-                          (≈trans (proj₂ 𝑳 ∨-comm η) (interp-node-∨ (ℊ 1F) (ℊ 0F) η))
+  lt-∨-comm : ∀ {x y} → x ∨ y ≈ y ∨ x
+  lt-∨-comm {x} {y} =
+    ≈trans  (≈sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η))
+            (≈trans (proj₂ 𝑳 ∨-comm η) (interp-node-∨ (ℊ 1F) (ℊ 0F) η))
     where η : Fin 3 → 𝕌[ 𝑨 ]
           η = λ { 0F → x ; 1F → y ; 2F → x }
 
-  lt-∨-idem : ∀ x → x ∨ x ≈ x
-  lt-∨-idem x = ≈trans (≈sym (interp-node-∨ (ℊ 0F) (ℊ 0F) η)) (proj₂ 𝑳 ∨-idem η)
+  lt-∨-idem : ∀ {x} → x ∨ x ≈ x
+  lt-∨-idem {x} = ≈trans (≈sym (interp-node-∨ (ℊ 0F) (ℊ 0F) η)) (proj₂ 𝑳 ∨-idem η)
     where  η : Fin 3 → 𝕌[ 𝑨 ]
            η = λ { 0F → x ; 1F → x ; 2F → x }
 
   -- x ∧ (x ∨ y) ≈ x   (meet absorbs join)
-  lt-absorbˡ : ∀ x y → x ∧ (x ∨ y) ≈ x
-  lt-absorbˡ x y = begin
+  lt-absorbˡ : ∀ {x y} → x ∧ (x ∨ y) ≈ x
+  lt-absorbˡ {x} {y} = begin
     x ∧ (x ∨ y)        ≈⟨ ∧-cong ≈refl (≈sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η)) ⟩
     x ∧ ⟦ x∨y ⟧ ⟨$⟩ η  ≈⟨ ≈sym (interp-node-∧ (ℊ 0F) x∨y η) ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η     ≈⟨ proj₂ 𝑳 absorbˡ η ⟩
@@ -257,8 +259,8 @@ module _ (𝑳 : Lattice α ρ) where
     lhsT = node ∧-Op (pair (ℊ 0F) x∨y)
 
   -- (x ∧ y) ∨ x ≈ x   (join absorbs meet, with x on the right of the outer ∨)
-  lt-absorbʳ : ∀ x y → (x ∧ y) ∨ x ≈ x
-  lt-absorbʳ x y = begin
+  lt-absorbʳ : ∀ {x y} → (x ∧ y) ∨ x ≈ x
+  lt-absorbʳ {x} {y} = begin
     (x ∧ y) ∨ x        ≈⟨ ∨-cong (≈sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η)) ≈refl ⟩
     ⟦ x∧y ⟧ ⟨$⟩ η ∨ x  ≈⟨ ≈sym (interp-node-∨ x∧y (ℊ 0F) η) ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η     ≈⟨ proj₂ 𝑳 absorbʳ η ⟩
@@ -310,28 +312,28 @@ module Lattice-Op {α ρ : Level} (𝑳 : Lattice α ρ) where
     → ⟦ node ∨-Op (pair s t) ⟧ ⟨$⟩ η ≈ ⟦ s ⟧ ⟨$⟩ η ∨ ⟦ t ⟧ ⟨$⟩ η
   interp-node-∨ s t = interp-cong 𝑨 ∨-Op λ { 0F → ≈refl ; 1F → ≈refl }
 
-  ∧-assoc-law : ∀ x y z → (x ∧ y) ∧ z ≈ x ∧ (y ∧ z)
+  ∧-assoc-law : ∀ {x y z} → (x ∧ y) ∧ z ≈ x ∧ (y ∧ z)
   ∧-assoc-law = lt-∧-assoc 𝑳
 
-  ∧-comm-law : ∀ x y → x ∧ y ≈ y ∧ x
+  ∧-comm-law : ∀ {x y} → x ∧ y ≈ y ∧ x
   ∧-comm-law = lt-∧-comm 𝑳
 
-  ∧-idem-law : ∀ x → x ∧ x ≈ x
+  ∧-idem-law : ∀ {x} → x ∧ x ≈ x
   ∧-idem-law = lt-∧-idem 𝑳
 
-  ∨-assoc-law : ∀ x y z → (x ∨ y) ∨ z ≈ x ∨ (y ∨ z)
+  ∨-assoc-law : ∀ {x y z} → (x ∨ y) ∨ z ≈ x ∨ (y ∨ z)
   ∨-assoc-law = lt-∨-assoc 𝑳
 
-  ∨-comm-law : ∀ x y → x ∨ y ≈ y ∨ x
+  ∨-comm-law : ∀ {x y} → x ∨ y ≈ y ∨ x
   ∨-comm-law = lt-∨-comm 𝑳
 
-  ∨-idem-law : ∀ x → x ∨ x ≈ x
+  ∨-idem-law : ∀ {x} → x ∨ x ≈ x
   ∨-idem-law = lt-∨-idem 𝑳
 
-  absorbˡ-law : ∀ x y → x ∧ (x ∨ y) ≈ x
+  absorbˡ-law : ∀ {x y} → x ∧ (x ∨ y) ≈ x
   absorbˡ-law = lt-absorbˡ 𝑳
 
-  absorbʳ-law : ∀ x y → (x ∧ y) ∨ x ≈ x
+  absorbʳ-law : ∀ {x y} → (x ∧ y) ∨ x ≈ x
   absorbʳ-law = lt-absorbʳ 𝑳
 ```
 
@@ -365,7 +367,7 @@ lattice→meetSemilattice ℒ@(𝑳 , _) = 𝑹 , thm
   thm assocˢˡ η = let x = η 0F ; y = η 1F ; z = η 2F in begin
     ⟦ Th-Semilattice assocˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ xy (ℊ 2F) η ⟩
     ⟦ xy ⟧ ⟨$⟩ η ∧ z                         ≈⟨ ∧-congᴿ (interp-congᴿ (ℊ 0F) (ℊ 1F) η) ≈refl ⟩
-    (x ∧ y) ∧ z                              ≈⟨ ∧-assoc-law x y z ⟩
+    (x ∧ y) ∧ z                              ≈⟨ ∧-assoc-law ⟩
     x ∧ (y ∧ z)                              ≈˘⟨ ∧-congᴿ ≈refl (interp-congᴿ (ℊ 1F) (ℊ 2F) η) ⟩
     x ∧ ⟦ yz ⟧ ⟨$⟩ η                         ≈˘⟨ interp-congᴿ (ℊ 0F) yz η ⟩
     ⟦ Th-Semilattice assocˢˡ .proj₂ ⟧ ⟨$⟩ η  ∎
@@ -376,13 +378,13 @@ lattice→meetSemilattice ℒ@(𝑳 , _) = 𝑹 , thm
 
   thm commˢˡ η = let x = η 0F ; y = η 1F in begin
     ⟦ Th-Semilattice commˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ (ℊ 0F) (ℊ 1F) η ⟩
-    x ∧ y                                   ≈⟨ ∧-comm-law x y ⟩
+    x ∧ y                                   ≈⟨ ∧-comm-law ⟩
     y ∧ x                                   ≈˘⟨ interp-congᴿ (ℊ 1F) (ℊ 0F) η ⟩
     ⟦ Th-Semilattice commˢˡ .proj₂ ⟧ ⟨$⟩ η  ∎
 
   thm idemˢˡ η = let x = η 0F in begin
     ⟦ Th-Semilattice idemˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ (ℊ 0F) (ℊ 0F) η ⟩
-    x ∧ x                                   ≈⟨ ∧-idem-law x ⟩
+    x ∧ x                                   ≈⟨ ∧-idem-law ⟩
     x                                       ∎
 
 lattice→joinSemilattice : Lattice α ρ → Semilattice α ρ
@@ -406,7 +408,7 @@ lattice→joinSemilattice ℒ@(𝑳 , _) = 𝑹 , thm
   thm assocˢˡ η = let x = η 0F ; y = η 1F ; z = η 2F in begin
     ⟦ Th-Semilattice assocˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ xy (ℊ 2F) η ⟩
     ⟦ xy ⟧ ⟨$⟩ η ∨ z                         ≈⟨ ∨-congᴿ (interp-congᴿ (ℊ 0F) (ℊ 1F) η) ≈refl ⟩
-    (x ∨ y) ∨ z                              ≈⟨ ∨-assoc-law x y z ⟩
+    (x ∨ y) ∨ z                              ≈⟨ ∨-assoc-law ⟩
     x ∨ (y ∨ z)                              ≈˘⟨ ∨-congᴿ ≈refl (interp-congᴿ (ℊ 1F) (ℊ 2F) η) ⟩
     x ∨ ⟦ yz ⟧ ⟨$⟩ η                         ≈˘⟨ interp-congᴿ (ℊ 0F) yz η ⟩
     ⟦ Th-Semilattice assocˢˡ .proj₂ ⟧ ⟨$⟩ η  ∎
@@ -417,13 +419,13 @@ lattice→joinSemilattice ℒ@(𝑳 , _) = 𝑹 , thm
 
   thm commˢˡ η = let x = η 0F ; y = η 1F in begin
     ⟦ Th-Semilattice commˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ (ℊ 0F) (ℊ 1F) η ⟩
-    x ∨ y                                   ≈⟨ ∨-comm-law x y ⟩
+    x ∨ y                                   ≈⟨ ∨-comm-law ⟩
     y ∨ x                                   ≈˘⟨ interp-congᴿ (ℊ 1F) (ℊ 0F) η ⟩
     ⟦ Th-Semilattice commˢˡ .proj₂ ⟧ ⟨$⟩ η  ∎
 
   thm idemˢˡ η = let x = η 0F in begin
     ⟦ Th-Semilattice idemˢˡ .proj₁ ⟧ ⟨$⟩ η  ≈⟨ interp-congᴿ (ℊ 0F) (ℊ 0F) η ⟩
-    x ∨ x                                   ≈⟨ ∨-idem-law x ⟩
+    x ∨ x                                   ≈⟨ ∨-idem-law ⟩
     x                                       ∎
 ```
 

--- a/src/Classical/Structures/Lattice/Dual.lagda.md
+++ b/src/Classical/Structures/Lattice/Dual.lagda.md
@@ -84,12 +84,12 @@ commutativity step each.
 
 ```agda
   -- a ∨ (a ∧ b) ≈ a : the dual reading of absorption, from absorbʳ by ∨-commutativity.
-  dual-absorbˡ : ∀ a b → (a ∨ (a ∧ b)) ≈ a
-  dual-absorbˡ a b = ≈trans ∨-comm-law absorbʳ-law
+  dual-absorbˡ : ∀ {a b} → a ∨ (a ∧ b) ≈ a
+  dual-absorbˡ = ≈trans ∨-comm-law absorbʳ-law
 
   -- (a ∨ b) ∧ a ≈ a : the other dual absorption, from absorbˡ by ∧-commutativity.
-  dual-absorbʳ : ∀ a b → ((a ∨ b) ∧ a) ≈ a
-  dual-absorbʳ a b = ≈trans ∧-comm-law absorbˡ-law
+  dual-absorbʳ : ∀ {a b} → (a ∨ b) ∧ a ≈ a
+  dual-absorbʳ = ≈trans ∧-comm-law absorbˡ-law
 ```
 
 The dual lattice: same carrier setoid, meet interpreted by `_∨_` and join by
@@ -99,12 +99,7 @@ absorption laws.
 ```agda
   dual-Lattice : Lattice α ρ
   dual-Lattice = setoidEqsToLattice 𝔻[ 𝑨 ] _∨_ _∧_ ∨-cong ∧-cong
-    (λ x y z → ∨-assoc-law{x}{y}{z})
-    (λ x y → ∨-comm-law {x}{y})
-    (λ x → ∨-idem-law{x})
-    (λ x y z → ∧-assoc-law {x}{y}{z})
-    (λ x y → ∧-comm-law {x}{y})
-    (λ x → ∧-idem-law{x})
+    ∨-assoc-law ∨-comm-law ∨-idem-law ∧-assoc-law ∧-comm-law ∧-idem-law
     dual-absorbˡ dual-absorbʳ
 ```
 
@@ -120,11 +115,11 @@ connecting lemmas); the two directions are one commutativity step each.
 
   -- An inequality in the dual reverses in 𝑳.
   ≤ᵈ-flip : ∀ {x y} → x ≤ᵈ y → y ≤₀ x
-  ≤ᵈ-flip {x} {y} x≤ᵈy = ≤-from-∨ (≈trans ∨-comm-law x≤ᵈy)
+  ≤ᵈ-flip x≤ᵈy = ≤-from-∨ (≈trans ∨-comm-law x≤ᵈy)
 
   -- An inequality in 𝑳 reverses in the dual.
   ≤ᵈ-unflip : ∀ {x y} → y ≤₀ x → x ≤ᵈ y
-  ≤ᵈ-unflip {x} {y} y≤x = ≈trans ∨-comm-law (≤-via-∨ y≤x)
+  ≤ᵈ-unflip y≤x = ≈trans ∨-comm-law (≤-via-∨ y≤x)
 ```
 
 #### Extrema swap under dualization
@@ -151,4 +146,5 @@ dualLattice 𝑳 = LatticeDual.dual-Lattice 𝑳
 ```
 
 --------------------------------------
+
 [^1]: See [FLRP.Assumptions][] and work package WP-5.

--- a/src/Classical/Structures/Lattice/Dual.lagda.md
+++ b/src/Classical/Structures/Lattice/Dual.lagda.md
@@ -10,21 +10,21 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Lattice.Dual][] module of the [Agda Universal Algebra Library][].
 
-The **dual** (or *opposite*) of a lattice swaps meet and join, equivalently
-reverses the order.  Because the lattice theory `Th-Lattice` is self-dual, the
-construction is a matter of re-interpreting the two operation symbols of
+The **dual** (or *opposite*) of a lattice swaps meet and join, equivalently reverses
+the order.  Because the lattice theory `Th-Lattice` is self-dual, the construction is
+a matter of re-interpreting the two operation symbols of
 [`Sig-Lattice`][Classical.Signatures.Lattice] on the *same* carrier setoid: the
 dual's meet is `𝑳`{.AgdaBound}'s join and vice versa, six of the eight equations
 transfer verbatim with the `∧`/`∨` roles exchanged, and the two absorption laws
 of the dual follow from those of `𝑳`{.AgdaBound} by one commutativity step each
 (`a ∨ (a ∧ b) ≈ a` is `absorbʳ`{.AgdaFunction} read backwards).
 
-The module also records how the dualization acts on the derived order-theoretic
-data of [Classical.Properties.Lattice][]:
+The module also records how the dualization acts on the derived order-theoretic data
+of [Classical.Properties.Lattice][].
 
-+  the meet order flips — `x ≤ y` in the dual iff `y ≤ x` in `𝑳`{.AgdaBound}
-   (`≤ᵈ-flip`{.AgdaFunction} / `≤ᵈ-unflip`{.AgdaFunction});
-+  chosen extrema swap — a top of `𝑳`{.AgdaBound} is a bottom of the dual and
++  The meet order flips: `x ≤ y` in the dual iff `y ≤ x` in `𝑳`{.AgdaBound}
+   (`≤ᵈ-flip`{.AgdaFunction} / `≤ᵈ-unflip`{.AgdaFunction}).
++  Chosen extrema swap: a top of `𝑳`{.AgdaBound} is a bottom of the dual and
    conversely (`dualBotOf`{.AgdaFunction} / `dualTopOf`{.AgdaFunction}).
 
 Dualization is involutive up to the evident isomorphism (the identity map on the
@@ -35,9 +35,9 @@ extensionality — and no current consumer requires it; a consumer that dualizes
 twice should transport along the identity carrier map.
 
 The first consumer is the Kurzweil–Netter duality entry of the FLRP assumptions
-registry ([FLRP.Assumptions][], work package WP-5): the classical theorem that the
+registry: the classical theorem that the
 class of representable lattices is closed under dualization is *stated* over
-`dualLattice`{.AgdaFunction} and imported as an explicit hypothesis.
+`dualLattice`{.AgdaFunction} and imported as an explicit hypothesis.[^1]
 
 <!--
 ```agda
@@ -45,10 +45,9 @@ class of representable lattices is closed under dualization is *stated* over
 
 module Classical.Structures.Lattice.Dual where
 
-open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
-open import Data.Product          using ( _,_ ; proj₁ ; proj₂ )
+open import Data.Product          using ( _,_ ; proj₁ )
 open import Level                 using ( Level )
 open import Relation.Binary       using ( Setoid )
 
@@ -72,7 +71,7 @@ module LatticeDual (𝑳 : Lattice α ρ) where
   private 𝑨 = proj₁ 𝑳
 
   open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
-    renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+    renaming ( trans to ≈trans )
   open Lattice-Op 𝑳 using
     ( _∧_ ; _∨_ ; ∧-cong ; ∨-cong
     ; ∧-assoc-law ; ∧-comm-law ; ∧-idem-law
@@ -86,11 +85,11 @@ commutativity step each.
 ```agda
   -- a ∨ (a ∧ b) ≈ a : the dual reading of absorption, from absorbʳ by ∨-commutativity.
   dual-absorbˡ : ∀ a b → (a ∨ (a ∧ b)) ≈ a
-  dual-absorbˡ a b = ≈trans (∨-comm-law a (a ∧ b)) (absorbʳ-law a b)
+  dual-absorbˡ a b = ≈trans ∨-comm-law absorbʳ-law
 
   -- (a ∨ b) ∧ a ≈ a : the other dual absorption, from absorbˡ by ∧-commutativity.
   dual-absorbʳ : ∀ a b → ((a ∨ b) ∧ a) ≈ a
-  dual-absorbʳ a b = ≈trans (∧-comm-law (a ∨ b) a) (absorbˡ-law a b)
+  dual-absorbʳ a b = ≈trans ∧-comm-law absorbˡ-law
 ```
 
 The dual lattice: same carrier setoid, meet interpreted by `_∨_` and join by
@@ -100,8 +99,12 @@ absorption laws.
 ```agda
   dual-Lattice : Lattice α ρ
   dual-Lattice = setoidEqsToLattice 𝔻[ 𝑨 ] _∨_ _∧_ ∨-cong ∧-cong
-    ∨-assoc-law ∨-comm-law ∨-idem-law
-    ∧-assoc-law ∧-comm-law ∧-idem-law
+    (λ x y z → ∨-assoc-law{x}{y}{z})
+    (λ x y → ∨-comm-law {x}{y})
+    (λ x → ∨-idem-law{x})
+    (λ x y z → ∧-assoc-law {x}{y}{z})
+    (λ x y → ∧-comm-law {x}{y})
+    (λ x → ∧-idem-law{x})
     dual-absorbˡ dual-absorbʳ
 ```
 
@@ -117,11 +120,11 @@ connecting lemmas); the two directions are one commutativity step each.
 
   -- An inequality in the dual reverses in 𝑳.
   ≤ᵈ-flip : ∀ {x y} → x ≤ᵈ y → y ≤₀ x
-  ≤ᵈ-flip {x} {y} x≤ᵈy = ≤-from-∨ (≈trans (∨-comm-law y x) x≤ᵈy)
+  ≤ᵈ-flip {x} {y} x≤ᵈy = ≤-from-∨ (≈trans ∨-comm-law x≤ᵈy)
 
   -- An inequality in 𝑳 reverses in the dual.
   ≤ᵈ-unflip : ∀ {x y} → y ≤₀ x → x ≤ᵈ y
-  ≤ᵈ-unflip {x} {y} y≤x = ≈trans (∨-comm-law x y) (≤-via-∨ y≤x)
+  ≤ᵈ-unflip {x} {y} y≤x = ≈trans ∨-comm-law (≤-via-∨ y≤x)
 ```
 
 #### Extrema swap under dualization
@@ -148,3 +151,4 @@ dualLattice 𝑳 = LatticeDual.dual-Lattice 𝑳
 ```
 
 --------------------------------------
+[^1]: See [FLRP.Assumptions][] and work package WP-5.

--- a/src/Classical/Structures/Lattice/Dual.lagda.md
+++ b/src/Classical/Structures/Lattice/Dual.lagda.md
@@ -1,0 +1,150 @@
+---
+layout: default
+file: "src/Classical/Structures/Lattice/Dual.lagda.md"
+title: "Classical.Structures.Lattice.Dual module"
+date: "2026-07-24"
+author: "the agda-algebras development team"
+---
+
+### The dual of a lattice {#classical-structures-lattice-dual}
+
+This is the [Classical.Structures.Lattice.Dual][] module of the [Agda Universal Algebra Library][].
+
+The **dual** (or *opposite*) of a lattice swaps meet and join, equivalently
+reverses the order.  Because the lattice theory `Th-Lattice` is self-dual, the
+construction is a matter of re-interpreting the two operation symbols of
+[`Sig-Lattice`][Classical.Signatures.Lattice] on the *same* carrier setoid: the
+dual's meet is `𝑳`{.AgdaBound}'s join and vice versa, six of the eight equations
+transfer verbatim with the `∧`/`∨` roles exchanged, and the two absorption laws
+of the dual follow from those of `𝑳`{.AgdaBound} by one commutativity step each
+(`a ∨ (a ∧ b) ≈ a` is `absorbʳ`{.AgdaFunction} read backwards).
+
+The module also records how the dualization acts on the derived order-theoretic
+data of [Classical.Properties.Lattice][]:
+
++  the meet order flips — `x ≤ y` in the dual iff `y ≤ x` in `𝑳`{.AgdaBound}
+   (`≤ᵈ-flip`{.AgdaFunction} / `≤ᵈ-unflip`{.AgdaFunction});
++  chosen extrema swap — a top of `𝑳`{.AgdaBound} is a bottom of the dual and
+   conversely (`dualBotOf`{.AgdaFunction} / `dualTopOf`{.AgdaFunction}).
+
+Dualization is involutive up to the evident isomorphism (the identity map on the
+carrier): applying `dualLattice`{.AgdaFunction} twice re-interprets each symbol by
+its original operation, pointwise.  We do not formalize the involution here — as a
+propositional equality of `Lattice`{.AgdaFunction} values it would need function
+extensionality — and no current consumer requires it; a consumer that dualizes
+twice should transport along the identity carrier map.
+
+The first consumer is the Kurzweil–Netter duality entry of the FLRP assumptions
+registry ([FLRP.Assumptions][], work package WP-5): the classical theorem that the
+class of representable lattices is closed under dualization is *stated* over
+`dualLattice`{.AgdaFunction} and imported as an explicit hypothesis.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Lattice.Dual where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Product          using ( _,_ ; proj₁ ; proj₂ )
+open import Level                 using ( Level )
+open import Relation.Binary       using ( Setoid )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Properties.Lattice  using ( module Lattice-Order ; TopOf ; BotOf )
+open import Classical.Structures.Lattice  using ( Lattice ; module Lattice-Op
+                                                ; setoidEqsToLattice )
+open import Setoid.Algebras.Basic         using ( 𝔻[_] )
+
+private variable α ρ : Level
+```
+-->
+
+#### The dual construction
+
+`LatticeDual`{.AgdaModule} `𝑳` packages the construction and its order-theoretic
+companions for a fixed lattice.
+
+```agda
+module LatticeDual (𝑳 : Lattice α ρ) where
+  private 𝑨 = proj₁ 𝑳
+
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
+    renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+  open Lattice-Op 𝑳 using
+    ( _∧_ ; _∨_ ; ∧-cong ; ∨-cong
+    ; ∧-assoc-law ; ∧-comm-law ; ∧-idem-law
+    ; ∨-assoc-law ; ∨-comm-law ; ∨-idem-law
+    ; absorbˡ-law ; absorbʳ-law )
+```
+
+The two absorption laws of the dual, derived from those of `𝑳` by one
+commutativity step each.
+
+```agda
+  -- a ∨ (a ∧ b) ≈ a : the dual reading of absorption, from absorbʳ by ∨-commutativity.
+  dual-absorbˡ : ∀ a b → (a ∨ (a ∧ b)) ≈ a
+  dual-absorbˡ a b = ≈trans (∨-comm-law a (a ∧ b)) (absorbʳ-law a b)
+
+  -- (a ∨ b) ∧ a ≈ a : the other dual absorption, from absorbˡ by ∧-commutativity.
+  dual-absorbʳ : ∀ a b → ((a ∨ b) ∧ a) ≈ a
+  dual-absorbʳ a b = ≈trans (∧-comm-law (a ∨ b) a) (absorbˡ-law a b)
+```
+
+The dual lattice: same carrier setoid, meet interpreted by `_∨_` and join by
+`_∧_`, the six semilattice equations exchanged wholesale, and the two derived
+absorption laws.
+
+```agda
+  dual-Lattice : Lattice α ρ
+  dual-Lattice = setoidEqsToLattice 𝔻[ 𝑨 ] _∨_ _∧_ ∨-cong ∧-cong
+    ∨-assoc-law ∨-comm-law ∨-idem-law
+    ∧-assoc-law ∧-comm-law ∧-idem-law
+    dual-absorbˡ dual-absorbʳ
+```
+
+#### The dual order is the reversed order
+
+The meet order of the dual unfolds definitionally to `x ∨ y ≈ x`, which is the
+join-form characterization of `y ≤ x` in `𝑳` ([Classical.Properties.Lattice][]'s
+connecting lemmas); the two directions are one commutativity step each.
+
+```agda
+  open Lattice-Order 𝑳 using ( ≤-via-∨ ; ≤-from-∨ ) renaming ( _≤_ to _≤₀_ )
+  open Lattice-Order dual-Lattice using () renaming ( _≤_ to _≤ᵈ_ )
+
+  -- An inequality in the dual reverses in 𝑳.
+  ≤ᵈ-flip : ∀ {x y} → x ≤ᵈ y → y ≤₀ x
+  ≤ᵈ-flip {x} {y} x≤ᵈy = ≤-from-∨ (≈trans (∨-comm-law y x) x≤ᵈy)
+
+  -- An inequality in 𝑳 reverses in the dual.
+  ≤ᵈ-unflip : ∀ {x y} → y ≤₀ x → x ≤ᵈ y
+  ≤ᵈ-unflip {x} {y} y≤x = ≈trans (∨-comm-law x y) (≤-via-∨ y≤x)
+```
+
+#### Extrema swap under dualization
+
+A chosen top of `𝑳` is a chosen bottom of the dual, and conversely — the element
+is unchanged, and its universal property flips through
+`≤ᵈ-unflip`{.AgdaFunction}.
+
+```agda
+  dualBotOf : TopOf 𝑳 → BotOf dual-Lattice
+  dualBotOf (t , t-top) = t , λ x → ≤ᵈ-unflip (t-top x)
+
+  dualTopOf : BotOf 𝑳 → TopOf dual-Lattice
+  dualTopOf (b , b-bot) = b , λ x → ≤ᵈ-unflip (b-bot x)
+```
+
+#### The dual operator
+
+The standalone operator, for consumers that need only the lattice.
+
+```agda
+dualLattice : Lattice α ρ → Lattice α ρ
+dualLattice 𝑳 = LatticeDual.dual-Lattice 𝑳
+```
+
+--------------------------------------

--- a/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
+++ b/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
@@ -412,10 +412,15 @@ the glue.  The four lemmas name these unfoldings for consumers.
   ≤ᵒ-up : (x : 𝕌[ 𝑨 ]) (y : 𝕌[ 𝑩 ]) → (inj₁ x) ≤ᵒ (inj₂ y)
   ≤ᵒ-up x y = refl₁ , refl₂
 
-  -- An upper element below a lower one forces both to the glue.
+  -- An upper element below a lower one forces both to the glue ...
   ≤ᵒ-down-elim : {x : 𝕌[ 𝑩 ]} {y : 𝕌[ 𝑨 ]}
     → (inj₂ x) ≤ᵒ (inj₁ y) → (y ≈₁ ⊤₁) × (x ≈₂ ⊥₂)
   ≤ᵒ-down-elim (p , q) = p , sym₂ q
+
+  -- ... and, at the glue, it does sit below.
+  ≤ᵒ-down : {x : 𝕌[ 𝑩 ]} {y : 𝕌[ 𝑨 ]}
+    → y ≈₁ ⊤₁ → x ≈₂ ⊥₂ → (inj₂ x) ≤ᵒ (inj₁ y)
+  ≤ᵒ-down y≈⊤ x≈⊥ = y≈⊤ , sym₂ x≈⊥
 ```
 
 #### The sum operator

--- a/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
+++ b/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
@@ -1,0 +1,431 @@
+---
+layout: default
+file: "src/Classical/Structures/Lattice/OrdinalSum.lagda.md"
+title: "Classical.Structures.Lattice.OrdinalSum module"
+date: "2026-07-24"
+author: "the agda-algebras development team"
+---
+
+### Ordinal sums of lattices {#classical-structures-lattice-ordinalsum}
+
+This is the [Classical.Structures.Lattice.OrdinalSum][] module of the [Agda Universal Algebra Library][].
+
+The **adjoined ordinal sum** of lattices `𝑳₁`{.AgdaBound} and `𝑳₂`{.AgdaBound}
+stacks `𝑳₂`{.AgdaBound} on top of `𝑳₁`{.AgdaBound} and *glues* the top of
+`𝑳₁`{.AgdaBound} to the bottom of `𝑳₂`{.AgdaBound}: every element of the lower
+summand lies below every element of the upper one, and the two chosen extrema
+become a single element.  This is the operation `L ⊕ₐ M` of the small-lattice
+representations manuscript (`docs/papers/fin-lat-rep/SmallLatticeReps.tex`,
+§ Ordinal Sums); the *unglued* ordinal sum, in which the top of the lower summand
+is covered by the bottom of the upper, is the derived composite
+`(𝑳₁ ⊕ₐ chain₂) ⊕ₐ 𝑳₂` — gluing a two-element chain in the middle leaves exactly
+one covering edge — so the glued form is the module's single canonical primitive.
+
+Because the sum glues at *chosen* extrema, the construction takes them as data:
+a `TopOf 𝑳₁`{.AgdaFunction} and a `BotOf 𝑳₂`{.AgdaFunction}
+([Classical.Properties.Lattice][]).  General lattices need not have extrema, and
+threading the choice keeps the construction total and the resulting carrier
+syntactically predictable (the corollaries that adjoin a fresh extremum to a
+lattice instantiate a summand at `chain₂` and its concrete `0`/`1`).
+
+Two design points:
+
++  **Gluing is by setoid equality, not element removal.**  The carrier is the
+   disjoint union `A ⊎ B` with the equivalence coarsened so that
+   `inj₁ ⊤₁ ≈ inj₂ ⊥₂`; removing a point would require deciding equality with it,
+   whereas coarsening is constructive and level-polymorphic.  The amalgam setoid is
+   isolated in `GlueSetoid`{.AgdaModule} (the Cubical-port equality locus), defined
+   for *any* two pointed setoids: its equivalence is the pullback of the component
+   equivalences along the two **retractions** that collapse the opposite summand to
+   the basepoint.  This pullback presentation makes reflexivity, symmetry, and
+   transitivity componentwise — no case analysis — and on each summand it restricts
+   to the original equivalence, while across summands it holds exactly at the glue.
++  **The operations never cross the glue.**  Meet sends a mixed pair to its lower
+   summand's member and join to its upper one, so the eight lattice equations hold
+   by case analysis with the component laws on the diagonal cases and definitional
+   reduction elsewhere; only the *congruence* of the operations interacts with the
+   glue, and there the extremum laws (`x ∧ ⊤ ≈ x`, `⊥ ∨ x ≈ x`, and their mirrors)
+   discharge every case.
+
+The first consumer is the FLRP closure toolkit ([FLRP.Closure][], work package
+WP-5), which represents the ordinal sum as a congruence lattice whenever its
+summands are so representable (roadmap § 3).
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Lattice.OrdinalSum where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Product          using ( _,_ ; _×_ ; proj₁ ; proj₂ )
+open import Data.Sum.Base         using ( _⊎_ ; inj₁ ; inj₂ )
+open import Level                 using ( Level ; _⊔_ )
+open import Relation.Binary       using ( Setoid )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Properties.Lattice  using ( module Lattice-Order ; TopOf ; BotOf )
+open import Classical.Structures.Lattice  using ( Lattice ; module Lattice-Op
+                                                ; setoidEqsToLattice )
+open import Setoid.Algebras.Basic         using ( 𝕌[_] ; 𝔻[_] )
+
+private variable α ρ β σ : Level
+```
+-->
+
+#### The amalgam of two pointed setoids
+
+`GlueSetoid`{.AgdaModule} `𝐴 a₀ 𝐵 b₀` is the disjoint union of the carriers with
+`inj₁ a₀` and `inj₂ b₀` identified.  The equivalence is stated through the two
+retractions: `retractˡ`{.AgdaFunction} keeps the left summand and collapses the
+right to `a₀`, and `retractʳ`{.AgdaFunction} mirrors it; two elements are glued
+equal exactly when both retractions agree.  On `inj₁`/`inj₁` pairs the right
+retraction is constantly `b₀`, so the condition is the left equivalence (dually on
+`inj₂`/`inj₂`), and on mixed pairs it says precisely "left component at `a₀`, right
+component at `b₀`" — the glue and nothing else.
+
+```agda
+module GlueSetoid (𝐴 : Setoid α ρ) (a₀ : Setoid.Carrier 𝐴)
+                  (𝐵 : Setoid β σ) (b₀ : Setoid.Carrier 𝐵) where
+  private
+    A = Setoid.Carrier 𝐴
+    B = Setoid.Carrier 𝐵
+
+  open Setoid 𝐴 using () renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝐵 using () renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
+
+  -- Keep the left summand; collapse the right to the left basepoint.
+  retractˡ : A ⊎ B → A
+  retractˡ (inj₁ x) = x
+  retractˡ (inj₂ _) = a₀
+
+  -- Keep the right summand; collapse the left to the right basepoint.
+  retractʳ : A ⊎ B → B
+  retractʳ (inj₁ _) = b₀
+  retractʳ (inj₂ y) = y
+
+  -- Glued equality: both retractions agree.
+  _≈ᵍ_ : A ⊎ B → A ⊎ B → Type (ρ ⊔ σ)
+  x ≈ᵍ y = (retractˡ x ≈₁ retractˡ y) × (retractʳ x ≈₂ retractʳ y)
+  infix 4 _≈ᵍ_
+
+  -- The amalgam setoid: A ⊎ B with the basepoints identified.
+  glueSetoid : Setoid (α ⊔ β) (ρ ⊔ σ)
+  glueSetoid = record
+    { Carrier        = A ⊎ B
+    ; _≈_            = _≈ᵍ_
+    ; isEquivalence  = record
+        { refl   = refl₁ , refl₂
+        ; sym    = λ e → sym₁ (proj₁ e) , sym₂ (proj₂ e)
+        ; trans  = λ d e → trans₁ (proj₁ d) (proj₁ e) , trans₂ (proj₂ d) (proj₂ e)
+        }
+    }
+
+  -- The glue itself: the two basepoints are identified.
+  glue-≈ : (inj₁ a₀) ≈ᵍ (inj₂ b₀)
+  glue-≈ = refl₁ , refl₂
+
+  -- Injections are ≈-embeddings: the intro forms supply the constant component.
+  ≈ᵍ-inj₁ : {x y : A} → x ≈₁ y → (inj₁ x) ≈ᵍ (inj₁ y)
+  ≈ᵍ-inj₁ e = e , refl₂
+
+  ≈ᵍ-inj₂ : {x y : B} → x ≈₂ y → (inj₂ x) ≈ᵍ (inj₂ y)
+  ≈ᵍ-inj₂ e = refl₁ , e
+```
+
+The elimination forms are the two projections: `proj₁` of an `inj₁`/`inj₁`
+equation is the left equivalence, `proj₂` of an `inj₂`/`inj₂` equation the right
+one, and on a mixed pair the two projections are exactly the basepoint conditions.
+
+#### The ordinal-sum construction
+
+`LatticeOrdinalSum`{.AgdaModule} packages the development for fixed summands and
+extremum choices; opening it provides the glued carrier, the operations with
+their congruences and equations, the sum lattice, and the characterization of its
+order.
+
+```agda
+module LatticeOrdinalSum (𝑳₁ : Lattice α ρ) (t : TopOf 𝑳₁)
+                         (𝑳₂ : Lattice β σ) (b : BotOf 𝑳₂) where
+  private
+    𝑨   = proj₁ 𝑳₁
+    𝑩   = proj₁ 𝑳₂
+    ⊤₁  = proj₁ t
+    ⊥₂  = proj₁ b
+
+  open Setoid 𝔻[ 𝑨 ] using () renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝔻[ 𝑩 ] using () renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
+
+  open Lattice-Op 𝑳₁ using ()
+    renaming ( _∧_ to _∧₁_ ; _∨_ to _∨₁_ ; ∧-cong to ∧₁-cong ; ∨-cong to ∨₁-cong
+             ; ∧-assoc-law to ∧₁-assoc ; ∧-comm-law to ∧₁-comm ; ∧-idem-law to ∧₁-idem
+             ; ∨-assoc-law to ∨₁-assoc ; ∨-comm-law to ∨₁-comm ; ∨-idem-law to ∨₁-idem
+             ; absorbˡ-law to absorbˡ₁ ; absorbʳ-law to absorbʳ₁ )
+  open Lattice-Op 𝑳₂ using ()
+    renaming ( _∧_ to _∧₂_ ; _∨_ to _∨₂_ ; ∧-cong to ∧₂-cong ; ∨-cong to ∨₂-cong
+             ; ∧-assoc-law to ∧₂-assoc ; ∧-comm-law to ∧₂-comm ; ∧-idem-law to ∧₂-idem
+             ; ∨-assoc-law to ∨₂-assoc ; ∨-comm-law to ∨₂-comm ; ∨-idem-law to ∨₂-idem
+             ; absorbˡ-law to absorbˡ₂ ; absorbʳ-law to absorbʳ₂ )
+
+  open Lattice-Order 𝑳₁ using () renaming ( _≤_ to _≤₁_ ; ≤-via-∨ to ≤-via-∨₁ )
+  open Lattice-Order 𝑳₂ using () renaming ( _≤_ to _≤₂_ ; ≤-via-∨ to ≤-via-∨₂ )
+```
+
+The absorption behaviour of the chosen extrema, in the eight one-sided forms the
+case analyses below consume.  Note that `x ≤₁ ⊤₁` *is* `x ∧₁ ⊤₁ ≈₁ x` and
+`⊥₂ ≤₂ x` *is* `⊥₂ ∧₂ x ≈₂ ⊥₂`, definitionally, so half of these are the
+universal properties themselves.
+
+```agda
+  private
+    x∧⊤ : ∀ x → (x ∧₁ ⊤₁) ≈₁ x
+    x∧⊤ x = proj₂ t x
+
+    ⊤∧x : ∀ x → (⊤₁ ∧₁ x) ≈₁ x
+    ⊤∧x x = trans₁ (∧₁-comm ⊤₁ x) (x∧⊤ x)
+
+    x∨⊤ : ∀ x → (x ∨₁ ⊤₁) ≈₁ ⊤₁
+    x∨⊤ x = ≤-via-∨₁ (proj₂ t x)
+
+    ⊤∨x : ∀ x → (⊤₁ ∨₁ x) ≈₁ ⊤₁
+    ⊤∨x x = trans₁ (∨₁-comm ⊤₁ x) (x∨⊤ x)
+
+    ⊥∧x : ∀ x → (⊥₂ ∧₂ x) ≈₂ ⊥₂
+    ⊥∧x x = proj₂ b x
+
+    x∧⊥ : ∀ x → (x ∧₂ ⊥₂) ≈₂ ⊥₂
+    x∧⊥ x = trans₂ (∧₂-comm x ⊥₂) (⊥∧x x)
+
+    ⊥∨x : ∀ x → (⊥₂ ∨₂ x) ≈₂ x
+    ⊥∨x x = ≤-via-∨₂ (proj₂ b x)
+
+    x∨⊥ : ∀ x → (x ∨₂ ⊥₂) ≈₂ x
+    x∨⊥ x = trans₂ (∨₂-comm x ⊥₂) (⊥∨x x)
+```
+
+The glued carrier, at the two chosen extrema.
+
+```agda
+  open GlueSetoid 𝔻[ 𝑨 ] ⊤₁ 𝔻[ 𝑩 ] ⊥₂ public
+
+  private
+    A⊎B : Type (α ⊔ β)
+    A⊎B = 𝕌[ 𝑨 ] ⊎ 𝕌[ 𝑩 ]
+```
+
+Meet and join.  A mixed meet lands in the lower summand and a mixed join in the
+upper one — the lower summand lies entirely below the upper.
+
+```agda
+  _∧ᵒ_ : A⊎B → A⊎B → A⊎B
+  inj₁ x ∧ᵒ inj₁ y = inj₁ (x ∧₁ y)
+  inj₁ x ∧ᵒ inj₂ y = inj₁ x
+  inj₂ x ∧ᵒ inj₁ y = inj₁ y
+  inj₂ x ∧ᵒ inj₂ y = inj₂ (x ∧₂ y)
+
+  _∨ᵒ_ : A⊎B → A⊎B → A⊎B
+  inj₁ x ∨ᵒ inj₁ y = inj₁ (x ∨₁ y)
+  inj₁ x ∨ᵒ inj₂ y = inj₂ y
+  inj₂ x ∨ᵒ inj₁ y = inj₂ x
+  inj₂ x ∨ᵒ inj₂ y = inj₂ (x ∨₂ y)
+
+  infixr 7 _∧ᵒ_
+  infixr 6 _∨ᵒ_
+```
+
+**Congruence.**  This is the one place the glue matters.  Each of the sixteen
+constructor combinations reduces to a pair of component goals; the diagonal
+combinations are the component congruences, and every combination that crosses the
+glue is discharged by the extremum-absorption lemmas above (an argument
+`≈ᵍ`-related across the glue pins its left component to `⊤₁` or its right one to
+`⊥₂`, and absorption then collapses the affected meet or join).
+
+```agda
+  ∧ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → (p ∧ᵒ u) ≈ᵍ (q ∧ᵒ v)
+  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
+    ∧₁-cong ea fa , refl₂
+  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , _) (fa , _) =
+    trans₁ (∧₁-cong ea fa) (x∧⊤ y) , refl₂
+  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , _) (fa , _) =
+    trans₁ ea (trans₁ (sym₁ (x∧⊤ y)) (∧₁-cong refl₁ fa)) , refl₂
+  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₂ v} (ea , _) _ =
+    ea , refl₂
+  ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
+    trans₁ (∧₁-cong ea fa) (⊤∧x v) , refl₂
+  ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
+    trans₁ (∧₁-cong ea fa) (∧₁-idem ⊤₁) , trans₂ (sym₂ (∧₂-idem ⊥₂)) (∧₂-cong eb fb)
+  ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₁ v} (ea , _) (fa , _) =
+    trans₁ ea fa , refl₂
+  ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₂ v} (ea , eb) _ =
+    ea , trans₂ (sym₂ (⊥∧x v)) (∧₂-cong eb refl₂)
+  ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
+    trans₁ fa (trans₁ (sym₁ (⊤∧x v)) (∧₁-cong ea refl₁)) , refl₂
+  ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , _) (fa , _) =
+    trans₁ fa ea , refl₂
+  ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
+    trans₁ (sym₁ (∧₁-idem ⊤₁)) (∧₁-cong ea fa) , trans₂ (∧₂-cong eb fb) (∧₂-idem ⊥₂)
+  ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₂ v} (ea , eb) _ =
+    ea , trans₂ (∧₂-cong eb refl₂) (⊥∧x u)
+  ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₁ v} _ (fa , _) =
+    fa , refl₂
+  ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₂ v} _ (fa , fb) =
+    fa , trans₂ (sym₂ (x∧⊥ y)) (∧₂-cong refl₂ fb)
+  ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₂ u} {inj₁ v} _ (fa , fb) =
+    fa , trans₂ (∧₂-cong refl₂ fb) (x∧⊥ x)
+  ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₂ u} {inj₂ v} (_ , eb) (_ , fb) =
+    refl₁ , ∧₂-cong eb fb
+
+  ∨ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → (p ∨ᵒ u) ≈ᵍ (q ∨ᵒ v)
+  ∨ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
+    ∨₁-cong ea fa , refl₂
+  ∨ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , _) (fa , fb) =
+    trans₁ (∨₁-cong refl₁ fa) (x∨⊤ x) , fb
+  ∨ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , _) (fa , fb) =
+    trans₁ (sym₁ (x∨⊤ y)) (∨₁-cong refl₁ fa) , fb
+  ∨ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₂ v} _ (_ , fb) =
+    refl₁ , fb
+  ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₁ v} (ea , eb) (fa , _) =
+    trans₁ (∨₁-cong ea refl₁) (⊤∨x u) , eb
+  ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
+    trans₁ (∨₁-cong ea fa) (∨₁-idem ⊤₁) , trans₂ (sym₂ (∨₂-idem ⊥₂)) (∨₂-cong eb fb)
+  ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
+    refl₁ , trans₂ fb eb
+  ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₂ v} (ea , eb) (_ , fb) =
+    refl₁ , trans₂ fb (trans₂ (sym₂ (⊥∨x v)) (∨₂-cong eb refl₂))
+  ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , eb) (fa , _) =
+    trans₁ (sym₁ (⊤∨x v)) (∨₁-cong ea refl₁) , eb
+  ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
+    refl₁ , trans₂ eb fb
+  ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
+    trans₁ (sym₁ (∨₁-idem ⊤₁)) (∨₁-cong ea fa) , trans₂ (∨₂-cong eb fb) (∨₂-idem ⊥₂)
+  ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₂ v} (ea , eb) (_ , fb) =
+    refl₁ , trans₂ (∨₂-cong eb refl₂) (trans₂ (⊥∨x u) fb)
+  ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₁ v} (_ , eb) _ =
+    refl₁ , eb
+  ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₂ v} (_ , eb) (_ , fb) =
+    refl₁ , trans₂ eb (trans₂ (sym₂ (x∨⊥ y)) (∨₂-cong refl₂ fb))
+  ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₂ u} {inj₁ v} (_ , eb) (_ , fb) =
+    refl₁ , trans₂ (∨₂-cong refl₂ fb) (trans₂ (x∨⊥ x) eb)
+  ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₂ u} {inj₂ v} (_ , eb) (_ , fb) =
+    refl₁ , ∨₂-cong eb fb
+```
+
+**The eight equations.**  The operations never cross the glue, so every mixed
+case reduces definitionally and is closed by reflexivity; the diagonal cases are
+the component laws, and the two absorption laws additionally consume one
+idempotency step in their `inj₂`-meets-`inj₁` (resp. mirrored) case.
+
+```agda
+  ∧ᵒ-assoc : ∀ p q r → ((p ∧ᵒ q) ∧ᵒ r) ≈ᵍ (p ∧ᵒ (q ∧ᵒ r))
+  ∧ᵒ-assoc (inj₁ x) (inj₁ y) (inj₁ z) = ∧₁-assoc x y z , refl₂
+  ∧ᵒ-assoc (inj₁ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
+  ∧ᵒ-assoc (inj₁ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
+  ∧ᵒ-assoc (inj₁ x) (inj₂ y) (inj₂ z) = refl₁ , refl₂
+  ∧ᵒ-assoc (inj₂ x) (inj₁ y) (inj₁ z) = refl₁ , refl₂
+  ∧ᵒ-assoc (inj₂ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
+  ∧ᵒ-assoc (inj₂ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
+  ∧ᵒ-assoc (inj₂ x) (inj₂ y) (inj₂ z) = refl₁ , ∧₂-assoc x y z
+
+  ∧ᵒ-comm : ∀ p q → (p ∧ᵒ q) ≈ᵍ (q ∧ᵒ p)
+  ∧ᵒ-comm (inj₁ x) (inj₁ y) = ∧₁-comm x y , refl₂
+  ∧ᵒ-comm (inj₁ x) (inj₂ y) = refl₁ , refl₂
+  ∧ᵒ-comm (inj₂ x) (inj₁ y) = refl₁ , refl₂
+  ∧ᵒ-comm (inj₂ x) (inj₂ y) = refl₁ , ∧₂-comm x y
+
+  ∧ᵒ-idem : ∀ p → (p ∧ᵒ p) ≈ᵍ p
+  ∧ᵒ-idem (inj₁ x) = ∧₁-idem x , refl₂
+  ∧ᵒ-idem (inj₂ x) = refl₁ , ∧₂-idem x
+
+  ∨ᵒ-assoc : ∀ p q r → ((p ∨ᵒ q) ∨ᵒ r) ≈ᵍ (p ∨ᵒ (q ∨ᵒ r))
+  ∨ᵒ-assoc (inj₁ x) (inj₁ y) (inj₁ z) = ∨₁-assoc x y z , refl₂
+  ∨ᵒ-assoc (inj₁ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
+  ∨ᵒ-assoc (inj₁ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
+  ∨ᵒ-assoc (inj₁ x) (inj₂ y) (inj₂ z) = refl₁ , refl₂
+  ∨ᵒ-assoc (inj₂ x) (inj₁ y) (inj₁ z) = refl₁ , refl₂
+  ∨ᵒ-assoc (inj₂ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
+  ∨ᵒ-assoc (inj₂ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
+  ∨ᵒ-assoc (inj₂ x) (inj₂ y) (inj₂ z) = refl₁ , ∨₂-assoc x y z
+
+  ∨ᵒ-comm : ∀ p q → (p ∨ᵒ q) ≈ᵍ (q ∨ᵒ p)
+  ∨ᵒ-comm (inj₁ x) (inj₁ y) = ∨₁-comm x y , refl₂
+  ∨ᵒ-comm (inj₁ x) (inj₂ y) = refl₁ , refl₂
+  ∨ᵒ-comm (inj₂ x) (inj₁ y) = refl₁ , refl₂
+  ∨ᵒ-comm (inj₂ x) (inj₂ y) = refl₁ , ∨₂-comm x y
+
+  ∨ᵒ-idem : ∀ p → (p ∨ᵒ p) ≈ᵍ p
+  ∨ᵒ-idem (inj₁ x) = ∨₁-idem x , refl₂
+  ∨ᵒ-idem (inj₂ x) = refl₁ , ∨₂-idem x
+
+  absorbˡᵒ : ∀ p q → (p ∧ᵒ (p ∨ᵒ q)) ≈ᵍ p
+  absorbˡᵒ (inj₁ x) (inj₁ y) = absorbˡ₁ x y , refl₂
+  absorbˡᵒ (inj₁ x) (inj₂ y) = refl₁ , refl₂
+  absorbˡᵒ (inj₂ x) (inj₁ y) = refl₁ , ∧₂-idem x
+  absorbˡᵒ (inj₂ x) (inj₂ y) = refl₁ , absorbˡ₂ x y
+
+  absorbʳᵒ : ∀ p q → ((p ∧ᵒ q) ∨ᵒ p) ≈ᵍ p
+  absorbʳᵒ (inj₁ x) (inj₁ y) = absorbʳ₁ x y , refl₂
+  absorbʳᵒ (inj₁ x) (inj₂ y) = ∨₁-idem x , refl₂
+  absorbʳᵒ (inj₂ x) (inj₁ y) = refl₁ , refl₂
+  absorbʳᵒ (inj₂ x) (inj₂ y) = refl₁ , absorbʳ₂ x y
+```
+
+Assembling through the setoid-level builder yields the ordinal sum.  (The two
+congruence arguments are η-expanded with their implicits forwarded: the carrier
+`A ⊎ B` has no η-rule, so Agda cannot recover the endpoints of an under-applied
+congruence through the non-injective retractions.)
+
+```agda
+  ⊕-Lattice : Lattice (α ⊔ β) (ρ ⊔ σ)
+  ⊕-Lattice = setoidEqsToLattice glueSetoid _∧ᵒ_ _∨ᵒ_
+    (λ {p} {q} {u} {v} → ∧ᵒ-cong {p} {q} {u} {v})
+    (λ {p} {q} {u} {v} → ∨ᵒ-cong {p} {q} {u} {v})
+    ∧ᵒ-assoc ∧ᵒ-comm ∧ᵒ-idem ∨ᵒ-assoc ∨ᵒ-comm ∨ᵒ-idem absorbˡᵒ absorbʳᵒ
+```
+
+#### The sum order, characterized
+
+The meet order of the sum unfolds definitionally on each constructor
+combination: within a summand it is that summand's order, everything low is below
+everything high, and the only way an upper element sits below a lower one is at
+the glue.  The four lemmas name these unfoldings for consumers.
+
+```agda
+  open Lattice-Order ⊕-Lattice using () renaming ( _≤_ to _≤ᵒ_ )
+
+  -- Within the lower summand, the sum order is the lower order.
+  ≤ᵒ-inj₁ : {x y : 𝕌[ 𝑨 ]} → x ≤₁ y → (inj₁ x) ≤ᵒ (inj₁ y)
+  ≤ᵒ-inj₁ e = e , refl₂
+
+  ≤ᵒ-inj₁-elim : {x y : 𝕌[ 𝑨 ]} → (inj₁ x) ≤ᵒ (inj₁ y) → x ≤₁ y
+  ≤ᵒ-inj₁-elim = proj₁
+
+  -- Within the upper summand, the sum order is the upper order.
+  ≤ᵒ-inj₂ : {x y : 𝕌[ 𝑩 ]} → x ≤₂ y → (inj₂ x) ≤ᵒ (inj₂ y)
+  ≤ᵒ-inj₂ e = refl₁ , e
+
+  ≤ᵒ-inj₂-elim : {x y : 𝕌[ 𝑩 ]} → (inj₂ x) ≤ᵒ (inj₂ y) → x ≤₂ y
+  ≤ᵒ-inj₂-elim = proj₂
+
+  -- Everything in the lower summand is below everything in the upper one.
+  ≤ᵒ-up : (x : 𝕌[ 𝑨 ]) (y : 𝕌[ 𝑩 ]) → (inj₁ x) ≤ᵒ (inj₂ y)
+  ≤ᵒ-up x y = refl₁ , refl₂
+
+  -- An upper element below a lower one forces both to the glue.
+  ≤ᵒ-down-elim : {x : 𝕌[ 𝑩 ]} {y : 𝕌[ 𝑨 ]}
+    → (inj₂ x) ≤ᵒ (inj₁ y) → (y ≈₁ ⊤₁) × (x ≈₂ ⊥₂)
+  ≤ᵒ-down-elim (p , q) = p , sym₂ q
+```
+
+#### The sum operator
+
+The standalone operator, for consumers that need only the lattice.
+
+```agda
+ordinalSum : (𝑳₁ : Lattice α ρ) → TopOf 𝑳₁ → (𝑳₂ : Lattice β σ) → BotOf 𝑳₂
+  → Lattice (α ⊔ β) (ρ ⊔ σ)
+ordinalSum 𝑳₁ t 𝑳₂ b = LatticeOrdinalSum.⊕-Lattice 𝑳₁ t 𝑳₂ b
+```
+
+--------------------------------------

--- a/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
+++ b/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
@@ -10,28 +10,32 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Lattice.OrdinalSum][] module of the [Agda Universal Algebra Library][].
 
-The **adjoined ordinal sum** of lattices `𝑳₁`{.AgdaBound} and `𝑳₂`{.AgdaBound}
-stacks `𝑳₂`{.AgdaBound} on top of `𝑳₁`{.AgdaBound} and *glues* the top of
-`𝑳₁`{.AgdaBound} to the bottom of `𝑳₂`{.AgdaBound}: every element of the lower
-summand lies below every element of the upper one, and the two chosen extrema
-become a single element.  This is the operation `L ⊕ₐ M` of the small-lattice
-representations manuscript (`docs/papers/fin-lat-rep/SmallLatticeReps.tex`,
-§ Ordinal Sums); the *unglued* ordinal sum, in which the top of the lower summand
-is covered by the bottom of the upper, is the derived composite
-`(𝑳₁ ⊕ₐ chain₂) ⊕ₐ 𝑳₂` — gluing a two-element chain in the middle leaves exactly
-one covering edge — so the glued form is the module's single canonical primitive.
+The **adjoined ordinal sum** of lattices `𝑳₁`{.AgdaBound} and `𝑳₂`{.AgdaBound} stacks
+`𝑳₂`{.AgdaBound} on top of `𝑳₁`{.AgdaBound} and *glues* the top of `𝑳₁`{.AgdaBound}
+to the bottom of `𝑳₂`{.AgdaBound}: every element of the lower summand lies below
+every element of the upper one, and the two chosen extrema become a single element.
 
-Because the sum glues at *chosen* extrema, the construction takes them as data:
-a `TopOf 𝑳₁`{.AgdaFunction} and a `BotOf 𝑳₂`{.AgdaFunction}
-([Classical.Properties.Lattice][]).  General lattices need not have extrema, and
-threading the choice keeps the construction total and the resulting carrier
-syntactically predictable (the corollaries that adjoin a fresh extremum to a
-lattice instantiate a summand at `chain₂` and its concrete `0`/`1`).
+This is the operation `L ⊕ₐ M` of the small-lattice representations manuscript
+(`docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Ordinal Sums); the *unglued*
+ordinal sum, in which the top of the lower summand is covered by the bottom of the
+upper, is the derived composite `(𝑳₁ ⊕ₐ chain₂) ⊕ₐ 𝑳₂`, gluing a two-element chain
+in the middle leaves exactly one covering edge, so the glued form is the module's
+single canonical primitive.
 
-Two design points:
+Because the sum glues at chosen extrema, the construction takes them as data: a
+`TopOf 𝑳₁`{.AgdaFunction} and a `BotOf 𝑳₂`{.AgdaFunction}
+([Classical.Properties.Lattice][]).
 
-+  **Gluing is by setoid equality, not element removal.**  The carrier is the
-   disjoint union `A ⊎ B` with the equivalence coarsened so that
+General lattices need not have extrema, and threading the choice keeps the
+construction total and the resulting carrier syntactically predictable (the
+corollaries that adjoin a fresh extremum to a lattice instantiate a summand at
+`chain₂` and its concrete `0`/`1`).
+
+**Remarks on the design**.
+
++  **Gluing is by setoid equality, not element removal**.
+
+   The carrier is the disjoint union `A ⊎ B` with the equivalence coarsened so that
    `inj₁ ⊤₁ ≈ inj₂ ⊥₂`; removing a point would require deciding equality with it,
    whereas coarsening is constructive and level-polymorphic.  The amalgam setoid is
    isolated in `GlueSetoid`{.AgdaModule} (the Cubical-port equality locus), defined
@@ -40,16 +44,17 @@ Two design points:
    the basepoint.  This pullback presentation makes reflexivity, symmetry, and
    transitivity componentwise — no case analysis — and on each summand it restricts
    to the original equivalence, while across summands it holds exactly at the glue.
-+  **The operations never cross the glue.**  Meet sends a mixed pair to its lower
-   summand's member and join to its upper one, so the eight lattice equations hold
-   by case analysis with the component laws on the diagonal cases and definitional
-   reduction elsewhere; only the *congruence* of the operations interacts with the
-   glue, and there the extremum laws (`x ∧ ⊤ ≈ x`, `⊥ ∨ x ≈ x`, and their mirrors)
-   discharge every case.
 
-The first consumer is the FLRP closure toolkit ([FLRP.Closure][], work package
-WP-5), which represents the ordinal sum as a congruence lattice whenever its
-summands are so representable (roadmap § 3).
++  **The operations never cross the glue**.
+
+   Meet sends a mixed pair to its lower summand's member and join to its upper one,
+   so the eight lattice equations hold by case analysis with the component laws on
+   the diagonal cases and definitional reduction elsewhere; only the *congruence* of
+   the operations interacts with the glue, and there the extremum laws (`x ∧ ⊤ ≈ x`,
+   `⊥ ∨ x ≈ x`, and their mirrors) discharge every case.
+
+The first consumer is the FLRP closure toolkit ([FLRP.Closure][]), which represents
+the ordinal sum as a congruence lattice whenever its summands are so representable.[^1]
 
 <!--
 ```agda
@@ -79,12 +84,13 @@ private variable α ρ β σ : Level
 
 `GlueSetoid`{.AgdaModule} `𝐴 a₀ 𝐵 b₀` is the disjoint union of the carriers with
 `inj₁ a₀` and `inj₂ b₀` identified.  The equivalence is stated through the two
-retractions: `retractˡ`{.AgdaFunction} keeps the left summand and collapses the
-right to `a₀`, and `retractʳ`{.AgdaFunction} mirrors it; two elements are glued
-equal exactly when both retractions agree.  On `inj₁`/`inj₁` pairs the right
-retraction is constantly `b₀`, so the condition is the left equivalence (dually on
-`inj₂`/`inj₂`), and on mixed pairs it says precisely "left component at `a₀`, right
-component at `b₀`" — the glue and nothing else.
+retractions: `retractˡ`{.AgdaFunction} keeps the left summand and collapses the right
+to `a₀`, and `retractʳ`{.AgdaFunction} mirrors it; two elements are glued equal
+exactly when both retractions agree.
+
+On `inj₁`/`inj₁` pairs the right retraction is constantly `b₀`, so the condition is
+the left equivalence (dually on `inj₂`/`inj₂`), and on mixed pairs it says precisely
+"left component at `a₀`, right component at `b₀`" — the glue and nothing else.
 
 ```agda
 module GlueSetoid (𝐴 : Setoid α ρ) (a₀ : Setoid.Carrier 𝐴)
@@ -184,25 +190,25 @@ universal properties themselves.
     x∧⊤ x = proj₂ t x
 
     ⊤∧x : ∀ x → (⊤₁ ∧₁ x) ≈₁ x
-    ⊤∧x x = trans₁ (∧₁-comm ⊤₁ x) (x∧⊤ x)
+    ⊤∧x x = trans₁ ∧₁-comm (x∧⊤ x)
 
     x∨⊤ : ∀ x → (x ∨₁ ⊤₁) ≈₁ ⊤₁
     x∨⊤ x = ≤-via-∨₁ (proj₂ t x)
 
     ⊤∨x : ∀ x → (⊤₁ ∨₁ x) ≈₁ ⊤₁
-    ⊤∨x x = trans₁ (∨₁-comm ⊤₁ x) (x∨⊤ x)
+    ⊤∨x x = trans₁ ∨₁-comm (x∨⊤ x)
 
     ⊥∧x : ∀ x → (⊥₂ ∧₂ x) ≈₂ ⊥₂
     ⊥∧x x = proj₂ b x
 
     x∧⊥ : ∀ x → (x ∧₂ ⊥₂) ≈₂ ⊥₂
-    x∧⊥ x = trans₂ (∧₂-comm x ⊥₂) (⊥∧x x)
+    x∧⊥ x = trans₂ ∧₂-comm (⊥∧x x)
 
     ⊥∨x : ∀ x → (⊥₂ ∨₂ x) ≈₂ x
     ⊥∨x x = ≤-via-∨₂ (proj₂ b x)
 
     x∨⊥ : ∀ x → (x ∨₂ ⊥₂) ≈₂ x
-    x∨⊥ x = trans₂ (∨₂-comm x ⊥₂) (⊥∨x x)
+    x∨⊥ x = trans₂ ∨₂-comm (⊥∨x x)
 ```
 
 The glued carrier, at the two chosen extrema.
@@ -235,7 +241,7 @@ upper one — the lower summand lies entirely below the upper.
   infixr 6 _∨ᵒ_
 ```
 
-**Congruence.**  This is the one place the glue matters.  Each of the sixteen
+**Congruence**.  This is the one place the glue matters.  Each of the sixteen
 constructor combinations reduces to a pair of component goals; the diagonal
 combinations are the component congruences, and every combination that crosses the
 glue is discharged by the extremum-absorption lemmas above (an argument
@@ -243,9 +249,8 @@ glue is discharged by the extremum-absorption lemmas above (an argument
 `⊥₂`, and absorption then collapses the affected meet or join).
 
 ```agda
-  ∧ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → (p ∧ᵒ u) ≈ᵍ (q ∧ᵒ v)
-  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
-    ∧₁-cong ea fa , refl₂
+  ∧ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → p ∧ᵒ u ≈ᵍ q ∧ᵒ v
+  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) = ∧₁-cong ea fa , refl₂
   ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , _) (fa , _) =
     trans₁ (∧₁-cong ea fa) (x∧⊤ y) , refl₂
   ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , _) (fa , _) =
@@ -255,7 +260,7 @@ glue is discharged by the extremum-absorption lemmas above (an argument
   ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
     trans₁ (∧₁-cong ea fa) (⊤∧x v) , refl₂
   ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
-    trans₁ (∧₁-cong ea fa) (∧₁-idem ⊤₁) , trans₂ (sym₂ (∧₂-idem ⊥₂)) (∧₂-cong eb fb)
+    trans₁ (∧₁-cong ea fa) ∧₁-idem , trans₂ (sym₂ ∧₂-idem) (∧₂-cong eb fb)
   ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₁ v} (ea , _) (fa , _) =
     trans₁ ea fa , refl₂
   ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₂ v} (ea , eb) _ =
@@ -265,7 +270,7 @@ glue is discharged by the extremum-absorption lemmas above (an argument
   ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , _) (fa , _) =
     trans₁ fa ea , refl₂
   ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
-    trans₁ (sym₁ (∧₁-idem ⊤₁)) (∧₁-cong ea fa) , trans₂ (∧₂-cong eb fb) (∧₂-idem ⊥₂)
+    trans₁ (sym₁ ∧₁-idem) (∧₁-cong ea fa) , trans₂ (∧₂-cong eb fb) ∧₂-idem
   ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₂ v} (ea , eb) _ =
     ea , trans₂ (∧₂-cong eb refl₂) (⊥∧x u)
   ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₁ v} _ (fa , _) =
@@ -289,7 +294,7 @@ glue is discharged by the extremum-absorption lemmas above (an argument
   ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₁ v} (ea , eb) (fa , _) =
     trans₁ (∨₁-cong ea refl₁) (⊤∨x u) , eb
   ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
-    trans₁ (∨₁-cong ea fa) (∨₁-idem ⊤₁) , trans₂ (sym₂ (∨₂-idem ⊥₂)) (∨₂-cong eb fb)
+    trans₁ (∨₁-cong ea fa) ∨₁-idem , trans₂ (sym₂ ∨₂-idem) (∨₂-cong eb fb)
   ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
     refl₁ , trans₂ fb eb
   ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₂ v} (ea , eb) (_ , fb) =
@@ -299,7 +304,7 @@ glue is discharged by the extremum-absorption lemmas above (an argument
   ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
     refl₁ , trans₂ eb fb
   ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
-    trans₁ (sym₁ (∨₁-idem ⊤₁)) (∨₁-cong ea fa) , trans₂ (∨₂-cong eb fb) (∨₂-idem ⊥₂)
+    trans₁ (sym₁ ∨₁-idem) (∨₁-cong ea fa) , trans₂ (∨₂-cong eb fb) ∨₂-idem
   ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₂ v} (ea , eb) (_ , fb) =
     refl₁ , trans₂ (∨₂-cong eb refl₂) (trans₂ (⊥∨x u) fb)
   ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₁ v} (_ , eb) _ =
@@ -319,56 +324,56 @@ idempotency step in their `inj₂`-meets-`inj₁` (resp. mirrored) case.
 
 ```agda
   ∧ᵒ-assoc : ∀ p q r → ((p ∧ᵒ q) ∧ᵒ r) ≈ᵍ (p ∧ᵒ (q ∧ᵒ r))
-  ∧ᵒ-assoc (inj₁ x) (inj₁ y) (inj₁ z) = ∧₁-assoc x y z , refl₂
+  ∧ᵒ-assoc (inj₁ x) (inj₁ y) (inj₁ z) = ∧₁-assoc , refl₂
   ∧ᵒ-assoc (inj₁ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
   ∧ᵒ-assoc (inj₁ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
   ∧ᵒ-assoc (inj₁ x) (inj₂ y) (inj₂ z) = refl₁ , refl₂
   ∧ᵒ-assoc (inj₂ x) (inj₁ y) (inj₁ z) = refl₁ , refl₂
   ∧ᵒ-assoc (inj₂ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
   ∧ᵒ-assoc (inj₂ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
-  ∧ᵒ-assoc (inj₂ x) (inj₂ y) (inj₂ z) = refl₁ , ∧₂-assoc x y z
+  ∧ᵒ-assoc (inj₂ x) (inj₂ y) (inj₂ z) = refl₁ , ∧₂-assoc
 
   ∧ᵒ-comm : ∀ p q → (p ∧ᵒ q) ≈ᵍ (q ∧ᵒ p)
-  ∧ᵒ-comm (inj₁ x) (inj₁ y) = ∧₁-comm x y , refl₂
+  ∧ᵒ-comm (inj₁ x) (inj₁ y) = ∧₁-comm , refl₂
   ∧ᵒ-comm (inj₁ x) (inj₂ y) = refl₁ , refl₂
   ∧ᵒ-comm (inj₂ x) (inj₁ y) = refl₁ , refl₂
-  ∧ᵒ-comm (inj₂ x) (inj₂ y) = refl₁ , ∧₂-comm x y
+  ∧ᵒ-comm (inj₂ x) (inj₂ y) = refl₁ , ∧₂-comm
 
   ∧ᵒ-idem : ∀ p → (p ∧ᵒ p) ≈ᵍ p
-  ∧ᵒ-idem (inj₁ x) = ∧₁-idem x , refl₂
-  ∧ᵒ-idem (inj₂ x) = refl₁ , ∧₂-idem x
+  ∧ᵒ-idem (inj₁ x) = ∧₁-idem , refl₂
+  ∧ᵒ-idem (inj₂ x) = refl₁ , ∧₂-idem
 
   ∨ᵒ-assoc : ∀ p q r → ((p ∨ᵒ q) ∨ᵒ r) ≈ᵍ (p ∨ᵒ (q ∨ᵒ r))
-  ∨ᵒ-assoc (inj₁ x) (inj₁ y) (inj₁ z) = ∨₁-assoc x y z , refl₂
+  ∨ᵒ-assoc (inj₁ x) (inj₁ y) (inj₁ z) = ∨₁-assoc , refl₂
   ∨ᵒ-assoc (inj₁ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
   ∨ᵒ-assoc (inj₁ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
   ∨ᵒ-assoc (inj₁ x) (inj₂ y) (inj₂ z) = refl₁ , refl₂
   ∨ᵒ-assoc (inj₂ x) (inj₁ y) (inj₁ z) = refl₁ , refl₂
   ∨ᵒ-assoc (inj₂ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
   ∨ᵒ-assoc (inj₂ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
-  ∨ᵒ-assoc (inj₂ x) (inj₂ y) (inj₂ z) = refl₁ , ∨₂-assoc x y z
+  ∨ᵒ-assoc (inj₂ x) (inj₂ y) (inj₂ z) = refl₁ , ∨₂-assoc
 
   ∨ᵒ-comm : ∀ p q → (p ∨ᵒ q) ≈ᵍ (q ∨ᵒ p)
-  ∨ᵒ-comm (inj₁ x) (inj₁ y) = ∨₁-comm x y , refl₂
+  ∨ᵒ-comm (inj₁ x) (inj₁ y) = ∨₁-comm , refl₂
   ∨ᵒ-comm (inj₁ x) (inj₂ y) = refl₁ , refl₂
   ∨ᵒ-comm (inj₂ x) (inj₁ y) = refl₁ , refl₂
-  ∨ᵒ-comm (inj₂ x) (inj₂ y) = refl₁ , ∨₂-comm x y
+  ∨ᵒ-comm (inj₂ x) (inj₂ y) = refl₁ , ∨₂-comm
 
   ∨ᵒ-idem : ∀ p → (p ∨ᵒ p) ≈ᵍ p
-  ∨ᵒ-idem (inj₁ x) = ∨₁-idem x , refl₂
-  ∨ᵒ-idem (inj₂ x) = refl₁ , ∨₂-idem x
+  ∨ᵒ-idem (inj₁ x) = ∨₁-idem , refl₂
+  ∨ᵒ-idem (inj₂ x) = refl₁ , ∨₂-idem
 
   absorbˡᵒ : ∀ p q → (p ∧ᵒ (p ∨ᵒ q)) ≈ᵍ p
-  absorbˡᵒ (inj₁ x) (inj₁ y) = absorbˡ₁ x y , refl₂
+  absorbˡᵒ (inj₁ x) (inj₁ y) = absorbˡ₁ , refl₂
   absorbˡᵒ (inj₁ x) (inj₂ y) = refl₁ , refl₂
-  absorbˡᵒ (inj₂ x) (inj₁ y) = refl₁ , ∧₂-idem x
-  absorbˡᵒ (inj₂ x) (inj₂ y) = refl₁ , absorbˡ₂ x y
+  absorbˡᵒ (inj₂ x) (inj₁ y) = refl₁ , ∧₂-idem
+  absorbˡᵒ (inj₂ x) (inj₂ y) = refl₁ , absorbˡ₂
 
   absorbʳᵒ : ∀ p q → ((p ∧ᵒ q) ∨ᵒ p) ≈ᵍ p
-  absorbʳᵒ (inj₁ x) (inj₁ y) = absorbʳ₁ x y , refl₂
-  absorbʳᵒ (inj₁ x) (inj₂ y) = ∨₁-idem x , refl₂
+  absorbʳᵒ (inj₁ x) (inj₁ y) = absorbʳ₁ , refl₂
+  absorbʳᵒ (inj₁ x) (inj₂ y) = ∨₁-idem , refl₂
   absorbʳᵒ (inj₂ x) (inj₁ y) = refl₁ , refl₂
-  absorbʳᵒ (inj₂ x) (inj₂ y) = refl₁ , absorbʳ₂ x y
+  absorbʳᵒ (inj₂ x) (inj₂ y) = refl₁ , absorbʳ₂
 ```
 
 Assembling through the setoid-level builder yields the ordinal sum.  (The two
@@ -434,3 +439,5 @@ ordinalSum 𝑳₁ t 𝑳₂ b = LatticeOrdinalSum.⊕-Lattice 𝑳₁ t 𝑳₂
 ```
 
 --------------------------------------
+
+[^1]: See Work Package 5 (WP-5) of [the roadmap](docs/notes/flrp-research-roadmap.md).

--- a/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
+++ b/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
@@ -16,20 +16,15 @@ to the bottom of `𝑳₂`{.AgdaBound}: every element of the lower summand lies 
 every element of the upper one, and the two chosen extrema become a single element.
 
 This is the operation `L ⊕ₐ M` of the small-lattice representations manuscript
-(`docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Ordinal Sums); the *unglued*
-ordinal sum, in which the top of the lower summand is covered by the bottom of the
-upper, is the derived composite `(𝑳₁ ⊕ₐ chain₂) ⊕ₐ 𝑳₂`, gluing a two-element chain
-in the middle leaves exactly one covering edge, so the glued form is the module's
-single canonical primitive.
+([docs/papers/fin-lat-rep/SmallLatticeReps.tex](docs/papers/fin-lat-rep/SmallLatticeReps.tex),
+§ Ordinal Sums); the *unglued* ordinal sum, in which the top of the lower summand is
+covered by the bottom of the upper, is the derived composite `(𝑳₁ ⊕ₐ chain₂) ⊕ₐ 𝑳₂`,
+gluing a two-element chain in the middle leaves exactly one covering edge, so the
+glued form is the module's single canonical primitive.
 
 Because the sum glues at chosen extrema, the construction takes them as data: a
 `TopOf 𝑳₁`{.AgdaFunction} and a `BotOf 𝑳₂`{.AgdaFunction}
-([Classical.Properties.Lattice][]).
-
-General lattices need not have extrema, and threading the choice keeps the
-construction total and the resulting carrier syntactically predictable (the
-corollaries that adjoin a fresh extremum to a lattice instantiate a summand at
-`chain₂` and its concrete `0`/`1`).
+([Classical.Properties.Lattice][]).[^1]
 
 **Remarks on the design**.
 
@@ -54,7 +49,7 @@ corollaries that adjoin a fresh extremum to a lattice instantiate a summand at
    `⊥ ∨ x ≈ x`, and their mirrors) discharge every case.
 
 The first consumer is the FLRP closure toolkit ([FLRP.Closure][]), which represents
-the ordinal sum as a congruence lattice whenever its summands are so representable.[^1]
+the ordinal sum as a congruence lattice whenever its summands are so representable.[^2]
 
 <!--
 ```agda
@@ -99,8 +94,8 @@ module GlueSetoid (𝐴 : Setoid α ρ) (a₀ : Setoid.Carrier 𝐴)
     A = Setoid.Carrier 𝐴
     B = Setoid.Carrier 𝐵
 
-  open Setoid 𝐴 using () renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
-  open Setoid 𝐵 using () renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
+  open Setoid 𝐴 renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝐵 renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
 
   -- Keep the left summand; collapse the right to the left basepoint.
   retractˡ : A ⊎ B → A
@@ -124,8 +119,8 @@ module GlueSetoid (𝐴 : Setoid α ρ) (a₀ : Setoid.Carrier 𝐴)
     ; _≈_            = _≈ᵍ_
     ; isEquivalence  = record
         { refl   = refl₁ , refl₂
-        ; sym    = λ e → sym₁ (proj₁ e) , sym₂ (proj₂ e)
-        ; trans  = λ d e → trans₁ (proj₁ d) (proj₁ e) , trans₂ (proj₂ d) (proj₂ e)
+        ; sym    = λ (e₁ , e₂) → sym₁ e₁ , sym₂ e₂
+        ; trans  = λ (d₁ , d₂) (e₁ , e₂) → trans₁ d₁ e₁ , trans₂ d₂ e₂
         }
     }
 
@@ -250,130 +245,119 @@ glue is discharged by the extremum-absorption lemmas above (an argument
 
 ```agda
   ∧ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → p ∧ᵒ u ≈ᵍ q ∧ᵒ v
-  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) = ∧₁-cong ea fa , refl₂
-  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , _) (fa , _) =
-    trans₁ (∧₁-cong ea fa) (x∧⊤ y) , refl₂
-  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , _) (fa , _) =
-    trans₁ ea (trans₁ (sym₁ (x∧⊤ y)) (∧₁-cong refl₁ fa)) , refl₂
-  ∧ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₂ v} (ea , _) _ =
-    ea , refl₂
-  ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
-    trans₁ (∧₁-cong ea fa) (⊤∧x v) , refl₂
-  ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
-    trans₁ (∧₁-cong ea fa) ∧₁-idem , trans₂ (sym₂ ∧₂-idem) (∧₂-cong eb fb)
-  ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₁ v} (ea , _) (fa , _) =
-    trans₁ ea fa , refl₂
-  ∧ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₂ v} (ea , eb) _ =
-    ea , trans₂ (sym₂ (⊥∧x v)) (∧₂-cong eb refl₂)
-  ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
-    trans₁ fa (trans₁ (sym₁ (⊤∧x v)) (∧₁-cong ea refl₁)) , refl₂
-  ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , _) (fa , _) =
-    trans₁ fa ea , refl₂
-  ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
-    trans₁ (sym₁ ∧₁-idem) (∧₁-cong ea fa) , trans₂ (∧₂-cong eb fb) ∧₂-idem
-  ∧ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₂ v} (ea , eb) _ =
-    ea , trans₂ (∧₂-cong eb refl₂) (⊥∧x u)
-  ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₁ v} _ (fa , _) =
-    fa , refl₂
-  ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₂ v} _ (fa , fb) =
-    fa , trans₂ (sym₂ (x∧⊥ y)) (∧₂-cong refl₂ fb)
-  ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₂ u} {inj₁ v} _ (fa , fb) =
-    fa , trans₂ (∧₂-cong refl₂ fb) (x∧⊥ x)
-  ∧ᵒ-cong {inj₂ x} {inj₂ y} {inj₂ u} {inj₂ v} (_ , eb) (_ , fb) =
-    refl₁ , ∧₂-cong eb fb
-
-  ∨ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → (p ∨ᵒ u) ≈ᵍ (q ∨ᵒ v)
-  ∨ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , _) (fa , _) =
-    ∨₁-cong ea fa , refl₂
-  ∨ᵒ-cong {inj₁ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , _) (fa , fb) =
-    trans₁ (∨₁-cong refl₁ fa) (x∨⊤ x) , fb
-  ∨ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , _) (fa , fb) =
-    trans₁ (sym₁ (x∨⊤ y)) (∨₁-cong refl₁ fa) , fb
-  ∨ᵒ-cong {inj₁ x} {inj₁ y} {inj₂ u} {inj₂ v} _ (_ , fb) =
-    refl₁ , fb
-  ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₁ v} (ea , eb) (fa , _) =
-    trans₁ (∨₁-cong ea refl₁) (⊤∨x u) , eb
-  ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
-    trans₁ (∨₁-cong ea fa) ∨₁-idem , trans₂ (sym₂ ∨₂-idem) (∨₂-cong eb fb)
-  ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
-    refl₁ , trans₂ fb eb
-  ∨ᵒ-cong {inj₁ x} {inj₂ y} {inj₂ u} {inj₂ v} (ea , eb) (_ , fb) =
-    refl₁ , trans₂ fb (trans₂ (sym₂ (⊥∨x v)) (∨₂-cong eb refl₂))
-  ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₁ v} (ea , eb) (fa , _) =
-    trans₁ (sym₁ (⊤∨x v)) (∨₁-cong ea refl₁) , eb
-  ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₁ u} {inj₂ v} (ea , eb) (fa , fb) =
-    refl₁ , trans₂ eb fb
-  ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₁ v} (ea , eb) (fa , fb) =
-    trans₁ (sym₁ ∨₁-idem) (∨₁-cong ea fa) , trans₂ (∨₂-cong eb fb) ∨₂-idem
-  ∨ᵒ-cong {inj₂ x} {inj₁ y} {inj₂ u} {inj₂ v} (ea , eb) (_ , fb) =
-    refl₁ , trans₂ (∨₂-cong eb refl₂) (trans₂ (⊥∨x u) fb)
-  ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₁ v} (_ , eb) _ =
-    refl₁ , eb
-  ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₁ u} {inj₂ v} (_ , eb) (_ , fb) =
-    refl₁ , trans₂ eb (trans₂ (sym₂ (x∨⊥ y)) (∨₂-cong refl₂ fb))
-  ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₂ u} {inj₁ v} (_ , eb) (_ , fb) =
-    refl₁ , trans₂ (∨₂-cong refl₂ fb) (trans₂ (x∨⊥ x) eb)
-  ∨ᵒ-cong {inj₂ x} {inj₂ y} {inj₂ u} {inj₂ v} (_ , eb) (_ , fb) =
-    refl₁ , ∨₂-cong eb fb
 ```
 
-**The eight equations.**  The operations never cross the glue, so every mixed
+<!--
+```agda
+  ∧ᵒ-cong {inj₁ _} {inj₁ _} {inj₁ _} {inj₁ _} (ea , _) (fa , _) = ∧₁-cong ea fa , refl₂
+  ∧ᵒ-cong {inj₂ _} {inj₂ _} {inj₂ _} {inj₂ _} (_ , eb) (_ , fb)  = refl₁ , ∧₂-cong eb fb
+
+  ∧ᵒ-cong {inj₁ _} {inj₁ y} {inj₁ _} {inj₂ _} (ea , _)  (fa , _)  = trans₁ (∧₁-cong ea fa) (x∧⊤ y) , refl₂
+  ∧ᵒ-cong {inj₁ _} {inj₁ y} {inj₂ _} {inj₁ _} (ea , _)  (fa , _)  = trans₁ ea (trans₁ (sym₁ (x∧⊤ y)) (∧₁-cong refl₁ fa)) , refl₂
+  ∧ᵒ-cong {inj₁ _} {inj₂ _} {inj₁ _} {inj₁ v} (ea , _)  (fa , _)  = trans₁ (∧₁-cong ea fa) (⊤∧x v) , refl₂
+  ∧ᵒ-cong {inj₂ _} {inj₁ _} {inj₁ _} {inj₁ v} (ea , _)  (fa , _)  = trans₁ fa (trans₁ (sym₁ (⊤∧x v)) (∧₁-cong ea refl₁)) , refl₂
+
+  ∧ᵒ-cong {inj₁ _} {inj₁ _} {inj₂ _} {inj₂ _} (ea , _)  _         = ea , refl₂
+  ∧ᵒ-cong {inj₂ _} {inj₂ _} {inj₁ _} {inj₁ _} _         (fa , _)  = fa , refl₂
+  ∧ᵒ-cong {inj₁ _} {inj₂ _} {inj₂ _} {inj₁ _} (ea , _)  (fa , _)  = trans₁ ea fa , refl₂
+  ∧ᵒ-cong {inj₂ _} {inj₁ _} {inj₁ _} {inj₂ _} (ea , _)  (fa , _)  = trans₁ fa ea , refl₂
+  ∧ᵒ-cong {inj₁ _} {inj₂ _} {inj₁ _} {inj₂ _} (ea , eb) (fa , fb) = trans₁ (∧₁-cong ea fa) ∧₁-idem , trans₂ (sym₂ ∧₂-idem) (∧₂-cong eb fb)
+  ∧ᵒ-cong {inj₂ _} {inj₁ _} {inj₂ _} {inj₁ _} (ea , eb) (fa , fb) = trans₁ (sym₁ ∧₁-idem) (∧₁-cong ea fa) , trans₂ (∧₂-cong eb fb) ∧₂-idem
+
+  ∧ᵒ-cong {inj₁ _} {inj₂ _} {inj₂ _} {inj₂ v} (ea , eb) _         = ea , trans₂ (sym₂ (⊥∧x v)) (∧₂-cong eb refl₂)
+  ∧ᵒ-cong {inj₂ _} {inj₁ _} {inj₂ u} {inj₂ _} (ea , eb) _         = ea , trans₂ (∧₂-cong eb refl₂) (⊥∧x u)
+  ∧ᵒ-cong {inj₂ _} {inj₂ y} {inj₁ _} {inj₂ _} _         (fa , fb) = fa , trans₂ (sym₂ (x∧⊥ y)) (∧₂-cong refl₂ fb)
+  ∧ᵒ-cong {inj₂ x} {inj₂ _} {inj₂ _} {inj₁ _} _         (fa , fb) = fa , trans₂ (∧₂-cong refl₂ fb) (x∧⊥ x)
+```
+-->
+
+```agda
+  ∨ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → p ∨ᵒ u ≈ᵍ q ∨ᵒ v
+```
+
+<!--
+```agda
+  ∨ᵒ-cong {inj₁ _} {inj₁ _} {inj₁ _} {inj₁ _} (ea , _)  (fa , _)  = ∨₁-cong ea fa , refl₂
+  ∨ᵒ-cong {inj₂ _} {inj₂ _} {inj₂ _} {inj₂ _} (_ , eb)  (_ , fb)  = refl₁ , ∨₂-cong eb fb
+
+  ∨ᵒ-cong {inj₁ x} {inj₁ _} {inj₁ _} {inj₂ _} (ea , _)  (fa , fb) = trans₁ (∨₁-cong refl₁ fa) (x∨⊤ x) , fb
+  ∨ᵒ-cong {inj₁ _} {inj₁ y} {inj₂ _} {inj₁ _} (ea , _)  (fa , fb) = trans₁ (sym₁ (x∨⊤ y)) (∨₁-cong refl₁ fa) , fb
+  ∨ᵒ-cong {inj₁ _} {inj₂ _} {inj₁ u} {inj₁ _} (ea , eb) (fa , _)  = trans₁ (∨₁-cong ea refl₁) (⊤∨x u) , eb
+  ∨ᵒ-cong {inj₂ _} {inj₁ _} {inj₁ _} {inj₁ v} (ea , eb) (fa , _)  = trans₁ (sym₁ (⊤∨x v)) (∨₁-cong ea refl₁) , eb
+
+  ∨ᵒ-cong {inj₁ _} {inj₁ _} {inj₂ _} {inj₂ _} _         (_ , fb)  = refl₁ , fb
+  ∨ᵒ-cong {inj₂ _} {inj₂ _} {inj₁ _} {inj₁ _} (_ , eb)  _         = refl₁ , eb
+  ∨ᵒ-cong {inj₁ _} {inj₂ _} {inj₂ _} {inj₁ _} (ea , eb) (fa , fb) = refl₁ , trans₂ fb eb
+  ∨ᵒ-cong {inj₂ _} {inj₁ _} {inj₁ _} {inj₂ _} (ea , eb) (fa , fb) = refl₁ , trans₂ eb fb
+  ∨ᵒ-cong {inj₁ _} {inj₂ _} {inj₁ _} {inj₂ _} (ea , eb) (fa , fb) = trans₁ (∨₁-cong ea fa) ∨₁-idem , trans₂ (sym₂ ∨₂-idem) (∨₂-cong eb fb)
+  ∨ᵒ-cong {inj₂ _} {inj₁ _} {inj₂ _} {inj₁ _} (ea , eb) (fa , fb) = trans₁ (sym₁ ∨₁-idem) (∨₁-cong ea fa) , trans₂ (∨₂-cong eb fb) ∨₂-idem
+
+  ∨ᵒ-cong {inj₁ _} {inj₂ _} {inj₂ _} {inj₂ v} (ea , eb) (_ , fb)  = refl₁ , trans₂ fb (trans₂ (sym₂ (⊥∨x v)) (∨₂-cong eb refl₂))
+  ∨ᵒ-cong {inj₂ _} {inj₁ _} {inj₂ u} {inj₂ _} (ea , eb) (_ , fb)  = refl₁ , trans₂ (∨₂-cong eb refl₂) (trans₂ (⊥∨x u) fb)
+  ∨ᵒ-cong {inj₂ _} {inj₂ y} {inj₁ _} {inj₂ _} (_ , eb)  (_ , fb)  = refl₁ , trans₂ eb (trans₂ (sym₂ (x∨⊥ y)) (∨₂-cong refl₂ fb))
+  ∨ᵒ-cong {inj₂ x} {inj₂ _} {inj₂ _} {inj₁ _} (_ , eb)  (_ , fb)  = refl₁ , trans₂ (∨₂-cong refl₂ fb) (trans₂ (x∨⊥ x) eb)
+```
+-->
+
+**The eight equations**.  The operations never cross the glue, so every mixed
 case reduces definitionally and is closed by reflexivity; the diagonal cases are
 the component laws, and the two absorption laws additionally consume one
 idempotency step in their `inj₂`-meets-`inj₁` (resp. mirrored) case.
 
 ```agda
-  ∧ᵒ-assoc : ∀ p q r → ((p ∧ᵒ q) ∧ᵒ r) ≈ᵍ (p ∧ᵒ (q ∧ᵒ r))
-  ∧ᵒ-assoc (inj₁ x) (inj₁ y) (inj₁ z) = ∧₁-assoc , refl₂
-  ∧ᵒ-assoc (inj₁ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
-  ∧ᵒ-assoc (inj₁ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
-  ∧ᵒ-assoc (inj₁ x) (inj₂ y) (inj₂ z) = refl₁ , refl₂
-  ∧ᵒ-assoc (inj₂ x) (inj₁ y) (inj₁ z) = refl₁ , refl₂
-  ∧ᵒ-assoc (inj₂ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
-  ∧ᵒ-assoc (inj₂ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
-  ∧ᵒ-assoc (inj₂ x) (inj₂ y) (inj₂ z) = refl₁ , ∧₂-assoc
+  ∧ᵒ-assoc : ∀ {p q r} → (p ∧ᵒ q) ∧ᵒ r ≈ᵍ p ∧ᵒ (q ∧ᵒ r)
+  ∧ᵒ-assoc {inj₁ _} {inj₁ _} {inj₁ _} = ∧₁-assoc , refl₂
+  ∧ᵒ-assoc {inj₂ _} {inj₂ _} {inj₂ _} = refl₁ , ∧₂-assoc
 
-  ∧ᵒ-comm : ∀ p q → (p ∧ᵒ q) ≈ᵍ (q ∧ᵒ p)
-  ∧ᵒ-comm (inj₁ x) (inj₁ y) = ∧₁-comm , refl₂
-  ∧ᵒ-comm (inj₁ x) (inj₂ y) = refl₁ , refl₂
-  ∧ᵒ-comm (inj₂ x) (inj₁ y) = refl₁ , refl₂
-  ∧ᵒ-comm (inj₂ x) (inj₂ y) = refl₁ , ∧₂-comm
+  ∧ᵒ-assoc {inj₁ _} {inj₁ _} {inj₂ _} = refl₁ , refl₂
+  ∧ᵒ-assoc {inj₁ _} {inj₂ _} {inj₁ _} = refl₁ , refl₂
+  ∧ᵒ-assoc {inj₂ _} {inj₁ _} {inj₁ _} = refl₁ , refl₂
+  ∧ᵒ-assoc {inj₁ _} {inj₂ _} {inj₂ _} = refl₁ , refl₂
+  ∧ᵒ-assoc {inj₂ _} {inj₁ _} {inj₂ _} = refl₁ , refl₂
+  ∧ᵒ-assoc {inj₂ _} {inj₂ _} {inj₁ _} = refl₁ , refl₂
 
-  ∧ᵒ-idem : ∀ p → (p ∧ᵒ p) ≈ᵍ p
-  ∧ᵒ-idem (inj₁ x) = ∧₁-idem , refl₂
-  ∧ᵒ-idem (inj₂ x) = refl₁ , ∧₂-idem
+  ∧ᵒ-comm : ∀ {p q} → p ∧ᵒ q ≈ᵍ q ∧ᵒ p
+  ∧ᵒ-comm {inj₁ _} {inj₁ _} = ∧₁-comm , refl₂
+  ∧ᵒ-comm {inj₁ _} {inj₂ _} = refl₁ , refl₂
+  ∧ᵒ-comm {inj₂ _} {inj₁ _} = refl₁ , refl₂
+  ∧ᵒ-comm {inj₂ _} {inj₂ _} = refl₁ , ∧₂-comm
 
-  ∨ᵒ-assoc : ∀ p q r → ((p ∨ᵒ q) ∨ᵒ r) ≈ᵍ (p ∨ᵒ (q ∨ᵒ r))
-  ∨ᵒ-assoc (inj₁ x) (inj₁ y) (inj₁ z) = ∨₁-assoc , refl₂
-  ∨ᵒ-assoc (inj₁ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
-  ∨ᵒ-assoc (inj₁ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
-  ∨ᵒ-assoc (inj₁ x) (inj₂ y) (inj₂ z) = refl₁ , refl₂
-  ∨ᵒ-assoc (inj₂ x) (inj₁ y) (inj₁ z) = refl₁ , refl₂
-  ∨ᵒ-assoc (inj₂ x) (inj₁ y) (inj₂ z) = refl₁ , refl₂
-  ∨ᵒ-assoc (inj₂ x) (inj₂ y) (inj₁ z) = refl₁ , refl₂
-  ∨ᵒ-assoc (inj₂ x) (inj₂ y) (inj₂ z) = refl₁ , ∨₂-assoc
+  ∧ᵒ-idem : ∀ {p} → p ∧ᵒ p ≈ᵍ p
+  ∧ᵒ-idem {inj₁ _} = ∧₁-idem , refl₂
+  ∧ᵒ-idem {inj₂ _} = refl₁ , ∧₂-idem
 
-  ∨ᵒ-comm : ∀ p q → (p ∨ᵒ q) ≈ᵍ (q ∨ᵒ p)
-  ∨ᵒ-comm (inj₁ x) (inj₁ y) = ∨₁-comm , refl₂
-  ∨ᵒ-comm (inj₁ x) (inj₂ y) = refl₁ , refl₂
-  ∨ᵒ-comm (inj₂ x) (inj₁ y) = refl₁ , refl₂
-  ∨ᵒ-comm (inj₂ x) (inj₂ y) = refl₁ , ∨₂-comm
+  ∨ᵒ-assoc : ∀ {p q r} → (p ∨ᵒ q) ∨ᵒ r ≈ᵍ p ∨ᵒ (q ∨ᵒ r)
+  ∨ᵒ-assoc {inj₁ _} {inj₁ _} {inj₁ _} = ∨₁-assoc , refl₂
+  ∨ᵒ-assoc {inj₂ _} {inj₂ _} {inj₂ _} = refl₁ , ∨₂-assoc
+  ∨ᵒ-assoc {inj₁ _} {inj₁ _} {inj₂ _} = refl₁ , refl₂
+  ∨ᵒ-assoc {inj₁ _} {inj₂ _} {inj₁ _} = refl₁ , refl₂
+  ∨ᵒ-assoc {inj₁ _} {inj₂ _} {inj₂ _} = refl₁ , refl₂
+  ∨ᵒ-assoc {inj₂ _} {inj₁ _} {inj₁ _} = refl₁ , refl₂
+  ∨ᵒ-assoc {inj₂ _} {inj₁ _} {inj₂ _} = refl₁ , refl₂
+  ∨ᵒ-assoc {inj₂ _} {inj₂ _} {inj₁ _} = refl₁ , refl₂
 
-  ∨ᵒ-idem : ∀ p → (p ∨ᵒ p) ≈ᵍ p
-  ∨ᵒ-idem (inj₁ x) = ∨₁-idem , refl₂
-  ∨ᵒ-idem (inj₂ x) = refl₁ , ∨₂-idem
+  ∨ᵒ-comm : ∀ {p q} → p ∨ᵒ q ≈ᵍ q ∨ᵒ p
+  ∨ᵒ-comm {inj₁ _} {inj₁ _} = ∨₁-comm , refl₂
+  ∨ᵒ-comm {inj₁ _} {inj₂ _} = refl₁ , refl₂
+  ∨ᵒ-comm {inj₂ _} {inj₁ _} = refl₁ , refl₂
+  ∨ᵒ-comm {inj₂ _} {inj₂ _} = refl₁ , ∨₂-comm
 
-  absorbˡᵒ : ∀ p q → (p ∧ᵒ (p ∨ᵒ q)) ≈ᵍ p
-  absorbˡᵒ (inj₁ x) (inj₁ y) = absorbˡ₁ , refl₂
-  absorbˡᵒ (inj₁ x) (inj₂ y) = refl₁ , refl₂
-  absorbˡᵒ (inj₂ x) (inj₁ y) = refl₁ , ∧₂-idem
-  absorbˡᵒ (inj₂ x) (inj₂ y) = refl₁ , absorbˡ₂
+  ∨ᵒ-idem : ∀ {p} → p ∨ᵒ p ≈ᵍ p
+  ∨ᵒ-idem {inj₁ _} = ∨₁-idem , refl₂
+  ∨ᵒ-idem {inj₂ _} = refl₁ , ∨₂-idem
 
-  absorbʳᵒ : ∀ p q → ((p ∧ᵒ q) ∨ᵒ p) ≈ᵍ p
-  absorbʳᵒ (inj₁ x) (inj₁ y) = absorbʳ₁ , refl₂
-  absorbʳᵒ (inj₁ x) (inj₂ y) = ∨₁-idem , refl₂
-  absorbʳᵒ (inj₂ x) (inj₁ y) = refl₁ , refl₂
-  absorbʳᵒ (inj₂ x) (inj₂ y) = refl₁ , absorbʳ₂
+  absorbˡᵒ : ∀ {p q} → p ∧ᵒ (p ∨ᵒ q) ≈ᵍ p
+  absorbˡᵒ {inj₁ _} {inj₁ _} = absorbˡ₁ , refl₂
+  absorbˡᵒ {inj₁ _} {inj₂ _} = refl₁ , refl₂
+  absorbˡᵒ {inj₂ _} {inj₁ _} = refl₁ , ∧₂-idem
+  absorbˡᵒ {inj₂ _} {inj₂ _} = refl₁ , absorbˡ₂
+
+  absorbʳᵒ : ∀ {p q} → (p ∧ᵒ q) ∨ᵒ p ≈ᵍ p
+  absorbʳᵒ {inj₁ _} {inj₁ _} = absorbʳ₁ , refl₂
+  absorbʳᵒ {inj₁ _} {inj₂ _} = ∨₁-idem , refl₂
+  absorbʳᵒ {inj₂ _} {inj₁ _} = refl₁ , refl₂
+  absorbʳᵒ {inj₂ _} {inj₂ _} = refl₁ , absorbʳ₂
+
 ```
 
 Assembling through the setoid-level builder yields the ordinal sum.  (The two
@@ -386,7 +370,14 @@ congruence through the non-injective retractions.)
   ⊕-Lattice = setoidEqsToLattice glueSetoid _∧ᵒ_ _∨ᵒ_
     (λ {p} {q} {u} {v} → ∧ᵒ-cong {p} {q} {u} {v})
     (λ {p} {q} {u} {v} → ∨ᵒ-cong {p} {q} {u} {v})
-    ∧ᵒ-assoc ∧ᵒ-comm ∧ᵒ-idem ∨ᵒ-assoc ∨ᵒ-comm ∨ᵒ-idem absorbˡᵒ absorbʳᵒ
+    (λ {p q u} → ∧ᵒ-assoc {p} {q} {u})
+    (λ {p q} → ∧ᵒ-comm {p} {q})
+    (λ {p} → ∧ᵒ-idem {p})
+    (λ {p q u} → ∨ᵒ-assoc {p} {q} {u})
+    (λ {p q} → ∨ᵒ-comm {p} {q})
+    (λ {p} → ∨ᵒ-idem {p})
+    (λ {p q} → absorbˡᵒ {p} {q})
+    (λ {p q} → absorbʳᵒ {p} {q})
 ```
 
 #### The sum order, characterized
@@ -400,31 +391,31 @@ the glue.  The four lemmas name these unfoldings for consumers.
   open Lattice-Order ⊕-Lattice using () renaming ( _≤_ to _≤ᵒ_ )
 
   -- Within the lower summand, the sum order is the lower order.
-  ≤ᵒ-inj₁ : {x y : 𝕌[ 𝑨 ]} → x ≤₁ y → (inj₁ x) ≤ᵒ (inj₁ y)
+  ≤ᵒ-inj₁ : {x y : 𝕌[ 𝑨 ]} → x ≤₁ y → inj₁ x ≤ᵒ inj₁ y
   ≤ᵒ-inj₁ e = e , refl₂
 
-  ≤ᵒ-inj₁-elim : {x y : 𝕌[ 𝑨 ]} → (inj₁ x) ≤ᵒ (inj₁ y) → x ≤₁ y
+  ≤ᵒ-inj₁-elim : {x y : 𝕌[ 𝑨 ]} → inj₁ x ≤ᵒ inj₁ y → x ≤₁ y
   ≤ᵒ-inj₁-elim = proj₁
 
   -- Within the upper summand, the sum order is the upper order.
-  ≤ᵒ-inj₂ : {x y : 𝕌[ 𝑩 ]} → x ≤₂ y → (inj₂ x) ≤ᵒ (inj₂ y)
+  ≤ᵒ-inj₂ : {x y : 𝕌[ 𝑩 ]} → x ≤₂ y → inj₂ x ≤ᵒ inj₂ y
   ≤ᵒ-inj₂ e = refl₁ , e
 
-  ≤ᵒ-inj₂-elim : {x y : 𝕌[ 𝑩 ]} → (inj₂ x) ≤ᵒ (inj₂ y) → x ≤₂ y
+  ≤ᵒ-inj₂-elim : {x y : 𝕌[ 𝑩 ]} → inj₂ x ≤ᵒ inj₂ y → x ≤₂ y
   ≤ᵒ-inj₂-elim = proj₂
 
   -- Everything in the lower summand is below everything in the upper one.
-  ≤ᵒ-up : (x : 𝕌[ 𝑨 ]) (y : 𝕌[ 𝑩 ]) → (inj₁ x) ≤ᵒ (inj₂ y)
-  ≤ᵒ-up x y = refl₁ , refl₂
+  ≤ᵒ-up : {x : 𝕌[ 𝑨 ]} {y : 𝕌[ 𝑩 ]} → inj₁ x ≤ᵒ inj₂ y
+  ≤ᵒ-up = refl₁ , refl₂
 
   -- An upper element below a lower one forces both to the glue ...
   ≤ᵒ-down-elim : {x : 𝕌[ 𝑩 ]} {y : 𝕌[ 𝑨 ]}
-    → (inj₂ x) ≤ᵒ (inj₁ y) → (y ≈₁ ⊤₁) × (x ≈₂ ⊥₂)
+    → inj₂ x ≤ᵒ (inj₁ y) → (y ≈₁ ⊤₁) × (x ≈₂ ⊥₂)
   ≤ᵒ-down-elim (p , q) = p , sym₂ q
 
   -- ... and, at the glue, it does sit below.
   ≤ᵒ-down : {x : 𝕌[ 𝑩 ]} {y : 𝕌[ 𝑨 ]}
-    → y ≈₁ ⊤₁ → x ≈₂ ⊥₂ → (inj₂ x) ≤ᵒ (inj₁ y)
+    → y ≈₁ ⊤₁ → x ≈₂ ⊥₂ → inj₂ x ≤ᵒ inj₁ y
   ≤ᵒ-down y≈⊤ x≈⊥ = y≈⊤ , sym₂ x≈⊥
 ```
 
@@ -440,4 +431,9 @@ ordinalSum 𝑳₁ t 𝑳₂ b = LatticeOrdinalSum.⊕-Lattice 𝑳₁ t 𝑳₂
 
 --------------------------------------
 
-[^1]: See Work Package 5 (WP-5) of [the roadmap](docs/notes/flrp-research-roadmap.md).
+[^1]: General lattices need not have extrema, and threading the choice keeps the
+      construction total and the resulting carrier syntactically predictable (the
+      corollaries that adjoin a fresh extremum to a lattice instantiate a summand at
+      `chain₂` and its concrete `0`/`1`).
+
+[^2]: See Work Package 5 (WP-5) of [the roadmap](docs/notes/flrp-research-roadmap.md).

--- a/src/Classical/Structures/Lattice/Product.lagda.md
+++ b/src/Classical/Structures/Lattice/Product.lagda.md
@@ -12,7 +12,8 @@ This is the [Classical.Structures.Lattice.Product][] module of the [Agda Univers
 
 Given lattices `𝑳₁`{.AgdaBound} and `𝑳₂`{.AgdaBound} over
 [`Sig-Lattice`][Classical.Signatures.Lattice], this module constructs their
-**binary direct product** `𝑳₁ ×ˡ 𝑳₂`{.AgdaFunction}: the lattice on the product
+**binary direct product** `𝑳₁`{.AgdaBound}` ×ˡ `{.AgdaFunction}`𝑳₂`{.AgdaBound}:
+the lattice on the product
 setoid whose meet and join act componentwise.  The construction mirrors the group
 case ([Classical.Structures.Group.Product][]) but is assembled through the
 setoid-level builder `setoidEqsToLattice`{.AgdaFunction} of
@@ -126,29 +127,29 @@ the pair of the component proofs, applied at the projections.
   ∨ₓ-cong : ∀ {p q u v} → p ≈ₓ q → u ≈ₓ v → (p ∨ₓ u) ≈ₓ (q ∨ₓ v)
   ∨ₓ-cong e f = ∨₁-cong (proj₁ e) (proj₁ f) , ∨₂-cong (proj₂ e) (proj₂ f)
 
-  ∧ₓ-assoc : ∀ p q r → ((p ∧ₓ q) ∧ₓ r) ≈ₓ (p ∧ₓ (q ∧ₓ r))
-  ∧ₓ-assoc p q r = ∧₁-assoc , ∧₂-assoc
+  ∧ₓ-assoc : ∀ {p q r} → ((p ∧ₓ q) ∧ₓ r) ≈ₓ (p ∧ₓ (q ∧ₓ r))
+  ∧ₓ-assoc = ∧₁-assoc , ∧₂-assoc
 
-  ∧ₓ-comm : ∀ p q → (p ∧ₓ q) ≈ₓ (q ∧ₓ p)
-  ∧ₓ-comm p q = ∧₁-comm , ∧₂-comm
+  ∧ₓ-comm : ∀ {p q} → (p ∧ₓ q) ≈ₓ (q ∧ₓ p)
+  ∧ₓ-comm = ∧₁-comm , ∧₂-comm
 
-  ∧ₓ-idem : ∀ p → (p ∧ₓ p) ≈ₓ p
-  ∧ₓ-idem p = ∧₁-idem , ∧₂-idem
+  ∧ₓ-idem : ∀ {p} → (p ∧ₓ p) ≈ₓ p
+  ∧ₓ-idem = ∧₁-idem , ∧₂-idem
 
-  ∨ₓ-assoc : ∀ p q r → ((p ∨ₓ q) ∨ₓ r) ≈ₓ (p ∨ₓ (q ∨ₓ r))
-  ∨ₓ-assoc p q r = ∨₁-assoc , ∨₂-assoc
+  ∨ₓ-assoc : ∀ {p q r} → ((p ∨ₓ q) ∨ₓ r) ≈ₓ (p ∨ₓ (q ∨ₓ r))
+  ∨ₓ-assoc = ∨₁-assoc , ∨₂-assoc
 
-  ∨ₓ-comm : ∀ p q → (p ∨ₓ q) ≈ₓ (q ∨ₓ p)
-  ∨ₓ-comm p q = ∨₁-comm , ∨₂-comm
+  ∨ₓ-comm : ∀ {p q} → (p ∨ₓ q) ≈ₓ (q ∨ₓ p)
+  ∨ₓ-comm = ∨₁-comm , ∨₂-comm
 
-  ∨ₓ-idem : ∀ p → (p ∨ₓ p) ≈ₓ p
-  ∨ₓ-idem p = ∨₁-idem , ∨₂-idem
+  ∨ₓ-idem : ∀ {p} → (p ∨ₓ p) ≈ₓ p
+  ∨ₓ-idem = ∨₁-idem , ∨₂-idem
 
-  absorbˡₓ : ∀ p q → (p ∧ₓ (p ∨ₓ q)) ≈ₓ p
-  absorbˡₓ p q = absorbˡ₁ , absorbˡ₂
+  absorbˡₓ : ∀ {p q} → (p ∧ₓ (p ∨ₓ q)) ≈ₓ p
+  absorbˡₓ = absorbˡ₁ , absorbˡ₂
 
-  absorbʳₓ : ∀ p q → ((p ∧ₓ q) ∨ₓ p) ≈ₓ p
-  absorbʳₓ p q = absorbʳ₁ , absorbʳ₂
+  absorbʳₓ : ∀ {p q} → ((p ∧ₓ q) ∨ₓ p) ≈ₓ p
+  absorbʳₓ = absorbʳ₁ , absorbʳ₂
 ```
 
 Assembling through the setoid-level builder yields the product lattice.

--- a/src/Classical/Structures/Lattice/Product.lagda.md
+++ b/src/Classical/Structures/Lattice/Product.lagda.md
@@ -40,7 +40,6 @@ equivalences — so it can be mechanically substituted on the eventual port.
 
 module Classical.Structures.Lattice.Product where
 
-open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
 open import Data.Product          using ( _,_ ; _×_ ; proj₁ ; proj₂ )
@@ -128,28 +127,28 @@ the pair of the component proofs, applied at the projections.
   ∨ₓ-cong e f = ∨₁-cong (proj₁ e) (proj₁ f) , ∨₂-cong (proj₂ e) (proj₂ f)
 
   ∧ₓ-assoc : ∀ p q r → ((p ∧ₓ q) ∧ₓ r) ≈ₓ (p ∧ₓ (q ∧ₓ r))
-  ∧ₓ-assoc p q r = ∧₁-assoc _ _ _ , ∧₂-assoc _ _ _
+  ∧ₓ-assoc p q r = ∧₁-assoc , ∧₂-assoc
 
   ∧ₓ-comm : ∀ p q → (p ∧ₓ q) ≈ₓ (q ∧ₓ p)
-  ∧ₓ-comm p q = ∧₁-comm _ _ , ∧₂-comm _ _
+  ∧ₓ-comm p q = ∧₁-comm , ∧₂-comm
 
   ∧ₓ-idem : ∀ p → (p ∧ₓ p) ≈ₓ p
-  ∧ₓ-idem p = ∧₁-idem _ , ∧₂-idem _
+  ∧ₓ-idem p = ∧₁-idem , ∧₂-idem
 
   ∨ₓ-assoc : ∀ p q r → ((p ∨ₓ q) ∨ₓ r) ≈ₓ (p ∨ₓ (q ∨ₓ r))
-  ∨ₓ-assoc p q r = ∨₁-assoc _ _ _ , ∨₂-assoc _ _ _
+  ∨ₓ-assoc p q r = ∨₁-assoc , ∨₂-assoc
 
   ∨ₓ-comm : ∀ p q → (p ∨ₓ q) ≈ₓ (q ∨ₓ p)
-  ∨ₓ-comm p q = ∨₁-comm _ _ , ∨₂-comm _ _
+  ∨ₓ-comm p q = ∨₁-comm , ∨₂-comm
 
   ∨ₓ-idem : ∀ p → (p ∨ₓ p) ≈ₓ p
-  ∨ₓ-idem p = ∨₁-idem _ , ∨₂-idem _
+  ∨ₓ-idem p = ∨₁-idem , ∨₂-idem
 
   absorbˡₓ : ∀ p q → (p ∧ₓ (p ∨ₓ q)) ≈ₓ p
-  absorbˡₓ p q = absorbˡ₁ _ _ , absorbˡ₂ _ _
+  absorbˡₓ p q = absorbˡ₁ , absorbˡ₂
 
   absorbʳₓ : ∀ p q → ((p ∧ₓ q) ∨ₓ p) ≈ₓ p
-  absorbʳₓ p q = absorbʳ₁ _ _ , absorbʳ₂ _ _
+  absorbʳₓ p q = absorbʳ₁ , absorbʳ₂
 ```
 
 Assembling through the setoid-level builder yields the product lattice.

--- a/src/Classical/Structures/Lattice/Product.lagda.md
+++ b/src/Classical/Structures/Lattice/Product.lagda.md
@@ -1,0 +1,201 @@
+---
+layout: default
+file: "src/Classical/Structures/Lattice/Product.lagda.md"
+title: "Classical.Structures.Lattice.Product module"
+date: "2026-07-24"
+author: "the agda-algebras development team"
+---
+
+### Binary products of lattices {#classical-structures-lattice-product}
+
+This is the [Classical.Structures.Lattice.Product][] module of the [Agda Universal Algebra Library][].
+
+Given lattices `𝑳₁`{.AgdaBound} and `𝑳₂`{.AgdaBound} over
+[`Sig-Lattice`][Classical.Signatures.Lattice], this module constructs their
+**binary direct product** `𝑳₁ ×ˡ 𝑳₂`{.AgdaFunction}: the lattice on the product
+setoid whose meet and join act componentwise.  The construction mirrors the group
+case ([Classical.Structures.Group.Product][]) but is assembled through the
+setoid-level builder `setoidEqsToLattice`{.AgdaFunction} of
+[Classical.Structures.Lattice][], whose interpretation clauses reduce
+definitionally; consequently each of the eight lattice equations for the product is
+*literally* the pair of the component equations, and no term-induction lemma is
+needed.
+
+Besides the product itself, the module characterizes the induced meet order of
+[Classical.Properties.Lattice][]: the product order is the componentwise order,
+definitionally, and the three accessors `≤ₓ-fst`{.AgdaFunction},
+`≤ₓ-snd`{.AgdaFunction}, `≤ₓ-pair`{.AgdaFunction} name the two projections and the
+pairing.  The first consumer is the FLRP closure toolkit
+([FLRP.Closure][]; roadmap § 3, work package WP-5), which represents
+`𝑳₁ ×ˡ 𝑳₂`{.AgdaFunction} as a congruence lattice whenever its factors are so
+representable.
+
+Following the Cubical-port discipline, the underlying equivalence of the product is
+isolated in `A×B`{.AgdaFunction} — the pointwise pair of the component
+equivalences — so it can be mechanically substituted on the eventual port.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Lattice.Product where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Product          using ( _,_ ; _×_ ; proj₁ ; proj₂ )
+open import Level                 using ( Level ; _⊔_ )
+open import Relation.Binary       using ( Setoid )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Properties.Lattice  using ( module Lattice-Order )
+open import Classical.Structures.Lattice  using ( Lattice ; module Lattice-Op
+                                                ; setoidEqsToLattice )
+open import Setoid.Algebras.Basic         using ( 𝕌[_] ; 𝔻[_] )
+
+private variable α ρ β σ : Level
+```
+-->
+
+#### The product construction
+
+`LatticeProduct`{.AgdaModule} `𝑳₁` `𝑳₂` packages the whole development for a fixed
+pair of lattices; opening it provides the product setoid, the componentwise
+operations with their congruences and equations, the product lattice, and the
+characterization of its order.
+
+```agda
+module LatticeProduct (𝑳₁ : Lattice α ρ) (𝑳₂ : Lattice β σ) where
+  private
+    𝑨 = proj₁ 𝑳₁
+    𝑩 = proj₁ 𝑳₂
+
+  open Setoid 𝔻[ 𝑨 ] using ()
+    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝔻[ 𝑩 ] using ()
+    renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
+
+  open Lattice-Op 𝑳₁ using ()
+    renaming ( _∧_ to _∧₁_ ; _∨_ to _∨₁_ ; ∧-cong to ∧₁-cong ; ∨-cong to ∨₁-cong
+             ; ∧-assoc-law to ∧₁-assoc ; ∧-comm-law to ∧₁-comm ; ∧-idem-law to ∧₁-idem
+             ; ∨-assoc-law to ∨₁-assoc ; ∨-comm-law to ∨₁-comm ; ∨-idem-law to ∨₁-idem
+             ; absorbˡ-law to absorbˡ₁ ; absorbʳ-law to absorbʳ₁ )
+  open Lattice-Op 𝑳₂ using ()
+    renaming ( _∧_ to _∧₂_ ; _∨_ to _∨₂_ ; ∧-cong to ∧₂-cong ; ∨-cong to ∨₂-cong
+             ; ∧-assoc-law to ∧₂-assoc ; ∧-comm-law to ∧₂-comm ; ∧-idem-law to ∧₂-idem
+             ; ∨-assoc-law to ∨₂-assoc ; ∨-comm-law to ∨₂-comm ; ∨-idem-law to ∨₂-idem
+             ; absorbˡ-law to absorbˡ₂ ; absorbʳ-law to absorbʳ₂ )
+```
+
+The carrier of the product is the pair type, and its equivalence is the pointwise
+pair of the component equivalences — the isolated-equality locus for the Cubical
+port.
+
+```agda
+  A×B : Setoid (α ⊔ β) (ρ ⊔ σ)
+  A×B = record
+    { Carrier        = 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]
+    ; _≈_            = λ p q → (proj₁ p ≈₁ proj₁ q) × (proj₂ p ≈₂ proj₂ q)
+    ; isEquivalence  = record
+        { refl   = refl₁ , refl₂
+        ; sym    = λ e → sym₁ (proj₁ e) , sym₂ (proj₂ e)
+        ; trans  = λ (d₁ , d₂) (e₁ , e₂) → trans₁ d₁ e₁ , trans₂ d₂ e₂
+        }
+    }
+
+  open Setoid A×B using () renaming ( _≈_ to _≈ₓ_ )
+```
+
+Meet and join act componentwise.  The operations project rather than pattern-match
+their arguments, so they reduce on any pair expression, matched or not.
+
+```agda
+  _∧ₓ_ : 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]
+  p ∧ₓ q = (proj₁ p ∧₁ proj₁ q) , (proj₂ p ∧₂ proj₂ q)
+
+  _∨ₓ_ : 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]
+  p ∨ₓ q = (proj₁ p ∨₁ proj₁ q) , (proj₂ p ∨₂ proj₂ q)
+```
+
+Congruence and the eight equations are all inherited componentwise: each proof is
+the pair of the component proofs, applied at the projections.
+
+```agda
+  ∧ₓ-cong : ∀ {p q u v} → p ≈ₓ q → u ≈ₓ v → (p ∧ₓ u) ≈ₓ (q ∧ₓ v)
+  ∧ₓ-cong e f = ∧₁-cong (proj₁ e) (proj₁ f) , ∧₂-cong (proj₂ e) (proj₂ f)
+
+  ∨ₓ-cong : ∀ {p q u v} → p ≈ₓ q → u ≈ₓ v → (p ∨ₓ u) ≈ₓ (q ∨ₓ v)
+  ∨ₓ-cong e f = ∨₁-cong (proj₁ e) (proj₁ f) , ∨₂-cong (proj₂ e) (proj₂ f)
+
+  ∧ₓ-assoc : ∀ p q r → ((p ∧ₓ q) ∧ₓ r) ≈ₓ (p ∧ₓ (q ∧ₓ r))
+  ∧ₓ-assoc p q r = ∧₁-assoc _ _ _ , ∧₂-assoc _ _ _
+
+  ∧ₓ-comm : ∀ p q → (p ∧ₓ q) ≈ₓ (q ∧ₓ p)
+  ∧ₓ-comm p q = ∧₁-comm _ _ , ∧₂-comm _ _
+
+  ∧ₓ-idem : ∀ p → (p ∧ₓ p) ≈ₓ p
+  ∧ₓ-idem p = ∧₁-idem _ , ∧₂-idem _
+
+  ∨ₓ-assoc : ∀ p q r → ((p ∨ₓ q) ∨ₓ r) ≈ₓ (p ∨ₓ (q ∨ₓ r))
+  ∨ₓ-assoc p q r = ∨₁-assoc _ _ _ , ∨₂-assoc _ _ _
+
+  ∨ₓ-comm : ∀ p q → (p ∨ₓ q) ≈ₓ (q ∨ₓ p)
+  ∨ₓ-comm p q = ∨₁-comm _ _ , ∨₂-comm _ _
+
+  ∨ₓ-idem : ∀ p → (p ∨ₓ p) ≈ₓ p
+  ∨ₓ-idem p = ∨₁-idem _ , ∨₂-idem _
+
+  absorbˡₓ : ∀ p q → (p ∧ₓ (p ∨ₓ q)) ≈ₓ p
+  absorbˡₓ p q = absorbˡ₁ _ _ , absorbˡ₂ _ _
+
+  absorbʳₓ : ∀ p q → ((p ∧ₓ q) ∨ₓ p) ≈ₓ p
+  absorbʳₓ p q = absorbʳ₁ _ _ , absorbʳ₂ _ _
+```
+
+Assembling through the setoid-level builder yields the product lattice.
+
+```agda
+  ×ˡ-Lattice : Lattice (α ⊔ β) (ρ ⊔ σ)
+  ×ˡ-Lattice = setoidEqsToLattice A×B _∧ₓ_ _∨ₓ_ ∧ₓ-cong ∨ₓ-cong
+    ∧ₓ-assoc ∧ₓ-comm ∧ₓ-idem ∨ₓ-assoc ∨ₓ-comm ∨ₓ-idem absorbˡₓ absorbʳₓ
+```
+
+#### The product order is the componentwise order
+
+The meet order of `×ˡ-Lattice`{.AgdaFunction} at `(p , q)` unfolds definitionally
+to the pair of the component meet orders, because the builder's interpretation
+applies its argument tuple and the product setoid's equality is the pointwise pair.
+The three accessors below are therefore projections and pairing, but we name them:
+they are the interface through which consumers (the FLRP closure lemmas) read the
+product order without unfolding the builder.
+
+```agda
+  open Lattice-Order ×ˡ-Lattice using () renaming ( _≤_ to _≤ₓ_ )
+  open Lattice-Order 𝑳₁ using () renaming ( _≤_ to _≤₁_ )
+  open Lattice-Order 𝑳₂ using () renaming ( _≤_ to _≤₂_ )
+
+  -- The product order projects to the first factor's order.
+  ≤ₓ-fst : ∀ {p q} → p ≤ₓ q → proj₁ p ≤₁ proj₁ q
+  ≤ₓ-fst = proj₁
+
+  -- The product order projects to the second factor's order.
+  ≤ₓ-snd : ∀ {p q} → p ≤ₓ q → proj₂ p ≤₂ proj₂ q
+  ≤ₓ-snd = proj₂
+
+  -- Componentwise order proofs pair into a product order proof.
+  ≤ₓ-pair : ∀ {p q} → proj₁ p ≤₁ proj₁ q → proj₂ p ≤₂ proj₂ q → p ≤ₓ q
+  ≤ₓ-pair e f = e , f
+```
+
+#### The product operator
+
+The standalone binary operator, for consumers that need only the lattice.
+
+```agda
+infixr 7 _×ˡ_
+
+_×ˡ_ : Lattice α ρ → Lattice β σ → Lattice (α ⊔ β) (ρ ⊔ σ)
+𝑳₁ ×ˡ 𝑳₂ = LatticeProduct.×ˡ-Lattice 𝑳₁ 𝑳₂
+```
+
+--------------------------------------

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -91,13 +91,13 @@ Two standing warnings apply to everything under this namespace.
 
 module FLRP where
 
-open import FLRP.Problem public
-open import FLRP.Enforceable public
-open import FLRP.Bridge public
-open import FLRP.Representable public
-open import FLRP.Assumptions public
-open import FLRP.Closure public
-open import FLRP.LayerBridge public
-open import FLRP.Certificates public
-open import FLRP.L7EqSix public
+open import FLRP.Problem        public
+open import FLRP.Enforceable    public
+open import FLRP.Bridge         public
+open import FLRP.Representable  public
+open import FLRP.Assumptions    public
+open import FLRP.Closure        public
+open import FLRP.LayerBridge    public
+open import FLRP.Certificates   public
+open import FLRP.L7EqSix        public
 ```

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -56,8 +56,14 @@ Two standing warnings apply to everything under this namespace.
    attained here with no postulate).
 +  [FLRP.Assumptions][] — the registry of classical theorems imported as
    explicit hypotheses (never postulates), keeping the tree honest under
-   `--safe`; its first entry is the congruence-completeness bridge
-   `CongruenceCompleteness`, the single Layer-S→Layer-D assumption of ADR-008.
+   `--safe`; Entry 1 is the congruence-completeness bridge
+   `CongruenceCompleteness`, the single Layer-S→Layer-D assumption of ADR-008,
+   and Entry 2 is Kurzweil–Netter duality, consumed by the WP-5 closure
+   toolkit.
++  [FLRP.Closure][] — the WP-5 closure toolkit: product and ordinal-sum
+   closure of `Representableᵈ` (issue #456), the adjoin-a-new-extremum
+   corollaries at `chain₂`, and the duality corollary `dual-Representableᵈ`
+   conditional on the registry's Entry 2.
 +  [FLRP.LayerBridge][] — the cross-layer bridge: under the congruence-completeness
    assumption, the semantic and decidable congruence posets are order-isomorphic
    (`conDecIso`), whence `Representable 𝑳 ↔ Representableᵈ 𝑳`.
@@ -90,6 +96,7 @@ open import FLRP.Enforceable public
 open import FLRP.Bridge public
 open import FLRP.Representable public
 open import FLRP.Assumptions public
+open import FLRP.Closure public
 open import FLRP.LayerBridge public
 open import FLRP.Certificates public
 open import FLRP.L7EqSix public

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -62,7 +62,7 @@ reproof.[^3]
 The module is structured as *per-assumption statement definitions* (rather than one
 monolithic record) precisely so that entries can be appended without disturbing one
 another, and downstream results take whichever entry they need as an ordinary
-argument.[^4]
+argument.
 
 <!--
 ```agda
@@ -251,6 +251,3 @@ KurzweilNetterDuality = (𝑳 : Lattice) → KurzweilNetterDualityAt 𝑳
       [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7
       and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456)).
 
-[^4]: The standing FLRP research-track separation warning of [FLRP.Problem][] applies
-      here too: this is problem-specific formal content, not to be conflated with the
-      algebraic-complexity / finite-CSP work elsewhere in the library.

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -249,5 +249,4 @@ KurzweilNetterDuality = (𝑳 : Lattice) → KurzweilNetterDualityAt 𝑳
       decidable representability outright in [FLRP.Closure][] and registered
       duality here as Entry 2 (see
       [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7
-      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456)).
-
+      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456).

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -51,12 +51,18 @@ free constructive data reconstitutes the full semantic
 `FiniteCongruences`{.AgdaRecord}, so the assumption is exactly the classical delta
 between the two layers, no more, no less.
 
-**Coordination note**.  Work package 5 (WP-5) also plans to register
-its Kurzweil–Netter duality in this module.[^3]  The module is structured as
-*per-assumption statement definitions* (rather than one monolithic record) precisely
-so that a second entry can be appended without disturbing the first: WP-5 should add
-its duality as "Entry 2" alongside `CongruenceCompleteness`{.AgdaFunction}, and
-downstream results take whichever entry they need as an ordinary argument.[^4]
+**Entry 2**: Kurzweil–Netter duality.  The class of representable lattices is
+closed under dualization — proved by Kurzweil (1985) for intervals in solvable
+groups and by Netter (1986) in general, the latter possibly never published.  The
+closure toolkit of work package WP-5 ([FLRP.Closure][]) proves product and
+ordinal-sum closure outright; duality enters as this registry's second entry,
+`KurzweilNetterDuality`{.AgdaFunction}, an explicit hypothesis pending a formal
+reproof.[^3]
+
+The module is structured as *per-assumption statement definitions* (rather than one
+monolithic record) precisely so that entries can be appended without disturbing one
+another, and downstream results take whichever entry they need as an ordinary
+argument.[^4]
 
 <!--
 ```agda
@@ -71,10 +77,13 @@ open import Data.List.Membership.Propositional    using  ( _∈_ )
 open import Data.Product                          using  ( _×_ ; _,_ ; Σ-syntax
                                                          ; proj₁ ; proj₂ )
 open import Function                              using  (_∘_)
-open import Level                                 using  ( Level ; _⊔_ )
+open import Level                                 using  ( Level ; _⊔_ ; 0ℓ )
                                                   renaming ( suc to lsuc )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Small.Structures.Lattice    using  ( Lattice )
+open import Classical.Structures.Lattice.Dual     using  ( dualLattice )
+open import FLRP.Representable                    using  ( Representableᵈ )
 open import Overture                              using  ( 𝓞 ; 𝓥 ; Signature )
 open import Setoid.Algebras.Basic                 using  ( Algebra )
 open import Setoid.Algebras.Finite                using  ( FiniteAlgebra )
@@ -176,6 +185,59 @@ transitivity.
       φ≑e = d≑e .proj₁ ∘ φ≑d .proj₁ , φ≑d .proj₂ ∘ d≑e .proj₂
 ```
 
+#### Entry 2: Kurzweil–Netter duality
+
+The **theorem of Kurzweil and Netter**: if a finite lattice is representable as
+the congruence lattice of a finite algebra, then so is its dual.  Kurzweil proved
+the group-interval case (H. Kurzweil, *Endliche Gruppen mit vielen Untergruppen*,
+J. reine angew. Math. 356 (1985) 140–160); his student Netter proved the general
+statement (R. Netter, 1986), in an article that may never have been published.
+The argument this library targets is the one presented in
+`docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals: the theorem of
+Kurzweil and Netter", following Pálfy's 2009 lectures: represent the dual of
+`Eq(n)` as the interval `[D , Sⁿ]` in the subgroup lattice of a power of a
+nonabelian simple group `S`, transport along the congruence lattice of the
+transitive `Sⁿ`-set on `Sⁿ/D`, and cut down to the desired dual by expanding the
+algebra with lifted operations.
+
++  **Meaning**.  `KurzweilNetterDualityAt`{.AgdaFunction} `𝑳` says: from a
+   decidable representation of `𝑳`{.AgdaBound}, one can produce a decidable
+   representation of `dualLattice 𝑳`{.AgdaFunction}
+   ([Classical.Structures.Lattice.Dual][]).  The ∀-form
+   `KurzweilNetterDuality`{.AgdaFunction} is the full theorem.  The per-lattice
+   form is the useful granularity downstream: a consumer may assume duality at
+   exactly the lattice it dualizes (the small-lattice census, issue #485, needs it
+   only at the certified partners of its two dual entries).
+
++  **Source and status**.  Unlike Entry 1 — an axiom-calibrated *bridge* whose
+   strength is pinned between WLEM and LEM — this entry is a *classically proven
+   theorem* imported pending formalization.  Its proof route needs the powers
+   `Sⁿ` of a finite simple group, the interval `[D , Sⁿ]`, and the transitive
+   G-set congruence bridge of work package WP-3, none of which is formalized yet;
+   when the stretch goal of issue #456 lands, this entry retires and
+   `dual-Representableᵈ`{.AgdaFunction} of [FLRP.Closure][] becomes a theorem.
+
++  **Layer**.  The entry is registered at Layer D (`Representableᵈ`{.AgdaRecord}),
+   the program's working notion per [ADR-008][]; the classical statement is the
+   Layer-S reading, and the two coincide classically through Entry 1.  A formal
+   Kurzweil–Netter proof would in any case produce the Layer-D form: the
+   construction is finite and explicit.
+
++  **Size**.  The construction represents the dual on an algebra of
+   `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹` elements (for an `n`-element original), which is why the
+   census keeps dual entries assumption-conditional rather than materializing
+   concrete certificate algebras.
+
+```agda
+-- Entry 2, per-lattice form: a decidable representation of 𝑳 yields one of its dual.
+KurzweilNetterDualityAt : Lattice → Type (lsuc 0ℓ)
+KurzweilNetterDualityAt 𝑳 = Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
+
+-- The full theorem of Kurzweil (1985) and Netter (1986), as an explicit hypothesis.
+KurzweilNetterDuality : Type (lsuc 0ℓ)
+KurzweilNetterDuality = (𝑳 : Lattice) → KurzweilNetterDualityAt 𝑳
+```
+
 --------------------------------------
 
 [^1]: This is the assumption-registry discipline of [ADR-008][] and the FLRP roadmap.
@@ -183,10 +245,11 @@ transitivity.
 [^2]: Pinning the exact strength is a side question the program does not need
       (see `docs/notes/flrp-two-layer-congruences.md` § 2.1, L4).
 
-[^3]: **WP-5: closure toolkit** formalizes product and ordinal-sum closure of
-      representability (see
+[^3]: **WP-5: closure toolkit** formalized product and ordinal-sum closure of
+      decidable representability outright in [FLRP.Closure][] and registered
+      duality here as Entry 2 (see
       [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7
-      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456).
+      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456)).
 
 [^4]: The standing FLRP research-track separation warning of [FLRP.Problem][] applies
       here too: this is problem-specific formal content, not to be conflated with the

--- a/src/FLRP/Certificates.lagda.md
+++ b/src/FLRP/Certificates.lagda.md
@@ -52,9 +52,8 @@ lattice's meet order `x ≤ y := x ∧ y ≈ x` ([Classical.Properties.Lattice][
 Since `toLattice`{.AgdaFunction} builds its carrier setoid on propositional equality,
 the translation is definitional.
 
-The standing FLRP research-track separation warning applies: this is problem-specific
-wiring; all reusable mathematics lives under the `Setoid` tree; in this case, under
-`Setoid.Congruences.Certificates`.
+This is problem-specific wiring; all reusable mathematics lives under the `Setoid`
+tree; in this case, under `Setoid.Congruences.Certificates`.
 
 <!--
 ```agda

--- a/src/FLRP/Certificates.lagda.md
+++ b/src/FLRP/Certificates.lagda.md
@@ -76,9 +76,8 @@ open import Relation.Nullary.Decidable             using  ( Dec )
 
 -- Imports from the Agda Universal Algebra Library ----------------------------
 open import FLRP.Problem                                using  ( FiniteLattice
-                                                               ; toLattice ; OrderIso )
-open import FLRP.Representable                          using  ( Representableᵈ ; _⊆ᵈ_
-                                                               ; ConIsoᵈ ; _≑ᵈ_ )
+                                                               ; toLattice )
+open import FLRP.Representable                          using  ( Representableᵈ ; ConIsoᵈ )
 open import Overture                                    using  ( Signature )
 open import Setoid.Algebras.Basic                       using  ( Algebra )
 open import Setoid.Algebras.Finite                      using  ( FiniteAlgebra )

--- a/src/FLRP/Certificates/SmallLatticeReps/SLR02.lagda.md
+++ b/src/FLRP/Certificates/SmallLatticeReps/SLR02.lagda.md
@@ -60,7 +60,7 @@ open import Setoid.Algebras.Finite       using ( FiniteAlgebra )
 open import Setoid.Congruences.Certificates.Schema
                                          using ( ParentVec ; Trace ; LatticeCert
                                                ; mkLatticeCert ; mkMerge
-                                               ; seed ; translate )
+                                               ; seed )
 open import Setoid.Congruences.Certificates.Congruence
                                          using ( module CertCheck )
 open import Setoid.Congruences.Certificates.Lattice

--- a/src/FLRP/Closure.lagda.md
+++ b/src/FLRP/Closure.lagda.md
@@ -38,8 +38,6 @@ small-lattice census (`L18` and `L22`, duals of the certified `SLR19` and
 `SLR23`) become assumption-conditional corollaries; materializing those
 conditional certificates is issue #485's concern, not this module's.
 
-The standing FLRP research-track separation warning applies to everything here.
-
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/FLRP/Closure.lagda.md
+++ b/src/FLRP/Closure.lagda.md
@@ -6,113 +6,14 @@ date: "2026-07-24"
 author: "the agda-algebras development team"
 ---
 
-### The closure toolkit for decidable representability
-
 This is the [FLRP.Closure][] module of the [Agda Universal Algebra Library][].
 
-The class of representable lattices is closed under a catalogue of operations
-(the roadmap's § 3; `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure
-properties).  This module is work package WP-5's umbrella over that catalogue at
-Layer D, re-exporting the two proved closure theorems and deriving the rest:
-
-+  **finite direct products** — `product-Representableᵈ`{.AgdaFunction}
-   ([FLRP.Closure.Product][], after Tůma);
-+  **ordinal sums** — `ordinalSum-Representableᵈ`{.AgdaFunction}
-   ([FLRP.Closure.OrdinalSum][], after McKenzie and Snow); the *unglued* sum is
-   the derived composite with `chain₂` glued in the middle;
-+  **adjoining a new bottom or top** — `adjoinBottom-Representableᵈ`{.AgdaFunction}
-   / `adjoinTop-Representableᵈ`{.AgdaFunction} below: *corollaries* of
-   ordinal-sum closure, not fresh results, obtained by instantiating one summand
-   at the two-element chain (whose Layer-D representation
-   `chain₂-Representableᵈ`{.AgdaFunction} is the constructive centerpiece of
-   [FLRP.Representable][]);
-+  **lattice duals** — `dual-Representableᵈ`{.AgdaFunction} below, *conditional*
-   on the Kurzweil–Netter entry of the assumptions registry
-   ([FLRP.Assumptions][], Entry 2): the theorem is classically proved but not yet
-   formalized, so it is threaded as an explicit hypothesis, keeping `--safe`
-   honest.  Once the planned formal reproof lands, the hypothesis discharges and
-   the corollary becomes a theorem.
-
-The payoff downstream: with Entry 2 in place, the two dual entries of the
-small-lattice census (`L18` and `L22`, duals of the certified `SLR19` and
-`SLR23`) become assumption-conditional corollaries; materializing those
-conditional certificates is issue #485's concern, not this module's.
-
-<!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module FLRP.Closure where
 
--- Imports from the Agda Standard Library -----------------------------------
-open import Data.Fin.Patterns                      using  ( 0F ; 1F )
-open import Data.Product                           using  ( _,_ )
-open import Relation.Binary.PropositionalEquality  using  ( refl )
-
--- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Properties.Lattice              using  ( TopOf ; BotOf )
-open import Classical.Small.Structures.Lattice        using  ( Lattice )
-open import Classical.Structures.Lattice.Dual         using  ( dualLattice )
-open import Classical.Structures.Lattice.OrdinalSum   using  ( ordinalSum )
-open import FLRP.Assumptions                          using  ( KurzweilNetterDuality )
-open import FLRP.Problem                              using  ( chain₂-lattice )
-open import FLRP.Representable                        using  ( Representableᵈ
-                                                             ; chain₂-Representableᵈ )
-
-open import FLRP.Closure.Product     public
-open import FLRP.Closure.OrdinalSum  public
+open import FLRP.Closure.Basic public
+open import FLRP.Closure.Product public
+open import FLRP.Closure.OrdinalSum public
 ```
--->
-
-#### Adjoining a new bottom or top
-
-The two-element chain carries concrete extremum data: its top is `1` and its
-bottom is `0`, each universal property decided by the four table entries.
-
-```agda
-chain₂-top : TopOf chain₂-lattice
-chain₂-top = 1F , λ { 0F → refl ; 1F → refl }
-
-chain₂-bot : BotOf chain₂-lattice
-chain₂-bot = 0F , λ { 0F → refl ; 1F → refl }
-```
-
-Adjoining a fresh extremum to a lattice is the special case of the glued
-ordinal sum in which one summand is the two-element chain: gluing `chain₂`'s
-top onto `𝑳`'s bottom leaves exactly one new element below everything
-(`adjoinBottom`), and mirrored for `adjoinTop`.  These are the roadmap § 3
-catalogue's "adjoining a new top or bottom", each a one-application corollary
-of `ordinalSum-Representableᵈ`{.AgdaFunction} at
-`chain₂-Representableᵈ`{.AgdaFunction} — a deliberate design check that the
-ordinal-sum statement carries no hidden nontriviality assumptions on its
-summands.
-
-```agda
--- Adjoin a new bottom: chain₂ glued below 𝑳, at 𝑳's chosen bottom.
-adjoinBottom-Representableᵈ : {𝑳 : Lattice} (b : BotOf 𝑳)
-  → Representableᵈ 𝑳 → Representableᵈ (ordinalSum chain₂-lattice chain₂-top 𝑳 b)
-adjoinBottom-Representableᵈ b r =
-  ordinalSum-Representableᵈ chain₂-top b chain₂-Representableᵈ r
-
--- Adjoin a new top: chain₂ glued above 𝑳, at 𝑳's chosen top.
-adjoinTop-Representableᵈ : {𝑳 : Lattice} (t : TopOf 𝑳)
-  → Representableᵈ 𝑳 → Representableᵈ (ordinalSum 𝑳 t chain₂-lattice chain₂-bot)
-adjoinTop-Representableᵈ t r =
-  ordinalSum-Representableᵈ t chain₂-bot r chain₂-Representableᵈ
-```
-
-#### Duality, conditionally
-
-Closure under dualization, threaded through the registry's Entry 2.  The body
-is instantiation — deliberately so: the mathematical content lives in the
-*named, cited* hypothesis, and every consumer of this corollary displays its
-classical debt in its own type.
-
-```agda
--- The Kurzweil–Netter closure, conditional on the registered assumption.
-dual-Representableᵈ : KurzweilNetterDuality
-  → (𝑳 : Lattice) → Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
-dual-Representableᵈ knd 𝑳 = knd 𝑳
-```
-
---------------------------------------

--- a/src/FLRP/Closure.lagda.md
+++ b/src/FLRP/Closure.lagda.md
@@ -1,0 +1,120 @@
+---
+layout: default
+file: "src/FLRP/Closure.lagda.md"
+title: "FLRP.Closure module (The Agda Universal Algebra Library)"
+date: "2026-07-24"
+author: "the agda-algebras development team"
+---
+
+### The closure toolkit for decidable representability
+
+This is the [FLRP.Closure][] module of the [Agda Universal Algebra Library][].
+
+The class of representable lattices is closed under a catalogue of operations
+(the roadmap's § 3; `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure
+properties).  This module is work package WP-5's umbrella over that catalogue at
+Layer D, re-exporting the two proved closure theorems and deriving the rest:
+
++  **finite direct products** — `product-Representableᵈ`{.AgdaFunction}
+   ([FLRP.Closure.Product][], after Tůma);
++  **ordinal sums** — `ordinalSum-Representableᵈ`{.AgdaFunction}
+   ([FLRP.Closure.OrdinalSum][], after McKenzie and Snow); the *unglued* sum is
+   the derived composite with `chain₂` glued in the middle;
++  **adjoining a new bottom or top** — `adjoinBottom-Representableᵈ`{.AgdaFunction}
+   / `adjoinTop-Representableᵈ`{.AgdaFunction} below: *corollaries* of
+   ordinal-sum closure, not fresh results, obtained by instantiating one summand
+   at the two-element chain (whose Layer-D representation
+   `chain₂-Representableᵈ`{.AgdaFunction} is the constructive centerpiece of
+   [FLRP.Representable][]);
++  **lattice duals** — `dual-Representableᵈ`{.AgdaFunction} below, *conditional*
+   on the Kurzweil–Netter entry of the assumptions registry
+   ([FLRP.Assumptions][], Entry 2): the theorem is classically proved but not yet
+   formalized, so it is threaded as an explicit hypothesis, keeping `--safe`
+   honest.  Once the planned formal reproof lands, the hypothesis discharges and
+   the corollary becomes a theorem.
+
+The payoff downstream: with Entry 2 in place, the two dual entries of the
+small-lattice census (`L18` and `L22`, duals of the certified `SLR19` and
+`SLR23`) become assumption-conditional corollaries; materializing those
+conditional certificates is issue #485's concern, not this module's.
+
+The standing FLRP research-track separation warning applies to everything here.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.Closure where
+
+-- Imports from the Agda Standard Library -----------------------------------
+open import Data.Fin.Patterns                      using  ( 0F ; 1F )
+open import Data.Product                           using  ( _,_ )
+open import Relation.Binary.PropositionalEquality  using  ( refl )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Properties.Lattice              using  ( TopOf ; BotOf )
+open import Classical.Small.Structures.Lattice        using  ( Lattice )
+open import Classical.Structures.Lattice.Dual         using  ( dualLattice )
+open import Classical.Structures.Lattice.OrdinalSum   using  ( ordinalSum )
+open import FLRP.Assumptions                          using  ( KurzweilNetterDuality )
+open import FLRP.Problem                              using  ( chain₂-lattice )
+open import FLRP.Representable                        using  ( Representableᵈ
+                                                             ; chain₂-Representableᵈ )
+
+open import FLRP.Closure.Product     public
+open import FLRP.Closure.OrdinalSum  public
+```
+-->
+
+#### Adjoining a new bottom or top
+
+The two-element chain carries concrete extremum data: its top is `1` and its
+bottom is `0`, each universal property decided by the four table entries.
+
+```agda
+chain₂-top : TopOf chain₂-lattice
+chain₂-top = 1F , λ { 0F → refl ; 1F → refl }
+
+chain₂-bot : BotOf chain₂-lattice
+chain₂-bot = 0F , λ { 0F → refl ; 1F → refl }
+```
+
+Adjoining a fresh extremum to a lattice is the special case of the glued
+ordinal sum in which one summand is the two-element chain: gluing `chain₂`'s
+top onto `𝑳`'s bottom leaves exactly one new element below everything
+(`adjoinBottom`), and mirrored for `adjoinTop`.  These are the roadmap § 3
+catalogue's "adjoining a new top or bottom", each a one-application corollary
+of `ordinalSum-Representableᵈ`{.AgdaFunction} at
+`chain₂-Representableᵈ`{.AgdaFunction} — a deliberate design check that the
+ordinal-sum statement carries no hidden nontriviality assumptions on its
+summands.
+
+```agda
+-- Adjoin a new bottom: chain₂ glued below 𝑳, at 𝑳's chosen bottom.
+adjoinBottom-Representableᵈ : {𝑳 : Lattice} (b : BotOf 𝑳)
+  → Representableᵈ 𝑳 → Representableᵈ (ordinalSum chain₂-lattice chain₂-top 𝑳 b)
+adjoinBottom-Representableᵈ b r =
+  ordinalSum-Representableᵈ chain₂-top b chain₂-Representableᵈ r
+
+-- Adjoin a new top: chain₂ glued above 𝑳, at 𝑳's chosen top.
+adjoinTop-Representableᵈ : {𝑳 : Lattice} (t : TopOf 𝑳)
+  → Representableᵈ 𝑳 → Representableᵈ (ordinalSum 𝑳 t chain₂-lattice chain₂-bot)
+adjoinTop-Representableᵈ t r =
+  ordinalSum-Representableᵈ t chain₂-bot r chain₂-Representableᵈ
+```
+
+#### Duality, conditionally
+
+Closure under dualization, threaded through the registry's Entry 2.  The body
+is instantiation — deliberately so: the mathematical content lives in the
+*named, cited* hypothesis, and every consumer of this corollary displays its
+classical debt in its own type.
+
+```agda
+-- The Kurzweil–Netter closure, conditional on the registered assumption.
+dual-Representableᵈ : KurzweilNetterDuality
+  → (𝑳 : Lattice) → Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
+dual-Representableᵈ knd 𝑳 = knd 𝑳
+```
+
+--------------------------------------

--- a/src/FLRP/Closure/Basic.lagda.md
+++ b/src/FLRP/Closure/Basic.lagda.md
@@ -1,0 +1,118 @@
+---
+layout: default
+file: "src/FLRP/Closure/Basic.lagda.md"
+title: "FLRP.Closure.Basic module (The Agda Universal Algebra Library)"
+date: "2026-07-24"
+author: "the agda-algebras development team"
+---
+
+### The closure toolkit for decidable representability
+
+This is the [FLRP.Closure][] module of the [Agda Universal Algebra Library][].
+
+The class of representable lattices is closed under a catalogue of operations
+(the roadmap's § 3; `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure
+properties).  This module is work package WP-5's umbrella over that catalogue at
+Layer D, re-exporting the two proved closure theorems and deriving the rest:
+
++  **finite direct products**. `product-Representableᵈ`{.AgdaFunction}
+   ([FLRP.Closure.Product][], after Tůma);
++  **ordinal sums**. `ordinalSum-Representableᵈ`{.AgdaFunction}
+   ([FLRP.Closure.OrdinalSum][], after McKenzie and Snow); the *unglued* sum is
+   the derived composite with `chain₂` glued in the middle;
++  **adjoining a new bottom or top**. `adjoinBottom-Representableᵈ`{.AgdaFunction}
+   / `adjoinTop-Representableᵈ`{.AgdaFunction} below: *corollaries* of
+   ordinal-sum closure, not fresh results, obtained by instantiating one summand
+   at the two-element chain (whose Layer-D representation
+   `chain₂-Representableᵈ`{.AgdaFunction} is the constructive centerpiece of
+   [FLRP.Representable][]);
++  **lattice duals**. `dual-Representableᵈ`{.AgdaFunction} below, *conditional*
+   on the Kurzweil–Netter entry of the assumptions registry
+   ([FLRP.Assumptions][], Entry 2): the theorem is classically proved but not yet
+   formalized, so it is threaded as an explicit hypothesis, keeping `--safe`
+   honest.  Once the planned formal reproof lands, the hypothesis discharges and
+   the corollary becomes a theorem.
+
+The payoff downstream: with Entry 2 in place, the two dual entries of the
+small-lattice census (`L18` and `L22`, duals of the certified `SLR19` and
+`SLR23`) become assumption-conditional corollaries; materializing those
+conditional certificates is issue #485's concern, not this module's.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.Closure.Basic where
+
+-- Imports from the Agda Standard Library -----------------------------------
+open import Data.Fin.Patterns                      using  ( 0F ; 1F )
+open import Data.Product                           using  ( _,_ )
+open import Relation.Binary.PropositionalEquality  using  ( refl )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Properties.Lattice              using  ( TopOf ; BotOf )
+open import Classical.Small.Structures.Lattice        using  ( Lattice )
+open import Classical.Structures.Lattice.Dual         using  ( dualLattice )
+open import Classical.Structures.Lattice.OrdinalSum   using  ( ordinalSum )
+open import FLRP.Assumptions                          using  ( KurzweilNetterDuality )
+open import FLRP.Problem                              using  ( chain₂-lattice )
+open import FLRP.Representable                        using  ( Representableᵈ
+                                                             ; chain₂-Representableᵈ )
+
+open import FLRP.Closure.Product     public
+open import FLRP.Closure.OrdinalSum  public
+```
+-->
+
+#### Adjoining a new bottom or top
+
+The two-element chain carries concrete extremum data: its top is `1` and its
+bottom is `0`, each universal property decided by the four table entries.
+
+```agda
+chain₂-top : TopOf chain₂-lattice
+chain₂-top = 1F , λ { 0F → refl ; 1F → refl }
+
+chain₂-bot : BotOf chain₂-lattice
+chain₂-bot = 0F , λ { 0F → refl ; 1F → refl }
+```
+
+Adjoining a fresh extremum to a lattice is the special case of the glued
+ordinal sum in which one summand is the two-element chain: gluing `chain₂`'s
+top onto `𝑳`'s bottom leaves exactly one new element below everything
+(`adjoinBottom`), and mirrored for `adjoinTop`.  These are the roadmap § 3
+catalogue's "adjoining a new top or bottom", each a one-application corollary
+of `ordinalSum-Representableᵈ`{.AgdaFunction} at
+`chain₂-Representableᵈ`{.AgdaFunction} — a deliberate design check that the
+ordinal-sum statement carries no hidden nontriviality assumptions on its
+summands.
+
+```agda
+-- Adjoin a new bottom: chain₂ glued below 𝑳, at 𝑳's chosen bottom.
+adjoinBottom-Representableᵈ : {𝑳 : Lattice} (b : BotOf 𝑳)
+  → Representableᵈ 𝑳 → Representableᵈ (ordinalSum chain₂-lattice chain₂-top 𝑳 b)
+adjoinBottom-Representableᵈ b r =
+  ordinalSum-Representableᵈ chain₂-top b chain₂-Representableᵈ r
+
+-- Adjoin a new top: chain₂ glued above 𝑳, at 𝑳's chosen top.
+adjoinTop-Representableᵈ : {𝑳 : Lattice} (t : TopOf 𝑳)
+  → Representableᵈ 𝑳 → Representableᵈ (ordinalSum 𝑳 t chain₂-lattice chain₂-bot)
+adjoinTop-Representableᵈ t r =
+  ordinalSum-Representableᵈ t chain₂-bot r chain₂-Representableᵈ
+```
+
+#### Duality, conditionally
+
+Closure under dualization, threaded through the registry's Entry 2.  The body
+is instantiation — deliberately so: the mathematical content lives in the
+*named, cited* hypothesis, and every consumer of this corollary displays its
+classical debt in its own type.
+
+```agda
+-- The Kurzweil–Netter closure, conditional on the registered assumption.
+dual-Representableᵈ : KurzweilNetterDuality
+  → (𝑳 : Lattice) → Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
+dual-Representableᵈ knd 𝑳 = knd 𝑳
+```
+
+--------------------------------------

--- a/src/FLRP/Closure/OrdinalSum.lagda.md
+++ b/src/FLRP/Closure/OrdinalSum.lagda.md
@@ -86,7 +86,7 @@ open import Data.Sum.Base                          using  ( _⊎_ ; inj₁ ; inj
 open import Data.Unit.Base                         using  ( tt )
 open import Function                               using  ( _∘_ )
 open import Function.Construct.Identity            using  ( ↔-id )
-open import Level                                  using  ( 0ℓ ; Lift ; lift ; lower )
+open import Level                                  using  ( 0ℓ ; lift ; lower )
 open import Relation.Binary                        using  ( Setoid ; IsEquivalence )
 open import Relation.Binary.PropositionalEquality  using  ( _≡_ ; refl ; cong ; trans ; sym )
 open import Relation.Nullary                       using  ( ¬_ ; Dec ; yes ; no )
@@ -114,7 +114,6 @@ open import Setoid.Algebras.Basic                    using  ( Algebra ; 𝔻[_] 
 open import Setoid.Algebras.Finite                   using  ( FiniteAlgebra )
 open import Setoid.Congruences.Basic                 using  ( mkcon ; reflexive ; _∣≈_
                                                             ; is-equivalence ; is-compatible )
-open import Setoid.Congruences.ChainJoin             using  ( Finitary )
 open import Setoid.Congruences.Finite.Basic          using  ( DecCon ; ConRel )
 open import Setoid.Signatures.Finite                 using  ( FiniteSignature )
 
@@ -159,7 +158,7 @@ retractions (the isolated-equality locus for the Cubical port lives in
     A⊎B = 𝕌[ 𝑨 ] ⊎ 𝕌[ 𝑩 ]
 
   open Setoid glueSetoid using ()
-    renaming ( refl to reflᵍ ; sym to symᵍ ; trans to transᵍ ; reflexive to ≡→≈ᵍ )
+    renaming ( trans to transᵍ ; reflexive to ≡→≈ᵍ )
 ```
 
 **The signature**: the two component signatures side by side with the

--- a/src/FLRP/Closure/OrdinalSum.lagda.md
+++ b/src/FLRP/Closure/OrdinalSum.lagda.md
@@ -10,60 +10,69 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.Closure.OrdinalSum][] module of the [Agda Universal Algebra Library][].
 
-The class of representable lattices is closed under ordinal sums (McKenzie 1984;
-Snow 2000; see `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Ordinal Sums,
-whose `m + n − 1`-element construction this module follows).  Here we formalize
-the *adjoined* (glued) ordinal sum of
-[Classical.Structures.Lattice.OrdinalSum][] at Layer D ([ADR-008][]): given
-decidable representations of the summands and chosen extremum data — a
-`TopOf 𝑳₁`{.AgdaFunction} and a `BotOf 𝑳₂`{.AgdaFunction} — it constructs a
+The class of representable lattices is closed under **ordinal sums**.[^1]
+
+Here we formalize the *adjoined* (glued) ordinal sum of
+[Classical.Structures.Lattice.OrdinalSum][] at Layer D of [ADR-008][].
+
+Given decidable representations of the summands and chosen extrema — a
+`TopOf 𝓛₁`{.AgdaFunction} and a `BotOf 𝓛₂`{.AgdaFunction} — we construct a
 finite finitary algebra whose decidable-congruence poset is order-isomorphic to
 the glued sum, yielding
 
-    ordinalSum-Representableᵈ : (t : TopOf 𝑳₁) (b : BotOf 𝑳₂)
-      → Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂
-      → Representableᵈ (ordinalSum 𝑳₁ t 𝑳₂ b)
+    ordinalSum-Representableᵈ : (t : TopOf 𝓛₁) (b : BotOf 𝓛₂)
+      → Representableᵈ 𝓛₁ → Representableᵈ 𝓛₂
+      → Representableᵈ (ordinalSum 𝓛₁ t 𝓛₂ b)
 
-**The witness algebra.**  Given representing algebras `𝑨` and `𝑩` with
-basepoints `a*` and `b*`, the composite `𝑪` lives on the amalgam setoid
-`A ⊎ B` glued at `(a* , b*)` (`GlueSetoid`{.AgdaModule}) — the constructive
-counterpart of the manuscript's universe `A ⊎ (B ∖ {b₀})` — over the signature
+
+#### The witness algebra
+
+Given representing algebras `𝑨` and `𝑩` with basepoints `a*` and `b*`, the composite
+`𝑪` lives on the amalgam setoid `A ⊎ B` glued at `(a* , b*)`
+(`GlueSetoid`{.AgdaModule}) — the constructive counterpart of the manuscript's
+universe `A ⊎ (B ∖ {b₀})` — over the signature
 
     𝑆₁  ⊎  𝑆₂  ⊎  (Fin (card 𝑩) × Fin (card 𝑨))
 
-interpreted as follows: a symbol of `𝑆₁` acts through the left retraction
-(collapse `B` to `a*`) and lands in the left summand, a symbol of `𝑆₂` acts
-through the right retraction and lands in the right summand, and the
-`(i , k)`-indexed family interprets the manuscript's unary maps
-`ĥ`{.AgdaFunction}: identity on the left summand, and on the right summand the
-**single-point collapse** `h` sending (anything `≈` to) `enum₂ i` to
-`enum₁ k`, the basepoint to `a*`, and everything else to `a*`.
+interpreted as follows:
 
-**The boundary congruence and the dichotomy.**  The kernel `α` of the right
-retraction — all of `A` in one class, `B` split by `≈` — is a decidable
-congruence, and the heart of the proof is that *every* decidable congruence of
-`𝑪` is comparable to it.  Both containments are decidable
-(`⊆ᵈ-dec`{.AgdaFunction} of [FLRP.Representable][]); if both fail, the two
-violating pairs they surrender are contradictory: a `θ`-unrelated pair inside
-the lower summand on the one hand, and a `θ`-related pair with distinct
-right-retraction images on the other, which the `ĥ` family maps onto the
-unrelated pair — one application if the related pair is mixed, two chained
-through `a*` if it is pure.  This dichotomy is exactly the step that is
-*non-constructive at Layer S*: for semantic congruences, comparability with
-`α` decides oracle propositions (the WP-1 phenomenon), which is why
-ordinal-sum closure is a Layer-D theorem only.
++  a symbol of `𝑆₁` acts through the left retraction (collapse `B` to `a*`) and lands
+   in the left summand;
 
-**The splitting.**  A congruence below `α` is determined by its restriction to
-the lower summand together with `α` itself, and one above `α` by its quotient
-along the right retraction (`lower-split`{.AgdaFunction} /
-`upper-split`{.AgdaFunction}); composing with the given isomorphisms sends the
-lower cone onto `inj₁`-elements, the upper cone onto `inj₂`-elements, and `α`
-itself onto the glue.
++  a symbol of `𝑆₂` acts through the right retraction and lands in the right summand;
 
-As in the product case, basepoints are supplied by
-`inhabited-witness`{.AgdaFunction} normalization, so the closure theorem has no
-side conditions beyond the extremum data the sum itself needs.  The standing
-FLRP research-track separation warning applies.
++  the `(i , k)`-indexed family interprets the manuscript's unary maps
+   `ĥ`{.AgdaFunction}: identity on the left summand, and on the right summand the
+   *single-point collapse* `h` sending (anything `≈` to) `enum₂ i` to `enum₁ k`, the
+   basepoint to `a*`, and everything else to `a*`.
+
+
+#### The boundary congruence and the dichotomy
+
+The kernel `α` of the right retraction — all of `A` in one class, `B` split by `≈` —
+is a decidable congruence, and the heart of the proof is that *every* decidable
+congruence of `𝑪` is comparable to it.  Both containments are decidable
+(`⊆ᵈ-dec`{.AgdaFunction} of [FLRP.Representable][]); if both fail, the two violating
+pairs they surrender are contradictory: a `θ`-unrelated pair inside the lower summand
+on the one hand, and a `θ`-related pair with distinct right-retraction images on the
+other, which the `ĥ` family maps onto the unrelated pair — one application if the
+related pair is mixed, two chained through `a*` if it is pure.
+
+This dichotomy is exactly the step that is *non-constructive at Layer S*: for
+semantic congruences, comparability with `α` decides arbitrary propositions, which is
+why ordinal-sum closure is a Layer-D theorem only.
+
+#### The splitting
+
+A congruence below `α` is determined by its restriction to the lower summand together
+with `α` itself, and one above `α` by its quotient along the right retraction
+(`lower-split`{.AgdaFunction} / `upper-split`{.AgdaFunction}); composing with the
+given isomorphisms sends the lower cone onto `inj₁`-elements, the upper cone onto
+`inj₂`-elements, and `α` itself onto the glue.
+
+As in the product case, basepoints are supplied by `inhabited-witness`{.AgdaFunction}
+normalization, so the closure theorem has no side conditions beyond the extremum data
+the sum itself needs.
 
 <!--
 ```agda
@@ -84,7 +93,7 @@ open import Data.Product                           using  ( _,_ ; _×_ ; proj₁
                                                           ; Σ-syntax )
 open import Data.Sum.Base                          using  ( _⊎_ ; inj₁ ; inj₂ ; [_,_]′ )
 open import Data.Unit.Base                         using  ( tt )
-open import Function                               using  ( _∘_ )
+open import Function                               using  ( _∘_ ; id )
 open import Function.Construct.Identity            using  ( ↔-id )
 open import Level                                  using  ( 0ℓ ; lift ; lower )
 open import Relation.Binary                        using  ( Setoid ; IsEquivalence )
@@ -95,6 +104,7 @@ open import Relation.Nullary.Decidable             using  ( _×-dec_ )
 -- Imports from the Agda Universal Algebra Library ------------------------------
 open import Classical.Properties.Lattice             using  ( module Lattice-Order
                                                             ; TopOf ; BotOf )
+open import Classical.Signatures.Lattice             using  (Sig-Lattice)
 open import Classical.Small.Structures.Lattice       using  ( Lattice )
 open import Classical.Structures.Interpret           using  ( interp-cong )
 open import Classical.Structures.Lattice.OrdinalSum  using  ( module GlueSetoid
@@ -130,8 +140,8 @@ finitary algebras with chosen basepoints, everything at level `0ℓ`.
 ```agda
 module OrdinalSumWitness
   {𝑆₁ 𝑆₂ : Signature 0ℓ 0ℓ}
-  (𝑨 : Algebra {𝑆 = 𝑆₁} 0ℓ 0ℓ) (𝑭₁ : FiniteAlgebra 𝑨) (𝑮₁ : FiniteSignature 𝑆₁) (a* : 𝕌[ 𝑨 ])
-  (𝑩 : Algebra {𝑆 = 𝑆₂} 0ℓ 0ℓ) (𝑭₂ : FiniteAlgebra 𝑩) (𝑮₂ : FiniteSignature 𝑆₂) (b* : 𝕌[ 𝑩 ])
+  (𝑨 : Algebra {𝑆 = 𝑆₁} 0ℓ 0ℓ) (𝑭₁ : FiniteAlgebra 𝑨) (S₁ : FiniteSignature 𝑆₁) (a* : 𝕌[ 𝑨 ])
+  (𝑩 : Algebra {𝑆 = 𝑆₂} 0ℓ 0ℓ) (𝑭₂ : FiniteAlgebra 𝑩) (S₂ : FiniteSignature 𝑆₂) (b* : 𝕌[ 𝑩 ])
   where
 
   private
@@ -146,9 +156,9 @@ module OrdinalSumWitness
     renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
 ```
 
-**The carrier**: the amalgam of the two carriers at the basepoints, with its
-retractions (the isolated-equality locus for the Cubical port lives in
-`GlueSetoid`{.AgdaModule}).
+#### The carrier
+
+The amalgam of the two carriers at the basepoints is accompanied by the retractions.[^2]
 
 ```agda
   open GlueSetoid 𝔻[ 𝑨 ] a* 𝔻[ 𝑩 ] b*
@@ -161,9 +171,11 @@ retractions (the isolated-equality locus for the Cubical port lives in
     renaming ( trans to transᵍ ; reflexive to ≡→≈ᵍ )
 ```
 
-**The signature**: the two component signatures side by side with the
-single-point collapse family, indexed by a source in `𝑩` and a target in `𝑨`
-(via the enumerations).  Family members are unary.
+#### The signature
+
+The two component signatures side-by-side with the single-point collapse family is
+indexed by a source in `𝑩` and a target in `𝑨` (via the enumerations).  Family
+members are unary.
 
 ```agda
   OpSymbols : Type 0ℓ
@@ -178,11 +190,14 @@ single-point collapse family, indexed by a source in `𝑩` and a target in `�
   𝑆ₒ = OpSymbols , arity
 ```
 
-**The collapse maps.**  `h i k` sends (anything `≈` to) the basepoint to `a*`,
-then (anything `≈` to) `enum₂ i` to `enum₁ k`, and everything else to `a*`;
-the guard keeps the lift `ĥ` congruent across the glue.  The three evaluation
-lemmas — at the basepoint, at the programmed point, away from it — are the
-module's workhorses.
+#### The collapse maps
+
+`h i k` sends (anything `≈` to) the basepoint to `a*`, then (anything `≈` to)
+`enum₂ i` to `enum₁ k`, and everything else to `a*`; the guard keeps the lift `ĥ`
+congruent across the glue.
+
+The three evaluation lemmas — at the basepoint, at the programmed point, away from it
+— are the module's workhorses.
 
 ```agda
   private
@@ -263,22 +278,24 @@ module's workhorses.
     ĥ-lands-left i k (inj₂ _) = refl
 ```
 
-**The algebra**: `𝑆₁` acts through the left retraction, `𝑆₂` through the
-right one, and the family symbols act by `ĥ`{.AgdaFunction}.
+#### The algebra
+
+`𝑆₁` acts through the left retraction, `𝑆₂` through the right one, and the family
+symbols act by `ĥ`{.AgdaFunction}.
 
 ```agda
   𝑪 : Algebra {𝑆 = 𝑆ₒ} 0ℓ 0ℓ
   𝑪 = mkAlgebra glueSetoid interp interp-congruence
     where
     interp : (o : OpSymbols) → Op (arity o) A⊎B
-    interp (inj₁ f)              args = inj₁ ((f ^ 𝑨) (retractˡ ∘ args))
-    interp (inj₂ (inj₁ g))       args = inj₂ ((g ^ 𝑩) (retractʳ ∘ args))
+    interp (inj₁ f) args = inj₁ ((f ^ 𝑨) (retractˡ ∘ args))
+    interp (inj₂ (inj₁ g)) args = inj₂ ((g ^ 𝑩) (retractʳ ∘ args))
     interp (inj₂ (inj₂ (i , k))) args = ĥ i k (args 0F)
 
     interp-congruence : ∀ o {u v : arity o → A⊎B}
       → (∀ i → u i ≈ᵍ v i) → interp o u ≈ᵍ interp o v
-    interp-congruence (inj₁ f)              e = ≈ᵍ-inj₁ (interp-cong 𝑨 f (λ i → proj₁ (e i)))
-    interp-congruence (inj₂ (inj₁ g))       e = ≈ᵍ-inj₂ (interp-cong 𝑩 g (λ i → proj₂ (e i)))
+    interp-congruence (inj₁ f) e = ≈ᵍ-inj₁ (interp-cong 𝑨 f (proj₁ ∘ e))
+    interp-congruence (inj₂ (inj₁ g)) e = ≈ᵍ-inj₂ (interp-cong 𝑩 g (proj₂ ∘ e))
     interp-congruence (inj₂ (inj₂ (i , k))) {u} {v} e = ĥ-cong i k {u 0F} {v 0F} (e 0F)
 ```
 
@@ -299,75 +316,87 @@ through a `combine`/`remQuot` layer.
   𝑪-FiniteAlgebra : FiniteAlgebra 𝑪
   𝑪-FiniteAlgebra ._≟_ = decEq
     where
+    open FiniteAlgebra 𝑭₁ using() renaming (_≟_ to _≟₁_ )
+    open FiniteAlgebra 𝑭₂ using() renaming (_≟_ to _≟₂_ )
+
     decEq : (x y : A⊎B) → Dec (x ≈ᵍ y)
-    decEq (inj₁ a) (inj₁ a') with 𝑭₁ ._≟_ a a'
+
+    decEq (inj₁ a) (inj₁ a') with a ≟₁ a'
     ... | yes p = yes (p , refl₂)
     ... | no ¬p = no λ e → ¬p (proj₁ e)
-    decEq (inj₁ a) (inj₂ b) with 𝑭₁ ._≟_ a a* | 𝑭₂ ._≟_ b* b
+
+    decEq (inj₁ a) (inj₂ b) with a ≟₁ a* | b* ≟₂ b
     ... | yes p  | yes q  = yes (p , q)
-    ... | yes _  | no ¬q  = no λ e → ¬q (proj₂ e)
-    ... | no ¬p  | yes _  = no λ e → ¬p (proj₁ e)
-    ... | no ¬p  | no _   = no λ e → ¬p (proj₁ e)
-    decEq (inj₂ b) (inj₁ a) with 𝑭₁ ._≟_ a* a | 𝑭₂ ._≟_ b b*
+    ... | yes _  | no ¬q  = no λ (_ , e) → ¬q e
+    ... | no ¬p  | yes _  = no λ (e , _) → ¬p e
+    ... | no ¬p  | no _   = no λ (e , _) → ¬p e
+
+    decEq (inj₂ b) (inj₁ a) with a* ≟₁ a | b ≟₂ b*
     ... | yes p  | yes q  = yes (p , q)
-    ... | yes _  | no ¬q  = no λ e → ¬q (proj₂ e)
-    ... | no ¬p  | yes _  = no λ e → ¬p (proj₁ e)
-    ... | no ¬p  | no _   = no λ e → ¬p (proj₁ e)
-    decEq (inj₂ b) (inj₂ b') with 𝑭₂ ._≟_ b b'
+    ... | yes _  | no ¬q  = no λ (_ , e) → ¬q e
+    ... | no ¬p  | yes _  = no λ (e , _) → ¬p e
+    ... | no ¬p  | no _   = no λ (e , _) → ¬p e
+    decEq (inj₂ b) (inj₂ b') with b ≟₂ b'
     ... | yes p = yes (refl₁ , p)
-    ... | no ¬p = no λ e → ¬p (proj₂ e)
+    ... | no ¬p = no λ (_ , e) → ¬p e
+
   𝑪-FiniteAlgebra .card = m + n
   𝑪-FiniteAlgebra .enum = enumC
   𝑪-FiniteAlgebra .enum-sur = sur
     where
     sur : ∀ x → Σ[ i ∈ Fin (m + n) ] enumC i ≈ᵍ x
     sur (inj₁ a) with 𝑭₁ .enum-sur a
-    ... | i , p = join m n (inj₁ i) ,
-      transᵍ {enumC (join m n (inj₁ i))} {inj₁ (enum₁ i)} {inj₁ a}
-        (≡→≈ᵍ (enumC-join (inj₁ i))) (≈ᵍ-inj₁ p)
+    ... | i , p =  join m n (inj₁ i)
+                   ,  transᵍ
+                      {enumC (join m n (inj₁ i))} {inj₁ (enum₁ i)} {inj₁ a}
+                      (≡→≈ᵍ (enumC-join (inj₁ i))) (≈ᵍ-inj₁ p)
     sur (inj₂ b) with 𝑭₂ .enum-sur b
-    ... | j , p = join m n (inj₂ j) ,
-      transᵍ {enumC (join m n (inj₂ j))} {inj₂ (enum₂ j)} {inj₂ b}
-        (≡→≈ᵍ (enumC-join (inj₂ j))) (≈ᵍ-inj₂ p)
-
+    ... | j , p =  join m n (inj₂ j)
+                   ,  transᵍ
+                      {enumC (join m n (inj₂ j))} {inj₂ (enum₂ j)} {inj₂ b}
+                      (≡→≈ᵍ (enumC-join (inj₂ j))) (≈ᵍ-inj₂ p)
   private
-    c₁ = 𝑮₁ .opCard
-    c₂ = 𝑮₂ .opCard
+    c₁ = S₁ .opCard
+    c₂ = S₂ .opCard
 
     decode₂ : Fin (c₂ + n * m) → OperationSymbolsOf 𝑆₂ ⊎ (Fin n × Fin m)
-    decode₂ = [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ ∘ splitAt c₂
+    decode₂ = [ inj₁ ∘ S₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ ∘ splitAt c₂
 
     decode : Fin (c₁ + (c₂ + n * m)) → OpSymbols
-    decode = [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ ∘ splitAt c₁
+    decode = [ inj₁ ∘ S₁ .opEnum , inj₂ ∘ decode₂ ]′ ∘ splitAt c₁
 
     decode-join : (x : Fin c₁ ⊎ Fin (c₂ + n * m))
-      → decode (join c₁ _ x) ≡ [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ x
-    decode-join x = cong [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ (splitAt-join c₁ _ x)
+      → decode (join c₁ _ x) ≡ [ inj₁ ∘ S₁ .opEnum , inj₂ ∘ decode₂ ]′ x
+    decode-join x = cong [ inj₁ ∘ S₁ .opEnum , inj₂ ∘ decode₂ ]′ (splitAt-join c₁ _ x)
 
     decode₂-join : (x : Fin c₂ ⊎ Fin (n * m))
-      → decode₂ (join c₂ _ x) ≡ [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ x
-    decode₂-join x = cong [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ (splitAt-join c₂ _ x)
+      → decode₂ (join c₂ _ x) ≡ [ inj₁ ∘ S₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ x
+    decode₂-join x = cong [ inj₁ ∘ S₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ (splitAt-join c₂ _ x)
+
 
     decode-sur : (o : OpSymbols) → Σ[ k ∈ Fin (c₁ + (c₂ + n * m)) ] decode k ≡ o
-    decode-sur (inj₁ f) with 𝑮₁ .opEnum-sur f
+
+    decode-sur (inj₁ f) with S₁ .opEnum-sur f
     ... | i , p = join c₁ _ (inj₁ i) , trans (decode-join (inj₁ i)) (cong inj₁ p)
-    decode-sur (inj₂ (inj₁ g)) with 𝑮₂ .opEnum-sur g
+
+    decode-sur (inj₂ (inj₁ g)) with S₂ .opEnum-sur g
     ... | j , p =
-      join c₁ _ (inj₂ (join c₂ _ (inj₁ j))) ,
-      trans (decode-join (inj₂ (join c₂ _ (inj₁ j))))
-        (trans (cong inj₂ (decode₂-join (inj₁ j))) (cong (inj₂ ∘ inj₁) p))
+      join c₁ _ (inj₂ (join c₂ _ (inj₁ j)))
+      , trans  (decode-join (inj₂ (join c₂ _ (inj₁ j))))
+               (trans  (cong inj₂ (decode₂-join (inj₁ j))) (cong (inj₂ ∘ inj₁) p))
+
     decode-sur (inj₂ (inj₂ (i , k))) =
-      join c₁ _ (inj₂ (join c₂ _ (inj₂ (combine i k)))) ,
-      trans (decode-join (inj₂ (join c₂ _ (inj₂ (combine i k)))))
-        (trans (cong inj₂ (decode₂-join (inj₂ (combine i k))))
-               (cong (inj₂ ∘ inj₂) (remQuot-combine i k)))
+      join c₁ _ (inj₂ (join c₂ _ (inj₂ (combine i k))))
+      , trans  (decode-join (inj₂ (join c₂ _ (inj₂ (combine i k)))))
+               (trans  (cong inj₂ (decode₂-join (inj₂ (combine i k))))
+                       (cong (inj₂ ∘ inj₂) (remQuot-combine i k)))
 
   𝑆ₒ-FiniteSignature : FiniteSignature 𝑆ₒ
-  𝑆ₒ-FiniteSignature .opCard      = c₁ + (c₂ + n * m)
-  𝑆ₒ-FiniteSignature .opEnum      = decode
-  𝑆ₒ-FiniteSignature .opEnum-sur  = decode-sur
-  𝑆ₒ-FiniteSignature .finitary (inj₁ f)         = 𝑮₁ .finitary f
-  𝑆ₒ-FiniteSignature .finitary (inj₂ (inj₁ g))  = 𝑮₂ .finitary g
+  𝑆ₒ-FiniteSignature .opCard                    = c₁ + (c₂ + n * m)
+  𝑆ₒ-FiniteSignature .opEnum                    = decode
+  𝑆ₒ-FiniteSignature .opEnum-sur                = decode-sur
+  𝑆ₒ-FiniteSignature .finitary (inj₁ f)         = S₁ .finitary f
+  𝑆ₒ-FiniteSignature .finitary (inj₂ (inj₁ g))  = S₂ .finitary g
   𝑆ₒ-FiniteSignature .finitary (inj₂ (inj₂ _))  = 1 , ↔-id _
 ```
 
@@ -390,20 +419,20 @@ operation of `𝑪` descends along the retraction, so compatibility is uniform.
     eqv : IsEquivalence rel
     eqv = record
       { refl   = λ {x} → refl₂ {retractʳ x}
-      ; sym    = λ e → sym₂ e
-      ; trans  = λ d e → trans₂ d e
+      ; sym    = sym₂
+      ; trans  = trans₂
       }
 
     cmp : 𝑪 ∣≈ rel
-    cmp (inj₁ f)              uv = refl₂
-    cmp (inj₂ (inj₁ g))       {U} {V} uv =
-      interp-cong 𝑩 g {retractʳ ∘ U} {retractʳ ∘ V} uv
-    cmp (inj₂ (inj₂ (i , k))) {U} {V} uv {- both images land left -} =
-      ≡→≈₂ (trans (ĥ-lands-left i k (U 0F)) (sym (ĥ-lands-left i k (V 0F))))
+    cmp (inj₁ f) _ = refl₂
+    cmp (inj₂ (inj₁ g)) {U} {V} uv = interp-cong 𝑩 g {retractʳ ∘ U} {retractʳ ∘ V} uv
+    cmp (inj₂ (inj₂ (i , k))) {U} {V} _ = ≡→≈₂ (trans  (ĥ-lands-left i k (U 0F))
+                                                       (sym (ĥ-lands-left i k (V 0F))))
       where ≡→≈₂ = Setoid.reflexive 𝔻[ 𝑩 ]
 
     dec : ∀ x y → Dec (rel x y)
-    dec x y = 𝑭₂ ._≟_ (retractʳ x) (retractʳ y)
+    dec x y = retractʳ x ≟₂ retractʳ y
+      where open FiniteAlgebra 𝑭₂ using () renaming ( _≟_ to _≟₂_ )
 ```
 
 #### Restrictions and extensions of congruences
@@ -467,9 +496,8 @@ compatibility proofs ride on the same reductions as the interpretations.
 
   -- Extend a lower-summand congruence below the boundary.
   lowerExt : DecCon 𝑨 0ℓ → DecCon 𝑪 0ℓ
-  lowerExt d₁ = (rel , mkcon (λ {x} {y} e → rfl {x} {y} e) eqv cmp) , dec
+  lowerExt d₁@((θ , con₁) , dec₁) = (rel , mkcon (λ {x} {y} e → rfl {x} {y} e) eqv cmp) , dec
     where
-    con₁ = proj₂ (proj₁ d₁)
 
     rel : A⊎B → A⊎B → Type 0ℓ
     rel x y = ConRel d₁ (retractˡ x) (retractˡ y) × (retractʳ x ≈₂ retractʳ y)
@@ -495,22 +523,17 @@ compatibility proofs ride on the same reductions as the interpretations.
       ConRel-resp d₁ {a*} {h i k b} {a} {a} (sym₁ (h-at-b* i k r)) refl₁ l , refl₂
 
     cmp : 𝑪 ∣≈ rel
-    cmp (inj₁ f)              uv = is-compatible con₁ f (λ i → proj₁ (uv i)) , refl₂
-    cmp (inj₂ (inj₁ g))       {U} {V} uv =
-      reflexive con₁ refl₁
-      , interp-cong 𝑩 g {retractʳ ∘ U} {retractʳ ∘ V} (λ i → proj₂ (uv i))
+    cmp (inj₁ f) uv = is-compatible con₁ f (proj₁ ∘ uv) , refl₂
+    cmp (inj₂ (inj₁ g)) {U} {V} uv =  reflexive con₁ refl₁ , interp-cong 𝑩 g (proj₂ ∘ uv)
     cmp (inj₂ (inj₂ (i , k))) {U} {V} uv = ĥ-pres i k {U 0F} {V 0F} (uv 0F)
 
     dec : ∀ x y → Dec (rel x y)
-    dec x y = (proj₂ d₁ (retractˡ x) (retractˡ y))
-              ×-dec (𝑭₂ ._≟_ (retractʳ x) (retractʳ y))
+    dec x y = (dec₁ (retractˡ x) (retractˡ y)) ×-dec (𝑭₂ ._≟_ (retractʳ x) (retractʳ y))
 
   -- Extend an upper-summand congruence above the boundary.
   upperExt : DecCon 𝑩 0ℓ → DecCon 𝑪 0ℓ
-  upperExt d₂ = (rel , mkcon (λ {x} {y} e → rfl {x} {y} e) eqv cmp) , dec
+  upperExt d₂@((_ , con₂) , dec₂) = (rel , mkcon (λ {x} {y} e → rfl {x} {y} e) eqv cmp) , dec
     where
-    con₂ = proj₂ (proj₁ d₂)
-
     rel : A⊎B → A⊎B → Type 0ℓ
     rel x y = ConRel d₂ (retractʳ x) (retractʳ y)
 
@@ -525,15 +548,14 @@ compatibility proofs ride on the same reductions as the interpretations.
       }
 
     cmp : 𝑪 ∣≈ rel
-    cmp (inj₁ f)              uv = reflexive con₂ refl₂
-    cmp (inj₂ (inj₁ g))       {U} {V} uv =
-      is-compatible con₂ g {retractʳ ∘ U} {retractʳ ∘ V} uv
+    cmp (inj₁ f) _ = reflexive con₂ refl₂
+    cmp (inj₂ (inj₁ g)) {U} {V} uv = is-compatible con₂ g {retractʳ ∘ U} {retractʳ ∘ V} uv
     cmp (inj₂ (inj₂ (i , k))) {U} {V} uv =
       reflexive con₂ (≡→≈₂ (trans (ĥ-lands-left i k (U 0F)) (sym (ĥ-lands-left i k (V 0F)))))
       where ≡→≈₂ = Setoid.reflexive 𝔻[ 𝑩 ]
 
     dec : ∀ x y → Dec (rel x y)
-    dec x y = proj₂ d₂ (retractʳ x) (retractʳ y)
+    dec x y = dec₂ (retractʳ x) (retractʳ y)
 ```
 
 The bookkeeping lemmas the isomorphism consumes: monotonicity and
@@ -558,28 +580,28 @@ boundary's restrictions with the extreme congruences.
   lowerExt-cong≑ (s₁ , s₂) = (λ (l , r) → s₁ l , r) , (λ (l , r) → s₂ l , r)
 
   upperExt-cong≑ : {d e : DecCon 𝑩 0ℓ} → d ≑ᵈ e → upperExt d ≑ᵈ upperExt e
-  upperExt-cong≑ (s₁ , s₂) = (λ p → s₁ p) , (λ p → s₂ p)
+  upperExt-cong≑ (s₁ , s₂) = s₁ , s₂
 
   -- Restricting an extension recovers the summand congruence.
   restrictA-lowerExt : (d₁ : DecCon 𝑨 0ℓ) → restrictA (lowerExt d₁) ≑ᵈ d₁
-  restrictA-lowerExt d₁ = (λ p → proj₁ p) , (λ p → p , refl₂)
+  restrictA-lowerExt d₁ = proj₁ , λ p → (p , refl₂)
 
   restrictB-upperExt : (d₂ : DecCon 𝑩 0ℓ) → restrictB (upperExt d₂) ≑ᵈ d₂
-  restrictB-upperExt d₂ = (λ p → p) , (λ p → p)
+  restrictB-upperExt d₂ = id , id
 
   -- Lower extensions sit below the boundary; upper ones sit above it.
   lowerExt-⊆-α : (d₁ : DecCon 𝑨 0ℓ) → lowerExt d₁ ⊆ᵈ αᵈ
-  lowerExt-⊆-α d₁ (_ , r) = r
+  lowerExt-⊆-α _ (_ , r) = r
 
   α-⊆-upperExt : (d₂ : DecCon 𝑩 0ℓ) → αᵈ ⊆ᵈ upperExt d₂
-  α-⊆-upperExt d₂ e = reflexive (proj₂ (proj₁ d₂)) e
+  α-⊆-upperExt ((_ , con₂) , _) e = reflexive con₂ e
 
   -- The boundary restricts to the total congruence below, the diagonal above.
   restrictA-α : restrictA αᵈ ≑ᵈ 𝟙ᵈ {ℓ = 0ℓ}
   restrictA-α = (λ _ → lift tt) , (λ _ → refl₂)
 
   restrictB-α : restrictB αᵈ ≑ᵈ 𝟘ᵈ (𝑭₂ ._≟_)
-  restrictB-α = (λ e → lift e) , (λ e → lower e)
+  restrictB-α = lift , lower
 ```
 
 #### The comparability dichotomy
@@ -601,11 +623,10 @@ chained through `a*` in the pure case.
     lower-gap θ ¬α⊆θ with ⊈ᵈ-witness 𝑪-FiniteAlgebra αᵈ θ ¬α⊆θ
     ... | inj₁ a , inj₁ a' , (_ , ¬θr)   = a , a' , ¬θr
     ... | inj₁ a , inj₂ b , (αr , ¬θr)   =
-      a , a* , λ p → ¬θr (ConRel-resp θ {inj₁ a} {inj₁ a} {inj₁ a*} {inj₂ b}
-                            (refl₁ , refl₂) (refl₁ , αr) p)
+      a , a* , λ p → ¬θr (ConRel-resp θ (refl₁ , refl₂) (refl₁ , αr) p)
+
     ... | inj₂ b , inj₁ a , (αr , ¬θr)   =
-      a* , a , λ p → ¬θr (ConRel-resp θ {inj₁ a*} {inj₂ b} {inj₁ a} {inj₁ a}
-                            (refl₁ , sym₂ αr) (refl₁ , refl₂) p)
+      a* , a , λ p → ¬θr (ConRel-resp θ (refl₁ , sym₂ αr) (refl₁ , refl₂) p)
     ... | inj₂ b , inj₂ b' , (αr , ¬θr)  =
       ⊥-elim (¬θr (reflexive (proj₂ (proj₁ θ)) (refl₁ , αr)))
 
@@ -621,8 +642,7 @@ chained through `a*` in the pure case.
 
       -- Send b to any designated target, staying θ-related to a.
       punch : (z : 𝕌[ 𝑨 ]) → ConRel θ (inj₁ a) (inj₁ z)
-      punch z = ConRel-resp θ {inj₁ a} {inj₁ a} {inj₁ (h[ b ↦ z ] b)} {inj₁ z}
-                  (refl₁ , refl₂) (≈ᵍ-inj₁ (h-at b z ¬b*))
+      punch z = ConRel-resp θ  (refl₁ , refl₂) (≈ᵍ-inj₁ (h-at b z ¬b*))
                   (is-compatible θcon (inj₂ (inj₂ (idx₂ b , idx₁ z))) (λ _ → θab))
 
       decide : ⊥
@@ -646,37 +666,29 @@ chained through `a*` in the pure case.
 
       final : Σ[ p ∈ A⊎B ] Σ[ q ∈ A⊎B ] (ConRel θ p q × ¬ (retractʳ p ≈₂ retractʳ q)) → ⊥
       final (inj₁ a , inj₁ a' , (_ , ¬ρ))   = ¬ρ refl₂
-      final (inj₁ a , inj₂ b , (θr , ¬ρ))   =
-        mixed-absurd θ x y ¬θxy a b (λ e → ¬ρ (sym₂ e)) θr
-      final (inj₂ b , inj₁ a , (θr , ¬ρ))   =
-        mixed-absurd θ x y ¬θxy a b ¬ρ (θsym θr)
+      final (inj₁ a , inj₂ b , (θr , ¬ρ))   = mixed-absurd θ x y ¬θxy a b (λ e → ¬ρ (sym₂ e)) θr
+      final (inj₂ b , inj₁ a , (θr , ¬ρ))   = mixed-absurd θ x y ¬θxy a b ¬ρ (θsym θr)
       final (inj₂ b , inj₂ b' , (θr , ¬ρ))  = pure ¬ρ
         where
         -- Both endpoints upper: peel off basepoint-touching subcases, then
         -- collapse twice through a*.
         pure : ¬ (b ≈₂ b') → ⊥
         pure ¬bb' with 𝑭₂ ._≟_ b b* | 𝑭₂ ._≟_ b' b*
-        ... | yes pb  | yes pb'  = ¬bb' (trans₂ pb (sym₂ pb'))
-        ... | yes pb  | no ¬pb'  =
-          mixed-absurd θ x y ¬θxy a* b' ¬pb'
-            (ConRel-resp θ {inj₂ b} {inj₁ a*} {inj₂ b'} {inj₂ b'}
-              (refl₁ , pb) (refl₁ , refl₂) θr)
-        ... | no ¬pb  | yes pb'  =
-          mixed-absurd θ x y ¬θxy a* b ¬pb
-            (θsym (ConRel-resp θ {inj₂ b} {inj₂ b} {inj₂ b'} {inj₁ a*}
-              (refl₁ , refl₂) (refl₁ , pb') θr))
-        ... | no ¬pb  | no ¬pb'  = ¬θxy (θtrans θx-a* θa*-y)
+        ... | yes pb  | yes pb'  =  ¬bb' (trans₂ pb (sym₂ pb'))
+        ... | yes pb  | no ¬pb'  =  mixed-absurd θ x y ¬θxy a* b' ¬pb'
+                                    (ConRel-resp θ (refl₁ , pb) (refl₁ , refl₂) θr)
+        ... | no ¬pb  | yes pb'  =  mixed-absurd θ x y ¬θxy a* b ¬pb
+                                    (θsym (ConRel-resp θ (refl₁ , refl₂) (refl₁ , pb') θr))
+        ... | no ¬pb  | no ¬pb'  =  ¬θxy (θtrans θx-a* θa*-y)
           where
           θx-a* : ConRel θ (inj₁ x) (inj₁ a*)
           θx-a* = ConRel-resp θ
-                    {inj₁ (h[ b ↦ x ] b)} {inj₁ x} {inj₁ (h[ b ↦ x ] b')} {inj₁ a*}
                     (≈ᵍ-inj₁ (h-at b x ¬pb))
                     (≈ᵍ-inj₁ (h-away b x b' (λ e → ¬bb' (sym₂ e))))
                     (is-compatible θcon (inj₂ (inj₂ (idx₂ b , idx₁ x))) (λ _ → θr))
 
           θa*-y : ConRel θ (inj₁ a*) (inj₁ y)
           θa*-y = ConRel-resp θ
-                    {inj₁ (h[ b' ↦ y ] b)} {inj₁ a*} {inj₁ (h[ b' ↦ y ] b')} {inj₁ y}
                     (≈ᵍ-inj₁ (h-away b' y b ¬bb'))
                     (≈ᵍ-inj₁ (h-at b' y ¬pb'))
                     (is-compatible θcon (inj₂ (inj₂ (idx₂ b' , idx₁ y))) (λ _ → θr))
@@ -703,36 +715,27 @@ upper extension.  These are the constructive readings of the manuscript's
     θcon = proj₂ (proj₁ θ)
 
     fwd : θ ⊆ᵈ lowerExt (restrictA θ)
-    fwd {inj₁ a} {inj₁ a'} p = p , θ⊆α p
-    fwd {inj₁ a} {inj₂ b}  p =
-      ConRel-resp θ {inj₁ a} {inj₁ a} {inj₂ b} {inj₁ a*}
-        (refl₁ , refl₂) (refl₁ , sym₂ (θ⊆α p)) p , θ⊆α p
-    fwd {inj₂ b} {inj₁ a}  p =
-      ConRel-resp θ {inj₂ b} {inj₁ a*} {inj₁ a} {inj₁ a}
-        (refl₁ , θ⊆α p) (refl₁ , refl₂) p , θ⊆α p
-    fwd {inj₂ b} {inj₂ b'} p = reflexive θcon (≈ᵍ-inj₁ refl₁) , θ⊆α p
+    fwd {inj₁ _} {inj₁ _} p = p , θ⊆α p
+    fwd {inj₁ _} {inj₂ _} p = ConRel-resp θ (refl₁ , refl₂) (refl₁ , sym₂ (θ⊆α p)) p , θ⊆α p
+    fwd {inj₂ _} {inj₁ _} p = ConRel-resp θ (refl₁ , θ⊆α p) (refl₁ , refl₂) p , θ⊆α p
+    fwd {inj₂ _} {inj₂ _} p = reflexive θcon (≈ᵍ-inj₁ refl₁) , θ⊆α p
 
     bwd : lowerExt (restrictA θ) ⊆ᵈ θ
-    bwd {inj₁ a} {inj₁ a'} (l , r) = l
-    bwd {inj₁ a} {inj₂ b}  (l , r) =
-      ConRel-resp θ {inj₁ a} {inj₁ a} {inj₁ a*} {inj₂ b}
-        (refl₁ , refl₂) (refl₁ , r) l
-    bwd {inj₂ b} {inj₁ a}  (l , r) =
-      ConRel-resp θ {inj₁ a*} {inj₂ b} {inj₁ a} {inj₁ a}
-        (refl₁ , sym₂ r) (refl₁ , refl₂) l
-    bwd {inj₂ b} {inj₂ b'} (l , r) = reflexive θcon (refl₁ , r)
+    bwd {inj₁ _} {inj₁ _} (l , r) = l
+    bwd {inj₁ _} {inj₂ _} (l , r) = ConRel-resp θ  (refl₁ , refl₂) (refl₁ , r) l
+    bwd {inj₂ _} {inj₁ _} (l , r) = ConRel-resp θ (refl₁ , sym₂ r) (refl₁ , refl₂) l
+    bwd {inj₂ _} {inj₂ _} (l , r) = reflexive θcon (refl₁ , r)
 
   upper-split : (θ : DecCon 𝑪 0ℓ) → αᵈ ⊆ᵈ θ → θ ≑ᵈ upperExt (restrictB θ)
-  upper-split θ α⊆θ = fwd , bwd
+  upper-split θ@((_ , θcon) , θdec) α⊆θ = fwd , bwd
     where
-    θcon    = proj₂ (proj₁ θ)
     θsym    = IsEquivalence.sym (is-equivalence θcon)
     θtrans  = IsEquivalence.trans (is-equivalence θcon)
 
     -- Every element is θ-related to the upper image of its right retraction:
     -- upper elements on the nose, lower ones through the boundary.
     bridge : ∀ z → ConRel θ z (inj₂ (retractʳ z))
-    bridge (inj₁ a) = α⊆θ {inj₁ a} {inj₂ b*} refl₂
+    bridge (inj₁ a) = α⊆θ refl₂
     bridge (inj₂ b) = reflexive θcon (refl₁ , refl₂)
 
     fwd : θ ⊆ᵈ upperExt (restrictB θ)
@@ -752,12 +755,18 @@ extrema (`top-unique`{.AgdaFunction} / `bot-unique`{.AgdaFunction}) applied to
 the images of the total and diagonal congruences.
 
 ```agda
-  module _ {𝑳₁ 𝑳₂ : Lattice} (t : TopOf 𝑳₁) (b : BotOf 𝑳₂)
-           (iso₁ : ConIsoᵈ 𝑨 𝑳₁) (iso₂ : ConIsoᵈ 𝑩 𝑳₂)
+  module _ {𝓛₁ 𝓛₂ : Lattice} (t : TopOf 𝓛₁) (b : BotOf 𝓛₂)
+           (iso₁ : ConIsoᵈ 𝑨 𝓛₁) (iso₂ : ConIsoᵈ 𝑩 𝓛₂)
     where
+    𝑳₁ 𝑳₂ : Algebra {𝑆 = Sig-Lattice} 0ℓ 0ℓ
+    𝑳₁ = 𝓛₁ .proj₁
+    𝑳₂ = 𝓛₂ .proj₁
 
     private
+      ⊤₁ : 𝕌[ 𝑳₁ ]
       ⊤₁ = proj₁ t
+
+      ⊥₂ : 𝕌[ 𝑳₂ ]
       ⊥₂ = proj₁ b
 
     open OrderIso iso₁
@@ -766,32 +775,32 @@ the images of the total and diagonal congruences.
     open OrderIso iso₂
       renaming ( to to to₂ ; from to from₂ ; to-mono to to-mono₂
                ; from-mono to from-mono₂ ; to∘from to to∘from₂ ; from∘to to from∘to₂ )
-    open ConIsoᵈ-Consequences {𝑆 = 𝑆₁} {𝑨 = 𝑨} {𝑳 = 𝑳₁} iso₁ using ()
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆₁} {𝑨 = 𝑨} {𝑳 = 𝓛₁} iso₁ using ()
       renaming ( to-cong≑ to to-cong≑₁ ; from-cong≈ to from-cong≈₁ ; to-𝟙-top to to-𝟙-top₁ )
-    open ConIsoᵈ-Consequences {𝑆 = 𝑆₂} {𝑨 = 𝑩} {𝑳 = 𝑳₂} iso₂ using ()
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆₂} {𝑨 = 𝑩} {𝑳 = 𝓛₂} iso₂ using ()
       renaming ( to-cong≑ to to-cong≑₂ ; from-cong≈ to from-cong≈₂ ; to-𝟘-bot to to-𝟘-bot₂ )
-    open Setoid 𝔻[ proj₁ 𝑳₁ ] using ()
+    open Setoid 𝔻[ 𝑳₁ ] using ()
       renaming ( _≈_ to _≈ᴸ¹_ ; refl to reflᴸ¹ ; sym to symᴸ¹ ; trans to transᴸ¹ )
-    open Setoid 𝔻[ proj₁ 𝑳₂ ] using ()
+    open Setoid 𝔻[ 𝑳₂ ] using ()
       renaming ( _≈_ to _≈ᴸ²_ ; refl to reflᴸ² ; sym to symᴸ² ; trans to transᴸ² )
-    open LatticeOrdinalSum 𝑳₁ t 𝑳₂ b using
+    open LatticeOrdinalSum 𝓛₁ t 𝓛₂ b using
       ( ≤ᵒ-inj₁ ; ≤ᵒ-inj₁-elim ; ≤ᵒ-inj₂ ; ≤ᵒ-inj₂-elim ; ≤ᵒ-up ; ≤ᵒ-down ; ≤ᵒ-down-elim )
 
     private
       -- Boundary coherence: the extreme images agree with the chosen extrema.
       to₁𝟙≈⊤ : to₁ (𝟙ᵈ {ℓ = 0ℓ}) ≈ᴸ¹ ⊤₁
-      to₁𝟙≈⊤ = Lattice-Order.top-unique 𝑳₁
+      to₁𝟙≈⊤ = Lattice-Order.top-unique 𝓛₁
                  {t = to₁ (𝟙ᵈ {ℓ = 0ℓ})} {t' = ⊤₁} to-𝟙-top₁ (proj₂ t)
 
       to₂𝟘≈⊥ : to₂ (𝟘ᵈ (𝑭₂ ._≟_)) ≈ᴸ² ⊥₂
-      to₂𝟘≈⊥ = Lattice-Order.bot-unique 𝑳₂
-                 {b = to₂ (𝟘ᵈ (𝑭₂ ._≟_))} {b' = ⊥₂} (to-𝟘-bot₂ (𝑭₂ ._≟_)) (proj₂ b)
+      to₂𝟘≈⊥ =  Lattice-Order.bot-unique 𝓛₂
+                {b = to₂ (𝟘ᵈ (𝑭₂ ._≟_))} {b' = ⊥₂} (to-𝟘-bot₂ (𝑭₂ ._≟_)) (proj₂ b)
 
       -- The images of a boundary-equal congruence sit at the glue.
       atGlue-⊤ : (θ : DecCon 𝑪 0ℓ) → θ ≑ᵈ αᵈ → to₁ (restrictA θ) ≈ᴸ¹ ⊤₁
       atGlue-⊤ θ (s₁ , s₂) =
-        transᴸ¹ (to-cong≑₁ ((λ _ → lift tt) , (λ {a} {a'} _ → s₂ {inj₁ a} {inj₁ a'} refl₂)))
-          to₁𝟙≈⊤
+        transᴸ¹  (to-cong≑₁ ((λ _ → lift tt) , (λ {a} {a'} _ → s₂ {inj₁ a} {inj₁ a'} refl₂)))
+                 to₁𝟙≈⊤
 
       atGlue-⊥ : (θ : DecCon 𝑪 0ℓ) → θ ≑ᵈ αᵈ → to₂ (restrictB θ) ≈ᴸ² ⊥₂
       atGlue-⊥ θ (s₁ , s₂) =
@@ -803,76 +812,72 @@ The map, its inverse, and the four obligations.  The map decides the side via
 branch, with the mixed branches all funneling through the glue coherences.
 
 ```agda
-    toᵒ : DecCon 𝑪 0ℓ → 𝕌[ proj₁ 𝑳₁ ] ⊎ 𝕌[ proj₁ 𝑳₂ ]
+    toᵒ : DecCon 𝑪 0ℓ → 𝕌[ 𝑳₁ ] ⊎ 𝕌[ 𝑳₂ ]
     toᵒ θ with compare θ
     ... | inj₁ _ = inj₁ (to₁ (restrictA θ))
     ... | inj₂ _ = inj₂ (to₂ (restrictB θ))
 
-    fromᵒ : 𝕌[ proj₁ 𝑳₁ ] ⊎ 𝕌[ proj₁ 𝑳₂ ] → DecCon 𝑪 0ℓ
+    fromᵒ : 𝕌[ 𝑳₁ ] ⊎ 𝕌[ 𝑳₂ ] → DecCon 𝑪 0ℓ
     fromᵒ (inj₁ u) = lowerExt (from₁ u)
     fromᵒ (inj₂ v) = upperExt (from₂ v)
 
     to-monoᵒ : {θ θ' : DecCon 𝑪 0ℓ} → θ ⊆ᵈ θ'
-      → Lattice-Order._≤_ (ordinalSum 𝑳₁ t 𝑳₂ b) (toᵒ θ) (toᵒ θ')
+      → Lattice-Order._≤_ (ordinalSum 𝓛₁ t 𝓛₂ b) (toᵒ θ) (toᵒ θ')
     to-monoᵒ {θ} {θ'} s with compare θ | compare θ'
-    ... | inj₁ _    | inj₁ _     =
-      ≤ᵒ-inj₁ {x = to₁ (restrictA θ)} {y = to₁ (restrictA θ')}
-        (to-mono₁ {restrictA θ} {restrictA θ'} (restrictA-mono {θ} {θ'} s))
-    ... | inj₁ _    | inj₂ _     = ≤ᵒ-up (to₁ (restrictA θ)) (to₂ (restrictB θ'))
-    ... | inj₂ α⊆θ  | inj₁ θ'⊆α  =
-      -- θ ⊆ θ' pins both to the boundary; both images land on the glue.
-      ≤ᵒ-down {x = to₂ (restrictB θ)} {y = to₁ (restrictA θ')}
-        (atGlue-⊤ θ' (θ'⊆α , λ {x} {y} p → s {x} {y} (α⊆θ {x} {y} p)))
-        (atGlue-⊥ θ ((λ {x} {y} p → θ'⊆α {x} {y} (s {x} {y} p)) , α⊆θ))
-    ... | inj₂ _    | inj₂ _     =
-      ≤ᵒ-inj₂ {x = to₂ (restrictB θ)} {y = to₂ (restrictB θ')}
-        (to-mono₂ {restrictB θ} {restrictB θ'} (restrictB-mono {θ} {θ'} s))
+    ... | inj₁ _   | inj₁ _    = ≤ᵒ-inj₁ (to-mono₁ (restrictA-mono {θ} {θ'} s))
+    ... | inj₁ _   | inj₂ _    = ≤ᵒ-up {to₁ (restrictA θ)} {to₂ (restrictB θ')}
+    ... | inj₂ _   | inj₂ _    = ≤ᵒ-inj₂ (to-mono₂ (restrictB-mono {θ} {θ'} s))
+    ... | inj₂ α⊆θ | inj₁ θ'⊆α = ≤ᵒ-down (atGlue-⊤ θ' (θ'⊆α , s ∘ α⊆θ)) (atGlue-⊥ θ (θ'⊆α ∘ s , α⊆θ))
+    -- θ ⊆ θ' pins both to the boundary; both images land on the glue.
 
-    from-monoᵒ : {u v : 𝕌[ proj₁ 𝑳₁ ] ⊎ 𝕌[ proj₁ 𝑳₂ ]}
-      → Lattice-Order._≤_ (ordinalSum 𝑳₁ t 𝑳₂ b) u v → fromᵒ u ⊆ᵈ fromᵒ v
+    from-monoᵒ : {u v : 𝕌[ 𝑳₁ ] ⊎ 𝕌[ 𝑳₂ ]}
+      → Lattice-Order._≤_ (ordinalSum 𝓛₁ t 𝓛₂ b) u v → fromᵒ u ⊆ᵈ fromᵒ v
+    from-monoᵒ {inj₁ _} {inj₂ v} le (l , r) = reflexive (proj₂ (proj₁ (from₂ v))) r
+
     from-monoᵒ {inj₁ u} {inj₁ v} le {x} {y} p =
-      lowerExt-mono {from₁ u} {from₁ v}
-        (from-mono₁ {u} {v} (≤ᵒ-inj₁-elim {x = u} {y = v} le)) {x} {y} p
-    -- (everything below the boundary sits below every upper extension)
-    from-monoᵒ {inj₁ u} {inj₂ v} le {x} {y} (l , r) =
-      reflexive (proj₂ (proj₁ (from₂ v))) {retractʳ x} {retractʳ y} r
+      lowerExt-mono {from₁ u} {from₁ v} (from-mono₁ (≤ᵒ-inj₁-elim le)) {x} {y} p
+
+    from-monoᵒ {inj₂ u} {inj₂ v} le {x} {y} p =
+      upperExt-mono {from₂ u} {from₂ v} (from-mono₂ (≤ᵒ-inj₂-elim le)) {x} {y} p
+
     from-monoᵒ {inj₂ u} {inj₁ v} le {x} {y} p = down {x} {y} p
       where
-      -- u at the bottom, v at the top: both preimages are extreme, and the
-      -- extreme extensions nest.
-      u≈⊥ = proj₂ (≤ᵒ-down-elim {x = u} {y = v} le)
-      v≈⊤ = proj₁ (≤ᵒ-down-elim {x = u} {y = v} le)
+      -- u at bottom, v at top: both preimages are extreme, and the extreme extensions nest.
+      u≈⊥ : u ≈ᴸ² ⊥₂
+      u≈⊥ = proj₂ (≤ᵒ-down-elim le)
+      v≈⊤ : v ≈ᴸ¹ ⊤₁
+      v≈⊤ = proj₁ (≤ᵒ-down-elim le)
 
-      from₂u≑𝟘 : from₂ u ≑ᵈ 𝟘ᵈ (𝑭₂ ._≟_)
-      from₂u≑𝟘 =
-        (λ p → proj₁ e₂ (proj₁ e₁ p)) , (λ q → proj₂ e₁ (proj₂ e₂ q))
+      open FiniteAlgebra 𝑭₂ using () renaming ( _≟_ to _≟₂_ )
+
+      from₂u≑𝟘 : from₂ u ≑ᵈ 𝟘ᵈ _≟₂_
+      from₂u≑𝟘 = (proj₁ e₂) ∘ (proj₁ e₁) , (proj₂ e₁) ∘ (proj₂ e₂)
         where
+        e₁ : from₂ u ≑ᵈ from₂ (to₂ (𝟘ᵈ _≟₂_))
         e₁ = from-cong≈₂ (transᴸ² u≈⊥ (symᴸ² to₂𝟘≈⊥))
-        e₂ = from∘to₂ (𝟘ᵈ (𝑭₂ ._≟_))
+        e₂ : from₂ (to₂ (𝟘ᵈ _≟₂_)) ≑ᵈ 𝟘ᵈ _≟₂_
+        e₂ = from∘to₂ (𝟘ᵈ _≟₂_)
 
-      from₁v≑𝟙 : from₁ v ≑ᵈ 𝟙ᵈ {ℓ = 0ℓ}
-      from₁v≑𝟙 =
-        (λ p → proj₁ e₂ (proj₁ e₁ p)) , (λ q → proj₂ e₁ (proj₂ e₂ q))
+      from₁v≑𝟙 : from₁ v ≑ᵈ 𝟙ᵈ
+      from₁v≑𝟙 = proj₁ e₂ ∘ proj₁ e₁ , proj₂ e₁ ∘ proj₂ e₂
         where
+        e₁ : from₁ v ≑ᵈ from₁ (to₁ 𝟙ᵈ)
         e₁ = from-cong≈₁ (transᴸ¹ v≈⊤ (symᴸ¹ to₁𝟙≈⊤))
-        e₂ = from∘to₁ (𝟙ᵈ {ℓ = 0ℓ})
+        e₂ : from₁ (to₁ 𝟙ᵈ) ≑ᵈ 𝟙ᵈ
+        e₂ = from∘to₁ 𝟙ᵈ
 
       down : upperExt (from₂ u) ⊆ᵈ lowerExt (from₁ v)
       down p = proj₂ from₁v≑𝟙 (lift tt) , lower (proj₁ from₂u≑𝟘 p)
-    from-monoᵒ {inj₂ u} {inj₂ v} le {x} {y} p =
-      upperExt-mono {from₂ u} {from₂ v}
-        (from-mono₂ {u} {v} (≤ᵒ-inj₂-elim {x = u} {y = v} le)) {x} {y} p
 
-    to∘fromᵒ : ∀ u → Setoid._≈_ 𝔻[ proj₁ (ordinalSum 𝑳₁ t 𝑳₂ b) ] (toᵒ (fromᵒ u)) u
+
+    to∘fromᵒ : ∀ u → Setoid._≈_ 𝔻[ proj₁ (ordinalSum 𝓛₁ t 𝓛₂ b) ] (toᵒ (fromᵒ u)) u
     to∘fromᵒ (inj₁ u) with compare (lowerExt (from₁ u))
-    ... | inj₁ _ =
-      transᴸ¹ (to-cong≑₁ (restrictA-lowerExt (from₁ u))) (to∘from₁ u) , reflᴸ²
+    ... | inj₁ _ = transᴸ¹ (to-cong≑₁ (restrictA-lowerExt (from₁ u))) (to∘from₁ u) , reflᴸ²
     ... | inj₂ α⊆ = symᴸ¹ u≈⊤ , atGlue-⊥ (lowerExt (from₁ u)) ext≑α
       where
       -- the extension is squeezed onto the boundary, so u is the top
       ext≑α : lowerExt (from₁ u) ≑ᵈ αᵈ
-      ext≑α = (λ {x} {y} p → lowerExt-⊆-α (from₁ u) {x} {y} p)
-            , (λ {x} {y} p → α⊆ {x} {y} p)
+      ext≑α = (λ {x y} p → lowerExt-⊆-α (from₁ u) {x}{y} p) , λ {x y} p → α⊆ {x}{y} p
 
       from₁u≑𝟙 : from₁ u ≑ᵈ 𝟙ᵈ {ℓ = 0ℓ}
       from₁u≑𝟙 = (λ _ → lift tt) , (λ {a} {a'} _ → proj₁ (α⊆ {inj₁ a} {inj₁ a'} refl₂))
@@ -880,16 +885,14 @@ branch, with the mixed branches all funneling through the glue coherences.
       u≈⊤ : u ≈ᴸ¹ ⊤₁
       u≈⊤ = transᴸ¹ (symᴸ¹ (to∘from₁ u)) (transᴸ¹ (to-cong≑₁ from₁u≑𝟙) to₁𝟙≈⊤)
     to∘fromᵒ (inj₂ v) with compare (upperExt (from₂ v))
-    ... | inj₂ _ =
-      reflᴸ¹ , transᴸ² (to-cong≑₂ (restrictB-upperExt (from₂ v))) (to∘from₂ v)
+    ... | inj₂ _ = reflᴸ¹ , transᴸ² (to-cong≑₂ (restrictB-upperExt (from₂ v))) (to∘from₂ v)
     ... | inj₁ θ⊆α = atGlue-⊤ (upperExt (from₂ v)) ext≑α , symᴸ² v≈⊥
       where
       ext≑α : upperExt (from₂ v) ≑ᵈ αᵈ
-      ext≑α = (λ {x} {y} p → θ⊆α {x} {y} p)
-            , (λ {x} {y} p → α-⊆-upperExt (from₂ v) {x} {y} p)
+      ext≑α = (λ {x y} p → θ⊆α {x}{y} p) , λ {x y} p → α-⊆-upperExt (from₂ v) {x}{y} p
 
       from₂v≑𝟘 : from₂ v ≑ᵈ 𝟘ᵈ (𝑭₂ ._≟_)
-      from₂v≑𝟘 = (λ {x} {y} p → lift (θ⊆α {inj₂ x} {inj₂ y} p))
+      from₂v≑𝟘 = (λ {x y} p → lift (θ⊆α {inj₂ x} {inj₂ y} p))
                , (λ q → reflexive (proj₂ (proj₁ (from₂ v))) (lower q))
 
       v≈⊥ : v ≈ᴸ² ⊥₂
@@ -908,7 +911,7 @@ branch, with the mixed branches all funneling through the glue coherences.
       where
       ext = upperExt-cong≑ {from₂ (to₂ (restrictB θ))} {restrictB θ} (from∘to₂ (restrictB θ))
 
-    𝑪-ConIsoᵈ : ConIsoᵈ 𝑪 (ordinalSum 𝑳₁ t 𝑳₂ b)
+    𝑪-ConIsoᵈ : ConIsoᵈ 𝑪 (ordinalSum 𝓛₁ t 𝓛₂ b)
     𝑪-ConIsoᵈ = record
       { to         = toᵒ
       ; from       = fromᵒ
@@ -919,28 +922,28 @@ branch, with the mixed branches all funneling through the glue coherences.
       }
 ```
 
-#### The closure theorem
+**The closure theorem**.
 
 Normalize both witnesses to inhabited carriers, instantiate the construction,
 and package the result.
 
 ```agda
-ordinalSum-Representableᵈ : {𝑳₁ 𝑳₂ : Lattice} (t : TopOf 𝑳₁) (b : BotOf 𝑳₂)
-  → Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂ → Representableᵈ (ordinalSum 𝑳₁ t 𝑳₂ b)
-ordinalSum-Representableᵈ {𝑳₁} {𝑳₂} t b r₁ r₂ =
+ordinalSum-Representableᵈ : {𝓛₁ 𝓛₂ : Lattice} (t : TopOf 𝓛₁) (b : BotOf 𝓛₂)
+  → Representableᵈ 𝓛₁ → Representableᵈ 𝓛₂ → Representableᵈ (ordinalSum 𝓛₁ t 𝓛₂ b)
+ordinalSum-Representableᵈ {𝓛₁} {𝓛₂} t b r₁ r₂ =
   assemble (inhabited-witness r₁) (inhabited-witness r₂)
   where
   open Representableᵈ
 
-  assemble : Σ[ r ∈ Representableᵈ 𝑳₁ ] 𝕌[ r .algᵈ ]
-           → Σ[ r ∈ Representableᵈ 𝑳₂ ] 𝕌[ r .algᵈ ]
-           → Representableᵈ (ordinalSum 𝑳₁ t 𝑳₂ b)
+  assemble : Σ[ r ∈ Representableᵈ 𝓛₁ ] 𝕌[ r .algᵈ ]
+           → Σ[ r ∈ Representableᵈ 𝓛₂ ] 𝕌[ r .algᵈ ]
+           → Representableᵈ (ordinalSum 𝓛₁ t 𝓛₂ b)
   assemble (r₁' , a*) (r₂' , b*) = record
     { sigᵈ      = W.𝑆ₒ
     ; algᵈ      = W.𝑪
     ; finiteᵈ   = W.𝑪-FiniteAlgebra
     ; finsigᵈ   = W.𝑆ₒ-FiniteSignature
-    ; con-isoᵈ  = W.𝑪-ConIsoᵈ {𝑳₁ = 𝑳₁} {𝑳₂ = 𝑳₂} t b (r₁' .con-isoᵈ) (r₂' .con-isoᵈ)
+    ; con-isoᵈ  = W.𝑪-ConIsoᵈ {𝓛₁ = 𝓛₁} {𝓛₂ = 𝓛₂} t b (r₁' .con-isoᵈ) (r₂' .con-isoᵈ)
     }
     where
     module W = OrdinalSumWitness
@@ -949,3 +952,9 @@ ordinalSum-Representableᵈ {𝑳₁} {𝑳₂} t b r₁ r₂ =
 ```
 
 --------------------------------------
+
+[^1]: McKenzie 1984; Snow 2000; see
+      [`docs/papers/fin-lat-rep/SmallLatticeReps.tex`](docs/papers/fin-lat-rep/SmallLatticeReps.tex),
+      § Ordinal Sums, whose `m + n − 1`-element construction this module follows.
+
+[^2]: The isolated-equality locus for the Cubical port lives in `GlueSetoid`{.AgdaModule}.

--- a/src/FLRP/Closure/OrdinalSum.lagda.md
+++ b/src/FLRP/Closure/OrdinalSum.lagda.md
@@ -1,0 +1,952 @@
+---
+layout: default
+file: "src/FLRP/Closure/OrdinalSum.lagda.md"
+title: "FLRP.Closure.OrdinalSum module (The Agda Universal Algebra Library)"
+date: "2026-07-24"
+author: "the agda-algebras development team"
+---
+
+### Ordinal-sum closure of decidable representability
+
+This is the [FLRP.Closure.OrdinalSum][] module of the [Agda Universal Algebra Library][].
+
+The class of representable lattices is closed under ordinal sums (McKenzie 1984;
+Snow 2000; see `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Ordinal Sums,
+whose `m + n − 1`-element construction this module follows).  Here we formalize
+the *adjoined* (glued) ordinal sum of
+[Classical.Structures.Lattice.OrdinalSum][] at Layer D ([ADR-008][]): given
+decidable representations of the summands and chosen extremum data — a
+`TopOf 𝑳₁`{.AgdaFunction} and a `BotOf 𝑳₂`{.AgdaFunction} — it constructs a
+finite finitary algebra whose decidable-congruence poset is order-isomorphic to
+the glued sum, yielding
+
+    ordinalSum-Representableᵈ : (t : TopOf 𝑳₁) (b : BotOf 𝑳₂)
+      → Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂
+      → Representableᵈ (ordinalSum 𝑳₁ t 𝑳₂ b)
+
+**The witness algebra.**  Given representing algebras `𝑨` and `𝑩` with
+basepoints `a*` and `b*`, the composite `𝑪` lives on the amalgam setoid
+`A ⊎ B` glued at `(a* , b*)` (`GlueSetoid`{.AgdaModule}) — the constructive
+counterpart of the manuscript's universe `A ⊎ (B ∖ {b₀})` — over the signature
+
+    𝑆₁  ⊎  𝑆₂  ⊎  (Fin (card 𝑩) × Fin (card 𝑨))
+
+interpreted as follows: a symbol of `𝑆₁` acts through the left retraction
+(collapse `B` to `a*`) and lands in the left summand, a symbol of `𝑆₂` acts
+through the right retraction and lands in the right summand, and the
+`(i , k)`-indexed family interprets the manuscript's unary maps
+`ĥ`{.AgdaFunction}: identity on the left summand, and on the right summand the
+**single-point collapse** `h` sending (anything `≈` to) `enum₂ i` to
+`enum₁ k`, the basepoint to `a*`, and everything else to `a*`.
+
+**The boundary congruence and the dichotomy.**  The kernel `α` of the right
+retraction — all of `A` in one class, `B` split by `≈` — is a decidable
+congruence, and the heart of the proof is that *every* decidable congruence of
+`𝑪` is comparable to it.  Both containments are decidable
+(`⊆ᵈ-dec`{.AgdaFunction} of [FLRP.Representable][]); if both fail, the two
+violating pairs they surrender are contradictory: a `θ`-unrelated pair inside
+the lower summand on the one hand, and a `θ`-related pair with distinct
+right-retraction images on the other, which the `ĥ` family maps onto the
+unrelated pair — one application if the related pair is mixed, two chained
+through `a*` if it is pure.  This dichotomy is exactly the step that is
+*non-constructive at Layer S*: for semantic congruences, comparability with
+`α` decides oracle propositions (the WP-1 phenomenon), which is why
+ordinal-sum closure is a Layer-D theorem only.
+
+**The splitting.**  A congruence below `α` is determined by its restriction to
+the lower summand together with `α` itself, and one above `α` by its quotient
+along the right retraction (`lower-split`{.AgdaFunction} /
+`upper-split`{.AgdaFunction}); composing with the given isomorphisms sends the
+lower cone onto `inj₁`-elements, the upper cone onto `inj₂`-elements, and `α`
+itself onto the glue.
+
+As in the product case, basepoints are supplied by
+`inhabited-witness`{.AgdaFunction} normalization, so the closure theorem has no
+side conditions beyond the extremum data the sum itself needs.  The standing
+FLRP research-track separation warning applies.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.Closure.OrdinalSum where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -----------------------------------
+open import Data.Empty                             using  ( ⊥ ; ⊥-elim )
+open import Data.Fin.Base                          using  ( Fin ; splitAt ; join
+                                                          ; combine ; remQuot )
+open import Data.Fin.Patterns                      using  ( 0F )
+open import Data.Fin.Properties                    using  ( splitAt-join ; remQuot-combine )
+open import Data.Nat.Base                          using  ( _+_ ; _*_ )
+open import Data.Product                           using  ( _,_ ; _×_ ; proj₁ ; proj₂
+                                                          ; Σ-syntax )
+open import Data.Sum.Base                          using  ( _⊎_ ; inj₁ ; inj₂ ; [_,_]′ )
+open import Data.Unit.Base                         using  ( tt )
+open import Function                               using  ( _∘_ )
+open import Function.Construct.Identity            using  ( ↔-id )
+open import Level                                  using  ( 0ℓ ; Lift ; lift ; lower )
+open import Relation.Binary                        using  ( Setoid ; IsEquivalence )
+open import Relation.Binary.PropositionalEquality  using  ( _≡_ ; refl ; cong ; trans ; sym )
+open import Relation.Nullary                       using  ( ¬_ ; Dec ; yes ; no )
+open import Relation.Nullary.Decidable             using  ( _×-dec_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Properties.Lattice             using  ( module Lattice-Order
+                                                            ; TopOf ; BotOf )
+open import Classical.Small.Structures.Lattice       using  ( Lattice )
+open import Classical.Structures.Interpret           using  ( interp-cong )
+open import Classical.Structures.Lattice.OrdinalSum  using  ( module GlueSetoid
+                                                            ; module LatticeOrdinalSum
+                                                            ; ordinalSum )
+open import FLRP.Problem                             using  ( OrderIso )
+open import FLRP.Representable                       using  ( Representableᵈ ; ConIsoᵈ
+                                                            ; _⊆ᵈ_ ; _≑ᵈ_ ; ConRel-resp
+                                                            ; 𝟘ᵈ ; 𝟙ᵈ ; ⊆ᵈ-dec ; ⊈ᵈ-witness
+                                                            ; module ConIsoᵈ-Consequences
+                                                            ; inhabited-witness )
+open import Overture                                 using  ( Signature
+                                                            ; OperationSymbolsOf ; ArityOf )
+open import Overture.Operations                      using  ( Op )
+open import Setoid.Algebras.Basic                    using  ( Algebra ; 𝔻[_] ; 𝕌[_] ; _^_
+                                                            ; mkAlgebra )
+open import Setoid.Algebras.Finite                   using  ( FiniteAlgebra )
+open import Setoid.Congruences.Basic                 using  ( mkcon ; reflexive ; _∣≈_
+                                                            ; is-equivalence ; is-compatible )
+open import Setoid.Congruences.ChainJoin             using  ( Finitary )
+open import Setoid.Congruences.Finite.Basic          using  ( DecCon ; ConRel )
+open import Setoid.Signatures.Finite                 using  ( FiniteSignature )
+
+open FiniteAlgebra
+open FiniteSignature
+```
+-->
+
+#### The composite witness algebra
+
+`OrdinalSumWitness`{.AgdaModule} packages the construction for two fixed finite
+finitary algebras with chosen basepoints, everything at level `0ℓ`.
+
+```agda
+module OrdinalSumWitness
+  {𝑆₁ 𝑆₂ : Signature 0ℓ 0ℓ}
+  (𝑨 : Algebra {𝑆 = 𝑆₁} 0ℓ 0ℓ) (𝑭₁ : FiniteAlgebra 𝑨) (𝑮₁ : FiniteSignature 𝑆₁) (a* : 𝕌[ 𝑨 ])
+  (𝑩 : Algebra {𝑆 = 𝑆₂} 0ℓ 0ℓ) (𝑭₂ : FiniteAlgebra 𝑩) (𝑮₂ : FiniteSignature 𝑆₂) (b* : 𝕌[ 𝑩 ])
+  where
+
+  private
+    m      = 𝑭₁ .card
+    n      = 𝑭₂ .card
+    enum₁  = 𝑭₁ .enum
+    enum₂  = 𝑭₂ .enum
+
+  open Setoid 𝔻[ 𝑨 ] using ()
+    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝔻[ 𝑩 ] using ()
+    renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
+```
+
+**The carrier**: the amalgam of the two carriers at the basepoints, with its
+retractions (the isolated-equality locus for the Cubical port lives in
+`GlueSetoid`{.AgdaModule}).
+
+```agda
+  open GlueSetoid 𝔻[ 𝑨 ] a* 𝔻[ 𝑩 ] b*
+
+  private
+    A⊎B : Type 0ℓ
+    A⊎B = 𝕌[ 𝑨 ] ⊎ 𝕌[ 𝑩 ]
+
+  open Setoid glueSetoid using ()
+    renaming ( refl to reflᵍ ; sym to symᵍ ; trans to transᵍ ; reflexive to ≡→≈ᵍ )
+```
+
+**The signature**: the two component signatures side by side with the
+single-point collapse family, indexed by a source in `𝑩` and a target in `𝑨`
+(via the enumerations).  Family members are unary.
+
+```agda
+  OpSymbols : Type 0ℓ
+  OpSymbols = OperationSymbolsOf 𝑆₁ ⊎ (OperationSymbolsOf 𝑆₂ ⊎ (Fin n × Fin m))
+
+  arity : OpSymbols → Type 0ℓ
+  arity (inj₁ f)          = ArityOf 𝑆₁ f
+  arity (inj₂ (inj₁ g))   = ArityOf 𝑆₂ g
+  arity (inj₂ (inj₂ _))   = Fin 1
+
+  𝑆ₒ : Signature 0ℓ 0ℓ
+  𝑆ₒ = OpSymbols , arity
+```
+
+**The collapse maps.**  `h i k` sends (anything `≈` to) the basepoint to `a*`,
+then (anything `≈` to) `enum₂ i` to `enum₁ k`, and everything else to `a*`;
+the guard keeps the lift `ĥ` congruent across the glue.  The three evaluation
+lemmas — at the basepoint, at the programmed point, away from it — are the
+module's workhorses.
+
+```agda
+  private
+    h : Fin n → Fin m → 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ]
+    h i k b with 𝑭₂ ._≟_ b b*
+    ... | yes _ = a*
+    ... | no _ with 𝑭₂ ._≟_ b (enum₂ i)
+    ...   | yes _ = enum₁ k
+    ...   | no _  = a*
+
+    -- h respects ≈₂: aligned decisions take the same branch, misaligned ones clash.
+    h-cong : ∀ i k {x y} → x ≈₂ y → h i k x ≈₁ h i k y
+    h-cong i k {x} {y} e with 𝑭₂ ._≟_ x b* | 𝑭₂ ._≟_ y b*
+    ... | yes _  | yes _   = refl₁
+    ... | yes p  | no ¬p'  = ⊥-elim (¬p' (trans₂ (sym₂ e) p))
+    ... | no ¬p  | yes p'  = ⊥-elim (¬p (trans₂ e p'))
+    ... | no _   | no _ with 𝑭₂ ._≟_ x (enum₂ i) | 𝑭₂ ._≟_ y (enum₂ i)
+    ...   | yes _  | yes _   = refl₁
+    ...   | yes q  | no ¬q'  = ⊥-elim (¬q' (trans₂ (sym₂ e) q))
+    ...   | no ¬q  | yes q'  = ⊥-elim (¬q (trans₂ e q'))
+    ...   | no _   | no _    = refl₁
+
+    -- At the basepoint the collapse gives a*.
+    h-at-b* : ∀ i k {x} → x ≈₂ b* → h i k x ≈₁ a*
+    h-at-b* i k {x} e with 𝑭₂ ._≟_ x b*
+    ... | yes _  = refl₁
+    ... | no ¬p  = ⊥-elim (¬p e)
+
+    -- Enumeration indices of designated elements, with their proofs.
+    idx₁ : 𝕌[ 𝑨 ] → Fin m
+    idx₁ x = proj₁ (𝑭₁ .enum-sur x)
+
+    idx₁-≈ : ∀ x → enum₁ (idx₁ x) ≈₁ x
+    idx₁-≈ x = proj₂ (𝑭₁ .enum-sur x)
+
+    idx₂ : 𝕌[ 𝑩 ] → Fin n
+    idx₂ x = proj₁ (𝑭₂ .enum-sur x)
+
+    idx₂-≈ : ∀ x → enum₂ (idx₂ x) ≈₂ x
+    idx₂-≈ x = proj₂ (𝑭₂ .enum-sur x)
+
+    -- The concrete family member sending b to x.
+    h[_↦_] : 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ]
+    h[ b ↦ x ] = h (idx₂ b) (idx₁ x)
+
+    -- Away from the basepoint, the map hits its programmed value at its source ...
+    h-at : ∀ b x → ¬ (b ≈₂ b*) → h[ b ↦ x ] b ≈₁ x
+    h-at b x ¬b* with 𝑭₂ ._≟_ b b*
+    ... | yes p = ⊥-elim (¬b* p)
+    ... | no _ with 𝑭₂ ._≟_ b (enum₂ (idx₂ b))
+    ...   | yes _  = idx₁-≈ x
+    ...   | no ¬q  = ⊥-elim (¬q (sym₂ (idx₂-≈ b)))
+
+    -- ... and collapses everything ≉ the source to a*.
+    h-away : ∀ b x b' → ¬ (b' ≈₂ b) → h[ b ↦ x ] b' ≈₁ a*
+    h-away b x b' ¬eq with 𝑭₂ ._≟_ b' b*
+    ... | yes _ = refl₁
+    ... | no _ with 𝑭₂ ._≟_ b' (enum₂ (idx₂ b))
+    ...   | yes q  = ⊥-elim (¬eq (trans₂ q (idx₂-≈ b)))
+    ...   | no _   = refl₁
+
+    -- The lift of h to the amalgam: identity on the left, collapse on the right.
+    ĥ : Fin n → Fin m → A⊎B → A⊎B
+    ĥ i k (inj₁ a) = inj₁ a
+    ĥ i k (inj₂ b) = inj₁ (h i k b)
+
+    ĥ-cong : ∀ i k {x y} → x ≈ᵍ y → ĥ i k x ≈ᵍ ĥ i k y
+    ĥ-cong i k {inj₁ a} {inj₁ a'} (ea , _)   = ≈ᵍ-inj₁ ea
+    ĥ-cong i k {inj₁ a} {inj₂ b}  (ea , eb)  =
+      ≈ᵍ-inj₁ (trans₁ ea (sym₁ (h-at-b* i k (sym₂ eb))))
+    ĥ-cong i k {inj₂ b} {inj₁ a}  (ea , eb)  =
+      ≈ᵍ-inj₁ (trans₁ (h-at-b* i k eb) ea)
+    ĥ-cong i k {inj₂ b} {inj₂ b'} (_ , eb)   = ≈ᵍ-inj₁ (h-cong i k eb)
+
+    -- The lift always lands in the left summand, so its right retraction is b*.
+    ĥ-lands-left : ∀ i k x → retractʳ (ĥ i k x) ≡ b*
+    ĥ-lands-left i k (inj₁ _) = refl
+    ĥ-lands-left i k (inj₂ _) = refl
+```
+
+**The algebra**: `𝑆₁` acts through the left retraction, `𝑆₂` through the
+right one, and the family symbols act by `ĥ`{.AgdaFunction}.
+
+```agda
+  𝑪 : Algebra {𝑆 = 𝑆ₒ} 0ℓ 0ℓ
+  𝑪 = mkAlgebra glueSetoid interp interp-congruence
+    where
+    interp : (o : OpSymbols) → Op (arity o) A⊎B
+    interp (inj₁ f)              args = inj₁ ((f ^ 𝑨) (retractˡ ∘ args))
+    interp (inj₂ (inj₁ g))       args = inj₂ ((g ^ 𝑩) (retractʳ ∘ args))
+    interp (inj₂ (inj₂ (i , k))) args = ĥ i k (args 0F)
+
+    interp-congruence : ∀ o {u v : arity o → A⊎B}
+      → (∀ i → u i ≈ᵍ v i) → interp o u ≈ᵍ interp o v
+    interp-congruence (inj₁ f)              e = ≈ᵍ-inj₁ (interp-cong 𝑨 f (λ i → proj₁ (e i)))
+    interp-congruence (inj₂ (inj₁ g))       e = ≈ᵍ-inj₂ (interp-cong 𝑩 g (λ i → proj₂ (e i)))
+    interp-congruence (inj₂ (inj₂ (i , k))) {u} {v} e = ĥ-cong i k {u 0F} {v 0F} (e 0F)
+```
+
+#### Finiteness of the composite
+
+The carrier is enumerated by `Fin (m + n)` through one `splitAt` layer, with
+glued equality decided by cases; the signature adds the `n * m` family symbols
+through a `combine`/`remQuot` layer.
+
+```agda
+  private
+    enumC : Fin (m + n) → A⊎B
+    enumC = [ inj₁ ∘ enum₁ , inj₂ ∘ enum₂ ]′ ∘ splitAt m
+
+    enumC-join : (x : Fin m ⊎ Fin n) → enumC (join m n x) ≡ [ inj₁ ∘ enum₁ , inj₂ ∘ enum₂ ]′ x
+    enumC-join x = cong [ inj₁ ∘ enum₁ , inj₂ ∘ enum₂ ]′ (splitAt-join m n x)
+
+  𝑪-FiniteAlgebra : FiniteAlgebra 𝑪
+  𝑪-FiniteAlgebra ._≟_ = decEq
+    where
+    decEq : (x y : A⊎B) → Dec (x ≈ᵍ y)
+    decEq (inj₁ a) (inj₁ a') with 𝑭₁ ._≟_ a a'
+    ... | yes p = yes (p , refl₂)
+    ... | no ¬p = no λ e → ¬p (proj₁ e)
+    decEq (inj₁ a) (inj₂ b) with 𝑭₁ ._≟_ a a* | 𝑭₂ ._≟_ b* b
+    ... | yes p  | yes q  = yes (p , q)
+    ... | yes _  | no ¬q  = no λ e → ¬q (proj₂ e)
+    ... | no ¬p  | yes _  = no λ e → ¬p (proj₁ e)
+    ... | no ¬p  | no _   = no λ e → ¬p (proj₁ e)
+    decEq (inj₂ b) (inj₁ a) with 𝑭₁ ._≟_ a* a | 𝑭₂ ._≟_ b b*
+    ... | yes p  | yes q  = yes (p , q)
+    ... | yes _  | no ¬q  = no λ e → ¬q (proj₂ e)
+    ... | no ¬p  | yes _  = no λ e → ¬p (proj₁ e)
+    ... | no ¬p  | no _   = no λ e → ¬p (proj₁ e)
+    decEq (inj₂ b) (inj₂ b') with 𝑭₂ ._≟_ b b'
+    ... | yes p = yes (refl₁ , p)
+    ... | no ¬p = no λ e → ¬p (proj₂ e)
+  𝑪-FiniteAlgebra .card = m + n
+  𝑪-FiniteAlgebra .enum = enumC
+  𝑪-FiniteAlgebra .enum-sur = sur
+    where
+    sur : ∀ x → Σ[ i ∈ Fin (m + n) ] enumC i ≈ᵍ x
+    sur (inj₁ a) with 𝑭₁ .enum-sur a
+    ... | i , p = join m n (inj₁ i) ,
+      transᵍ {enumC (join m n (inj₁ i))} {inj₁ (enum₁ i)} {inj₁ a}
+        (≡→≈ᵍ (enumC-join (inj₁ i))) (≈ᵍ-inj₁ p)
+    sur (inj₂ b) with 𝑭₂ .enum-sur b
+    ... | j , p = join m n (inj₂ j) ,
+      transᵍ {enumC (join m n (inj₂ j))} {inj₂ (enum₂ j)} {inj₂ b}
+        (≡→≈ᵍ (enumC-join (inj₂ j))) (≈ᵍ-inj₂ p)
+
+  private
+    c₁ = 𝑮₁ .opCard
+    c₂ = 𝑮₂ .opCard
+
+    decode₂ : Fin (c₂ + n * m) → OperationSymbolsOf 𝑆₂ ⊎ (Fin n × Fin m)
+    decode₂ = [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ ∘ splitAt c₂
+
+    decode : Fin (c₁ + (c₂ + n * m)) → OpSymbols
+    decode = [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ ∘ splitAt c₁
+
+    decode-join : (x : Fin c₁ ⊎ Fin (c₂ + n * m))
+      → decode (join c₁ _ x) ≡ [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ x
+    decode-join x = cong [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ (splitAt-join c₁ _ x)
+
+    decode₂-join : (x : Fin c₂ ⊎ Fin (n * m))
+      → decode₂ (join c₂ _ x) ≡ [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ x
+    decode₂-join x = cong [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ remQuot {n} m ]′ (splitAt-join c₂ _ x)
+
+    decode-sur : (o : OpSymbols) → Σ[ k ∈ Fin (c₁ + (c₂ + n * m)) ] decode k ≡ o
+    decode-sur (inj₁ f) with 𝑮₁ .opEnum-sur f
+    ... | i , p = join c₁ _ (inj₁ i) , trans (decode-join (inj₁ i)) (cong inj₁ p)
+    decode-sur (inj₂ (inj₁ g)) with 𝑮₂ .opEnum-sur g
+    ... | j , p =
+      join c₁ _ (inj₂ (join c₂ _ (inj₁ j))) ,
+      trans (decode-join (inj₂ (join c₂ _ (inj₁ j))))
+        (trans (cong inj₂ (decode₂-join (inj₁ j))) (cong (inj₂ ∘ inj₁) p))
+    decode-sur (inj₂ (inj₂ (i , k))) =
+      join c₁ _ (inj₂ (join c₂ _ (inj₂ (combine i k)))) ,
+      trans (decode-join (inj₂ (join c₂ _ (inj₂ (combine i k)))))
+        (trans (cong inj₂ (decode₂-join (inj₂ (combine i k))))
+               (cong (inj₂ ∘ inj₂) (remQuot-combine i k)))
+
+  𝑆ₒ-FiniteSignature : FiniteSignature 𝑆ₒ
+  𝑆ₒ-FiniteSignature .opCard      = c₁ + (c₂ + n * m)
+  𝑆ₒ-FiniteSignature .opEnum      = decode
+  𝑆ₒ-FiniteSignature .opEnum-sur  = decode-sur
+  𝑆ₒ-FiniteSignature .finitary (inj₁ f)         = 𝑮₁ .finitary f
+  𝑆ₒ-FiniteSignature .finitary (inj₂ (inj₁ g))  = 𝑮₂ .finitary g
+  𝑆ₒ-FiniteSignature .finitary (inj₂ (inj₂ _))  = 1 , ↔-id _
+```
+
+#### The boundary congruence
+
+`αᵈ`{.AgdaFunction} is the kernel of the right retraction: the whole lower
+summand in one class, the upper summand split by its own equality.  Every
+operation of `𝑪` descends along the retraction, so compatibility is uniform.
+
+```agda
+  αᵈ : DecCon 𝑪 0ℓ
+  αᵈ = (rel , mkcon (λ {x} {y} e → rfl {x} {y} e) eqv cmp) , dec
+    where
+    rel : A⊎B → A⊎B → Type 0ℓ
+    rel x y = retractʳ x ≈₂ retractʳ y
+
+    rfl : ∀ {x y} → x ≈ᵍ y → rel x y
+    rfl e = proj₂ e
+
+    eqv : IsEquivalence rel
+    eqv = record
+      { refl   = λ {x} → refl₂ {retractʳ x}
+      ; sym    = λ e → sym₂ e
+      ; trans  = λ d e → trans₂ d e
+      }
+
+    cmp : 𝑪 ∣≈ rel
+    cmp (inj₁ f)              uv = refl₂
+    cmp (inj₂ (inj₁ g))       {U} {V} uv =
+      interp-cong 𝑩 g {retractʳ ∘ U} {retractʳ ∘ V} uv
+    cmp (inj₂ (inj₂ (i , k))) {U} {V} uv {- both images land left -} =
+      ≡→≈₂ (trans (ĥ-lands-left i k (U 0F)) (sym (ĥ-lands-left i k (V 0F))))
+      where ≡→≈₂ = Setoid.reflexive 𝔻[ 𝑩 ]
+
+    dec : ∀ x y → Dec (rel x y)
+    dec x y = 𝑭₂ ._≟_ (retractʳ x) (retractʳ y)
+```
+
+#### Restrictions and extensions of congruences
+
+A congruence of the composite restricts to each summand; a congruence of a
+summand extends to the composite — below `α` for the lower summand (paired
+with the kernel condition) and above `α` for the upper one (pulled back along
+the retraction).  All four constructions preserve decidability, and their
+compatibility proofs ride on the same reductions as the interpretations.
+
+```agda
+  -- Restrict to the lower summand.
+  restrictA : DecCon 𝑪 0ℓ → DecCon 𝑨 0ℓ
+  restrictA d = (rel , mkcon rfl eqv cmp) , dec
+    where
+    θcon = proj₂ (proj₁ d)
+
+    rel : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → Type 0ℓ
+    rel a a' = ConRel d (inj₁ a) (inj₁ a')
+
+    rfl : ∀ {x y} → x ≈₁ y → rel x y
+    rfl e = reflexive θcon (≈ᵍ-inj₁ e)
+
+    eqv : IsEquivalence rel
+    eqv = record
+      { refl   = IsEquivalence.refl (is-equivalence θcon)
+      ; sym    = IsEquivalence.sym (is-equivalence θcon)
+      ; trans  = IsEquivalence.trans (is-equivalence θcon)
+      }
+
+    cmp : 𝑨 ∣≈ rel
+    cmp f uv = is-compatible θcon (inj₁ f) uv
+
+    dec : ∀ x y → Dec (rel x y)
+    dec x y = proj₂ d (inj₁ x) (inj₁ y)
+
+  -- Restrict to the upper summand.
+  restrictB : DecCon 𝑪 0ℓ → DecCon 𝑩 0ℓ
+  restrictB d = (rel , mkcon rfl eqv cmp) , dec
+    where
+    θcon = proj₂ (proj₁ d)
+
+    rel : 𝕌[ 𝑩 ] → 𝕌[ 𝑩 ] → Type 0ℓ
+    rel b b' = ConRel d (inj₂ b) (inj₂ b')
+
+    rfl : ∀ {x y} → x ≈₂ y → rel x y
+    rfl e = reflexive θcon (≈ᵍ-inj₂ e)
+
+    eqv : IsEquivalence rel
+    eqv = record
+      { refl   = IsEquivalence.refl (is-equivalence θcon)
+      ; sym    = IsEquivalence.sym (is-equivalence θcon)
+      ; trans  = IsEquivalence.trans (is-equivalence θcon)
+      }
+
+    cmp : 𝑩 ∣≈ rel
+    cmp g uv = is-compatible θcon (inj₂ (inj₁ g)) uv
+
+    dec : ∀ x y → Dec (rel x y)
+    dec x y = proj₂ d (inj₂ x) (inj₂ y)
+
+  -- Extend a lower-summand congruence below the boundary.
+  lowerExt : DecCon 𝑨 0ℓ → DecCon 𝑪 0ℓ
+  lowerExt d₁ = (rel , mkcon (λ {x} {y} e → rfl {x} {y} e) eqv cmp) , dec
+    where
+    con₁ = proj₂ (proj₁ d₁)
+
+    rel : A⊎B → A⊎B → Type 0ℓ
+    rel x y = ConRel d₁ (retractˡ x) (retractˡ y) × (retractʳ x ≈₂ retractʳ y)
+
+    rfl : ∀ {x y} → x ≈ᵍ y → rel x y
+    rfl {x} {y} (l , r) = reflexive con₁ l , r
+
+    eqv : IsEquivalence rel
+    eqv = record
+      { refl   = IsEquivalence.refl (is-equivalence con₁) , refl₂
+      ; sym    = λ (l , r) → IsEquivalence.sym (is-equivalence con₁) l , sym₂ r
+      ; trans  = λ (l , r) (l' , r') →
+                   IsEquivalence.trans (is-equivalence con₁) l l' , trans₂ r r'
+      }
+
+    -- The family maps preserve the extension: pointwise, by shape.
+    ĥ-pres : ∀ i k {x y} → rel x y → rel (ĥ i k x) (ĥ i k y)
+    ĥ-pres i k {inj₁ a} {inj₁ a'} (l , _)  = l , refl₂
+    ĥ-pres i k {inj₂ b} {inj₂ b'} (_ , r)  = reflexive con₁ (h-cong i k r) , refl₂
+    ĥ-pres i k {inj₁ a} {inj₂ b}  (l , r)  =
+      ConRel-resp d₁ {a} {a} {a*} {h i k b} refl₁ (sym₁ (h-at-b* i k (sym₂ r))) l , refl₂
+    ĥ-pres i k {inj₂ b} {inj₁ a}  (l , r)  =
+      ConRel-resp d₁ {a*} {h i k b} {a} {a} (sym₁ (h-at-b* i k r)) refl₁ l , refl₂
+
+    cmp : 𝑪 ∣≈ rel
+    cmp (inj₁ f)              uv = is-compatible con₁ f (λ i → proj₁ (uv i)) , refl₂
+    cmp (inj₂ (inj₁ g))       {U} {V} uv =
+      reflexive con₁ refl₁
+      , interp-cong 𝑩 g {retractʳ ∘ U} {retractʳ ∘ V} (λ i → proj₂ (uv i))
+    cmp (inj₂ (inj₂ (i , k))) {U} {V} uv = ĥ-pres i k {U 0F} {V 0F} (uv 0F)
+
+    dec : ∀ x y → Dec (rel x y)
+    dec x y = (proj₂ d₁ (retractˡ x) (retractˡ y))
+              ×-dec (𝑭₂ ._≟_ (retractʳ x) (retractʳ y))
+
+  -- Extend an upper-summand congruence above the boundary.
+  upperExt : DecCon 𝑩 0ℓ → DecCon 𝑪 0ℓ
+  upperExt d₂ = (rel , mkcon (λ {x} {y} e → rfl {x} {y} e) eqv cmp) , dec
+    where
+    con₂ = proj₂ (proj₁ d₂)
+
+    rel : A⊎B → A⊎B → Type 0ℓ
+    rel x y = ConRel d₂ (retractʳ x) (retractʳ y)
+
+    rfl : ∀ {x y} → x ≈ᵍ y → rel x y
+    rfl {x} {y} (_ , r) = reflexive con₂ r
+
+    eqv : IsEquivalence rel
+    eqv = record
+      { refl   = IsEquivalence.refl (is-equivalence con₂)
+      ; sym    = IsEquivalence.sym (is-equivalence con₂)
+      ; trans  = IsEquivalence.trans (is-equivalence con₂)
+      }
+
+    cmp : 𝑪 ∣≈ rel
+    cmp (inj₁ f)              uv = reflexive con₂ refl₂
+    cmp (inj₂ (inj₁ g))       {U} {V} uv =
+      is-compatible con₂ g {retractʳ ∘ U} {retractʳ ∘ V} uv
+    cmp (inj₂ (inj₂ (i , k))) {U} {V} uv =
+      reflexive con₂ (≡→≈₂ (trans (ĥ-lands-left i k (U 0F)) (sym (ĥ-lands-left i k (V 0F)))))
+      where ≡→≈₂ = Setoid.reflexive 𝔻[ 𝑩 ]
+
+    dec : ∀ x y → Dec (rel x y)
+    dec x y = proj₂ d₂ (retractʳ x) (retractʳ y)
+```
+
+The bookkeeping lemmas the isomorphism consumes: monotonicity and
+`≑ᵈ`-congruence of the four maps, the two round trips on the summand side, the
+standing containments against the boundary, and the identification of the
+boundary's restrictions with the extreme congruences.
+
+```agda
+  restrictA-mono : {d e : DecCon 𝑪 0ℓ} → d ⊆ᵈ e → restrictA d ⊆ᵈ restrictA e
+  restrictA-mono s p = s p
+
+  restrictB-mono : {d e : DecCon 𝑪 0ℓ} → d ⊆ᵈ e → restrictB d ⊆ᵈ restrictB e
+  restrictB-mono s p = s p
+
+  lowerExt-mono : {d e : DecCon 𝑨 0ℓ} → d ⊆ᵈ e → lowerExt d ⊆ᵈ lowerExt e
+  lowerExt-mono s (l , r) = s l , r
+
+  upperExt-mono : {d e : DecCon 𝑩 0ℓ} → d ⊆ᵈ e → upperExt d ⊆ᵈ upperExt e
+  upperExt-mono s p = s p
+
+  lowerExt-cong≑ : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → lowerExt d ≑ᵈ lowerExt e
+  lowerExt-cong≑ (s₁ , s₂) = (λ (l , r) → s₁ l , r) , (λ (l , r) → s₂ l , r)
+
+  upperExt-cong≑ : {d e : DecCon 𝑩 0ℓ} → d ≑ᵈ e → upperExt d ≑ᵈ upperExt e
+  upperExt-cong≑ (s₁ , s₂) = (λ p → s₁ p) , (λ p → s₂ p)
+
+  -- Restricting an extension recovers the summand congruence.
+  restrictA-lowerExt : (d₁ : DecCon 𝑨 0ℓ) → restrictA (lowerExt d₁) ≑ᵈ d₁
+  restrictA-lowerExt d₁ = (λ p → proj₁ p) , (λ p → p , refl₂)
+
+  restrictB-upperExt : (d₂ : DecCon 𝑩 0ℓ) → restrictB (upperExt d₂) ≑ᵈ d₂
+  restrictB-upperExt d₂ = (λ p → p) , (λ p → p)
+
+  -- Lower extensions sit below the boundary; upper ones sit above it.
+  lowerExt-⊆-α : (d₁ : DecCon 𝑨 0ℓ) → lowerExt d₁ ⊆ᵈ αᵈ
+  lowerExt-⊆-α d₁ (_ , r) = r
+
+  α-⊆-upperExt : (d₂ : DecCon 𝑩 0ℓ) → αᵈ ⊆ᵈ upperExt d₂
+  α-⊆-upperExt d₂ e = reflexive (proj₂ (proj₁ d₂)) e
+
+  -- The boundary restricts to the total congruence below, the diagonal above.
+  restrictA-α : restrictA αᵈ ≑ᵈ 𝟙ᵈ {ℓ = 0ℓ}
+  restrictA-α = (λ _ → lift tt) , (λ _ → refl₂)
+
+  restrictB-α : restrictB αᵈ ≑ᵈ 𝟘ᵈ (𝑭₂ ._≟_)
+  restrictB-α = (λ e → lift e) , (λ e → lower e)
+```
+
+#### The comparability dichotomy
+
+Every decidable congruence of `𝑪` is comparable to the boundary.  Decide both
+containments; if both fail, `⊈ᵈ-witness`{.AgdaFunction} surrenders (i) a pair
+related by `α` but not by `θ` — which normalizes to a `θ`-unrelated pair
+*inside the lower summand*, since `α`-related pairs touching the upper summand
+are glued — and (ii) a `θ`-related pair with distinct retraction images.  The
+collapse family then maps pair (ii) onto pair (i): one application in the
+mixed case (after checking which endpoint the unrelated pair misses), two
+chained through `a*` in the pure case.
+
+```agda
+  private
+    -- (i): a θ-unrelated pair in the lower summand.
+    lower-gap : (θ : DecCon 𝑪 0ℓ) → ¬ (αᵈ ⊆ᵈ θ)
+      → Σ[ x ∈ 𝕌[ 𝑨 ] ] Σ[ y ∈ 𝕌[ 𝑨 ] ] (¬ ConRel θ (inj₁ x) (inj₁ y))
+    lower-gap θ ¬α⊆θ with ⊈ᵈ-witness 𝑪-FiniteAlgebra αᵈ θ ¬α⊆θ
+    ... | inj₁ a , inj₁ a' , (_ , ¬θr)   = a , a' , ¬θr
+    ... | inj₁ a , inj₂ b , (αr , ¬θr)   =
+      a , a* , λ p → ¬θr (ConRel-resp θ {inj₁ a} {inj₁ a} {inj₁ a*} {inj₂ b}
+                            (refl₁ , refl₂) (refl₁ , αr) p)
+    ... | inj₂ b , inj₁ a , (αr , ¬θr)   =
+      a* , a , λ p → ¬θr (ConRel-resp θ {inj₁ a*} {inj₂ b} {inj₁ a} {inj₁ a}
+                            (refl₁ , sym₂ αr) (refl₁ , refl₂) p)
+    ... | inj₂ b , inj₂ b' , (αr , ¬θr)  =
+      ⊥-elim (¬θr (reflexive (proj₂ (proj₁ θ)) (refl₁ , αr)))
+
+    -- The mixed engine: a θ-related pair (inj₁ a , inj₂ b) with b off the
+    -- basepoint collapses onto any given lower pair, refuting its unrelatedness.
+    mixed-absurd : (θ : DecCon 𝑪 0ℓ) (x y : 𝕌[ 𝑨 ]) → ¬ ConRel θ (inj₁ x) (inj₁ y)
+      → (a : 𝕌[ 𝑨 ]) (b : 𝕌[ 𝑩 ]) → ¬ (b ≈₂ b*) → ConRel θ (inj₁ a) (inj₂ b) → ⊥
+    mixed-absurd θ x y ¬θxy a b ¬b* θab = decide
+      where
+      θcon    = proj₂ (proj₁ θ)
+      θsym    = IsEquivalence.sym (is-equivalence θcon)
+      θtrans  = IsEquivalence.trans (is-equivalence θcon)
+
+      -- Send b to any designated target, staying θ-related to a.
+      punch : (z : 𝕌[ 𝑨 ]) → ConRel θ (inj₁ a) (inj₁ z)
+      punch z = ConRel-resp θ {inj₁ a} {inj₁ a} {inj₁ (h[ b ↦ z ] b)} {inj₁ z}
+                  (refl₁ , refl₂) (≈ᵍ-inj₁ (h-at b z ¬b*))
+                  (is-compatible θcon (inj₂ (inj₂ (idx₂ b , idx₁ z))) (λ _ → θab))
+
+      decide : ⊥
+      decide with proj₂ θ (inj₁ x) (inj₁ a) | proj₂ θ (inj₁ y) (inj₁ a)
+      ... | yes θxa  | yes θya  = ¬θxy (θtrans θxa (θsym θya))
+      ... | yes _    | no ¬θya  = ¬θya (θsym (punch y))
+      ... | no ¬θxa  | yes _    = ¬θxa (θsym (punch x))
+      ... | no ¬θxa  | no _     = ¬θxa (θsym (punch x))
+
+    incomparable-absurd : (θ : DecCon 𝑪 0ℓ) → ¬ (θ ⊆ᵈ αᵈ) → ¬ (αᵈ ⊆ᵈ θ) → ⊥
+    incomparable-absurd θ ¬θ⊆α ¬α⊆θ = final (⊈ᵈ-witness 𝑪-FiniteAlgebra θ αᵈ ¬θ⊆α)
+      where
+      θcon    = proj₂ (proj₁ θ)
+      θsym    = IsEquivalence.sym (is-equivalence θcon)
+      θtrans  = IsEquivalence.trans (is-equivalence θcon)
+
+      gap  = lower-gap θ ¬α⊆θ
+      x    = proj₁ gap
+      y    = proj₁ (proj₂ gap)
+      ¬θxy = proj₂ (proj₂ gap)
+
+      final : Σ[ p ∈ A⊎B ] Σ[ q ∈ A⊎B ] (ConRel θ p q × ¬ (retractʳ p ≈₂ retractʳ q)) → ⊥
+      final (inj₁ a , inj₁ a' , (_ , ¬ρ))   = ¬ρ refl₂
+      final (inj₁ a , inj₂ b , (θr , ¬ρ))   =
+        mixed-absurd θ x y ¬θxy a b (λ e → ¬ρ (sym₂ e)) θr
+      final (inj₂ b , inj₁ a , (θr , ¬ρ))   =
+        mixed-absurd θ x y ¬θxy a b ¬ρ (θsym θr)
+      final (inj₂ b , inj₂ b' , (θr , ¬ρ))  = pure ¬ρ
+        where
+        -- Both endpoints upper: peel off basepoint-touching subcases, then
+        -- collapse twice through a*.
+        pure : ¬ (b ≈₂ b') → ⊥
+        pure ¬bb' with 𝑭₂ ._≟_ b b* | 𝑭₂ ._≟_ b' b*
+        ... | yes pb  | yes pb'  = ¬bb' (trans₂ pb (sym₂ pb'))
+        ... | yes pb  | no ¬pb'  =
+          mixed-absurd θ x y ¬θxy a* b' ¬pb'
+            (ConRel-resp θ {inj₂ b} {inj₁ a*} {inj₂ b'} {inj₂ b'}
+              (refl₁ , pb) (refl₁ , refl₂) θr)
+        ... | no ¬pb  | yes pb'  =
+          mixed-absurd θ x y ¬θxy a* b ¬pb
+            (θsym (ConRel-resp θ {inj₂ b} {inj₂ b} {inj₂ b'} {inj₁ a*}
+              (refl₁ , refl₂) (refl₁ , pb') θr))
+        ... | no ¬pb  | no ¬pb'  = ¬θxy (θtrans θx-a* θa*-y)
+          where
+          θx-a* : ConRel θ (inj₁ x) (inj₁ a*)
+          θx-a* = ConRel-resp θ
+                    {inj₁ (h[ b ↦ x ] b)} {inj₁ x} {inj₁ (h[ b ↦ x ] b')} {inj₁ a*}
+                    (≈ᵍ-inj₁ (h-at b x ¬pb))
+                    (≈ᵍ-inj₁ (h-away b x b' (λ e → ¬bb' (sym₂ e))))
+                    (is-compatible θcon (inj₂ (inj₂ (idx₂ b , idx₁ x))) (λ _ → θr))
+
+          θa*-y : ConRel θ (inj₁ a*) (inj₁ y)
+          θa*-y = ConRel-resp θ
+                    {inj₁ (h[ b' ↦ y ] b)} {inj₁ a*} {inj₁ (h[ b' ↦ y ] b')} {inj₁ y}
+                    (≈ᵍ-inj₁ (h-away b' y b ¬bb'))
+                    (≈ᵍ-inj₁ (h-at b' y ¬pb'))
+                    (is-compatible θcon (inj₂ (inj₂ (idx₂ b' , idx₁ y))) (λ _ → θr))
+
+  -- The dichotomy: every decidable congruence of 𝑪 is comparable to αᵈ.
+  compare : (θ : DecCon 𝑪 0ℓ) → θ ⊆ᵈ αᵈ ⊎ αᵈ ⊆ᵈ θ
+  compare θ with ⊆ᵈ-dec 𝑪-FiniteAlgebra θ αᵈ
+  ... | yes s = inj₁ s
+  ... | no ¬s with ⊆ᵈ-dec 𝑪-FiniteAlgebra αᵈ θ
+  ...   | yes s' = inj₂ s'
+  ...   | no ¬s' = ⊥-elim (incomparable-absurd θ ¬s ¬s')
+```
+
+#### The two splittings
+
+A congruence below the boundary is its lower extension; one above it is its
+upper extension.  These are the constructive readings of the manuscript's
+"congruences comparable to `α` are determined on one side".
+
+```agda
+  lower-split : (θ : DecCon 𝑪 0ℓ) → θ ⊆ᵈ αᵈ → θ ≑ᵈ lowerExt (restrictA θ)
+  lower-split θ θ⊆α = fwd , bwd
+    where
+    θcon = proj₂ (proj₁ θ)
+
+    fwd : θ ⊆ᵈ lowerExt (restrictA θ)
+    fwd {inj₁ a} {inj₁ a'} p = p , θ⊆α p
+    fwd {inj₁ a} {inj₂ b}  p =
+      ConRel-resp θ {inj₁ a} {inj₁ a} {inj₂ b} {inj₁ a*}
+        (refl₁ , refl₂) (refl₁ , sym₂ (θ⊆α p)) p , θ⊆α p
+    fwd {inj₂ b} {inj₁ a}  p =
+      ConRel-resp θ {inj₂ b} {inj₁ a*} {inj₁ a} {inj₁ a}
+        (refl₁ , θ⊆α p) (refl₁ , refl₂) p , θ⊆α p
+    fwd {inj₂ b} {inj₂ b'} p = reflexive θcon (≈ᵍ-inj₁ refl₁) , θ⊆α p
+
+    bwd : lowerExt (restrictA θ) ⊆ᵈ θ
+    bwd {inj₁ a} {inj₁ a'} (l , r) = l
+    bwd {inj₁ a} {inj₂ b}  (l , r) =
+      ConRel-resp θ {inj₁ a} {inj₁ a} {inj₁ a*} {inj₂ b}
+        (refl₁ , refl₂) (refl₁ , r) l
+    bwd {inj₂ b} {inj₁ a}  (l , r) =
+      ConRel-resp θ {inj₁ a*} {inj₂ b} {inj₁ a} {inj₁ a}
+        (refl₁ , sym₂ r) (refl₁ , refl₂) l
+    bwd {inj₂ b} {inj₂ b'} (l , r) = reflexive θcon (refl₁ , r)
+
+  upper-split : (θ : DecCon 𝑪 0ℓ) → αᵈ ⊆ᵈ θ → θ ≑ᵈ upperExt (restrictB θ)
+  upper-split θ α⊆θ = fwd , bwd
+    where
+    θcon    = proj₂ (proj₁ θ)
+    θsym    = IsEquivalence.sym (is-equivalence θcon)
+    θtrans  = IsEquivalence.trans (is-equivalence θcon)
+
+    -- Every element is θ-related to the upper image of its right retraction:
+    -- upper elements on the nose, lower ones through the boundary.
+    bridge : ∀ z → ConRel θ z (inj₂ (retractʳ z))
+    bridge (inj₁ a) = α⊆θ {inj₁ a} {inj₂ b*} refl₂
+    bridge (inj₂ b) = reflexive θcon (refl₁ , refl₂)
+
+    fwd : θ ⊆ᵈ upperExt (restrictB θ)
+    fwd {x} {y} p = θtrans (θsym (bridge x)) (θtrans p (bridge y))
+
+    bwd : upperExt (restrictB θ) ⊆ᵈ θ
+    bwd {x} {y} p = θtrans (bridge x) (θtrans p (θsym (bridge y)))
+```
+
+#### The order isomorphism onto the ordinal sum
+
+Fix the target lattices, the extremum data the sum glues at, and the two
+isomorphisms.  The map sends a congruence below the boundary into the lower
+summand and one above it into the upper summand; the boundary itself lands on
+the glue, and the coherence of that overlap is exactly the uniqueness of
+extrema (`top-unique`{.AgdaFunction} / `bot-unique`{.AgdaFunction}) applied to
+the images of the total and diagonal congruences.
+
+```agda
+  module _ {𝑳₁ 𝑳₂ : Lattice} (t : TopOf 𝑳₁) (b : BotOf 𝑳₂)
+           (iso₁ : ConIsoᵈ 𝑨 𝑳₁) (iso₂ : ConIsoᵈ 𝑩 𝑳₂)
+    where
+
+    private
+      ⊤₁ = proj₁ t
+      ⊥₂ = proj₁ b
+
+    open OrderIso iso₁
+      renaming ( to to to₁ ; from to from₁ ; to-mono to to-mono₁
+               ; from-mono to from-mono₁ ; to∘from to to∘from₁ ; from∘to to from∘to₁ )
+    open OrderIso iso₂
+      renaming ( to to to₂ ; from to from₂ ; to-mono to to-mono₂
+               ; from-mono to from-mono₂ ; to∘from to to∘from₂ ; from∘to to from∘to₂ )
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆₁} {𝑨 = 𝑨} {𝑳 = 𝑳₁} iso₁ using ()
+      renaming ( to-cong≑ to to-cong≑₁ ; from-cong≈ to from-cong≈₁ ; to-𝟙-top to to-𝟙-top₁ )
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆₂} {𝑨 = 𝑩} {𝑳 = 𝑳₂} iso₂ using ()
+      renaming ( to-cong≑ to to-cong≑₂ ; from-cong≈ to from-cong≈₂ ; to-𝟘-bot to to-𝟘-bot₂ )
+    open Setoid 𝔻[ proj₁ 𝑳₁ ] using ()
+      renaming ( _≈_ to _≈ᴸ¹_ ; refl to reflᴸ¹ ; sym to symᴸ¹ ; trans to transᴸ¹ )
+    open Setoid 𝔻[ proj₁ 𝑳₂ ] using ()
+      renaming ( _≈_ to _≈ᴸ²_ ; refl to reflᴸ² ; sym to symᴸ² ; trans to transᴸ² )
+    open LatticeOrdinalSum 𝑳₁ t 𝑳₂ b using
+      ( ≤ᵒ-inj₁ ; ≤ᵒ-inj₁-elim ; ≤ᵒ-inj₂ ; ≤ᵒ-inj₂-elim ; ≤ᵒ-up ; ≤ᵒ-down ; ≤ᵒ-down-elim )
+
+    private
+      -- Boundary coherence: the extreme images agree with the chosen extrema.
+      to₁𝟙≈⊤ : to₁ (𝟙ᵈ {ℓ = 0ℓ}) ≈ᴸ¹ ⊤₁
+      to₁𝟙≈⊤ = Lattice-Order.top-unique 𝑳₁
+                 {t = to₁ (𝟙ᵈ {ℓ = 0ℓ})} {t' = ⊤₁} to-𝟙-top₁ (proj₂ t)
+
+      to₂𝟘≈⊥ : to₂ (𝟘ᵈ (𝑭₂ ._≟_)) ≈ᴸ² ⊥₂
+      to₂𝟘≈⊥ = Lattice-Order.bot-unique 𝑳₂
+                 {b = to₂ (𝟘ᵈ (𝑭₂ ._≟_))} {b' = ⊥₂} (to-𝟘-bot₂ (𝑭₂ ._≟_)) (proj₂ b)
+
+      -- The images of a boundary-equal congruence sit at the glue.
+      atGlue-⊤ : (θ : DecCon 𝑪 0ℓ) → θ ≑ᵈ αᵈ → to₁ (restrictA θ) ≈ᴸ¹ ⊤₁
+      atGlue-⊤ θ (s₁ , s₂) =
+        transᴸ¹ (to-cong≑₁ ((λ _ → lift tt) , (λ {a} {a'} _ → s₂ {inj₁ a} {inj₁ a'} refl₂)))
+          to₁𝟙≈⊤
+
+      atGlue-⊥ : (θ : DecCon 𝑪 0ℓ) → θ ≑ᵈ αᵈ → to₂ (restrictB θ) ≈ᴸ² ⊥₂
+      atGlue-⊥ θ (s₁ , s₂) =
+        transᴸ² (to-cong≑₂ ((λ p → lift (s₁ p)) , (λ q → s₂ (lower q)))) to₂𝟘≈⊥
+```
+
+The map, its inverse, and the four obligations.  The map decides the side via
+`compare`{.AgdaFunction}; each obligation re-runs that decision and reasons per
+branch, with the mixed branches all funneling through the glue coherences.
+
+```agda
+    toᵒ : DecCon 𝑪 0ℓ → 𝕌[ proj₁ 𝑳₁ ] ⊎ 𝕌[ proj₁ 𝑳₂ ]
+    toᵒ θ with compare θ
+    ... | inj₁ _ = inj₁ (to₁ (restrictA θ))
+    ... | inj₂ _ = inj₂ (to₂ (restrictB θ))
+
+    fromᵒ : 𝕌[ proj₁ 𝑳₁ ] ⊎ 𝕌[ proj₁ 𝑳₂ ] → DecCon 𝑪 0ℓ
+    fromᵒ (inj₁ u) = lowerExt (from₁ u)
+    fromᵒ (inj₂ v) = upperExt (from₂ v)
+
+    to-monoᵒ : {θ θ' : DecCon 𝑪 0ℓ} → θ ⊆ᵈ θ'
+      → Lattice-Order._≤_ (ordinalSum 𝑳₁ t 𝑳₂ b) (toᵒ θ) (toᵒ θ')
+    to-monoᵒ {θ} {θ'} s with compare θ | compare θ'
+    ... | inj₁ _    | inj₁ _     =
+      ≤ᵒ-inj₁ {x = to₁ (restrictA θ)} {y = to₁ (restrictA θ')}
+        (to-mono₁ {restrictA θ} {restrictA θ'} (restrictA-mono {θ} {θ'} s))
+    ... | inj₁ _    | inj₂ _     = ≤ᵒ-up (to₁ (restrictA θ)) (to₂ (restrictB θ'))
+    ... | inj₂ α⊆θ  | inj₁ θ'⊆α  =
+      -- θ ⊆ θ' pins both to the boundary; both images land on the glue.
+      ≤ᵒ-down {x = to₂ (restrictB θ)} {y = to₁ (restrictA θ')}
+        (atGlue-⊤ θ' (θ'⊆α , λ {x} {y} p → s {x} {y} (α⊆θ {x} {y} p)))
+        (atGlue-⊥ θ ((λ {x} {y} p → θ'⊆α {x} {y} (s {x} {y} p)) , α⊆θ))
+    ... | inj₂ _    | inj₂ _     =
+      ≤ᵒ-inj₂ {x = to₂ (restrictB θ)} {y = to₂ (restrictB θ')}
+        (to-mono₂ {restrictB θ} {restrictB θ'} (restrictB-mono {θ} {θ'} s))
+
+    from-monoᵒ : {u v : 𝕌[ proj₁ 𝑳₁ ] ⊎ 𝕌[ proj₁ 𝑳₂ ]}
+      → Lattice-Order._≤_ (ordinalSum 𝑳₁ t 𝑳₂ b) u v → fromᵒ u ⊆ᵈ fromᵒ v
+    from-monoᵒ {inj₁ u} {inj₁ v} le {x} {y} p =
+      lowerExt-mono {from₁ u} {from₁ v}
+        (from-mono₁ {u} {v} (≤ᵒ-inj₁-elim {x = u} {y = v} le)) {x} {y} p
+    -- (everything below the boundary sits below every upper extension)
+    from-monoᵒ {inj₁ u} {inj₂ v} le {x} {y} (l , r) =
+      reflexive (proj₂ (proj₁ (from₂ v))) {retractʳ x} {retractʳ y} r
+    from-monoᵒ {inj₂ u} {inj₁ v} le {x} {y} p = down {x} {y} p
+      where
+      -- u at the bottom, v at the top: both preimages are extreme, and the
+      -- extreme extensions nest.
+      u≈⊥ = proj₂ (≤ᵒ-down-elim {x = u} {y = v} le)
+      v≈⊤ = proj₁ (≤ᵒ-down-elim {x = u} {y = v} le)
+
+      from₂u≑𝟘 : from₂ u ≑ᵈ 𝟘ᵈ (𝑭₂ ._≟_)
+      from₂u≑𝟘 =
+        (λ p → proj₁ e₂ (proj₁ e₁ p)) , (λ q → proj₂ e₁ (proj₂ e₂ q))
+        where
+        e₁ = from-cong≈₂ (transᴸ² u≈⊥ (symᴸ² to₂𝟘≈⊥))
+        e₂ = from∘to₂ (𝟘ᵈ (𝑭₂ ._≟_))
+
+      from₁v≑𝟙 : from₁ v ≑ᵈ 𝟙ᵈ {ℓ = 0ℓ}
+      from₁v≑𝟙 =
+        (λ p → proj₁ e₂ (proj₁ e₁ p)) , (λ q → proj₂ e₁ (proj₂ e₂ q))
+        where
+        e₁ = from-cong≈₁ (transᴸ¹ v≈⊤ (symᴸ¹ to₁𝟙≈⊤))
+        e₂ = from∘to₁ (𝟙ᵈ {ℓ = 0ℓ})
+
+      down : upperExt (from₂ u) ⊆ᵈ lowerExt (from₁ v)
+      down p = proj₂ from₁v≑𝟙 (lift tt) , lower (proj₁ from₂u≑𝟘 p)
+    from-monoᵒ {inj₂ u} {inj₂ v} le {x} {y} p =
+      upperExt-mono {from₂ u} {from₂ v}
+        (from-mono₂ {u} {v} (≤ᵒ-inj₂-elim {x = u} {y = v} le)) {x} {y} p
+
+    to∘fromᵒ : ∀ u → Setoid._≈_ 𝔻[ proj₁ (ordinalSum 𝑳₁ t 𝑳₂ b) ] (toᵒ (fromᵒ u)) u
+    to∘fromᵒ (inj₁ u) with compare (lowerExt (from₁ u))
+    ... | inj₁ _ =
+      transᴸ¹ (to-cong≑₁ (restrictA-lowerExt (from₁ u))) (to∘from₁ u) , reflᴸ²
+    ... | inj₂ α⊆ = symᴸ¹ u≈⊤ , atGlue-⊥ (lowerExt (from₁ u)) ext≑α
+      where
+      -- the extension is squeezed onto the boundary, so u is the top
+      ext≑α : lowerExt (from₁ u) ≑ᵈ αᵈ
+      ext≑α = (λ {x} {y} p → lowerExt-⊆-α (from₁ u) {x} {y} p)
+            , (λ {x} {y} p → α⊆ {x} {y} p)
+
+      from₁u≑𝟙 : from₁ u ≑ᵈ 𝟙ᵈ {ℓ = 0ℓ}
+      from₁u≑𝟙 = (λ _ → lift tt) , (λ {a} {a'} _ → proj₁ (α⊆ {inj₁ a} {inj₁ a'} refl₂))
+
+      u≈⊤ : u ≈ᴸ¹ ⊤₁
+      u≈⊤ = transᴸ¹ (symᴸ¹ (to∘from₁ u)) (transᴸ¹ (to-cong≑₁ from₁u≑𝟙) to₁𝟙≈⊤)
+    to∘fromᵒ (inj₂ v) with compare (upperExt (from₂ v))
+    ... | inj₂ _ =
+      reflᴸ¹ , transᴸ² (to-cong≑₂ (restrictB-upperExt (from₂ v))) (to∘from₂ v)
+    ... | inj₁ θ⊆α = atGlue-⊤ (upperExt (from₂ v)) ext≑α , symᴸ² v≈⊥
+      where
+      ext≑α : upperExt (from₂ v) ≑ᵈ αᵈ
+      ext≑α = (λ {x} {y} p → θ⊆α {x} {y} p)
+            , (λ {x} {y} p → α-⊆-upperExt (from₂ v) {x} {y} p)
+
+      from₂v≑𝟘 : from₂ v ≑ᵈ 𝟘ᵈ (𝑭₂ ._≟_)
+      from₂v≑𝟘 = (λ {x} {y} p → lift (θ⊆α {inj₂ x} {inj₂ y} p))
+               , (λ q → reflexive (proj₂ (proj₁ (from₂ v))) (lower q))
+
+      v≈⊥ : v ≈ᴸ² ⊥₂
+      v≈⊥ = transᴸ² (symᴸ² (to∘from₂ v)) (transᴸ² (to-cong≑₂ from₂v≑𝟘) to₂𝟘≈⊥)
+
+    from∘toᵒ : ∀ θ → fromᵒ (toᵒ θ) ≑ᵈ θ
+    from∘toᵒ θ with compare θ
+    ... | inj₁ θ⊆α =
+      (λ {x} {y} p → proj₂ (lower-split θ θ⊆α) {x} {y} (proj₁ ext {x} {y} p))
+      , (λ {x} {y} q → proj₂ ext {x} {y} (proj₁ (lower-split θ θ⊆α) {x} {y} q))
+      where
+      ext = lowerExt-cong≑ {from₁ (to₁ (restrictA θ))} {restrictA θ} (from∘to₁ (restrictA θ))
+    ... | inj₂ α⊆θ =
+      (λ {x} {y} p → proj₂ (upper-split θ α⊆θ) {x} {y} (proj₁ ext {x} {y} p))
+      , (λ {x} {y} q → proj₂ ext {x} {y} (proj₁ (upper-split θ α⊆θ) {x} {y} q))
+      where
+      ext = upperExt-cong≑ {from₂ (to₂ (restrictB θ))} {restrictB θ} (from∘to₂ (restrictB θ))
+
+    𝑪-ConIsoᵈ : ConIsoᵈ 𝑪 (ordinalSum 𝑳₁ t 𝑳₂ b)
+    𝑪-ConIsoᵈ = record
+      { to         = toᵒ
+      ; from       = fromᵒ
+      ; to-mono    = λ {θ} {θ'} → to-monoᵒ {θ} {θ'}
+      ; from-mono  = λ {u} {v} → from-monoᵒ {u} {v}
+      ; to∘from    = to∘fromᵒ
+      ; from∘to    = from∘toᵒ
+      }
+```
+
+#### The closure theorem
+
+Normalize both witnesses to inhabited carriers, instantiate the construction,
+and package the result.
+
+```agda
+ordinalSum-Representableᵈ : {𝑳₁ 𝑳₂ : Lattice} (t : TopOf 𝑳₁) (b : BotOf 𝑳₂)
+  → Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂ → Representableᵈ (ordinalSum 𝑳₁ t 𝑳₂ b)
+ordinalSum-Representableᵈ {𝑳₁} {𝑳₂} t b r₁ r₂ =
+  assemble (inhabited-witness r₁) (inhabited-witness r₂)
+  where
+  open Representableᵈ
+
+  assemble : Σ[ r ∈ Representableᵈ 𝑳₁ ] 𝕌[ r .algᵈ ]
+           → Σ[ r ∈ Representableᵈ 𝑳₂ ] 𝕌[ r .algᵈ ]
+           → Representableᵈ (ordinalSum 𝑳₁ t 𝑳₂ b)
+  assemble (r₁' , a*) (r₂' , b*) = record
+    { sigᵈ      = W.𝑆ₒ
+    ; algᵈ      = W.𝑪
+    ; finiteᵈ   = W.𝑪-FiniteAlgebra
+    ; finsigᵈ   = W.𝑆ₒ-FiniteSignature
+    ; con-isoᵈ  = W.𝑪-ConIsoᵈ {𝑳₁ = 𝑳₁} {𝑳₂ = 𝑳₂} t b (r₁' .con-isoᵈ) (r₂' .con-isoᵈ)
+    }
+    where
+    module W = OrdinalSumWitness
+      (r₁' .algᵈ) (r₁' .finiteᵈ) (r₁' .finsigᵈ) a*
+      (r₂' .algᵈ) (r₂' .finiteᵈ) (r₂' .finsigᵈ) b*
+```
+
+--------------------------------------

--- a/src/FLRP/Closure/Product.lagda.md
+++ b/src/FLRP/Closure/Product.lagda.md
@@ -100,7 +100,6 @@ open import Setoid.Algebras.Basic                  using  ( Algebra ; 𝔻[_] ; 
 open import Setoid.Algebras.Finite                 using  ( FiniteAlgebra )
 open import Setoid.Congruences.Basic               using  ( mkcon ; reflexive ; _∣≈_
                                                           ; is-equivalence ; is-compatible )
-open import Setoid.Congruences.ChainJoin           using  ( Finitary )
 open import Setoid.Congruences.Finite.Basic        using  ( DecCon ; ConRel )
 open import Setoid.Signatures.Finite               using  ( FiniteSignature )
 

--- a/src/FLRP/Closure/Product.lagda.md
+++ b/src/FLRP/Closure/Product.lagda.md
@@ -10,9 +10,8 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.Closure.Product][] module of the [Agda Universal Algebra Library][].
 
-The class of representable lattices is closed under finite direct products
-(Tůma 1986; see `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure
-properties).  This module formalizes the binary case at Layer D of the two-layer
+The class of representable lattices is closed under finite direct products.[^1]
+This module formalizes the binary case at Layer D of the two-layer
 discipline ([ADR-008][]): given decidable representations of `𝑳₁`{.AgdaBound} and
 `𝑳₂`{.AgdaBound}, it constructs a finite finitary algebra whose
 decidable-congruence poset is order-isomorphic to the product lattice
@@ -21,7 +20,9 @@ decidable-congruence poset is order-isomorphic to the product lattice
     product-Representableᵈ : Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂
                            → Representableᵈ (𝑳₁ ×ˡ 𝑳₂)
 
-**The witness algebra.**  Given representing algebras `𝑨` and `𝑩` with chosen
+**The witness algebra**.
+
+Given representing algebras `𝑨` and `𝑩` with chosen
 basepoints `a*` and `b*`, the composite `𝑪` lives on the product setoid `A × B`
 over the signature
 
@@ -33,30 +34,32 @@ are the unary **coordinate setters** `(a , b) ↦ (enum i , b)` and
 `(a , b) ↦ (a , enum j)` that overwrite one coordinate with an enumerated
 element while carrying the other along.
 
-**Why the congruences split.**  The setters force every congruence `θ` of `𝑪` to
-be a product: writing `θˡ a a' := θ (a , b*) (a' , b*)` and symmetrically `θʳ`,
-setting the second coordinate shows any `θ`-related pair is `θˡ`-related in the
-first coordinate (and dually), while conversely a common overwrite lets
-`θˡ`-relatedness and `θʳ`-relatedness be chained through the intermediate point
-`(a' , b)` — so `θ` is exactly the conjunction `θˡ × θʳ`
-(`restrict-pair-⊆`{.AgdaFunction} / `restrict-pair-⊇`{.AgdaFunction} below).
-This is the constructive heart of the closure proof; everything else is the
-transport of that splitting through the two given isomorphisms, componentwise.
+**Why the congruences split**.
+
+The setters force every congruence `θ` of `𝑪` to be a product: writing
+`θˡ a a' := θ (a , b*) (a' , b*)` and symmetrically `θʳ`, setting the second
+coordinate shows any `θ`-related pair is `θˡ`-related in the first coordinate (and
+dually), while conversely a common overwrite lets `θˡ`-relatedness and
+`θʳ`-relatedness be chained through the intermediate point `(a' , b)` — so `θ` is
+exactly the conjunction `θˡ × θʳ` (`restrict-pair-⊆`{.AgdaFunction} /
+`restrict-pair-⊇`{.AgdaFunction} below).
+
+This is the constructive heart of the closure proof; everything else is the transport
+of that splitting through the two given isomorphisms, componentwise.
 
 Both coordinatewise restrictions and the pairing preserve decidability, so the
 whole argument stays at Layer D with no classical assumption.  (At Layer S the
-same splitting goes through verbatim, but its consumers would be the
-WLEM-hard `Representable`{.AgdaRecord} witnesses of the no-go theorem, so the
-library states product closure at Layer D only.)
+same splitting goes through verbatim, but its consumers would be the WLEM-hard
+`Representable`{.AgdaRecord} witnesses of the no-go theorem, so the library states
+product closure at Layer D only.)
 
 Basepoints exist because representing algebras may be *normalized to inhabited
 carriers*: `inhabited-witness`{.AgdaFunction} of [FLRP.Representable][] replaces
 an empty-carrier witness (whose lattice is then trivial) by the one-element
 algebra.  The closure theorem therefore has no side conditions.
 
-The standing FLRP research-track separation warning applies: this is
-problem-specific formal content; the lattice-level product it targets lives in
-the `Classical/` tree.
+This is problem-specific formal content; the lattice-level product it targets
+lives in the `Classical/` tree.
 
 <!--
 ```agda
@@ -70,8 +73,9 @@ open import Agda.Primitive using () renaming ( Set to Type )
 open import Data.Fin.Base                          using  ( Fin ; splitAt ; join
                                                           ; combine ; remQuot )
 open import Data.Fin.Patterns                      using  ( 0F )
-open import Data.Fin.Properties                    using  ( splitAt-join ; remQuot-combine )
-open import Data.Nat.Base                          using  ( _+_ ; _*_ )
+open import Data.Fin.Properties                    using  ( splitAt-join
+                                                          ; remQuot-combine )
+open import Data.Nat.Base                          using  ( _+_ ; _*_ ; ℕ)
 open import Data.Product                           using  ( _,_ ; _×_ ; proj₁ ; proj₂
                                                           ; Σ-syntax )
 open import Data.Sum.Base                          using  ( _⊎_ ; inj₁ ; inj₂ ; [_,_]′ )
@@ -84,24 +88,24 @@ open import Relation.Nullary                       using  ( Dec )
 open import Relation.Nullary.Decidable             using  ( _×-dec_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Small.Structures.Lattice     using  ( Lattice )
-open import Classical.Structures.Interpret         using  ( interp-cong )
-open import Classical.Structures.Lattice.Product   using  ( module LatticeProduct ; _×ˡ_ )
-open import FLRP.Problem                           using  ( OrderIso )
-open import FLRP.Representable                     using  ( Representableᵈ ; ConIsoᵈ
-                                                          ; _⊆ᵈ_ ; _≑ᵈ_ ; ConRel-resp
-                                                          ; module ConIsoᵈ-Consequences
-                                                          ; inhabited-witness )
-open import Overture                               using  ( Signature
-                                                          ; OperationSymbolsOf ; ArityOf )
-open import Overture.Operations                    using  ( Op )
-open import Setoid.Algebras.Basic                  using  ( Algebra ; 𝔻[_] ; 𝕌[_] ; _^_
-                                                          ; mkAlgebra )
-open import Setoid.Algebras.Finite                 using  ( FiniteAlgebra )
-open import Setoid.Congruences.Basic               using  ( mkcon ; reflexive ; _∣≈_
-                                                          ; is-equivalence ; is-compatible )
-open import Setoid.Congruences.Finite.Basic        using  ( DecCon ; ConRel )
-open import Setoid.Signatures.Finite               using  ( FiniteSignature )
+open import Classical.Small.Structures.Lattice    using  ( Lattice )
+open import Classical.Structures.Interpret        using  ( interp-cong )
+open import Classical.Structures.Lattice.Product  using  ( module LatticeProduct ; _×ˡ_ )
+open import FLRP.Problem                          using  ( OrderIso )
+open import FLRP.Representable                    using  ( Representableᵈ ; ConIsoᵈ
+                                                         ; _⊆ᵈ_ ; _≑ᵈ_ ; ConRel-resp
+                                                         ; module ConIsoᵈ-Consequences
+                                                         ; inhabited-witness )
+open import Overture                              using  ( Signature
+                                                         ; OperationSymbolsOf ; ArityOf )
+open import Overture.Operations                   using  ( Op )
+open import Setoid.Algebras.Basic                 using  ( Algebra ; 𝔻[_] ; 𝕌[_] ; _^_
+                                                         ; mkAlgebra )
+open import Setoid.Algebras.Finite                using  ( FiniteAlgebra )
+open import Setoid.Congruences.Basic              using  ( mkcon ; is-equivalence ; _∣≈_
+                                                         ; reflexive ; is-compatible )
+open import Setoid.Congruences.Finite.Basic       using  ( DecCon ; ConRel )
+open import Setoid.Signatures.Finite              using  ( FiniteSignature )
 
 open FiniteAlgebra
 open FiniteSignature
@@ -117,8 +121,8 @@ matching `Representableᵈ`{.AgdaRecord}.
 ```agda
 module ProductWitness
   {𝑆₁ 𝑆₂ : Signature 0ℓ 0ℓ}
-  (𝑨 : Algebra {𝑆 = 𝑆₁} 0ℓ 0ℓ) (𝑭₁ : FiniteAlgebra 𝑨) (𝑮₁ : FiniteSignature 𝑆₁) (a* : 𝕌[ 𝑨 ])
-  (𝑩 : Algebra {𝑆 = 𝑆₂} 0ℓ 0ℓ) (𝑭₂ : FiniteAlgebra 𝑩) (𝑮₂ : FiniteSignature 𝑆₂) (b* : 𝕌[ 𝑩 ])
+  (𝑨 : Algebra {𝑆 = 𝑆₁} 0ℓ 0ℓ) (𝑭₁ : FiniteAlgebra 𝑨) (S₁ : FiniteSignature 𝑆₁) (a* : 𝕌[ 𝑨 ])
+  (𝑩 : Algebra {𝑆 = 𝑆₂} 0ℓ 0ℓ) (𝑭₂ : FiniteAlgebra 𝑩) (S₂ : FiniteSignature 𝑆₂) (b* : 𝕌[ 𝑩 ])
   where
 
   private
@@ -133,8 +137,10 @@ module ProductWitness
     renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
 ```
 
-**The signature**: the two component signatures side by side with the two
-setter families.  Setters are unary; component symbols keep their arities.
+**The signature**.
+
+The two component signatures sit side-by-side with the two setter families.
+Setters are unary; component symbols keep their arities.
 
 ```agda
   OpSymbols : Type 0ℓ
@@ -149,8 +155,9 @@ setter families.  Setters are unary; component symbols keep their arities.
   𝑆ₓ = OpSymbols , arity
 ```
 
-**The carrier**: the product setoid, with the pointwise pair equivalence (the
-isolated-equality locus for the Cubical port).
+**The carrier**.
+
+The product setoid is accompanied by the pointwise pair equivalence.[^2]
 
 ```agda
   A×B : Setoid 0ℓ 0ℓ
@@ -164,12 +171,14 @@ isolated-equality locus for the Cubical port).
         }
     }
 
-  open Setoid A×B using () renaming ( _≈_ to _≈ₓ_ ; trans to transₓ ; reflexive to ≡→≈ₓ )
+  open Setoid A×B using ()
+    renaming ( _≈_ to _≈ₓ_ ; trans to transₓ ; reflexive to ≡→≈ₓ )
 ```
 
-**The algebra**: component symbols act through their coordinate with the other
-pinned to the basepoint; setters overwrite their coordinate with an enumerated
-element.
+**The algebra**.
+
+Component symbols act through their coordinate with the other pinned to the
+basepoint; setters overwrite their coordinate with an enumerated element.
 
 ```agda
   𝑪 : Algebra {𝑆 = 𝑆ₓ} 0ℓ 0ℓ
@@ -183,8 +192,8 @@ element.
 
     interp-congruence : ∀ o {u v : arity o → 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]}
       → (∀ i → u i ≈ₓ v i) → interp o u ≈ₓ interp o v
-    interp-congruence (inj₁ f)               e = interp-cong 𝑨 f (λ i → proj₁ (e i)) , refl₂
-    interp-congruence (inj₂ (inj₁ g))        e = refl₁ , interp-cong 𝑩 g (λ i → proj₂ (e i))
+    interp-congruence (inj₁ f)               e = interp-cong 𝑨 f (proj₁ ∘ e) , refl₂
+    interp-congruence (inj₂ (inj₁ g))        e = refl₁ , interp-cong 𝑩 g (proj₂ ∘ e)
     interp-congruence (inj₂ (inj₂ (inj₁ i))) e = refl₁ , proj₂ (e 0F)
     interp-congruence (inj₂ (inj₂ (inj₂ j))) e = proj₁ (e 0F) , refl₂
 ```
@@ -205,11 +214,10 @@ decidable equality componentwise.
       ≡→≈ₓ (cong (λ z → enum₁ (proj₁ z) , enum₂ (proj₂ z)) (remQuot-combine i j))
 
   𝑪-FiniteAlgebra : FiniteAlgebra 𝑪
-  𝑪-FiniteAlgebra ._≟_ = λ p q →
-    (𝑭₁ ._≟_ (proj₁ p) (proj₁ q)) ×-dec (𝑭₂ ._≟_ (proj₂ p) (proj₂ q))
+  𝑪-FiniteAlgebra ._≟_ p q = 𝑭₁ ._≟_ (proj₁ p) (proj₁ q) ×-dec 𝑭₂ ._≟_ (proj₂ p) (proj₂ q)
   𝑪-FiniteAlgebra .card = m * n
   𝑪-FiniteAlgebra .enum = enumC
-  𝑪-FiniteAlgebra .enum-sur = λ p → sur p
+  𝑪-FiniteAlgebra .enum-sur = sur
     where
     sur : ∀ p → Σ[ k ∈ Fin (m * n) ] enumC k ≈ₓ p
     sur p with 𝑭₁ .enum-sur (proj₁ p) | 𝑭₂ .enum-sur (proj₂ p)
@@ -222,70 +230,75 @@ setter symbols are unary.
 
 ```agda
   private
-    c₁ = 𝑮₁ .opCard
-    c₂ = 𝑮₂ .opCard
+    c₁ c₂ : ℕ
+    c₁ = S₁ .opCard
+    c₂ = S₂ .opCard
 
     -- Decode a flat index into a symbol, one ⊎-layer of splitAt at a time.
     decode₂ : Fin (c₂ + (m + n)) → OperationSymbolsOf 𝑆₂ ⊎ (Fin m ⊎ Fin n)
-    decode₂ = [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ splitAt m ]′ ∘ splitAt c₂
+    decode₂ = [ inj₁ ∘ S₂ .opEnum , inj₂ ∘ splitAt m ]′ ∘ splitAt c₂
 
     decode : Fin (c₁ + (c₂ + (m + n))) → OpSymbols
-    decode = [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ ∘ splitAt c₁
+    decode = [ inj₁ ∘ S₁ .opEnum , inj₂ ∘ decode₂ ]′ ∘ splitAt c₁
 
     -- One computation rule per ⊎-layer: decoding a joined index reduces to the branch.
     decode-join : (x : Fin c₁ ⊎ Fin (c₂ + (m + n)))
-      → decode (join c₁ _ x) ≡ [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ x
-    decode-join x = cong [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ (splitAt-join c₁ _ x)
+      → decode (join c₁ _ x) ≡ [ inj₁ ∘ S₁ .opEnum , inj₂ ∘ decode₂ ]′ x
+    decode-join x = cong [ inj₁ ∘ S₁ .opEnum , inj₂ ∘ decode₂ ]′ (splitAt-join c₁ _ x)
 
     decode₂-join : (x : Fin c₂ ⊎ Fin (m + n))
-      → decode₂ (join c₂ _ x) ≡ [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ splitAt m ]′ x
-    decode₂-join x = cong [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ splitAt m ]′ (splitAt-join c₂ _ x)
+      → decode₂ (join c₂ _ x) ≡ [ inj₁ ∘ S₂ .opEnum , inj₂ ∘ splitAt m ]′ x
+    decode₂-join x = cong [ inj₁ ∘ S₂ .opEnum , inj₂ ∘ splitAt m ]′ (splitAt-join c₂ _ x)
+
 
     -- Encoding hits every symbol: chain the computation rules layer by layer.
     decode-sur : (o : OpSymbols) → Σ[ k ∈ Fin (c₁ + (c₂ + (m + n))) ] decode k ≡ o
-    decode-sur (inj₁ f) with 𝑮₁ .opEnum-sur f
+
+    decode-sur (inj₁ f) with S₁ .opEnum-sur f
     ... | i , p = join c₁ _ (inj₁ i) , trans (decode-join (inj₁ i)) (cong inj₁ p)
-    decode-sur (inj₂ (inj₁ g)) with 𝑮₂ .opEnum-sur g
-    ... | j , p =
-      join c₁ _ (inj₂ (join c₂ _ (inj₁ j))) ,
-      trans (decode-join (inj₂ (join c₂ _ (inj₁ j))))
-        (trans (cong inj₂ (decode₂-join (inj₁ j))) (cong (inj₂ ∘ inj₁) p))
+
+    decode-sur (inj₂ (inj₁ g)) with S₂ .opEnum-sur g
+    ... | j , p =  join c₁ _ (inj₂ (join c₂ _ (inj₁ j)))
+                   , trans  (decode-join (inj₂ (join c₂ _ (inj₁ j))))
+                            (trans  (cong inj₂ (decode₂-join (inj₁ j)))
+                                    (cong (inj₂ ∘ inj₁) p))
+
     decode-sur (inj₂ (inj₂ (inj₁ i))) =
-      join c₁ _ (inj₂ (join c₂ _ (inj₂ (join m n (inj₁ i))))) ,
-      trans (decode-join (inj₂ (join c₂ _ (inj₂ (join m n (inj₁ i))))))
-        (trans (cong inj₂ (decode₂-join (inj₂ (join m n (inj₁ i)))))
-               (cong (inj₂ ∘ inj₂) (splitAt-join m n (inj₁ i))))
+      join c₁ _ (inj₂ (join c₂ _ (inj₂ (join m n (inj₁ i)))))
+      , trans  (decode-join (inj₂ (join c₂ _ (inj₂ (join m n (inj₁ i))))))
+               (trans  (cong inj₂ (decode₂-join (inj₂ (join m n (inj₁ i)))))
+                       (cong (inj₂ ∘ inj₂) (splitAt-join m n (inj₁ i))))
+
     decode-sur (inj₂ (inj₂ (inj₂ j))) =
-      join c₁ _ (inj₂ (join c₂ _ (inj₂ (join m n (inj₂ j))))) ,
-      trans (decode-join (inj₂ (join c₂ _ (inj₂ (join m n (inj₂ j))))))
-        (trans (cong inj₂ (decode₂-join (inj₂ (join m n (inj₂ j)))))
-               (cong (inj₂ ∘ inj₂) (splitAt-join m n (inj₂ j))))
+      join c₁ _ (inj₂ (join c₂ _ (inj₂ (join m n (inj₂ j)))))
+      , trans  (decode-join (inj₂ (join c₂ _ (inj₂ (join m n (inj₂ j))))))
+               (trans  (cong inj₂ (decode₂-join (inj₂ (join m n (inj₂ j)))))
+                       (cong (inj₂ ∘ inj₂) (splitAt-join m n (inj₂ j))))
 
   𝑆ₓ-FiniteSignature : FiniteSignature 𝑆ₓ
   𝑆ₓ-FiniteSignature .opCard      = c₁ + (c₂ + (m + n))
   𝑆ₓ-FiniteSignature .opEnum      = decode
   𝑆ₓ-FiniteSignature .opEnum-sur  = decode-sur
-  𝑆ₓ-FiniteSignature .finitary (inj₁ f)         = 𝑮₁ .finitary f
-  𝑆ₓ-FiniteSignature .finitary (inj₂ (inj₁ g))  = 𝑮₂ .finitary g
+  𝑆ₓ-FiniteSignature .finitary (inj₁ f)         = S₁ .finitary f
+  𝑆ₓ-FiniteSignature .finitary (inj₂ (inj₁ g))  = S₂ .finitary g
   𝑆ₓ-FiniteSignature .finitary (inj₂ (inj₂ _))  = 1 , ↔-id _
 ```
 
 #### Restriction and pairing of congruences
 
 A congruence of the composite restricts to each coordinate along the opposite
-basepoint, and a pair of component congruences pairs into a composite one.  All
-three constructions preserve decidability.  Compatibility of a restriction with
-a component symbol `f` is exactly compatibility of the original congruence with
-`inj₁ f`: the composite interpretation pins the second coordinate to `b*`, which
-is precisely the restriction's frame.
+basepoint, and a pair of component congruences pairs into a composite one.
+
+All three constructions preserve decidability.  Compatibility of a restriction with a
+component symbol `f` is exactly compatibility of the original congruence with `inj₁ f`:
+the composite interpretation pins the second coordinate to `b*`, which is precisely
+the restriction's frame.
 
 ```agda
   -- Restrict to the first coordinate, along b*.
   restrictˡ : DecCon 𝑪 0ℓ → DecCon 𝑨 0ℓ
-  restrictˡ d = (rel , mkcon rfl eqv cmp) , dec
+  restrictˡ d@((_ , θcon) , θdec) = (rel , mkcon rfl eqv cmp) , dec
     where
-    θcon = proj₂ (proj₁ d)
-
     rel : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → Type 0ℓ
     rel a a' = ConRel d (a , b*) (a' , b*)
 
@@ -303,14 +316,12 @@ is precisely the restriction's frame.
     cmp f uv = is-compatible θcon (inj₁ f) uv
 
     dec : ∀ x y → Dec (rel x y)
-    dec x y = proj₂ d (x , b*) (y , b*)
+    dec x y = θdec (x , b*) (y , b*)
 
   -- Restrict to the second coordinate, along a*.
   restrictʳ : DecCon 𝑪 0ℓ → DecCon 𝑩 0ℓ
-  restrictʳ d = (rel , mkcon rfl eqv cmp) , dec
+  restrictʳ d@((_ , θcon) , θdec) = (rel , mkcon rfl eqv cmp) , dec
     where
-    θcon = proj₂ (proj₁ d)
-
     rel : 𝕌[ 𝑩 ] → 𝕌[ 𝑩 ] → Type 0ℓ
     rel b b' = ConRel d (a* , b) (a* , b')
 
@@ -328,41 +339,39 @@ is precisely the restriction's frame.
     cmp g uv = is-compatible θcon (inj₂ (inj₁ g)) uv
 
     dec : ∀ x y → Dec (rel x y)
-    dec x y = proj₂ d (a* , x) (a* , y)
+    dec x y = θdec (a* , x) (a* , y)
 
   -- Pair component congruences into a composite one (the product congruence).
   ⟨_,_⟩ᶜ : DecCon 𝑨 0ℓ → DecCon 𝑩 0ℓ → DecCon 𝑪 0ℓ
-  ⟨ d₁ , d₂ ⟩ᶜ = (rel , mkcon rfl eqv cmp) , dec
+  ⟨ d₁@((_ , θcon₁) , θdec₁)  , d₂@((_ , θcon₂) , θdec₂) ⟩ᶜ =
+    (rel , mkcon rfl eqv cmp) , dec
     where
-    con₁ = proj₂ (proj₁ d₁)
-    con₂ = proj₂ (proj₁ d₂)
-
-    rel : (𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]) → (𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]) → Type 0ℓ
-    rel p q = ConRel d₁ (proj₁ p) (proj₁ q) × ConRel d₂ (proj₂ p) (proj₂ q)
+    rel : 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ] → 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ] → Type 0ℓ
+    rel (p₁ , p₂) (q₁ , q₂) = ConRel d₁ p₁ q₁ × ConRel d₂ p₂ q₂
 
     rfl : ∀ {p q} → p ≈ₓ q → rel p q
-    rfl (e₁ , e₂) = reflexive con₁ e₁ , reflexive con₂ e₂
+    rfl (e₁ , e₂) = reflexive θcon₁ e₁ , reflexive θcon₂ e₂
 
     eqv : IsEquivalence rel
     eqv = record
-      { refl   = IsEquivalence.refl (is-equivalence con₁)
-               , IsEquivalence.refl (is-equivalence con₂)
-      ; sym    = λ (p , q) → IsEquivalence.sym (is-equivalence con₁) p
-                           , IsEquivalence.sym (is-equivalence con₂) q
-      ; trans  = λ (p , q) (p' , q') → IsEquivalence.trans (is-equivalence con₁) p p'
-                                     , IsEquivalence.trans (is-equivalence con₂) q q'
+      { refl   = IsEquivalence.refl (is-equivalence θcon₁)
+               , IsEquivalence.refl (is-equivalence θcon₂)
+      ; sym    = λ (p , q) → IsEquivalence.sym (is-equivalence θcon₁) p
+                           , IsEquivalence.sym (is-equivalence θcon₂) q
+      ; trans  = λ (p , q) (p' , q') → IsEquivalence.trans (is-equivalence θcon₁) p p'
+                                     , IsEquivalence.trans (is-equivalence θcon₂) q q'
       }
 
     cmp : 𝑪 ∣≈ rel
-    cmp (inj₁ f)               uv = is-compatible con₁ f (λ i → proj₁ (uv i))
-                                  , reflexive con₂ refl₂
-    cmp (inj₂ (inj₁ g))        uv = reflexive con₁ refl₁
-                                  , is-compatible con₂ g (λ i → proj₂ (uv i))
-    cmp (inj₂ (inj₂ (inj₁ i))) uv = reflexive con₁ refl₁ , proj₂ (uv 0F)
-    cmp (inj₂ (inj₂ (inj₂ j))) uv = proj₁ (uv 0F) , reflexive con₂ refl₂
+    cmp (inj₁ f)               uv = is-compatible θcon₁ f (λ i → proj₁ (uv i))
+                                  , reflexive θcon₂ refl₂
+    cmp (inj₂ (inj₁ g))        uv = reflexive θcon₁ refl₁
+                                  , is-compatible θcon₂ g (λ i → proj₂ (uv i))
+    cmp (inj₂ (inj₂ (inj₁ i))) uv = reflexive θcon₁ refl₁ , proj₂ (uv 0F)
+    cmp (inj₂ (inj₂ (inj₂ j))) uv = proj₁ (uv 0F) , reflexive θcon₂ refl₂
 
     dec : ∀ p q → Dec (rel p q)
-    dec p q = (proj₂ d₁ (proj₁ p) (proj₁ q)) ×-dec (proj₂ d₂ (proj₂ p) (proj₂ q))
+    dec (p₁ , p₂) (q₁ , q₂) = θdec₁ p₁ q₁ ×-dec θdec₂ p₂ q₂
 ```
 
 #### Every congruence of the composite splits
@@ -377,15 +386,17 @@ nose) the setter overwrite is corrected up to `≈` by
   private
     setʳ-onto : (d : DecCon 𝑪 0ℓ) (b : 𝕌[ 𝑩 ]) {p q : 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]}
       → ConRel d p q → ConRel d (proj₁ p , b) (proj₁ q , b)
-    setʳ-onto d b {p} {q} pdq with 𝑭₂ .enum-sur b
-    ... | j , pj = ConRel-resp d (refl₁ , pj) (refl₁ , pj)
-                     (is-compatible (proj₂ (proj₁ d)) (inj₂ (inj₂ (inj₂ j))) (λ _ → pdq))
+    setʳ-onto d b pdq with 𝑭₂ .enum-sur b
+    ... | j , pj =
+      ConRel-resp d (refl₁ , pj) (refl₁ , pj)
+        (is-compatible (proj₂ (proj₁ d)) (inj₂ (inj₂ (inj₂ j))) (λ _ → pdq))
 
     setˡ-onto : (d : DecCon 𝑪 0ℓ) (a : 𝕌[ 𝑨 ]) {p q : 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]}
       → ConRel d p q → ConRel d (a , proj₂ p) (a , proj₂ q)
-    setˡ-onto d a {p} {q} pdq with 𝑭₁ .enum-sur a
-    ... | i , pi = ConRel-resp d (pi , refl₂) (pi , refl₂)
-                     (is-compatible (proj₂ (proj₁ d)) (inj₂ (inj₂ (inj₁ i))) (λ _ → pdq))
+    setˡ-onto d a pdq with 𝑭₁ .enum-sur a
+    ... | i , pi =
+      ConRel-resp d (pi , refl₂) (pi , refl₂)
+        (is-compatible (proj₂ (proj₁ d)) (inj₂ (inj₂ (inj₁ i))) (λ _ → pdq))
 
   -- Related pairs restrict to related coordinates.
   restrict-pair-⊆ : (d : DecCon 𝑪 0ℓ) → d ⊆ᵈ ⟨ restrictˡ d , restrictʳ d ⟩ᶜ
@@ -393,10 +404,9 @@ nose) the setter overwrite is corrected up to `≈` by
 
   -- Coordinatewise related pairs are related, chaining through a mixed point.
   restrict-pair-⊇ : (d : DecCon 𝑪 0ℓ) → ⟨ restrictˡ d , restrictʳ d ⟩ᶜ ⊆ᵈ d
-  restrict-pair-⊇ d {p} {q} (r₁ , r₂) =
+  restrict-pair-⊇ d {p₁ , p₂} {q₁ , q₂} (r₁ , r₂) =
     IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
-      (setʳ-onto d (proj₂ p) {proj₁ p , b*} {proj₁ q , b*} r₁)
-      (setˡ-onto d (proj₁ q) {a* , proj₂ p} {a* , proj₂ q} r₂)
+      (setʳ-onto d p₂ {p₁ , b*} {q₁ , b*} r₁) (setˡ-onto d q₁ {a* , p₂} {a* , q₂} r₂)
 ```
 
 Restriction and pairing are monotone, and restricting a pair recovers its
@@ -415,10 +425,10 @@ consume.
   pairᶜ-mono s₁ s₂ (r₁ , r₂) = s₁ r₁ , s₂ r₂
 
   restrictˡ-pair : (d₁ : DecCon 𝑨 0ℓ) (d₂ : DecCon 𝑩 0ℓ) → restrictˡ ⟨ d₁ , d₂ ⟩ᶜ ≑ᵈ d₁
-  restrictˡ-pair d₁ d₂ = (λ r → proj₁ r) , (λ r → r , reflexive (proj₂ (proj₁ d₂)) refl₂)
+  restrictˡ-pair _ ((_ , con₂) , _) = proj₁ , (λ r → r , reflexive con₂ refl₂)
 
   restrictʳ-pair : (d₁ : DecCon 𝑨 0ℓ) (d₂ : DecCon 𝑩 0ℓ) → restrictʳ ⟨ d₁ , d₂ ⟩ᶜ ≑ᵈ d₂
-  restrictʳ-pair d₁ d₂ = (λ r → proj₂ r) , (λ r → reflexive (proj₂ (proj₁ d₁)) refl₁ , r)
+  restrictʳ-pair ((_ , con₁) , _) _ = proj₂ , (λ r → reflexive con₁ refl₁ , r)
 ```
 
 #### The order isomorphism onto the product lattice
@@ -431,16 +441,25 @@ splits into its two coordinates.
 ```agda
   module _ {𝑳₁ 𝑳₂ : Lattice} (iso₁ : ConIsoᵈ 𝑨 𝑳₁) (iso₂ : ConIsoᵈ 𝑩 𝑳₂) where
     open LatticeProduct 𝑳₁ 𝑳₂ using ( ≤ₓ-fst ; ≤ₓ-snd )
-    open OrderIso iso₁
-      renaming ( to to to₁ ; from to from₁ ; to-mono to to-mono₁
-               ; from-mono to from-mono₁ ; to∘from to to∘from₁ ; from∘to to from∘to₁ )
-    open OrderIso iso₂
-      renaming ( to to to₂ ; from to from₂ ; to-mono to to-mono₂
-               ; from-mono to from-mono₂ ; to∘from to to∘from₂ ; from∘to to from∘to₂ )
+    open OrderIso iso₁ renaming  ( to        to to₁
+                                 ; from      to from₁
+                                 ; to-mono   to to-mono₁
+                                 ; from-mono to from-mono₁
+                                 ; to∘from   to to∘from₁
+                                 ; from∘to   to from∘to₁ )
+
+    open OrderIso iso₂ renaming  ( to        to to₂
+                                 ; from      to from₂
+                                 ; to-mono   to to-mono₂
+                                 ; from-mono to from-mono₂
+                                 ; to∘from   to to∘from₂
+                                 ; from∘to   to from∘to₂ )
+
     open ConIsoᵈ-Consequences {𝑆 = 𝑆₁} {𝑨 = 𝑨} {𝑳 = 𝑳₁} iso₁ using ()
       renaming ( to-cong≑ to to-cong≑₁ )
     open ConIsoᵈ-Consequences {𝑆 = 𝑆₂} {𝑨 = 𝑩} {𝑳 = 𝑳₂} iso₂ using ()
       renaming ( to-cong≑ to to-cong≑₂ )
+
     open Setoid 𝔻[ proj₁ 𝑳₁ ] using () renaming ( trans to ≈transᴸ¹ )
     open Setoid 𝔻[ proj₁ 𝑳₂ ] using () renaming ( trans to ≈transᴸ² )
 
@@ -448,27 +467,22 @@ splits into its two coordinates.
     𝑪-ConIsoᵈ = record
       { to         = λ d → to₁ (restrictˡ d) , to₂ (restrictʳ d)
       ; from       = λ uv → ⟨ from₁ (proj₁ uv) , from₂ (proj₂ uv) ⟩ᶜ
-      ; to-mono    = λ {d} {e} d⊆e →
-          to-mono₁ (restrictˡ-mono {d} {e} d⊆e) , to-mono₂ (restrictʳ-mono {d} {e} d⊆e)
-      ; from-mono  = λ {u} {v} u≤v →
-          pairᶜ-mono
-            {d₁ = from₁ (proj₁ u)} {e₁ = from₁ (proj₁ v)}
-            {d₂ = from₂ (proj₂ u)} {e₂ = from₂ (proj₂ v)}
-            (from-mono₁ {proj₁ u} {proj₁ v} (≤ₓ-fst {u} {v} u≤v))
-            (from-mono₂ {proj₂ u} {proj₂ v} (≤ₓ-snd {u} {v} u≤v))
-      ; to∘from    = λ uv →
-          ≈transᴸ¹ (to-cong≑₁ (restrictˡ-pair (from₁ (proj₁ uv)) (from₂ (proj₂ uv))))
-                   (to∘from₁ (proj₁ uv))
-        , ≈transᴸ² (to-cong≑₂ (restrictʳ-pair (from₁ (proj₁ uv)) (from₂ (proj₂ uv))))
-                   (to∘from₂ (proj₂ uv))
-      ; from∘to    = λ d →
-          (λ (r₁ , r₂) → restrict-pair-⊇ d
-            ( proj₁ (from∘to₁ (restrictˡ d)) r₁
-            , proj₁ (from∘to₂ (restrictʳ d)) r₂ ))
-        , (λ pdq →
-            let s = restrict-pair-⊆ d pdq
-            in  proj₂ (from∘to₁ (restrictˡ d)) (proj₁ s)
-              , proj₂ (from∘to₂ (restrictʳ d)) (proj₂ s))
+      ; to-mono    = λ {d} {e} d⊆e →  to-mono₁ (restrictˡ-mono {d} {e} d⊆e)
+                                      , to-mono₂ (restrictʳ-mono {d} {e} d⊆e)
+      ; from-mono  = λ {u} {v} u≤v →  pairᶜ-mono
+                                      {d₁ = from₁ (proj₁ u)} {e₁ = from₁ (proj₁ v)}
+                                      {d₂ = from₂ (proj₂ u)} {e₂ = from₂ (proj₂ v)}
+                                      (from-mono₁ {proj₁ u} {proj₁ v} (≤ₓ-fst {u} {v} u≤v))
+                                      (from-mono₂ {proj₂ u} {proj₂ v} (≤ₓ-snd {u} {v} u≤v))
+      ; to∘from    = λ uv → ≈transᴸ¹  (to-cong≑₁ (restrictˡ-pair (from₁ (proj₁ uv)) (from₂ (proj₂ uv))))
+                                      (to∘from₁ (proj₁ uv))
+                            , ≈transᴸ²  (to-cong≑₂ (restrictʳ-pair (from₁ (proj₁ uv)) (from₂ (proj₂ uv))))
+                                        (to∘from₂ (proj₂ uv))
+      ; from∘to    = λ d →  ( λ (r₁ , r₂) → restrict-pair-⊇ d ( proj₁ (from∘to₁ (restrictˡ d)) r₁
+                                                              , proj₁ (from∘to₂ (restrictʳ d)) r₂ ))
+                            , λ pdq →  let s = restrict-pair-⊆ d pdq in
+                                       proj₂ (from∘to₁ (restrictˡ d)) (proj₁ s)
+                                       , proj₂ (from∘to₂ (restrictʳ d)) (proj₂ s)
       }
 ```
 
@@ -502,3 +516,9 @@ product-Representableᵈ {𝑳₁} {𝑳₂} r₁ r₂ =
 ```
 
 --------------------------------------
+
+[^1]: Tůma 1986; see
+      [`docs/papers/fin-lat-rep/SmallLatticeReps.tex`](docs/papers/fin-lat-rep/SmallLatticeReps.tex),
+      § Closure properties.
+
+[^2]: This is the isolated-equality locus for the proposed Cubical port.

--- a/src/FLRP/Closure/Product.lagda.md
+++ b/src/FLRP/Closure/Product.lagda.md
@@ -1,0 +1,505 @@
+---
+layout: default
+file: "src/FLRP/Closure/Product.lagda.md"
+title: "FLRP.Closure.Product module (The Agda Universal Algebra Library)"
+date: "2026-07-24"
+author: "the agda-algebras development team"
+---
+
+### Product closure of decidable representability
+
+This is the [FLRP.Closure.Product][] module of the [Agda Universal Algebra Library][].
+
+The class of representable lattices is closed under finite direct products
+(Tůma 1986; see `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure
+properties).  This module formalizes the binary case at Layer D of the two-layer
+discipline ([ADR-008][]): given decidable representations of `𝑳₁`{.AgdaBound} and
+`𝑳₂`{.AgdaBound}, it constructs a finite finitary algebra whose
+decidable-congruence poset is order-isomorphic to the product lattice
+`𝑳₁ ×ˡ 𝑳₂`{.AgdaFunction} of [Classical.Structures.Lattice.Product][], yielding
+
+    product-Representableᵈ : Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂
+                           → Representableᵈ (𝑳₁ ×ˡ 𝑳₂)
+
+**The witness algebra.**  Given representing algebras `𝑨` and `𝑩` with chosen
+basepoints `a*` and `b*`, the composite `𝑪` lives on the product setoid `A × B`
+over the signature
+
+    𝑆₁  ⊎  𝑆₂  ⊎  Fin (card 𝑨)  ⊎  Fin (card 𝑩)
+
+interpreted as follows: a symbol of `𝑆₁` acts through the first coordinates with
+the second pinned to `b*` (dually for `𝑆₂`), and the two `Fin`-indexed families
+are the unary **coordinate setters** `(a , b) ↦ (enum i , b)` and
+`(a , b) ↦ (a , enum j)` that overwrite one coordinate with an enumerated
+element while carrying the other along.
+
+**Why the congruences split.**  The setters force every congruence `θ` of `𝑪` to
+be a product: writing `θˡ a a' := θ (a , b*) (a' , b*)` and symmetrically `θʳ`,
+setting the second coordinate shows any `θ`-related pair is `θˡ`-related in the
+first coordinate (and dually), while conversely a common overwrite lets
+`θˡ`-relatedness and `θʳ`-relatedness be chained through the intermediate point
+`(a' , b)` — so `θ` is exactly the conjunction `θˡ × θʳ`
+(`restrict-pair-⊆`{.AgdaFunction} / `restrict-pair-⊇`{.AgdaFunction} below).
+This is the constructive heart of the closure proof; everything else is the
+transport of that splitting through the two given isomorphisms, componentwise.
+
+Both coordinatewise restrictions and the pairing preserve decidability, so the
+whole argument stays at Layer D with no classical assumption.  (At Layer S the
+same splitting goes through verbatim, but its consumers would be the
+WLEM-hard `Representable`{.AgdaRecord} witnesses of the no-go theorem, so the
+library states product closure at Layer D only.)
+
+Basepoints exist because representing algebras may be *normalized to inhabited
+carriers*: `inhabited-witness`{.AgdaFunction} of [FLRP.Representable][] replaces
+an empty-carrier witness (whose lattice is then trivial) by the one-element
+algebra.  The closure theorem therefore has no side conditions.
+
+The standing FLRP research-track separation warning applies: this is
+problem-specific formal content; the lattice-level product it targets lives in
+the `Classical/` tree.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.Closure.Product where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library -----------------------------------
+open import Data.Fin.Base                          using  ( Fin ; splitAt ; join
+                                                          ; combine ; remQuot )
+open import Data.Fin.Patterns                      using  ( 0F )
+open import Data.Fin.Properties                    using  ( splitAt-join ; remQuot-combine )
+open import Data.Nat.Base                          using  ( _+_ ; _*_ )
+open import Data.Product                           using  ( _,_ ; _×_ ; proj₁ ; proj₂
+                                                          ; Σ-syntax )
+open import Data.Sum.Base                          using  ( _⊎_ ; inj₁ ; inj₂ ; [_,_]′ )
+open import Function                               using  ( _∘_ )
+open import Function.Construct.Identity            using  ( ↔-id )
+open import Level                                  using  ( 0ℓ )
+open import Relation.Binary                        using  ( Setoid ; IsEquivalence )
+open import Relation.Binary.PropositionalEquality  using  ( _≡_ ; cong ; trans )
+open import Relation.Nullary                       using  ( Dec )
+open import Relation.Nullary.Decidable             using  ( _×-dec_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Small.Structures.Lattice     using  ( Lattice )
+open import Classical.Structures.Interpret         using  ( interp-cong )
+open import Classical.Structures.Lattice.Product   using  ( module LatticeProduct ; _×ˡ_ )
+open import FLRP.Problem                           using  ( OrderIso )
+open import FLRP.Representable                     using  ( Representableᵈ ; ConIsoᵈ
+                                                          ; _⊆ᵈ_ ; _≑ᵈ_ ; ConRel-resp
+                                                          ; module ConIsoᵈ-Consequences
+                                                          ; inhabited-witness )
+open import Overture                               using  ( Signature
+                                                          ; OperationSymbolsOf ; ArityOf )
+open import Overture.Operations                    using  ( Op )
+open import Setoid.Algebras.Basic                  using  ( Algebra ; 𝔻[_] ; 𝕌[_] ; _^_
+                                                          ; mkAlgebra )
+open import Setoid.Algebras.Finite                 using  ( FiniteAlgebra )
+open import Setoid.Congruences.Basic               using  ( mkcon ; reflexive ; _∣≈_
+                                                          ; is-equivalence ; is-compatible )
+open import Setoid.Congruences.ChainJoin           using  ( Finitary )
+open import Setoid.Congruences.Finite.Basic        using  ( DecCon ; ConRel )
+open import Setoid.Signatures.Finite               using  ( FiniteSignature )
+
+open FiniteAlgebra
+open FiniteSignature
+```
+-->
+
+#### The composite witness algebra
+
+`ProductWitness`{.AgdaModule} packages the construction for a fixed pair of
+finite finitary algebras with chosen basepoints.  Everything is at level `0ℓ`,
+matching `Representableᵈ`{.AgdaRecord}.
+
+```agda
+module ProductWitness
+  {𝑆₁ 𝑆₂ : Signature 0ℓ 0ℓ}
+  (𝑨 : Algebra {𝑆 = 𝑆₁} 0ℓ 0ℓ) (𝑭₁ : FiniteAlgebra 𝑨) (𝑮₁ : FiniteSignature 𝑆₁) (a* : 𝕌[ 𝑨 ])
+  (𝑩 : Algebra {𝑆 = 𝑆₂} 0ℓ 0ℓ) (𝑭₂ : FiniteAlgebra 𝑩) (𝑮₂ : FiniteSignature 𝑆₂) (b* : 𝕌[ 𝑩 ])
+  where
+
+  private
+    m      = 𝑭₁ .card
+    n      = 𝑭₂ .card
+    enum₁  = 𝑭₁ .enum
+    enum₂  = 𝑭₂ .enum
+
+  open Setoid 𝔻[ 𝑨 ] using ()
+    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝔻[ 𝑩 ] using ()
+    renaming ( _≈_ to _≈₂_ ; refl to refl₂ ; sym to sym₂ ; trans to trans₂ )
+```
+
+**The signature**: the two component signatures side by side with the two
+setter families.  Setters are unary; component symbols keep their arities.
+
+```agda
+  OpSymbols : Type 0ℓ
+  OpSymbols = OperationSymbolsOf 𝑆₁ ⊎ (OperationSymbolsOf 𝑆₂ ⊎ (Fin m ⊎ Fin n))
+
+  arity : OpSymbols → Type 0ℓ
+  arity (inj₁ f)          = ArityOf 𝑆₁ f
+  arity (inj₂ (inj₁ g))   = ArityOf 𝑆₂ g
+  arity (inj₂ (inj₂ _))   = Fin 1
+
+  𝑆ₓ : Signature 0ℓ 0ℓ
+  𝑆ₓ = OpSymbols , arity
+```
+
+**The carrier**: the product setoid, with the pointwise pair equivalence (the
+isolated-equality locus for the Cubical port).
+
+```agda
+  A×B : Setoid 0ℓ 0ℓ
+  A×B = record
+    { Carrier        = 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]
+    ; _≈_            = λ p q → (proj₁ p ≈₁ proj₁ q) × (proj₂ p ≈₂ proj₂ q)
+    ; isEquivalence  = record
+        { refl   = refl₁ , refl₂
+        ; sym    = λ e → sym₁ (proj₁ e) , sym₂ (proj₂ e)
+        ; trans  = λ d e → trans₁ (proj₁ d) (proj₁ e) , trans₂ (proj₂ d) (proj₂ e)
+        }
+    }
+
+  open Setoid A×B using () renaming ( _≈_ to _≈ₓ_ ; trans to transₓ ; reflexive to ≡→≈ₓ )
+```
+
+**The algebra**: component symbols act through their coordinate with the other
+pinned to the basepoint; setters overwrite their coordinate with an enumerated
+element.
+
+```agda
+  𝑪 : Algebra {𝑆 = 𝑆ₓ} 0ℓ 0ℓ
+  𝑪 = mkAlgebra A×B interp interp-congruence
+    where
+    interp : (o : OpSymbols) → Op (arity o) (𝕌[ 𝑨 ] × 𝕌[ 𝑩 ])
+    interp (inj₁ f)               args = (f ^ 𝑨) (proj₁ ∘ args) , b*
+    interp (inj₂ (inj₁ g))        args = a* , (g ^ 𝑩) (proj₂ ∘ args)
+    interp (inj₂ (inj₂ (inj₁ i))) args = enum₁ i , proj₂ (args 0F)
+    interp (inj₂ (inj₂ (inj₂ j))) args = proj₁ (args 0F) , enum₂ j
+
+    interp-congruence : ∀ o {u v : arity o → 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]}
+      → (∀ i → u i ≈ₓ v i) → interp o u ≈ₓ interp o v
+    interp-congruence (inj₁ f)               e = interp-cong 𝑨 f (λ i → proj₁ (e i)) , refl₂
+    interp-congruence (inj₂ (inj₁ g))        e = refl₁ , interp-cong 𝑩 g (λ i → proj₂ (e i))
+    interp-congruence (inj₂ (inj₂ (inj₁ i))) e = refl₁ , proj₂ (e 0F)
+    interp-congruence (inj₂ (inj₂ (inj₂ j))) e = proj₁ (e 0F) , refl₂
+```
+
+#### Finiteness of the composite
+
+The carrier is enumerated by `Fin (m * n)` through `combine`/`remQuot`, with
+decidable equality componentwise.
+
+```agda
+  private
+    enumC : Fin (m * n) → 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]
+    enumC k = enum₁ (proj₁ (remQuot {m} n k)) , enum₂ (proj₂ (remQuot {m} n k))
+
+    -- Enumerating at a combined index recovers the component enumerations.
+    enumC-combine : (i : Fin m) (j : Fin n) → enumC (combine i j) ≈ₓ (enum₁ i , enum₂ j)
+    enumC-combine i j =
+      ≡→≈ₓ (cong (λ z → enum₁ (proj₁ z) , enum₂ (proj₂ z)) (remQuot-combine i j))
+
+  𝑪-FiniteAlgebra : FiniteAlgebra 𝑪
+  𝑪-FiniteAlgebra ._≟_ = λ p q →
+    (𝑭₁ ._≟_ (proj₁ p) (proj₁ q)) ×-dec (𝑭₂ ._≟_ (proj₂ p) (proj₂ q))
+  𝑪-FiniteAlgebra .card = m * n
+  𝑪-FiniteAlgebra .enum = enumC
+  𝑪-FiniteAlgebra .enum-sur = λ p → sur p
+    where
+    sur : ∀ p → Σ[ k ∈ Fin (m * n) ] enumC k ≈ₓ p
+    sur p with 𝑭₁ .enum-sur (proj₁ p) | 𝑭₂ .enum-sur (proj₂ p)
+    ... | i , pi | j , pj = combine i j , transₓ (enumC-combine i j) (pi , pj)
+```
+
+The signature is finite finitary: symbols are enumerated by
+`Fin (c₁ + (c₂ + (m + n)))` through a three-layer `splitAt` decoder, and the new
+setter symbols are unary.
+
+```agda
+  private
+    c₁ = 𝑮₁ .opCard
+    c₂ = 𝑮₂ .opCard
+
+    -- Decode a flat index into a symbol, one ⊎-layer of splitAt at a time.
+    decode₂ : Fin (c₂ + (m + n)) → OperationSymbolsOf 𝑆₂ ⊎ (Fin m ⊎ Fin n)
+    decode₂ = [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ splitAt m ]′ ∘ splitAt c₂
+
+    decode : Fin (c₁ + (c₂ + (m + n))) → OpSymbols
+    decode = [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ ∘ splitAt c₁
+
+    -- One computation rule per ⊎-layer: decoding a joined index reduces to the branch.
+    decode-join : (x : Fin c₁ ⊎ Fin (c₂ + (m + n)))
+      → decode (join c₁ _ x) ≡ [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ x
+    decode-join x = cong [ inj₁ ∘ 𝑮₁ .opEnum , inj₂ ∘ decode₂ ]′ (splitAt-join c₁ _ x)
+
+    decode₂-join : (x : Fin c₂ ⊎ Fin (m + n))
+      → decode₂ (join c₂ _ x) ≡ [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ splitAt m ]′ x
+    decode₂-join x = cong [ inj₁ ∘ 𝑮₂ .opEnum , inj₂ ∘ splitAt m ]′ (splitAt-join c₂ _ x)
+
+    -- Encoding hits every symbol: chain the computation rules layer by layer.
+    decode-sur : (o : OpSymbols) → Σ[ k ∈ Fin (c₁ + (c₂ + (m + n))) ] decode k ≡ o
+    decode-sur (inj₁ f) with 𝑮₁ .opEnum-sur f
+    ... | i , p = join c₁ _ (inj₁ i) , trans (decode-join (inj₁ i)) (cong inj₁ p)
+    decode-sur (inj₂ (inj₁ g)) with 𝑮₂ .opEnum-sur g
+    ... | j , p =
+      join c₁ _ (inj₂ (join c₂ _ (inj₁ j))) ,
+      trans (decode-join (inj₂ (join c₂ _ (inj₁ j))))
+        (trans (cong inj₂ (decode₂-join (inj₁ j))) (cong (inj₂ ∘ inj₁) p))
+    decode-sur (inj₂ (inj₂ (inj₁ i))) =
+      join c₁ _ (inj₂ (join c₂ _ (inj₂ (join m n (inj₁ i))))) ,
+      trans (decode-join (inj₂ (join c₂ _ (inj₂ (join m n (inj₁ i))))))
+        (trans (cong inj₂ (decode₂-join (inj₂ (join m n (inj₁ i)))))
+               (cong (inj₂ ∘ inj₂) (splitAt-join m n (inj₁ i))))
+    decode-sur (inj₂ (inj₂ (inj₂ j))) =
+      join c₁ _ (inj₂ (join c₂ _ (inj₂ (join m n (inj₂ j))))) ,
+      trans (decode-join (inj₂ (join c₂ _ (inj₂ (join m n (inj₂ j))))))
+        (trans (cong inj₂ (decode₂-join (inj₂ (join m n (inj₂ j)))))
+               (cong (inj₂ ∘ inj₂) (splitAt-join m n (inj₂ j))))
+
+  𝑆ₓ-FiniteSignature : FiniteSignature 𝑆ₓ
+  𝑆ₓ-FiniteSignature .opCard      = c₁ + (c₂ + (m + n))
+  𝑆ₓ-FiniteSignature .opEnum      = decode
+  𝑆ₓ-FiniteSignature .opEnum-sur  = decode-sur
+  𝑆ₓ-FiniteSignature .finitary (inj₁ f)         = 𝑮₁ .finitary f
+  𝑆ₓ-FiniteSignature .finitary (inj₂ (inj₁ g))  = 𝑮₂ .finitary g
+  𝑆ₓ-FiniteSignature .finitary (inj₂ (inj₂ _))  = 1 , ↔-id _
+```
+
+#### Restriction and pairing of congruences
+
+A congruence of the composite restricts to each coordinate along the opposite
+basepoint, and a pair of component congruences pairs into a composite one.  All
+three constructions preserve decidability.  Compatibility of a restriction with
+a component symbol `f` is exactly compatibility of the original congruence with
+`inj₁ f`: the composite interpretation pins the second coordinate to `b*`, which
+is precisely the restriction's frame.
+
+```agda
+  -- Restrict to the first coordinate, along b*.
+  restrictˡ : DecCon 𝑪 0ℓ → DecCon 𝑨 0ℓ
+  restrictˡ d = (rel , mkcon rfl eqv cmp) , dec
+    where
+    θcon = proj₂ (proj₁ d)
+
+    rel : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → Type 0ℓ
+    rel a a' = ConRel d (a , b*) (a' , b*)
+
+    rfl : ∀ {x y} → x ≈₁ y → rel x y
+    rfl e = reflexive θcon (e , refl₂)
+
+    eqv : IsEquivalence rel
+    eqv = record
+      { refl   = IsEquivalence.refl (is-equivalence θcon)
+      ; sym    = IsEquivalence.sym (is-equivalence θcon)
+      ; trans  = IsEquivalence.trans (is-equivalence θcon)
+      }
+
+    cmp : 𝑨 ∣≈ rel
+    cmp f uv = is-compatible θcon (inj₁ f) uv
+
+    dec : ∀ x y → Dec (rel x y)
+    dec x y = proj₂ d (x , b*) (y , b*)
+
+  -- Restrict to the second coordinate, along a*.
+  restrictʳ : DecCon 𝑪 0ℓ → DecCon 𝑩 0ℓ
+  restrictʳ d = (rel , mkcon rfl eqv cmp) , dec
+    where
+    θcon = proj₂ (proj₁ d)
+
+    rel : 𝕌[ 𝑩 ] → 𝕌[ 𝑩 ] → Type 0ℓ
+    rel b b' = ConRel d (a* , b) (a* , b')
+
+    rfl : ∀ {x y} → x ≈₂ y → rel x y
+    rfl e = reflexive θcon (refl₁ , e)
+
+    eqv : IsEquivalence rel
+    eqv = record
+      { refl   = IsEquivalence.refl (is-equivalence θcon)
+      ; sym    = IsEquivalence.sym (is-equivalence θcon)
+      ; trans  = IsEquivalence.trans (is-equivalence θcon)
+      }
+
+    cmp : 𝑩 ∣≈ rel
+    cmp g uv = is-compatible θcon (inj₂ (inj₁ g)) uv
+
+    dec : ∀ x y → Dec (rel x y)
+    dec x y = proj₂ d (a* , x) (a* , y)
+
+  -- Pair component congruences into a composite one (the product congruence).
+  ⟨_,_⟩ᶜ : DecCon 𝑨 0ℓ → DecCon 𝑩 0ℓ → DecCon 𝑪 0ℓ
+  ⟨ d₁ , d₂ ⟩ᶜ = (rel , mkcon rfl eqv cmp) , dec
+    where
+    con₁ = proj₂ (proj₁ d₁)
+    con₂ = proj₂ (proj₁ d₂)
+
+    rel : (𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]) → (𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]) → Type 0ℓ
+    rel p q = ConRel d₁ (proj₁ p) (proj₁ q) × ConRel d₂ (proj₂ p) (proj₂ q)
+
+    rfl : ∀ {p q} → p ≈ₓ q → rel p q
+    rfl (e₁ , e₂) = reflexive con₁ e₁ , reflexive con₂ e₂
+
+    eqv : IsEquivalence rel
+    eqv = record
+      { refl   = IsEquivalence.refl (is-equivalence con₁)
+               , IsEquivalence.refl (is-equivalence con₂)
+      ; sym    = λ (p , q) → IsEquivalence.sym (is-equivalence con₁) p
+                           , IsEquivalence.sym (is-equivalence con₂) q
+      ; trans  = λ (p , q) (p' , q') → IsEquivalence.trans (is-equivalence con₁) p p'
+                                     , IsEquivalence.trans (is-equivalence con₂) q q'
+      }
+
+    cmp : 𝑪 ∣≈ rel
+    cmp (inj₁ f)               uv = is-compatible con₁ f (λ i → proj₁ (uv i))
+                                  , reflexive con₂ refl₂
+    cmp (inj₂ (inj₁ g))        uv = reflexive con₁ refl₁
+                                  , is-compatible con₂ g (λ i → proj₂ (uv i))
+    cmp (inj₂ (inj₂ (inj₁ i))) uv = reflexive con₁ refl₁ , proj₂ (uv 0F)
+    cmp (inj₂ (inj₂ (inj₂ j))) uv = proj₁ (uv 0F) , reflexive con₂ refl₂
+
+    dec : ∀ p q → Dec (rel p q)
+    dec p q = (proj₂ d₁ (proj₁ p) (proj₁ q)) ×-dec (proj₂ d₂ (proj₂ p) (proj₂ q))
+```
+
+#### Every congruence of the composite splits
+
+The two directions of the splitting `θ ≑ᵈ ⟨ θˡ , θʳ ⟩ᶜ`.  Both use the setters:
+to land exactly on a basepoint (which need not be an enumerated element on the
+nose) the setter overwrite is corrected up to `≈` by
+`ConRel-resp`{.AgdaFunction}, using the surjectivity proof of the enumeration.
+
+```agda
+  -- One setter application, transported to the intended target coordinate value.
+  private
+    setʳ-onto : (d : DecCon 𝑪 0ℓ) (b : 𝕌[ 𝑩 ]) {p q : 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]}
+      → ConRel d p q → ConRel d (proj₁ p , b) (proj₁ q , b)
+    setʳ-onto d b {p} {q} pdq with 𝑭₂ .enum-sur b
+    ... | j , pj = ConRel-resp d (refl₁ , pj) (refl₁ , pj)
+                     (is-compatible (proj₂ (proj₁ d)) (inj₂ (inj₂ (inj₂ j))) (λ _ → pdq))
+
+    setˡ-onto : (d : DecCon 𝑪 0ℓ) (a : 𝕌[ 𝑨 ]) {p q : 𝕌[ 𝑨 ] × 𝕌[ 𝑩 ]}
+      → ConRel d p q → ConRel d (a , proj₂ p) (a , proj₂ q)
+    setˡ-onto d a {p} {q} pdq with 𝑭₁ .enum-sur a
+    ... | i , pi = ConRel-resp d (pi , refl₂) (pi , refl₂)
+                     (is-compatible (proj₂ (proj₁ d)) (inj₂ (inj₂ (inj₁ i))) (λ _ → pdq))
+
+  -- Related pairs restrict to related coordinates.
+  restrict-pair-⊆ : (d : DecCon 𝑪 0ℓ) → d ⊆ᵈ ⟨ restrictˡ d , restrictʳ d ⟩ᶜ
+  restrict-pair-⊆ d pdq = setʳ-onto d b* pdq , setˡ-onto d a* pdq
+
+  -- Coordinatewise related pairs are related, chaining through a mixed point.
+  restrict-pair-⊇ : (d : DecCon 𝑪 0ℓ) → ⟨ restrictˡ d , restrictʳ d ⟩ᶜ ⊆ᵈ d
+  restrict-pair-⊇ d {p} {q} (r₁ , r₂) =
+    IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+      (setʳ-onto d (proj₂ p) {proj₁ p , b*} {proj₁ q , b*} r₁)
+      (setˡ-onto d (proj₁ q) {a* , proj₂ p} {a* , proj₂ q} r₂)
+```
+
+Restriction and pairing are monotone, and restricting a pair recovers its
+components (up to `≑ᵈ`) — the four little lemmas the isomorphism's round trips
+consume.
+
+```agda
+  restrictˡ-mono : {d e : DecCon 𝑪 0ℓ} → d ⊆ᵈ e → restrictˡ d ⊆ᵈ restrictˡ e
+  restrictˡ-mono d⊆e p = d⊆e p
+
+  restrictʳ-mono : {d e : DecCon 𝑪 0ℓ} → d ⊆ᵈ e → restrictʳ d ⊆ᵈ restrictʳ e
+  restrictʳ-mono d⊆e p = d⊆e p
+
+  pairᶜ-mono : {d₁ e₁ : DecCon 𝑨 0ℓ} {d₂ e₂ : DecCon 𝑩 0ℓ}
+    → d₁ ⊆ᵈ e₁ → d₂ ⊆ᵈ e₂ → ⟨ d₁ , d₂ ⟩ᶜ ⊆ᵈ ⟨ e₁ , e₂ ⟩ᶜ
+  pairᶜ-mono s₁ s₂ (r₁ , r₂) = s₁ r₁ , s₂ r₂
+
+  restrictˡ-pair : (d₁ : DecCon 𝑨 0ℓ) (d₂ : DecCon 𝑩 0ℓ) → restrictˡ ⟨ d₁ , d₂ ⟩ᶜ ≑ᵈ d₁
+  restrictˡ-pair d₁ d₂ = (λ r → proj₁ r) , (λ r → r , reflexive (proj₂ (proj₁ d₂)) refl₂)
+
+  restrictʳ-pair : (d₁ : DecCon 𝑨 0ℓ) (d₂ : DecCon 𝑩 0ℓ) → restrictʳ ⟨ d₁ , d₂ ⟩ᶜ ≑ᵈ d₂
+  restrictʳ-pair d₁ d₂ = (λ r → proj₂ r) , (λ r → reflexive (proj₂ (proj₁ d₁)) refl₁ , r)
+```
+
+#### The order isomorphism onto the product lattice
+
+Composing the splitting with the two given isomorphisms, componentwise.  The
+product lattice's order and equivalence are the componentwise ones
+(definitionally — [Classical.Structures.Lattice.Product][]), so each obligation
+splits into its two coordinates.
+
+```agda
+  module _ {𝑳₁ 𝑳₂ : Lattice} (iso₁ : ConIsoᵈ 𝑨 𝑳₁) (iso₂ : ConIsoᵈ 𝑩 𝑳₂) where
+    open LatticeProduct 𝑳₁ 𝑳₂ using ( ≤ₓ-fst ; ≤ₓ-snd )
+    open OrderIso iso₁
+      renaming ( to to to₁ ; from to from₁ ; to-mono to to-mono₁
+               ; from-mono to from-mono₁ ; to∘from to to∘from₁ ; from∘to to from∘to₁ )
+    open OrderIso iso₂
+      renaming ( to to to₂ ; from to from₂ ; to-mono to to-mono₂
+               ; from-mono to from-mono₂ ; to∘from to to∘from₂ ; from∘to to from∘to₂ )
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆₁} {𝑨 = 𝑨} {𝑳 = 𝑳₁} iso₁ using ()
+      renaming ( to-cong≑ to to-cong≑₁ )
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆₂} {𝑨 = 𝑩} {𝑳 = 𝑳₂} iso₂ using ()
+      renaming ( to-cong≑ to to-cong≑₂ )
+    open Setoid 𝔻[ proj₁ 𝑳₁ ] using () renaming ( trans to ≈transᴸ¹ )
+    open Setoid 𝔻[ proj₁ 𝑳₂ ] using () renaming ( trans to ≈transᴸ² )
+
+    𝑪-ConIsoᵈ : ConIsoᵈ 𝑪 (𝑳₁ ×ˡ 𝑳₂)
+    𝑪-ConIsoᵈ = record
+      { to         = λ d → to₁ (restrictˡ d) , to₂ (restrictʳ d)
+      ; from       = λ uv → ⟨ from₁ (proj₁ uv) , from₂ (proj₂ uv) ⟩ᶜ
+      ; to-mono    = λ {d} {e} d⊆e →
+          to-mono₁ (restrictˡ-mono {d} {e} d⊆e) , to-mono₂ (restrictʳ-mono {d} {e} d⊆e)
+      ; from-mono  = λ {u} {v} u≤v →
+          pairᶜ-mono
+            {d₁ = from₁ (proj₁ u)} {e₁ = from₁ (proj₁ v)}
+            {d₂ = from₂ (proj₂ u)} {e₂ = from₂ (proj₂ v)}
+            (from-mono₁ {proj₁ u} {proj₁ v} (≤ₓ-fst {u} {v} u≤v))
+            (from-mono₂ {proj₂ u} {proj₂ v} (≤ₓ-snd {u} {v} u≤v))
+      ; to∘from    = λ uv →
+          ≈transᴸ¹ (to-cong≑₁ (restrictˡ-pair (from₁ (proj₁ uv)) (from₂ (proj₂ uv))))
+                   (to∘from₁ (proj₁ uv))
+        , ≈transᴸ² (to-cong≑₂ (restrictʳ-pair (from₁ (proj₁ uv)) (from₂ (proj₂ uv))))
+                   (to∘from₂ (proj₂ uv))
+      ; from∘to    = λ d →
+          (λ (r₁ , r₂) → restrict-pair-⊇ d
+            ( proj₁ (from∘to₁ (restrictˡ d)) r₁
+            , proj₁ (from∘to₂ (restrictʳ d)) r₂ ))
+        , (λ pdq →
+            let s = restrict-pair-⊆ d pdq
+            in  proj₂ (from∘to₁ (restrictˡ d)) (proj₁ s)
+              , proj₂ (from∘to₂ (restrictʳ d)) (proj₂ s))
+      }
+```
+
+#### The closure theorem
+
+Normalize both witnesses to inhabited carriers, instantiate the construction at
+the resulting basepoints, and package the result.
+
+```agda
+product-Representableᵈ : {𝑳₁ 𝑳₂ : Lattice}
+  → Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂ → Representableᵈ (𝑳₁ ×ˡ 𝑳₂)
+product-Representableᵈ {𝑳₁} {𝑳₂} r₁ r₂ =
+  assemble (inhabited-witness r₁) (inhabited-witness r₂)
+  where
+  open Representableᵈ
+
+  assemble : Σ[ r ∈ Representableᵈ 𝑳₁ ] 𝕌[ r .algᵈ ]
+           → Σ[ r ∈ Representableᵈ 𝑳₂ ] 𝕌[ r .algᵈ ]
+           → Representableᵈ (𝑳₁ ×ˡ 𝑳₂)
+  assemble (r₁' , a*) (r₂' , b*) = record
+    { sigᵈ      = P.𝑆ₓ
+    ; algᵈ      = P.𝑪
+    ; finiteᵈ   = P.𝑪-FiniteAlgebra
+    ; finsigᵈ   = P.𝑆ₓ-FiniteSignature
+    ; con-isoᵈ  = P.𝑪-ConIsoᵈ {𝑳₁ = 𝑳₁} {𝑳₂ = 𝑳₂} (r₁' .con-isoᵈ) (r₂' .con-isoᵈ)
+    }
+    where
+    module P = ProductWitness
+      (r₁' .algᵈ) (r₁' .finiteᵈ) (r₁' .finsigᵈ) a*
+      (r₂' .algᵈ) (r₂' .finiteᵈ) (r₂' .finsigᵈ) b*
+```
+
+--------------------------------------

--- a/src/FLRP/LayerBridge.lagda.md
+++ b/src/FLRP/LayerBridge.lagda.md
@@ -53,7 +53,7 @@ The `OrderIso`{.AgdaRecord} composition here is done by hand at each of the two
 transports rather than through a general transitivity combinator: the round trips
 need the middle lattice map to respect `≑`{.AgdaFunction} (antisymmetry), which a
 fully generic `OrderIso`-transitivity cannot supply without extra hypotheses, so the
-direct assembly from small named lemmas is clearer.[^2]
+direct assembly from small named lemmas is clearer.
 
 <!--
 ```agda
@@ -293,5 +293,3 @@ module _ {𝑳 : Lattice} where
       (`≤-antisym`{.AgdaFunction} of [Classical.Properties.Lattice][]
       — the same one-line fact the no-go theorem of [FLRP.Problem][] uses).
 
-[^2]: The standing FLRP research-track separation warning of [FLRP.Problem][] applies
-      here too.

--- a/src/FLRP/Representable.lagda.md
+++ b/src/FLRP/Representable.lagda.md
@@ -37,10 +37,6 @@ with no axiom.  Concretely, this module provides:
    with **no postulate**.  This is the object the no-go theorem showed impossible at
    Layer S; making it constructive here closes that loop.
 
-The standing FLRP research-track separation warning of [FLRP.Problem][] applies here
-too: this is problem-specific formal content, not to be conflated with the
-algebraic-complexity / finite-CSP work elsewhere in the library.
-
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/FLRP/Representable.lagda.md
+++ b/src/FLRP/Representable.lagda.md
@@ -52,8 +52,10 @@ open import Agda.Primitive       using () renaming ( Set to Type )
 open import Data.Empty           using ( ⊥-elim )
 open import Data.Fin.Base        using ( Fin )
 open import Data.Fin.Patterns    using ( 0F ; 1F )
-open import Data.Fin.Properties  using () renaming ( _≟_ to _≟ᶠ_ )
-open import Data.Product         using ( _,_ ; proj₁ ; proj₂ )
+open import Data.Fin.Properties  using ( ¬Fin0 ) renaming ( _≟_ to _≟ᶠ_ )
+open import Data.Nat.Base        using ( zero ; suc )
+open import Data.Product         using ( _,_ ; proj₁ ; proj₂ ; Σ-syntax )
+open import Data.Sum.Base        using ( _⊎_ ; inj₁ ; inj₂ )
 open import Data.Unit.Base       using ( tt )
 open import Level                using ( Level ; 0ℓ ; _⊔_ ; Lift ; lift ; lower )
                                  renaming ( suc to lsuc )
@@ -63,13 +65,16 @@ open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary     using ( ¬_ ; Dec ; yes ; no )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Properties.Lattice         using  ( module Lattice-Order )
+open import Classical.Properties.Lattice         using  ( module Lattice-Order
+                                                        ; TopOf ; BotOf )
 open import Classical.Small.Structures.Lattice   using  ( Lattice )
 open import FLRP.Problem                         using  ( OrderIso ; FiniteLattice
                                                         ; toLattice ; 𝑆∅ ; chain₂-lattice )
 open import Overture                             using  ( 𝓞 ; 𝓥 ; Signature )
-open import Setoid.Algebras.Basic                using  ( Algebra ; 𝔻[_] ; mkAlgebraₚ )
-open import Setoid.Algebras.Finite               using  ( FiniteAlgebra )
+open import Setoid.Algebras.Basic                using  ( Algebra ; 𝔻[_] ; 𝕌[_]
+                                                        ; mkAlgebraₚ )
+open import Setoid.Algebras.Finite               using  ( FiniteAlgebra ; 𝟏
+                                                        ; 𝟏-FiniteAlgebra )
 open import Setoid.Congruences.Basic             using  ( reflexive ; 𝟘[_]
                                                         ; is-equivalence ; 𝟙[_] )
 open import Setoid.Congruences.Finite.Basic      using  ( DecCon ; ConRel )
@@ -443,6 +448,180 @@ chain₂-Representableᵈ = record
   ; finsigᵈ    = 𝑆∅-FiniteSignature
   ; con-isoᵈ  = 𝟚-ConIsoᵈ
   }
+```
+
+#### The extreme decidable congruences
+
+Every algebra has a least and a greatest decidable congruence.  The total
+congruence `𝟙[ 𝑨 ]`{.AgdaFunction} is decidable outright; the diagonal
+`𝟘[ 𝑨 ]`{.AgdaFunction} upgrades to a `DecCon`{.AgdaFunction} exactly when the
+setoid equality is decidable — the datum the `_≟_`{.AgdaField} field of
+`FiniteAlgebra`{.AgdaRecord} supplies.  (These generalize the two-element-specific
+`Δᵈ`{.AgdaFunction} and `∇ᵈ`{.AgdaFunction} above; the closure constructions of
+[FLRP.Closure][] use them at their composite witness algebras.)
+
+```agda
+module _ {𝑆 : Signature 𝓞 𝓥} {𝑨 : Algebra {𝑆 = 𝑆} α ρ} where
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
+
+  -- The diagonal congruence, as a DecCon, given a decision procedure for ≈.
+  𝟘ᵈ : (∀ x y → Dec (x ≈ y)) → DecCon 𝑨 (ρ ⊔ ℓ)
+  𝟘ᵈ {ℓ} _≟_ = 𝟘[ 𝑨 ] {ℓ} , dec
+    where
+    dec : ∀ x y → Dec (Lift ℓ (x ≈ y))
+    dec x y with x ≟ y
+    ... | yes p  = yes (lift p)
+    ... | no ¬p  = no λ q → ¬p (lower q)
+
+  -- The total congruence, as a DecCon.
+  𝟙ᵈ : DecCon 𝑨 ℓ
+  𝟙ᵈ {ℓ} = 𝟙[ 𝑨 ] {ℓ} , λ _ _ → yes (lift tt)
+```
+
+#### Congruence-trivial algebras
+
+`ConTrivialᵈ`{.AgdaFunction} says the decidable-congruence poset of
+`𝑨`{.AgdaBound} is trivial: any two decidable congruences are mutually contained.
+Two sources matter downstream: an algebra with *empty* carrier (there are no pairs
+to relate) and the one-element algebra `𝟏`{.AgdaFunction} (every pair is related
+by reflexivity, since the setoid equality of `𝟏`{.AgdaFunction} is total).  A
+decidable-layer isomorphism transports across congruence-trivial algebras
+(`trivial-ConIsoᵈ-transport`{.AgdaFunction} below), which is how the closure
+constructions replace a possibly-empty witness algebra by `𝟏`{.AgdaFunction}.
+
+```agda
+  -- All decidable congruences of 𝑨 are ≑ᵈ-equal.
+  ConTrivialᵈ : (ℓ : Level) → Type (𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ ⊔ lsuc ℓ)
+  ConTrivialᵈ ℓ = (d e : DecCon 𝑨 ℓ) → d ≑ᵈ e
+
+  -- An algebra with empty carrier is congruence-trivial: no pairs exist to relate.
+  empty→ConTrivialᵈ : ¬ 𝕌[ 𝑨 ] → ConTrivialᵈ ℓ
+  empty→ConTrivialᵈ ¬x d e = (λ {x} _ → ⊥-elim (¬x x)) , (λ {x} _ → ⊥-elim (¬x x))
+
+-- The one-element algebra is congruence-trivial: its setoid equality is total,
+-- so reflexivity of any congruence relates every pair.
+𝟏-ConTrivialᵈ : {𝑆 : Signature 𝓞 𝓥} → ConTrivialᵈ {𝑨 = 𝟏 {𝑆 = 𝑆}} ℓ
+𝟏-ConTrivialᵈ d e =
+  (λ _ → reflexive (proj₂ (proj₁ e)) tt) , (λ _ → reflexive (proj₂ (proj₁ d)) tt)
+```
+
+#### Consequences of a decidable-layer isomorphism
+
+An order isomorphism transports more than the order: it respects
+`≑ᵈ`{.AgdaFunction} (monotonicity in both directions plus antisymmetry of the
+lattice's meet order), it respects `≈`{.AgdaFunction} in the reverse direction
+(via `≤-reflexive`{.AgdaFunction}), and it sends the extreme congruences to
+extrema of the target lattice.  The last point equips every decidably
+representable lattice with *chosen* extrema — the `TopOf`{.AgdaFunction} /
+`BotOf`{.AgdaFunction} data of [Classical.Properties.Lattice][] that the
+ordinal-sum construction consumes.
+
+```agda
+module ConIsoᵈ-Consequences {𝑆 : Signature 0ℓ 0ℓ} {𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ}
+                            {𝑳 : Lattice} (iso : ConIsoᵈ 𝑨 𝑳) where
+  -- The isomorphism's own maps are renamed ᴸ-side to keep them distinct from the
+  -- 𝟚-specific `to`/`from` defined above.
+  open OrderIso iso
+    renaming ( to to toᴸ ; from to fromᴸ ; to-mono to to-monoᴸ ; from-mono to from-monoᴸ
+             ; to∘from to to∘fromᴸ ; from∘to to from∘toᴸ )
+  open Setoid 𝔻[ proj₁ 𝑳 ] using ( _≈_ ) renaming ( sym to ≈sym ; trans to ≈trans )
+  open Lattice-Order 𝑳 using ( _≤_ ; ≤-antisym ; ≤-reflexive ; ≤-respˡ-≈ ; ≤-respʳ-≈
+                             ; IsTop ; IsBot )
+
+  -- ≑ᵈ-equal congruences have ≈-equal images.
+  to-cong≑ : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → toᴸ d ≈ toᴸ e
+  to-cong≑ (d⊆e , e⊆d) = ≤-antisym (to-monoᴸ d⊆e) (to-monoᴸ e⊆d)
+
+  -- ≈-equal lattice elements have ≑ᵈ-equal preimages.
+  from-cong≈ : {u v : 𝕌[ proj₁ 𝑳 ]} → u ≈ v → fromᴸ u ≑ᵈ fromᴸ v
+  from-cong≈ e = from-monoᴸ (≤-reflexive e) , from-monoᴸ (≤-reflexive (≈sym e))
+
+  -- The image of the total congruence is a top of the target lattice ...
+  to-𝟙-top : IsTop (toᴸ (𝟙ᵈ {ℓ = 0ℓ}))
+  to-𝟙-top u = ≤-respˡ-≈ (to∘fromᴸ u) (to-monoᴸ λ _ → lift tt)
+
+  -- ... and the image of the diagonal is a bottom.
+  to-𝟘-bot : (≈dec : ∀ x y → Dec (Setoid._≈_ 𝔻[ 𝑨 ] x y)) → IsBot (toᴸ (𝟘ᵈ ≈dec))
+  to-𝟘-bot ≈dec u = ≤-respʳ-≈ (to∘fromᴸ u) (to-monoᴸ (𝟘-min (proj₁ (fromᴸ u))))
+
+-- Chosen extrema for any decidably representable lattice.
+module _ {𝑳 : Lattice} (r : Representableᵈ 𝑳) where
+  open Representableᵈ r
+  open OrderIso con-isoᵈ using () renaming ( to to toᴸ )
+  -- ConIsoᵈ is not injective in its lattice argument, so the module's implicit
+  -- parameters are supplied explicitly.
+  open ConIsoᵈ-Consequences {𝑆 = sigᵈ} {𝑨 = algᵈ} {𝑳 = 𝑳} con-isoᵈ
+
+  Representableᵈ-TopOf : TopOf 𝑳
+  Representableᵈ-TopOf = toᴸ (𝟙ᵈ {ℓ = 0ℓ}) , to-𝟙-top
+
+  Representableᵈ-BotOf : BotOf 𝑳
+  Representableᵈ-BotOf = toᴸ (𝟘ᵈ (finiteᵈ ._≟_)) , to-𝟘-bot (finiteᵈ ._≟_)
+```
+
+#### Inhabited witnesses
+
+A decidable-layer isomorphism transports across congruence-trivial algebras: both
+sides have exactly one congruence up to `≑ᵈ`{.AgdaFunction}, so constant maps do
+the job, with the round trips supplied by triviality and the original round trip.
+
+```agda
+module _ {𝑆₁ 𝑆₂ : Signature 0ℓ 0ℓ} {𝑨 : Algebra {𝑆 = 𝑆₁} 0ℓ 0ℓ}
+         {𝑩 : Algebra {𝑆 = 𝑆₂} 0ℓ 0ℓ} {𝑳 : Lattice} where
+
+  trivial-ConIsoᵈ-transport : ConTrivialᵈ {𝑨 = 𝑨} 0ℓ → ConTrivialᵈ {𝑨 = 𝑩} 0ℓ
+    → ConIsoᵈ 𝑨 𝑳 → ConIsoᵈ 𝑩 𝑳
+  trivial-ConIsoᵈ-transport trivA trivB iso = record
+    { to         = λ _ → toᴸ (𝟙ᵈ {ℓ = 0ℓ})
+    ; from       = λ _ → 𝟙ᵈ {ℓ = 0ℓ}
+    ; to-mono    = λ _ → ≤-refl
+    ; from-mono  = λ _ p → p
+    ; to∘from    = λ u → ≈trans (to-cong≑ (trivA (𝟙ᵈ {ℓ = 0ℓ}) (fromᴸ u))) (to∘fromᴸ u)
+    ; from∘to    = λ d → trivB (𝟙ᵈ {ℓ = 0ℓ}) d
+    }
+    where
+    open OrderIso iso
+      renaming ( to to toᴸ ; from to fromᴸ ; to-mono to to-monoᴸ ; from-mono to from-monoᴸ
+               ; to∘from to to∘fromᴸ ; from∘to to from∘toᴸ )
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆₁} {𝑨 = 𝑨} {𝑳 = 𝑳} iso using ( to-cong≑ )
+    open Setoid 𝔻[ proj₁ 𝑳 ] using () renaming ( trans to ≈trans )
+    open Lattice-Order 𝑳 using ( ≤-refl )
+```
+
+The carrier of a finite algebra is inhabited or provably empty — run the
+enumeration.  Hence every decidably representable lattice has a witness with
+*inhabited* carrier: either the given one, or — when its carrier is empty, which
+forces the decidable-congruence poset trivial — the one-element algebra
+`𝟏`{.AgdaFunction} over the empty signature, with the isomorphism transported
+across the two trivial posets.  The closure constructions of [FLRP.Closure][]
+normalize their inputs through this lemma, so their basepoint-hungry composite
+algebras never meet an empty summand.
+
+```agda
+-- Decide inhabitation of a finite algebra's carrier from its enumeration.
+carrier-inhabited? : {𝑆 : Signature 𝓞 𝓥} {𝑨 : Algebra {𝑆 = 𝑆} α ρ}
+  → FiniteAlgebra 𝑨 → 𝕌[ 𝑨 ] ⊎ ¬ 𝕌[ 𝑨 ]
+carrier-inhabited? 𝑭 with 𝑭 .card | 𝑭 .enum | 𝑭 .enum-sur
+... | zero   | e | sur = inj₂ (λ x → ¬Fin0 (proj₁ (sur x)))
+... | suc k  | e | sur = inj₁ (e 0F)
+
+-- Every decidably representable lattice has a witness with inhabited carrier.
+inhabited-witness : {𝑳 : Lattice} (r : Representableᵈ 𝑳)
+  → Σ[ r' ∈ Representableᵈ 𝑳 ] 𝕌[ Representableᵈ.algᵈ r' ]
+inhabited-witness {𝑳} r with carrier-inhabited? (Representableᵈ.finiteᵈ r)
+... | inj₁ x   = r , x
+... | inj₂ ¬x  = record
+    { sigᵈ      = 𝑆∅
+    ; algᵈ      = 𝟏
+    ; finiteᵈ   = 𝟏-FiniteAlgebra
+    ; finsigᵈ   = 𝑆∅-FiniteSignature
+    ; con-isoᵈ  = trivial-ConIsoᵈ-transport
+                    {𝑆₁ = Representableᵈ.sigᵈ r} {𝑆₂ = 𝑆∅}
+                    {𝑨 = Representableᵈ.algᵈ r} {𝑩 = 𝟏} {𝑳 = 𝑳}
+                    (empty→ConTrivialᵈ {𝑨 = Representableᵈ.algᵈ r} ¬x)
+                    (𝟏-ConTrivialᵈ {𝑆 = 𝑆∅})
+                    (Representableᵈ.con-isoᵈ r)
+    } , tt
 ```
 
 --------------------------------------

--- a/src/FLRP/Representable.lagda.md
+++ b/src/FLRP/Representable.lagda.md
@@ -476,6 +476,17 @@ module _ {𝑆 : Signature 𝓞 𝓥} {𝑨 : Algebra {𝑆 = 𝑆} α ρ} where
   -- The total congruence, as a DecCon.
   𝟙ᵈ : DecCon 𝑨 ℓ
   𝟙ᵈ {ℓ} = 𝟙[ 𝑨 ] {ℓ} , λ _ _ → yes (lift tt)
+
+  -- A congruence's relation respects the setoid equality on both sides
+  -- (reflexivity feeds ≈ into the relation, equivalence moves it around).
+  ConRel-resp : (d : DecCon 𝑨 ℓ) {x x' y y' : 𝕌[ 𝑨 ]}
+    → x ≈ x' → y ≈ y' → ConRel d x y → ConRel d x' y'
+  ConRel-resp d x≈x' y≈y' p = θtrans (θsym (θrefl x≈x')) (θtrans p (θrefl y≈y'))
+    where
+    θcon    = proj₂ (proj₁ d)
+    θrefl   = reflexive θcon
+    θsym    = IsEquivalence.sym (is-equivalence θcon)
+    θtrans  = IsEquivalence.trans (is-equivalence θcon)
 ```
 
 #### Congruence-trivial algebras

--- a/src/FLRP/Representable.lagda.md
+++ b/src/FLRP/Representable.lagda.md
@@ -52,9 +52,9 @@ open import Agda.Primitive       using () renaming ( Set to Type )
 open import Data.Empty           using ( ⊥-elim )
 open import Data.Fin.Base        using ( Fin )
 open import Data.Fin.Patterns    using ( 0F ; 1F )
-open import Data.Fin.Properties  using ( ¬Fin0 ) renaming ( _≟_ to _≟ᶠ_ )
+open import Data.Fin.Properties  using ( ¬Fin0 ; all? ; ¬∀⟶∃¬ ) renaming ( _≟_ to _≟ᶠ_ )
 open import Data.Nat.Base        using ( zero ; suc )
-open import Data.Product         using ( _,_ ; proj₁ ; proj₂ ; Σ-syntax )
+open import Data.Product         using ( _,_ ; _×_ ; proj₁ ; proj₂ ; Σ-syntax )
 open import Data.Sum.Base        using ( _⊎_ ; inj₁ ; inj₂ )
 open import Data.Unit.Base       using ( tt )
 open import Level                using ( Level ; 0ℓ ; _⊔_ ; Lift ; lift ; lower )
@@ -63,6 +63,8 @@ open import Relation.Binary      using ( Setoid ; IsEquivalence )
 open import Relation.Binary.PropositionalEquality
                                  using ( _≡_ ; refl ; sym ; subst )
 open import Relation.Nullary     using ( ¬_ ; Dec ; yes ; no )
+open import Relation.Nullary.Decidable
+                                 using ( _→-dec_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
 open import Classical.Properties.Lattice         using  ( module Lattice-Order
@@ -514,6 +516,62 @@ constructions replace a possibly-empty witness algebra by `𝟏`{.AgdaFunction}.
 𝟏-ConTrivialᵈ : {𝑆 : Signature 𝓞 𝓥} → ConTrivialᵈ {𝑨 = 𝟏 {𝑆 = 𝑆}} ℓ
 𝟏-ConTrivialᵈ d e =
   (λ _ → reflexive (proj₂ (proj₁ e)) tt) , (λ _ → reflexive (proj₂ (proj₁ d)) tt)
+```
+
+#### Containment of decidable congruences is decidable
+
+On a finite algebra, `d ⊆ᵈ e` reduces to finitely many decidable implications:
+check the enumerated pairs and lift the verdict through surjectivity via
+`ConRel-resp`{.AgdaFunction}.  Consequently a *failed* containment yields a
+concrete violating pair (of enumerated elements) — the constructive
+witness-extraction step the ordinal-sum closure's comparability argument runs
+on.
+
+```agda
+module _ {𝑆 : Signature 𝓞 𝓥} {𝑨 : Algebra {𝑆 = 𝑆} α ρ} (𝑭 : FiniteAlgebra 𝑨) where
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ) renaming ( sym to ≈sym )
+
+  private
+    -- The enumerated-pairs table of a containment.
+    Table : DecCon 𝑨 ℓ → DecCon 𝑨 ℓ → Type ℓ
+    Table d e = ∀ i j → ConRel d (𝑭 .enum i) (𝑭 .enum j) → ConRel e (𝑭 .enum i) (𝑭 .enum j)
+
+    table? : (d e : DecCon 𝑨 ℓ) → Dec (Table d e)
+    table? d e = all? (λ i → all? (λ j →
+      proj₂ d (𝑭 .enum i) (𝑭 .enum j) →-dec proj₂ e (𝑭 .enum i) (𝑭 .enum j)))
+
+    -- Lift a full table to the containment, through surjectivity.
+    table→⊆ : (d e : DecCon 𝑨 ℓ) → Table d e → d ⊆ᵈ e
+    table→⊆ d e tbl {x} {y} dxy with 𝑭 .enum-sur x | 𝑭 .enum-sur y
+    ... | i , pi | j , pj =
+      ConRel-resp e pi pj (tbl i j (ConRel-resp d (≈sym pi) (≈sym pj) dxy))
+
+  -- Containment of decidable congruences is decidable.
+  ⊆ᵈ-dec : (d e : DecCon 𝑨 ℓ) → Dec (d ⊆ᵈ e)
+  ⊆ᵈ-dec d e with table? d e
+  ... | yes tbl  = yes (table→⊆ d e tbl)
+  ... | no ¬tbl  = no (λ sub → ¬tbl (λ i j dij → sub dij))
+
+  -- A failed containment yields a concrete violating pair.
+  ⊈ᵈ-witness : (d e : DecCon 𝑨 ℓ) → ¬ (d ⊆ᵈ e)
+    → Σ[ x ∈ 𝕌[ 𝑨 ] ] Σ[ y ∈ 𝕌[ 𝑨 ] ] (ConRel d x y × ¬ ConRel e x y)
+  ⊈ᵈ-witness d e ¬sub with table? d e
+  ... | yes tbl  = ⊥-elim (¬sub (table→⊆ d e tbl))
+  ... | no ¬tbl  = unpack
+    where
+    -- Peel the two Fin quantifiers off the refuted table, then split the
+    -- refuted (decidable) implication into premise and refuted conclusion.
+    ¬→-split : {P Q : Type ℓ} → Dec P → ¬ (P → Q) → P × ¬ Q
+    ¬→-split (yes p) ¬imp  = p , λ q → ¬imp (λ _ → q)
+    ¬→-split (no ¬p) ¬imp  = ⊥-elim (¬imp (λ p → ⊥-elim (¬p p)))
+
+    unpack : Σ[ x ∈ 𝕌[ 𝑨 ] ] Σ[ y ∈ 𝕌[ 𝑨 ] ] (ConRel d x y × ¬ ConRel e x y)
+    unpack with ¬∀⟶∃¬ _ _ (λ i → all? (λ j →
+                   proj₂ d (𝑭 .enum i) (𝑭 .enum j) →-dec proj₂ e (𝑭 .enum i) (𝑭 .enum j))) ¬tbl
+    ... | i , ¬rowᵢ with ¬∀⟶∃¬ _ _ (λ j →
+                   proj₂ d (𝑭 .enum i) (𝑭 .enum j) →-dec proj₂ e (𝑭 .enum i) (𝑭 .enum j)) ¬rowᵢ
+    ...   | j , ¬impᵢⱼ =
+      𝑭 .enum i , 𝑭 .enum j , ¬→-split (proj₂ d (𝑭 .enum i) (𝑭 .enum j)) ¬impᵢⱼ
 ```
 
 #### Consequences of a decidable-layer isomorphism

--- a/src/Setoid/Congruences/Certificates/Congruence.lagda.md
+++ b/src/Setoid/Congruences/Certificates/Congruence.lagda.md
@@ -134,8 +134,7 @@ open import Setoid.Congruences.Certificates.Schema  using  ( ParentVec ; parent
                                                            ; IdempotentParent
                                                            ; forestEdges
                                                            ; Justification ; seed
-                                                           ; translate ; Merge
-                                                           ; mkMerge ; Trace
+                                                           ; translate ; mkMerge ; Trace
                                                            ; CgCert )
 open import Setoid.Signatures.Finite                using  ( FiniteSignature )
 

--- a/src/Setoid/Congruences/Certificates/Lattice.lagda.md
+++ b/src/Setoid/Congruences/Certificates/Lattice.lagda.md
@@ -93,12 +93,12 @@ open import Data.List.Relation.Unary.Any
 open import Data.List.Relation.Unary.Any.Properties
                                   using  ( ++⁺ˡ ; ++⁺ʳ ; ++⁻ )
 open import Data.Nat.Base         using  ( ℕ )
-open import Data.Product          using  ( _×_ ; _,_ ; proj₁ ; proj₂ ; Σ-syntax )
+open import Data.Product          using  ( _×_ ; _,_ ; proj₁ ; proj₂ )
 open import Data.Sum.Base         using  ( inj₁ ; inj₂ )
-open import Level                 using  ( Level ; _⊔_ ; Lift ; lift ; lower )
+open import Level                 using  ( Level ; _⊔_ ; lift ; lower )
 open import Relation.Binary       using  ( Setoid )
 open import Relation.Binary.PropositionalEquality
-                                  using  ( _≡_ ; refl ; sym ; trans ; cong ; subst )
+                                  using  ( _≡_ ; sym ; trans ; subst )
 open import Relation.Nullary.Decidable
                                   using  ( Dec ; map′ ; _×-dec_ ; _→-dec_ )
 
@@ -116,11 +116,11 @@ open import Setoid.Congruences.Lattice                  using  ( _⊆_ ; _≑_
                                                                ; ≑-sym ; ≑-trans )
 open import Setoid.Congruences.Presented                using  ( fromPairs
                                                                ; con-resp-≈ )
-open import Setoid.Congruences.Certificates.Schema      using  ( ParentVec ; parent
+open import Setoid.Congruences.Certificates.Schema      using  ( parent
                                                                ; NormalForm
                                                                ; normalForm?
                                                                ; forestEdges
-                                                               ; Trace ; LatticeCert )
+                                                               ; LatticeCert )
 open import Setoid.Congruences.Certificates.Congruence  using  ( module CertCheck )
 open import Setoid.Signatures.Finite                    using  ( FiniteSignature )
 
@@ -142,7 +142,7 @@ module LatticeCheck {𝑆 : Signature 𝓞 𝓥} {𝑨 : Algebra {𝑆 = 𝑆} �
   open FiniteAlgebra 𝑭 using ( _≟_ ; card ; enum ; enum-sur )
   open FiniteSignature 𝑺 using ( opCard )
   open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
-    renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+    renaming ( sym to ≈sym ; trans to ≈trans )
 
   private
     -- A chosen enumeration index for each carrier element, and its correctness.

--- a/src/Setoid/Congruences/Certificates/Schema.lagda.md
+++ b/src/Setoid/Congruences/Certificates/Schema.lagda.md
@@ -61,8 +61,7 @@ open import Agda.Primitive using () renaming ( Set to Type )
 -- Imports from the Agda Standard Library -----------------------------------
 open import Data.Fin.Base                          using  ( Fin ; _≤_ )
 open import Data.Fin.Properties                    using  ( _≟_ ; _≤?_ ; all? )
-open import Data.List.Base                         using  ( List ; [] ; _∷_
-                                                          ; map ; filter ; allFin )
+open import Data.List.Base                         using  ( List ; map ; filter ; allFin )
 open import Data.Nat.Base                          using  ( ℕ )
 open import Data.Product                           using  ( _×_ ; _,_ )
 open import Data.Vec.Base                          using  ( Vec ; lookup )


### PR DESCRIPTION
## Summary

Implements #456 (WP-5 of the FLRP program #451): the closure toolkit for decidable representability, plus the assumptions registry's second entry.  All new code is `--safe`, postulate-free, and lands as small named lemmas with prose on every public definition.

+  **Product closure** — `product-Representableᵈ : Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂ → Representableᵈ (𝑳₁ ×ˡ 𝑳₂)` (`FLRP.Closure.Product`, after Tůma).  The composite witness lives on the product setoid over `𝑆₁ ⊎ 𝑆₂ ⊎ Fin m ⊎ Fin n`; the coordinate-setter operations force every decidable congruence to split as the product of its two basepoint restrictions.
+  **Ordinal-sum closure** — `ordinalSum-Representableᵈ : (t : TopOf 𝑳₁) (b : BotOf 𝑳₂) → Representableᵈ 𝑳₁ → Representableᵈ 𝑳₂ → Representableᵈ (ordinalSum 𝑳₁ t 𝑳₂ b)` (`FLRP.Closure.OrdinalSum`, the manuscript's `m + n − 1` construction, § Ordinal Sums).  The spine is the comparability dichotomy against the boundary congruence `α = ker retractʳ`, decided by the new `⊆ᵈ-dec` and closed by the single-point collapse family when both containments fail; the module prose records why this step is provably non-constructive at Layer S, so ordinal-sum closure is a Layer-D theorem only.
+  **Adjoining a new bottom or top** — `adjoinBottom-Representableᵈ` / `adjoinTop-Representableᵈ` (`FLRP.Closure`): one-application corollaries of ordinal-sum closure at `chain₂`'s concrete extrema, exactly the roadmap § 3 catalogue entry, and a design check that the sum statement carries no hidden nontriviality assumptions.
+  **Assumptions Entry 2** — `KurzweilNetterDualityAt` / `KurzweilNetterDuality` (`FLRP.Assumptions`): the Kurzweil–Netter theorem (Kurzweil, J. reine angew. Math. 356 (1985) 140–160; Netter 1986, possibly never published; argument per Pálfy's 2009 lectures as presented in `SmallLatticeReps.tex` § Lattice duals) registered as a named, cited, explicit hypothesis in the established per-assumption style, with its status (a classically proven theorem pending formalization, unlike Entry 1's axiom-calibrated bridge), layer rationale, size remark, and retirement path documented at the registration site.  The toolkit's `dual-Representableᵈ` threads it as an ordinary argument.

## Reusable infrastructure (per roadmap § 6, outside `FLRP/`)

+  `Classical.Structures.Lattice.{Product, Dual, OrdinalSum}` — binary product, dual, and glued ordinal sum of classical lattices, each with its induced `Lattice-Order` characterized; the ordinal sum takes explicit extremum data and glues by setoid equality on the amalgam `GlueSetoid` (basepoint retractions, no element removal, no decidability).
+  `Classical.Structures.Lattice` — setoid-level builders `setoidOpsToBareLattice` / `setoidEqsToLattice`, whose interpretation clauses reduce definitionally so each construction's equations are consumed in curried form.
+  `Classical.Properties.Lattice` — `IsTop` / `IsBot` with uniqueness, the packaged `TopOf` / `BotOf`, and `≤-reflexive`.
+  `FLRP.Representable` — extreme decidable congruences `𝟘ᵈ` / `𝟙ᵈ`, `ConRel-resp`, the `ConIsoᵈ-Consequences` toolkit (isomorphisms respect `≑ᵈ` and send extreme congruences to lattice extrema, hence `Representableᵈ-TopOf/BotOf`), congruence-trivial transport with `inhabited-witness` normalization (so the closure theorems have no carrier side conditions), and decidable containment `⊆ᵈ-dec` with witness extraction `⊈ᵈ-witness`.

## Notes

+  Both witness constructions carry general signatures directly, avoiding the manuscript's unary-reduction step; formalizing that reduction is now #501.
+  The stretch goal (a formal Kurzweil–Netter proof, retiring Entry 2) is deliberately not attempted here: it needs the WP-2/WP-3 group infrastructure on #454's critical path.  Filed as #502 with prerequisites recorded.
+  Census payoff (#485): with Entry 2 in place, `L18` and `L22` (duals of the certified `SLR19`/`SLR23`) are assumption-conditional corollaries; the conditional certificate modules remain #485's call.
+  `docs/_links.md` regenerated; `make check` and `make check-links` pass locally.

## Issue #456 tasks

- [x] Product closure of `Representable` — at Layer D, per ADR-008.
- [x] Ordinal-sum closure of `Representable` — at Layer D, with the Layer-S obstruction documented.
- [x] `FLRP/Assumptions` duality entry with statement, source, and citation discipline — Entry 2 (the issue text's "first entry" predated Entry 1's landing).
- [ ] Stretch: formal duality proof — deferred to #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
