### PR TITLE
[M6-22] Normal subgroups and congruences of a group: the missing correspondence

### DIFF
--- a/docs/_links.md
+++ b/docs/_links.md
@@ -187,6 +187,7 @@
 [Classical.Structures.Group.Dedekind]: /Classical/Structures/Group/Dedekind/
 [Classical.Structures.Group.GSet]: /Classical/Structures/Group/GSet/
 [Classical.Structures.Group.NormalCore]: /Classical/Structures/Group/NormalCore/
+[Classical.Structures.Group.NormalSubgroupLattice]: /Classical/Structures/Group/NormalSubgroupLattice/
 [Classical.Structures.Group.Product]: /Classical/Structures/Group/Product/
 [Classical.Structures.Group.SubgroupLattice]: /Classical/Structures/Group/SubgroupLattice/
 [Classical.Structures.Group.Subgroups]: /Classical/Structures/Group/Subgroups/
@@ -564,6 +565,7 @@
 [Classical/Structures/Group/Dedekind.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Dedekind.lagda.md
 [Classical/Structures/Group/GSet.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/GSet.lagda.md
 [Classical/Structures/Group/NormalCore.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/NormalCore.lagda.md
+[Classical/Structures/Group/NormalSubgroupLattice.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/NormalSubgroupLattice.lagda.md
 [Classical/Structures/Group/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Product.lagda.md
 [Classical/Structures/Group/SubgroupLattice.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/SubgroupLattice.lagda.md
 [Classical/Structures/Group/Subgroups.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Subgroups.lagda.md

--- a/docs/_links.md
+++ b/docs/_links.md
@@ -181,6 +181,7 @@
 [Classical.Structures.Group.Centralizer]: /Classical/Structures/Group/Centralizer/
 [Classical.Structures.Group.Complements]: /Classical/Structures/Group/Complements/
 [Classical.Structures.Group.Complexes]: /Classical/Structures/Group/Complexes/
+[Classical.Structures.Group.Congruences]: /Classical/Structures/Group/Congruences/
 [Classical.Structures.Group.Conjugation]: /Classical/Structures/Group/Conjugation/
 [Classical.Structures.Group.Cosets]: /Classical/Structures/Group/Cosets/
 [Classical.Structures.Group.Dedekind]: /Classical/Structures/Group/Dedekind/
@@ -219,6 +220,7 @@
 [Order]: /Order/
 [Order.CompleteLattice]: /Order/CompleteLattice/
 [Order.Interval]: /Order/Interval/
+[Order.Iso]: /Order/Iso/
 
 [Examples]: /Examples/
 [Examples.Classical]: /Examples/Classical/
@@ -556,6 +558,7 @@
 [Classical/Structures/Group/Centralizer.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Centralizer.lagda.md
 [Classical/Structures/Group/Complements.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Complements.lagda.md
 [Classical/Structures/Group/Complexes.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Complexes.lagda.md
+[Classical/Structures/Group/Congruences.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Congruences.lagda.md
 [Classical/Structures/Group/Conjugation.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Conjugation.lagda.md
 [Classical/Structures/Group/Cosets.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Cosets.lagda.md
 [Classical/Structures/Group/Dedekind.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Dedekind.lagda.md
@@ -594,6 +597,7 @@
 [Order.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Order.lagda.md
 [Order/CompleteLattice.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Order/CompleteLattice.lagda.md
 [Order/Interval.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Order/Interval.lagda.md
+[Order/Iso.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Order/Iso.lagda.md
 
 [Examples.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Examples.lagda.md
 [Examples/Classical.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Examples/Classical.lagda.md

--- a/scripts/python/test_unused_imports.py
+++ b/scripts/python/test_unused_imports.py
@@ -147,8 +147,8 @@ def test_syntax_backed_name_genuinely_unused() -> None:
 # --------------------------------------------------------------------------- #
 
 def test_parse_syntax_decl_operator() -> None:
-    assert ui.parse_syntax_decl("  syntax cong-syntax g x = x ^ g") == (
-        "cong-syntax", frozenset({"^"}))
+    assert ui.parse_syntax_decl("  syntax conj-syntax g x = x ^ g") == (
+        "conj-syntax", frozenset({"^"}))
 
 
 def test_parse_syntax_decl_bracket() -> None:
@@ -163,28 +163,28 @@ def test_parse_syntax_decl_not_a_declaration() -> None:
 
 def test_harvest_syntax_notations() -> None:
     text = block(
-        "cong-syntax : G → G → G",
-        "cong-syntax = conj",
-        "syntax cong-syntax g x = x ^ g",
+        "conj-syntax : G → G → G",
+        "conj-syntax = conj",
+        "syntax conj-syntax g x = x ^ g",
     )
     assert ui.harvest_syntax_notations([(Path("C.lagda.md"), text)]) == {
-        "cong-syntax": frozenset({"^"})}
+        "conj-syntax": frozenset({"^"})}
 
 
 def test_syntax_notation_used() -> None:
     text = block(
-        "open import M using ( cong-syntax )",
+        "open import M using ( conj-syntax )",
         "foo : x ^ g ≈ y",
     )
-    assert flagged_with(text, {"cong-syntax": frozenset({"^"})}) == {}
+    assert flagged_with(text, {"conj-syntax": frozenset({"^"})}) == {}
 
 
 def test_syntax_notation_unused() -> None:
     text = block(
-        "open import M using ( cong-syntax )",
+        "open import M using ( conj-syntax )",
         "foo = bar",
     )
-    assert flagged_with(text, {"cong-syntax": frozenset({"^"})}) == {"M": ("cong-syntax",)}
+    assert flagged_with(text, {"conj-syntax": frozenset({"^"})}) == {"M": ("conj-syntax",)}
 
 
 def test_syntax_notation_partially_present_is_unused() -> None:

--- a/scripts/python/unused_imports.py
+++ b/scripts/python/unused_imports.py
@@ -346,7 +346,7 @@ NO_NOTATIONS: SyntaxNotations = MappingProxyType({})
 
 
 def parse_syntax_decl(code_line: str) -> Optional[tuple[str, frozenset[str]]]:
-    """``syntax cong-syntax g x = x ^ g`` -> ``("cong-syntax", {"^"})``, and
+    """``syntax conj-syntax g x = x ^ g`` -> ``("conj-syntax", {"^"})``, and
     ``syntax Σ-syntax A (λ x → B) = Σ[ x ∈ A ] B`` -> ``("Σ-syntax", {"Σ[", "∈", "]"})``.
 
     The literal tokens are those of the notation that are not bound on the left of

--- a/src/Classical/Structures/Group.lagda.md
+++ b/src/Classical/Structures/Group.lagda.md
@@ -20,6 +20,7 @@ open import Classical.Structures.Group.Centralizer public
 open import Classical.Structures.Group.AbelianGroup public
 open import Classical.Structures.Group.Complements public
 open import Classical.Structures.Group.Complexes public
+open import Classical.Structures.Group.Congruences public
 open import Classical.Structures.Group.Conjugation public
 open import Classical.Structures.Group.Cosets public
 open import Classical.Structures.Group.Dedekind public

--- a/src/Classical/Structures/Group.lagda.md
+++ b/src/Classical/Structures/Group.lagda.md
@@ -26,6 +26,7 @@ open import Classical.Structures.Group.Cosets public
 open import Classical.Structures.Group.Dedekind public
 open import Classical.Structures.Group.GSet public
 open import Classical.Structures.Group.NormalCore public
+open import Classical.Structures.Group.NormalSubgroupLattice public
 open import Classical.Structures.Group.Product public
 open import Classical.Structures.Group.Subgroups public
 open import Classical.Structures.Group.SubgroupLattice public

--- a/src/Classical/Structures/Group/Complements.lagda.md
+++ b/src/Classical/Structures/Group/Complements.lagda.md
@@ -95,7 +95,7 @@ module Complements {α ρ : Level} (𝒢 : Group α ρ) where
   open Group-Op 𝒢
   open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ  using ( ⁻¹-involutive ; ⁻¹-anti-homo-∙ )
   open Complex 𝒢 using ( _∙ᶜ_ ; mem-∙ᶜ ; ∙ᶜ-respects ; ∙ᶜ-mono ; subgroup-∙ᶜ-idem )
-  open Conjugate 𝒢 using ( cong-syntax ; IsNormal )
+  open Conjugate 𝒢 using ( conj-syntax ; IsNormal )
 ```
 
 A member of one factor is a member of the product, provided the *other* factor

--- a/src/Classical/Structures/Group/Congruences.lagda.md
+++ b/src/Classical/Structures/Group/Congruences.lagda.md
@@ -1,0 +1,716 @@
+---
+layout: default
+file: "src/Classical/Structures/Group/Congruences.lagda.md"
+title: "Classical.Structures.Group.Congruences module"
+date: "2026-07-26"
+author: "the agda-algebras development team"
+---
+
+### Normal subgroups and congruences of a group
+
+This is the [Classical.Structures.Group.Congruences][] module of the [Agda Universal Algebra Library][].
+
+For a group `𝒢`{.AgdaBound}, the congruences of the underlying `Sig-Group`-algebra and
+the normal subgroups of `𝒢`{.AgdaBound} are the same thing.  This module proves it, as
+an order isomorphism `Con 𝑮 ℓ ≅ NormalSubgroup ℓ`{.AgdaFunction}, and identifies the
+congruence-side notion of a **nonzero** congruence with the subgroup-side notion of a
+**nontrivial** normal subgroup.
+
+The correspondence has two mutually inverse, order-preserving maps.
+
++  **`N ↦ θ_N`** (`congruenceOf`{.AgdaFunction}).  A normal subgroup `N`{.AgdaBound}
+   maps to the relation `NormalRel N`{.AgdaFunction}, defined by
+   `x θ_N y ⟺ x ∙ y ⁻¹ ∈ N`.  We prove it is an equivalence containing the setoid
+   equality — for that, `N`{.AgdaBound} being an equality-respecting subgroup is
+   enough — and that it is compatible with the three operations of
+   `Sig-Group`{.AgdaFunction}, which is where normality is consumed.
+
++  **`θ ↦ N_θ`** (`normalOf`{.AgdaFunction}).  A congruence `θ`{.AgdaBound} maps to
+   the `θ`-class of the identity — `IdentityClass`{.AgdaFunction} `θ`{.AgdaBound}, the
+   predicate `{ x ∣ x θ ε }`.  We prove it is an equality-respecting subgroup and that
+   it is normal.
+
+The two maps are monotone and mutually inverse — up to `≑`{.AgdaFunction} on
+congruences and mutual inclusion on normal subgroups — so together they are an
+`OrderIso`{.AgdaRecord} of [Order.Iso][].
+
+This is the bridge that `Classical.Structures.Group.MinimalNormal` was written
+without: it lets the library's `IsSubdirectlyIrreducible`{.AgdaFunction} of
+[Setoid.Congruences.Monolith][] — a statement about `Con 𝑨`{.AgdaFunction} — be applied
+to a group, whose subdirect irreducibility the group theorist states as "there is a
+least nontrivial normal subgroup".  The final step of that identification,
+`HasMonolithᵍ → HasMonolith`, is deliberately *not* taken here; see **What this module
+does not do** below.
+
+Four points about the formal statement deserve to be recorded up front, because in each
+case the informal slogan "congruences are normal subgroups" conceals a choice that the
+mechanized version has to make.
+
++  **The correspondence is level-uniform, not level-collapsing**.  It is an
+   isomorphism `Con 𝑮 ℓ ≅ NormalSubgroup ℓ`{.AgdaFunction} for each *fixed* relation
+   level `ℓ`{.AgdaBound}, since `NormalRel`{.AgdaFunction} of a `Pred G ℓ` is a
+   `BinaryRel G ℓ` and `IdentityClass`{.AgdaFunction} of a `Con 𝑮 ℓ` is a `Pred G ℓ`.
+   It says nothing about congruences at one level versus normal subgroups at another.
+   The instance the monolith needs is `ℓ = ρ`, where the congruence side is the `Con 𝑮 ρ`
+   of `IsMonolith`{.AgdaRecord} and the subgroup side contains
+   `trivialSubgroup`{.AgdaFunction}, itself a `Subgroup ρ`.  A consumer that wants to
+   compose with the subgroup *lattice* must instead take `ℓ = α ⊔ ℓ₀`, the predicate
+   level `L` at which `GroupSublattice 𝒢 ℓ₀`{.AgdaModule} of
+   [Classical.Structures.Group.SubgroupLattice][] holds its elements.
+
++  **Equality on each side is mutual containment, not propositional equality**.  On the
+   congruence side this is `_≑_`{.AgdaFunction} of [Setoid.Congruences.Lattice][], for
+   the reasons given there (upgrading it would need propositional extensionality, which
+   `--safe --cubical-compatible` does not provide); on the subgroup side we take the
+   matching `_≈ⁿ_`{.AgdaFunction}.  So `to∘from`{.AgdaField} and `from∘to`{.AgdaField}
+   are *bi-implications of membership*, not equalities of predicates.
+
++  **The round trip on subgroups uses the `respects`{.AgdaField} field**.  Recovering
+   `N`{.AgdaBound} from `θ_N` produces `{ x ∣ x ∙ ε ⁻¹ ∈ N }`, and identifying that with
+   `N`{.AgdaBound} moves membership across `x ∙ ε ⁻¹ ≈ x`.  A normal *subuniverse* that
+   does not respect the setoid equality therefore need not be recovered by the round
+   trip, exactly as in the respecting-interval finding of [FLRP.Bridge][].  This is why
+   `NormalSubgroup`{.AgdaFunction} is built on `IsSubgroup`{.AgdaRecord} (which carries
+   `respects`{.AgdaField}) rather than on bare `Subuniverses`{.AgdaFunction}.
+
++  **Normality is consumed only by compatibility, and it is consumed exactly**.  For an
+   arbitrary equality-respecting subgroup `N`{.AgdaBound}, `NormalRel N`{.AgdaFunction}
+   is already an equivalence relation containing `_≈_`{.AgdaFunction}; this is
+   `SubgroupRel`{.AgdaModule} below, and it holds with no normality hypothesis.  What
+   needs normality is compatibility with `∙-Op`{.AgdaInductiveConstructor} and
+   `⁻¹-Op`{.AgdaInductiveConstructor}, so the separation is stated rather than folded
+   into one monolithic lemma — and the converse `congruence→normal`{.AgdaFunction} is
+   proved, so that "the correspondence is with the *normal* subgroups" is a theorem of
+   the module and not a claim its prose makes on the development's behalf.
+
+**On the choice of relation.**  `x ∙ y ⁻¹ ∈ N` is the *right*-coset relation of
+`N`{.AgdaBound}, whereas `Coset._∼_`{.AgdaFunction} of
+[Classical.Structures.Group.Cosets][] — the relation [FLRP.Bridge][] uses — is the
+*left*-coset relation `x ⁻¹ ∙ y ∈ N`.  For a general subgroup the two need not agree;
+for a normal subgroup they do, which we prove (`rel→coset`{.AgdaFunction},
+`coset→rel`{.AgdaFunction}) rather than assume, so that either presentation may be used
+downstream.
+
+**What this module does not do.**  Issue #508 also asks that
+`HasMonolithᵍ`{.AgdaFunction} of `Classical.Structures.Group.MinimalNormal` be
+transported to `HasMonolith`{.AgdaFunction}, that the `ᵍ` superscript be retired, and
+that `𝒢₂` of `FLRP.Reductions` be restated.  Those steps are held back until the pull
+request that introduces `MinimalNormal` lands; everything above is independent of them.
+The `Nonzero`{.AgdaFunction}/nontriviality equivalences proved here
+(`nonzero→nontrivial`{.AgdaFunction} and friends) are precisely the ingredient that
+transport will need beyond the isomorphism itself.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Group.Congruences where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Fin.Patterns             using  ( 0F ; 1F )
+open import Data.Product                  using  ( _,_ ; _×_ ; Σ-syntax
+                                                 ; proj₁ ; proj₂ )
+open import Level                         using  ( Level ; _⊔_ ; suc )
+open import Relation.Binary               using  ( Setoid ; IsEquivalence )
+                                          renaming ( Rel to BinaryRel )
+open import Relation.Binary.Definitions   using  ( _Respects_ )
+open import Relation.Nullary              using  ( ¬_ )
+open import Relation.Unary                using  ( Pred ; _∈_ ; _⊆_ )
+
+import Algebra.Properties.Group as GroupProperties
+import Relation.Binary.Reasoning.Setoid as SetoidReasoning
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Bundles.Group                 using  ( ⟨_⟩ᵍᵖ )
+open import Classical.Operations                    using  ( pair )
+open import Classical.Signatures.Group              using  ( ∙-Op ; ε-Op ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic        using  ( Group ; module Group-Op )
+open import Classical.Structures.Group.Conjugation  using  ( module Conj )
+open import Classical.Structures.Group.Cosets       using  ( module Coset )
+open import Classical.Structures.Group.Subgroups    using  ( IsSubgroup ; mkIsSubgroup
+                                                           ; trivialSubgroup
+                                                           ; interp-tuple-∙
+                                                           ; interp-tuple-ε
+                                                           ; interp-tuple-⁻¹ )
+open import Order.Iso                               using  ( OrderIso )
+open import Setoid.Algebras.Basic                   using  ( 𝕌[_] ; 𝔻[_] )
+open import Setoid.Congruences.Basic                using  ( Con ; IsCongruence ; mkcon
+                                                           ; _∣≈_ ; is-compatible
+                                                           ; is-equivalence ; reflexive )
+open import Setoid.Congruences.Lattice              using  ( _≑_ )
+                                                    renaming ( _⊆_ to _⊑_ )
+open import Setoid.Congruences.Monolith             using  ( BelowDiagonal ; Nonzero )
+
+private variable α ρ ℓ : Level
+```
+-->
+
+#### The ambient group
+
+Everything below is developed inside one parameterized module, so that the group, its
+carrier, its curried operations, and the conjugation vocabulary are fixed once.
+
+```agda
+module GroupCongruences {α ρ : Level} (𝒢 : Group α ρ) where
+  private
+    𝑮 = proj₁ 𝒢
+    G = 𝕌[ 𝑮 ]
+
+  open Setoid 𝔻[ 𝑮 ]            using  ( _≈_ )
+                                renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+  open SetoidReasoning 𝔻[ 𝑮 ]
+  open Group-Op 𝒢               using  ( _∙_ ; ε ; _⁻¹ ; ∙-cong ; assoc-law
+                                       ; idˡ-law ; idʳ-law ; invˡ-law ; invʳ-law )
+  open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ  using  ( ε⁻¹≈ε ; ⁻¹-involutive ; ⁻¹-anti-homo-∙
+                                       ; \\-leftDividesʳ )
+  open Conj 𝒢                   using  ( conj ; conj-ε ; IsNormal )
+```
+
+#### Four facts of group arithmetic
+
+The correspondence rests on four small identities, each named so that no proof below
+has to inline an equational chain about them.  The first two say that `x ∙ y ⁻¹ ≈ ε`
+is *equivalent* to `x ≈ y` — this is what makes the relation `x ∙ y ⁻¹ ∈ N` collapse to
+the setoid equality exactly when `N` is trivial.  The third is right-cancellation in the
+form the round trip needs, and the fourth is the unit law that identifies `x ∙ ε ⁻¹`
+with `x`.
+
+```agda
+  -- x ∙ y ⁻¹ ≈ ε implies x ≈ y (multiply on the right by y).
+  ∙⁻¹≈ε→≈ : ∀ {x y} → x ∙ y ⁻¹ ≈ ε → x ≈ y
+  ∙⁻¹≈ε→≈ {x} {y} h = begin
+    x               ≈˘⟨ idʳ-law x ⟩
+    x ∙ ε           ≈˘⟨ ∙-cong ≈refl (invˡ-law y) ⟩
+    x ∙ (y ⁻¹ ∙ y)  ≈˘⟨ assoc-law x (y ⁻¹) y ⟩
+    x ∙ y ⁻¹ ∙ y    ≈⟨ ∙-cong h ≈refl ⟩
+    ε ∙ y           ≈⟨ idˡ-law y ⟩
+    y               ∎
+
+  -- ... and conversely, equal elements have trivial right quotient.
+  ≈→∙⁻¹≈ε : ∀ {x y} → x ≈ y → x ∙ y ⁻¹ ≈ ε
+  ≈→∙⁻¹≈ε {x} {y} x≈y = ≈trans (∙-cong x≈y ≈refl) (invʳ-law y)
+
+  -- Right cancellation: the right quotient by y, multiplied back by y, is the identity.
+  ∙⁻¹∙ : ∀ x y → x ∙ y ⁻¹ ∙ y ≈ x
+  ∙⁻¹∙ x y = begin
+    x ∙ y ⁻¹ ∙ y    ≈⟨ assoc-law x (y ⁻¹) y ⟩
+    x ∙ (y ⁻¹ ∙ y)  ≈⟨ ∙-cong ≈refl (invˡ-law y) ⟩
+    x ∙ ε           ≈⟨ idʳ-law x ⟩
+    x               ∎
+
+  -- The right quotient by the identity is the identity map.
+  ∙ε⁻¹ : ∀ x → x ∙ ε ⁻¹ ≈ x
+  ∙ε⁻¹ x = ≈trans (∙-cong ≈refl ε⁻¹≈ε) (idʳ-law x)
+```
+
+#### Normal subgroups as an ordered object
+
+A **normal subgroup** of `𝒢`{.AgdaBound} at predicate level `ℓ`{.AgdaBound} is a
+predicate on the carrier together with a proof that it is an equality-respecting
+subgroup and a proof that it is closed under conjugation.  This is
+`Subgroup`{.AgdaFunction} of [Classical.Structures.Group.Subgroups][] with
+`IsNormal`{.AgdaFunction} of [Classical.Structures.Group.Conjugation][] adjoined; it is
+introduced here rather than there because normality is the *only* extra datum the
+correspondence needs, and no earlier module had cause to bundle it.
+
+Normal subgroups are ordered by inclusion of the underlying predicates, with equality
+mutual inclusion — the same shape as `_⊑_`{.AgdaFunction} and `_≑_`{.AgdaFunction} on
+congruences, so that the isomorphism below can be stated without any bridging
+construction on either side.
+
+```agda
+  -- A normal subgroup: an equality-respecting subgroup closed under conjugation.
+  NormalSubgroup : (ℓ : Level) → Type (α ⊔ ρ ⊔ suc ℓ)
+  NormalSubgroup ℓ = Σ[ N ∈ Pred G ℓ ] (IsSubgroup 𝒢 N × IsNormal N)
+
+  -- The underlying predicate of a normal subgroup ...
+  set : NormalSubgroup ℓ → Pred G ℓ
+  set = proj₁
+
+  -- ... and its two proof components.
+  set-isSubgroup : (𝑵 : NormalSubgroup ℓ) → IsSubgroup 𝒢 (set 𝑵)
+  set-isSubgroup 𝑵 = proj₁ (proj₂ 𝑵)
+
+  set-normal : (𝑵 : NormalSubgroup ℓ) → IsNormal (set 𝑵)
+  set-normal 𝑵 = proj₂ (proj₂ 𝑵)
+
+  infix 4 _≤ⁿ_ _≈ⁿ_
+
+  -- The inclusion order on normal subgroups ...
+  _≤ⁿ_ : NormalSubgroup ℓ → NormalSubgroup ℓ → Type (α ⊔ ℓ)
+  𝑴 ≤ⁿ 𝑵 = set 𝑴 ⊆ set 𝑵
+
+  -- ... and the equivalence of mutual inclusion it is antisymmetric over.
+  _≈ⁿ_ : NormalSubgroup ℓ → NormalSubgroup ℓ → Type (α ⊔ ℓ)
+  𝑴 ≈ⁿ 𝑵 = 𝑴 ≤ⁿ 𝑵 × 𝑵 ≤ⁿ 𝑴
+```
+
+#### The relation attached to a subgroup
+
+`NormalRel N`{.AgdaFunction} is the relation "`x` and `y` differ by an element of
+`N`", written with the *right* quotient `x ∙ y ⁻¹`.  It is defined for an arbitrary
+predicate, so that the hypotheses each of its properties needs can be stated exactly.
+
+```agda
+  -- x and y are related when their right quotient lies in N.
+  NormalRel : Pred G ℓ → BinaryRel G ℓ
+  NormalRel N x y = x ∙ y ⁻¹ ∈ N
+```
+
+For an equality-respecting subgroup `N`{.AgdaBound} — with no normality hypothesis —
+`NormalRel N`{.AgdaFunction} is an equivalence relation that contains the setoid
+equality.  Each clause is one closure property of `N`{.AgdaBound} transported along one
+line of group arithmetic, exactly as in `Coset`{.AgdaModule} of
+[Classical.Structures.Group.Cosets][] for the left-handed relation.
+
+```agda
+  module SubgroupRel {ℓ : Level} (N : Pred G ℓ) (N-sg : IsSubgroup 𝒢 N) where
+
+    open IsSubgroup N-sg  using ( respects ; ∙-closed ; ε-closed ; ⁻¹-closed )
+
+    infix 4 _∼_
+
+    _∼_ : BinaryRel G ℓ
+    _∼_ = NormalRel N
+
+    -- Reflexivity is ε ∈ N transported along x ∙ x ⁻¹ ≈ ε.
+    ∼-refl : ∀ {x} → x ∼ x
+    ∼-refl {x} = respects (≈sym (invʳ-law x)) ε-closed
+
+    -- Symmetry is closure under inverses, since (x ∙ y ⁻¹) ⁻¹ ≈ y ∙ x ⁻¹.
+    ∼-sym : ∀ {x y} → x ∼ y → y ∼ x
+    ∼-sym {x} {y} x∼y = respects inv-eq (⁻¹-closed x∼y)
+      where
+      inv-eq : (x ∙ y ⁻¹) ⁻¹ ≈ y ∙ x ⁻¹
+      inv-eq = begin
+        (x ∙ y ⁻¹) ⁻¹     ≈⟨ ⁻¹-anti-homo-∙ x (y ⁻¹) ⟩
+        (y ⁻¹) ⁻¹ ∙ x ⁻¹  ≈⟨ ∙-cong (⁻¹-involutive y) ≈refl ⟩
+        y ∙ x ⁻¹          ∎
+
+    -- Transitivity is closure under products, since (x ∙ y ⁻¹) ∙ (y ∙ z ⁻¹) ≈ x ∙ z ⁻¹.
+    ∼-trans : ∀ {x y z} → x ∼ y → y ∼ z → x ∼ z
+    ∼-trans {x} {y} {z} x∼y y∼z = respects prod-eq (∙-closed x∼y y∼z)
+      where
+      prod-eq : (x ∙ y ⁻¹) ∙ (y ∙ z ⁻¹) ≈ x ∙ z ⁻¹
+      prod-eq = begin
+        (x ∙ y ⁻¹) ∙ (y ∙ z ⁻¹)  ≈⟨ assoc-law x (y ⁻¹) (y ∙ z ⁻¹) ⟩
+        x ∙ (y ⁻¹ ∙ (y ∙ z ⁻¹))  ≈⟨ ∙-cong ≈refl (\\-leftDividesʳ y (z ⁻¹)) ⟩
+        x ∙ z ⁻¹                 ∎
+
+    ∼-isEquivalence : IsEquivalence _∼_
+    ∼-isEquivalence = record { refl = ∼-refl ; sym = ∼-sym ; trans = ∼-trans }
+
+    -- The setoid equality refines the relation (this is the `reflexive` field a
+    -- congruence must supply, and it is what makes the relation contain the diagonal).
+    ≈⇒∼ : ∀ {x y} → x ≈ y → x ∼ y
+    ≈⇒∼ x≈y = respects (≈sym (≈→∙⁻¹≈ε x≈y)) ε-closed
+
+    -- Consequently the relation may be transported along ≈ in either argument.
+    ∼-resp : ∀ {x x' y y'} → x ≈ x' → y ≈ y' → x ∼ y → x' ∼ y'
+    ∼-resp x≈x' y≈y' p = ∼-trans (∼-trans (≈⇒∼ (≈sym x≈x')) p) (≈⇒∼ y≈y')
+```
+
+#### From a normal subgroup to a congruence
+
+Adding normality makes the relation compatible with the three operations of
+`Sig-Group`{.AgdaFunction}, hence a congruence.
+
+Compatibility with `∙-Op`{.AgdaInductiveConstructor} is the substantive clause and the
+only one that uses normality in an essential way: from `x ∙ y ⁻¹ ∈ N` and
+`u ∙ v ⁻¹ ∈ N` we must produce `(x ∙ u) ∙ (y ∙ v) ⁻¹ ∈ N`, and the two given elements do
+not multiply to it — one of them must first be *moved past* `x`{.AgdaBound}, which is
+precisely conjugation.  Compatibility with `⁻¹-Op`{.AgdaInductiveConstructor} is one
+conjugation as well; with `ε-Op`{.AgdaInductiveConstructor} it is reflexivity.
+
+```agda
+  module NormalCon {ℓ : Level} (𝑵 : NormalSubgroup ℓ) where
+
+    private
+      N : Pred G ℓ
+      N = set 𝑵
+
+    open IsSubgroup (set-isSubgroup 𝑵)  using ( respects ; ∙-closed )
+    open SubgroupRel N (set-isSubgroup 𝑵) public
+
+    normal : IsNormal N
+    normal = set-normal 𝑵
+
+    -- Compatibility with the curried multiplication.  The element x ∙ y ⁻¹ is on the
+    -- wrong side of x ∙ u, so u ∙ v ⁻¹ is first conjugated by x — the one step that
+    -- normality supplies and that fails for a non-normal subgroup.
+    ∼-∙ : ∀ {x y u v} → x ∼ y → u ∼ v → (x ∙ u) ∼ (y ∙ v)
+    ∼-∙ {x} {y} {u} {v} p q = respects step (∙-closed (normal x q) p)
+      where
+      step : x ∙ (u ∙ v ⁻¹) ∙ x ⁻¹ ∙ (x ∙ y ⁻¹) ≈ x ∙ u ∙ (y ∙ v) ⁻¹
+      step = begin
+        x ∙ (u ∙ v ⁻¹) ∙ x ⁻¹ ∙ (x ∙ y ⁻¹)    ≈⟨ assoc-law (x ∙ (u ∙ v ⁻¹)) (x ⁻¹) (x ∙ y ⁻¹) ⟩
+        x ∙ (u ∙ v ⁻¹) ∙ (x ⁻¹ ∙ (x ∙ y ⁻¹))  ≈⟨ ∙-cong ≈refl (\\-leftDividesʳ x (y ⁻¹)) ⟩
+        x ∙ (u ∙ v ⁻¹) ∙ y ⁻¹                 ≈˘⟨ ∙-cong (assoc-law x u (v ⁻¹)) ≈refl ⟩
+        x ∙ u ∙ v ⁻¹ ∙ y ⁻¹                   ≈⟨ assoc-law (x ∙ u) (v ⁻¹) (y ⁻¹) ⟩
+        x ∙ u ∙ (v ⁻¹ ∙ y ⁻¹)                 ≈˘⟨ ∙-cong ≈refl (⁻¹-anti-homo-∙ y v) ⟩
+        x ∙ u ∙ (y ∙ v) ⁻¹                    ∎
+
+    -- Compatibility with the curried inverse: conjugating x ∙ y ⁻¹ by x ⁻¹ produces
+    -- y ⁻¹ ∙ (x ⁻¹) ⁻¹, which is the relation the other way round.
+    ∼-⁻¹ : ∀ {x y} → x ∼ y → x ⁻¹ ∼ y ⁻¹
+    ∼-⁻¹ {x} {y} p = ∼-sym (respects step (normal (x ⁻¹) p))
+      where
+      step : x ⁻¹ ∙ (x ∙ y ⁻¹) ∙ (x ⁻¹) ⁻¹ ≈ y ⁻¹ ∙ (x ⁻¹) ⁻¹
+      step = ∙-cong (\\-leftDividesʳ x (y ⁻¹)) ≈refl
+
+    -- Compatibility with every operation symbol.  Each clause is the corresponding
+    -- curried fact, transported across the tuple-vs-curried interpretation bridges of
+    -- [Classical.Structures.Group.Subgroups].
+    ∼-compatible : 𝑮 ∣≈ _∼_
+    ∼-compatible ∙-Op   {u} {v} p = ∼-resp  (≈sym (interp-tuple-∙ 𝒢 u))
+                                            (≈sym (interp-tuple-∙ 𝒢 v))
+                                            (∼-∙ (p 0F) (p 1F))
+    ∼-compatible ε-Op   {u} {v} p = ∼-resp  (≈sym (interp-tuple-ε 𝒢 u))
+                                            (≈sym (interp-tuple-ε 𝒢 v))
+                                            ∼-refl
+    ∼-compatible ⁻¹-Op  {u} {v} p = ∼-resp  (≈sym (interp-tuple-⁻¹ 𝒢 u))
+                                            (≈sym (interp-tuple-⁻¹ 𝒢 v))
+                                            (∼-⁻¹ (p 0F))
+
+    -- The relation of a normal subgroup is a congruence of the group algebra.
+    ∼-isCongruence : IsCongruence 𝑮 _∼_
+    ∼-isCongruence = mkcon ≈⇒∼ ∼-isEquivalence ∼-compatible
+```
+
+For a normal subgroup the right-handed relation used here agrees with the left-handed
+coset relation `Coset._∼_`{.AgdaFunction} of [Classical.Structures.Group.Cosets][],
+which is the one [FLRP.Bridge][] builds on.  Both directions are one application of
+`∼-⁻¹`{.AgdaFunction} followed by an involutivity rewrite, so nothing about the
+development depends on which of the two presentations a consumer prefers.
+
+```agda
+    -- The right-coset relation of a normal subgroup is its left-coset relation ...
+    rel→coset : ∀ {x y} → x ∼ y → Coset._∼_ 𝒢 N (set-isSubgroup 𝑵) x y
+    rel→coset {x} {y} p = respects (∙-cong ≈refl (⁻¹-involutive y)) (∼-⁻¹ p)
+
+    -- ... and conversely.
+    coset→rel : ∀ {x y} → Coset._∼_ 𝒢 N (set-isSubgroup 𝑵) x y → x ∼ y
+    coset→rel {x} {y} p = ∼-resp  (⁻¹-involutive x) (⁻¹-involutive y)
+                                  (∼-⁻¹ (respects (∙-cong ≈refl (≈sym (⁻¹-involutive y))) p))
+```
+
+The forward map of the correspondence packages the relation with its congruence proof.
+
+```agda
+  -- N ↦ θ_N : a normal subgroup gives a congruence of the group algebra.
+  congruenceOf : NormalSubgroup ℓ → Con 𝑮 ℓ
+  congruenceOf 𝑵 = NormalRel (set 𝑵) , NormalCon.∼-isCongruence 𝑵
+```
+
+#### From a congruence to a normal subgroup
+
+In the other direction the ingredients are the curried consequences of a congruence's
+compatibility: it is preserved by multiplication, by inversion, and hence by
+conjugation.  These are read off from `is-compatible`{.AgdaFunction} at the canonical
+tuples, with no interpretation bridge needed — the curried accessors of
+`Group-Op`{.AgdaModule} are *defined* by applying the interpreted symbol to exactly
+those tuples.
+
+```agda
+  module ConNormal {ℓ : Level} (θ : Con 𝑮 ℓ) where
+
+    infix 4 _≐_
+
+    _≐_ : BinaryRel G ℓ
+    _≐_ = proj₁ θ
+
+    ≐-refl : ∀ {x} → x ≐ x
+    ≐-refl = IsEquivalence.refl (is-equivalence (proj₂ θ))
+
+    ≐-trans : ∀ {x y z} → x ≐ y → y ≐ z → x ≐ z
+    ≐-trans = IsEquivalence.trans (is-equivalence (proj₂ θ))
+
+    -- A congruence relates ≈-equal elements.
+    ≐-reflexive : ∀ {x y} → x ≈ y → x ≐ y
+    ≐-reflexive = reflexive (proj₂ θ)
+
+    -- Compatibility with the curried multiplication ...
+    ≐-∙ : ∀ {x y u v} → x ≐ y → u ≐ v → (x ∙ u) ≐ (y ∙ v)
+    ≐-∙ {x} {y} {u} {v} p q =
+      is-compatible (proj₂ θ) ∙-Op {pair x u} {pair y v} (λ { 0F → p ; 1F → q })
+
+    -- ... and with the curried inverse.
+    ≐-⁻¹ : ∀ {x y} → x ≐ y → x ⁻¹ ≐ y ⁻¹
+    ≐-⁻¹ {x} {y} p = is-compatible (proj₂ θ) ⁻¹-Op {λ _ → x} {λ _ → y} (λ _ → p)
+
+    -- Hence conjugation by any element preserves the congruence.
+    ≐-conj : ∀ g {x y} → x ≐ y → conj g x ≐ conj g y
+    ≐-conj g p = ≐-∙ (≐-∙ ≐-refl p) ≐-refl
+```
+
+The class of the identity is an equality-respecting subgroup, and it is normal.
+Membership is `x θ ε`, so each subgroup law is one application of the corresponding
+compatibility fact followed by a `≈`-step that renormalizes the right-hand side back to
+`ε`{.AgdaFunction}: `ε ∙ ε ≈ ε`, `ε ⁻¹ ≈ ε`, and `conj g ε ≈ ε`.
+
+```agda
+    -- The θ-class of the identity.
+    IdentityClass : Pred G ℓ
+    IdentityClass x = x ≐ ε
+
+    -- It respects the setoid equality, because a congruence contains it.
+    IdentityClass-respects : IdentityClass Respects _≈_
+    IdentityClass-respects x≈y p = ≐-trans (≐-reflexive (≈sym x≈y)) p
+
+    IdentityClass-ε : ε ∈ IdentityClass
+    IdentityClass-ε = ≐-refl
+
+    IdentityClass-∙ : ∀ {x y} → x ∈ IdentityClass → y ∈ IdentityClass
+      → x ∙ y ∈ IdentityClass
+    IdentityClass-∙ p q = ≐-trans (≐-∙ p q) (≐-reflexive (idˡ-law ε))
+
+    IdentityClass-⁻¹ : ∀ {x} → x ∈ IdentityClass → x ⁻¹ ∈ IdentityClass
+    IdentityClass-⁻¹ p = ≐-trans (≐-⁻¹ p) (≐-reflexive ε⁻¹≈ε)
+
+    -- The identity class is an equality-respecting subgroup ...
+    IdentityClass-isSubgroup : IsSubgroup 𝒢 IdentityClass
+    IdentityClass-isSubgroup = mkIsSubgroup 𝒢  IdentityClass-respects IdentityClass-∙
+                                               IdentityClass-ε IdentityClass-⁻¹
+
+    -- ... and it is normal, since conjugation fixes the identity.
+    IdentityClass-normal : IsNormal IdentityClass
+    IdentityClass-normal g p = ≐-trans (≐-conj g p) (≐-reflexive (conj-ε g))
+```
+
+The backward map of the correspondence packages the class with its two proofs.
+
+```agda
+  -- θ ↦ N_θ : a congruence gives a normal subgroup of the group.
+  normalOf : Con 𝑮 ℓ → NormalSubgroup ℓ
+  normalOf θ =  ConNormal.IdentityClass θ
+             ,  ConNormal.IdentityClass-isSubgroup θ
+             ,  ConNormal.IdentityClass-normal θ
+```
+
+#### Normality is necessary, not merely sufficient
+
+`NormalCon`{.AgdaModule} shows normality *suffices* for `NormalRel N`{.AgdaFunction} to
+be a congruence.  The converse holds too, and is worth proving rather than asserting:
+were it left as prose, the claim "the correspondence is with the *normal* subgroups"
+would be doing work the formal development had not done, and nothing would rule out the
+relation of some non-normal subgroup slipping into `Con 𝑮 ℓ`{.AgdaFunction}.
+
+The proof needs no new group arithmetic.  If `NormalRel N`{.AgdaFunction} is a
+congruence, its identity class is normal by
+`IdentityClass-normal`{.AgdaFunction} — and that class is
+`{ x ∣ x ∙ ε ⁻¹ ∈ N }`, which `respects`{.AgdaField} identifies with
+`N`{.AgdaBound} itself.
+
+```agda
+  -- If the relation of an equality-respecting subgroup is a congruence, the subgroup
+  -- is normal.  With `NormalCon.∼-isCongruence` this makes normality *equivalent* to
+  -- compatibility, so `NormalSubgroup ℓ` is exactly the source of the correspondence.
+  congruence→normal : {ℓ : Level} (N : Pred G ℓ) → IsSubgroup 𝒢 N
+    →  IsCongruence 𝑮 (NormalRel N) → IsNormal N
+  congruence→normal N N-sg isCon g {x} x∈N =
+    respects  (∙ε⁻¹ (conj g x))
+              (ConNormal.IdentityClass-normal (NormalRel N , isCon) g
+                (respects (≈sym (∙ε⁻¹ x)) x∈N))
+    where open IsSubgroup N-sg using ( respects )
+```
+
+#### Monotonicity
+
+Both maps act by (co)restriction of the underlying predicates and relations, so
+monotonicity is immediate in each direction.
+
+```agda
+  -- The congruence-to-subgroup map is monotone.
+  normalOf-mono : {θ φ : Con 𝑮 ℓ} → θ ⊑ φ → normalOf θ ≤ⁿ normalOf φ
+  normalOf-mono θ⊑φ p = θ⊑φ p
+
+  -- The subgroup-to-congruence map is monotone.
+  congruenceOf-mono : {𝑴 𝑵 : NormalSubgroup ℓ} → 𝑴 ≤ⁿ 𝑵 → congruenceOf 𝑴 ⊑ congruenceOf 𝑵
+  congruenceOf-mono 𝑴≤𝑵 p = 𝑴≤𝑵 p
+```
+
+`OrderIso`{.AgdaRecord} asks only for monotonicity, not for the maps to be well defined
+on equivalence classes, so that latter property — which "isomorphism of posets" is
+usually taken to include — is recorded here rather than left implicit.  It costs
+nothing: each equivalence *is* mutual containment, so applying the matching
+monotonicity twice suffices.
+
+```agda
+  -- Both maps respect the equivalences of the two sides.
+  normalOf-cong : {θ φ : Con 𝑮 ℓ} → θ ≑ φ → normalOf θ ≈ⁿ normalOf φ
+  normalOf-cong {ℓ} {θ} {φ} (θ⊑φ , φ⊑θ) =
+    normalOf-mono {ℓ} {θ} {φ} θ⊑φ , normalOf-mono {ℓ} {φ} {θ} φ⊑θ
+
+  congruenceOf-cong : {𝑴 𝑵 : NormalSubgroup ℓ}
+    →  𝑴 ≈ⁿ 𝑵 → congruenceOf 𝑴 ≑ congruenceOf 𝑵
+  congruenceOf-cong {ℓ} {𝑴} {𝑵} (𝑴≤𝑵 , 𝑵≤𝑴) =
+    congruenceOf-mono {ℓ} {𝑴} {𝑵} 𝑴≤𝑵 , congruenceOf-mono {ℓ} {𝑵} {𝑴} 𝑵≤𝑴
+```
+
+#### Mutual inverseness
+
+On congruences, `θ_{N_θ} ≑ θ`: the relation `θ_{N_θ}` holds at `(x , y)` when
+`(x ∙ y ⁻¹) θ ε`, and multiplying on the right by `y`{.AgdaBound} converts that to
+`x θ y` through `∙⁻¹∙`{.AgdaFunction} and the unit law — while multiplying `x θ y` on
+the right by `y ⁻¹` converts it back through `invʳ-law`{.AgdaFunction}.
+
+```agda
+  -- Round trip on congruences: θ_{N_θ} ≑ θ.
+  congruenceOf∘normalOf : (θ : Con 𝑮 ℓ) → congruenceOf (normalOf θ) ≑ θ
+  congruenceOf∘normalOf θ = fwd , bwd
+    where
+    open ConNormal θ
+
+    -- From (x ∙ y ⁻¹) θ ε derive x θ y.
+    fwd : congruenceOf (normalOf θ) ⊑ θ
+    fwd {x} {y} p = ≐-trans  (≐-reflexive (≈sym (∙⁻¹∙ x y)))
+                             (≐-trans (≐-∙ p ≐-refl) (≐-reflexive (idˡ-law y)))
+
+    -- From x θ y derive (x ∙ y ⁻¹) θ ε.
+    bwd : θ ⊑ congruenceOf (normalOf θ)
+    bwd {x} {y} p = ≐-trans (≐-∙ p (≐-refl {y ⁻¹})) (≐-reflexive (invʳ-law y))
+```
+
+On normal subgroups, `N_{θ_N} ≈ⁿ N`: an element `x`{.AgdaBound} lies in `N_{θ_N}` when
+`x ∙ ε ⁻¹ ∈ N`, and `x ∙ ε ⁻¹ ≈ x`, so the `respects`{.AgdaField} proof carried by the
+subgroup identifies the two.  **This is the step that consumes the
+`respects`{.AgdaField} field**, and the sole place the correspondence would break for a
+normal subuniverse not closed under the setoid equality.
+
+```agda
+  -- Round trip on normal subgroups: N_{θ_N} ≈ⁿ N (needs the respecting field).
+  normalOf∘congruenceOf : (𝑵 : NormalSubgroup ℓ) → normalOf (congruenceOf 𝑵) ≈ⁿ 𝑵
+  normalOf∘congruenceOf 𝑵 = fwd , bwd
+    where
+    open IsSubgroup (set-isSubgroup 𝑵) using ( respects )
+
+    -- x ∙ ε ⁻¹ ∈ N and x ∙ ε ⁻¹ ≈ x give x ∈ N.
+    fwd : normalOf (congruenceOf 𝑵) ≤ⁿ 𝑵
+    fwd {x} p = respects (∙ε⁻¹ x) p
+
+    -- x ∈ N and x ≈ x ∙ ε ⁻¹ give x ∙ ε ⁻¹ ∈ N.
+    bwd : 𝑵 ≤ⁿ normalOf (congruenceOf 𝑵)
+    bwd {x} p = respects (≈sym (∙ε⁻¹ x)) p
+```
+
+#### The order isomorphism
+
+Assembling the four facts — two maps, both monotone, mutually inverse — gives the
+correspondence as an `OrderIso`{.AgdaRecord} between the congruence containment order of
+the group algebra and the inclusion order on normal subgroups.  (The endpoint implicits
+of the monotone maps are bound and forwarded explicitly: `Con`{.AgdaFunction} and
+`NormalSubgroup`{.AgdaFunction} are defined functions, not injective type formers, so
+Agda cannot recover them from the field types.)
+
+```agda
+  -- The order isomorphism Con 𝑮 ℓ ≅ NormalSubgroup ℓ.
+  NormalCongruenceIso : (ℓ : Level) → Type (α ⊔ ρ ⊔ suc ℓ)
+  NormalCongruenceIso ℓ =
+    OrderIso (_≑_ {𝑨 = 𝑮} {ℓ = ℓ}) (_⊑_ {𝑨 = 𝑮} {ℓ = ℓ}) (_≈ⁿ_ {ℓ}) (_≤ⁿ_ {ℓ})
+
+  normal-congruence-iso : (ℓ : Level) → NormalCongruenceIso ℓ
+  normal-congruence-iso ℓ = record
+    { to         = normalOf
+    ; from       = congruenceOf
+    ; to-mono    = λ {θ} {φ} → normalOf-mono {ℓ} {θ} {φ}
+    ; from-mono  = λ {𝑴} {𝑵} → congruenceOf-mono {ℓ} {𝑴} {𝑵}
+    ; to∘from    = normalOf∘congruenceOf
+    ; from∘to    = congruenceOf∘normalOf
+    }
+```
+
+The reverse isomorphism presents the normal subgroups of `𝒢`{.AgdaBound} as the
+congruence poset of its underlying algebra — the form a representability argument wants.
+
+```agda
+  NormalCongruenceIso⁻¹ : (ℓ : Level) → Type (α ⊔ ρ ⊔ suc ℓ)
+  NormalCongruenceIso⁻¹ ℓ =
+    OrderIso (_≈ⁿ_ {ℓ}) (_≤ⁿ_ {ℓ}) (_≑_ {𝑨 = 𝑮} {ℓ = ℓ}) (_⊑_ {𝑨 = 𝑮} {ℓ = ℓ})
+
+  normal-congruence-iso⁻¹ : (ℓ : Level) → NormalCongruenceIso⁻¹ ℓ
+  normal-congruence-iso⁻¹ ℓ = record
+    { to         = congruenceOf
+    ; from       = normalOf
+    ; to-mono    = λ {𝑴} {𝑵} → congruenceOf-mono {ℓ} {𝑴} {𝑵}
+    ; from-mono  = λ {θ} {φ} → normalOf-mono {ℓ} {θ} {φ}
+    ; to∘from    = congruenceOf∘normalOf
+    ; from∘to    = normalOf∘congruenceOf
+    }
+```
+
+#### Nonzero congruences and nontrivial normal subgroups
+
+The order isomorphism alone does not say that the two sides agree on which elements are
+*above the bottom*; that has to be proved, and it is what the monolith transport will
+consume.  The bottom of the subgroup side is `trivialSubgroup`{.AgdaFunction} of
+[Classical.Structures.Group.Subgroups][] — the `≈`-class of the identity, which over a
+setoid carrier is the right notion of the one-element subgroup — and the bottom of the
+congruence side is the diagonal, whose "at the bottom" predicate is
+`BelowDiagonal`{.AgdaFunction} of [Setoid.Congruences.Monolith][].
+
+```agda
+  -- N is contained in the trivial subgroup { x ∣ x ≈ ε }.
+  BelowTrivial : Pred G ℓ → Type (α ⊔ ρ ⊔ ℓ)
+  BelowTrivial N = N ⊆ proj₁ (trivialSubgroup 𝒢)
+
+  -- N is nontrivial: it is not contained in the trivial subgroup.
+  Nontrivialᴺ : Pred G ℓ → Type (α ⊔ ρ ⊔ ℓ)
+  Nontrivialᴺ N = ¬ BelowTrivial N
+```
+
+The two positive statements are equivalent on each side, constructively and in both
+directions; `Nonzero`{.AgdaFunction} and `Nontrivialᴺ`{.AgdaFunction} are their
+negations, so the equivalence of the negations follows by contraposition with no
+classical input.  We state the four positive implications first, since a downstream
+proof usually wants one of them directly rather than the negated form.
+
+```agda
+  -- If N is trivial then θ_N relates only equal elements ...
+  below-trivial→below-diagonal : (𝑵 : NormalSubgroup ℓ)
+    →  BelowTrivial (set 𝑵) → BelowDiagonal 𝑮 (congruenceOf 𝑵)
+  below-trivial→below-diagonal 𝑵 N⊆1 p = ∙⁻¹≈ε→≈ (N⊆1 p)
+
+  -- ... and conversely, if θ_N relates only equal elements then N is trivial.
+  below-diagonal→below-trivial : (𝑵 : NormalSubgroup ℓ)
+    →  BelowDiagonal 𝑮 (congruenceOf 𝑵) → BelowTrivial (set 𝑵)
+  below-diagonal→below-trivial 𝑵 θ⊆Δ {x} x∈N = θ⊆Δ (respects (≈sym (∙ε⁻¹ x)) x∈N)
+    where open IsSubgroup (set-isSubgroup 𝑵) using ( respects )
+
+  -- If θ relates only equal elements then its identity class is trivial ...
+  con-below-diagonal→below-trivial : (θ : Con 𝑮 ℓ)
+    →  BelowDiagonal 𝑮 θ → BelowTrivial (set (normalOf θ))
+  con-below-diagonal→below-trivial θ θ⊆Δ x∈N = θ⊆Δ x∈N
+
+  -- ... and conversely, a trivial identity class forces θ below the diagonal.
+  con-below-trivial→below-diagonal : (θ : Con 𝑮 ℓ)
+    →  BelowTrivial (set (normalOf θ)) → BelowDiagonal 𝑮 θ
+  con-below-trivial→below-diagonal θ N⊆1 {x} {y} p =
+    ∙⁻¹≈ε→≈ (N⊆1 (≐-trans (≐-∙ p (≐-refl {y ⁻¹})) (≐-reflexive (invʳ-law y))))
+    where open ConNormal θ
+```
+
+Negating both sides gives the statement the monolith transport needs: under the
+correspondence, a congruence is nonzero exactly when the matching normal subgroup is
+nontrivial.
+
+```agda
+  -- θ_N is nonzero iff N is nontrivial.
+  nonzero→nontrivial : (𝑵 : NormalSubgroup ℓ)
+    →  Nonzero 𝑮 (congruenceOf 𝑵) → Nontrivialᴺ (set 𝑵)
+  nonzero→nontrivial 𝑵 nz N⊆1 = nz (below-trivial→below-diagonal 𝑵 N⊆1)
+
+  nontrivial→nonzero : (𝑵 : NormalSubgroup ℓ)
+    →  Nontrivialᴺ (set 𝑵) → Nonzero 𝑮 (congruenceOf 𝑵)
+  nontrivial→nonzero 𝑵 nt θ⊆Δ = nt (below-diagonal→below-trivial 𝑵 θ⊆Δ)
+
+  -- N_θ is nontrivial iff θ is nonzero.
+  con-nonzero→nontrivial : (θ : Con 𝑮 ℓ)
+    →  Nonzero 𝑮 θ → Nontrivialᴺ (set (normalOf θ))
+  con-nonzero→nontrivial θ nz N⊆1 = nz (con-below-trivial→below-diagonal θ N⊆1)
+
+  con-nontrivial→nonzero : (θ : Con 𝑮 ℓ)
+    →  Nontrivialᴺ (set (normalOf θ)) → Nonzero 𝑮 θ
+  con-nontrivial→nonzero θ nt θ⊆Δ = nt (con-below-diagonal→below-trivial θ θ⊆Δ)
+```

--- a/src/Classical/Structures/Group/Congruences.lagda.md
+++ b/src/Classical/Structures/Group/Congruences.lagda.md
@@ -500,7 +500,7 @@ those tuples.
 
     -- Hence conjugation by any element preserves the congruence.
     θ-conj : ∀ g {x y} → x θ y → x ^ g θ y ^ g
-    θ-conj g p = θ-∙ (θ-∙ θ-refl p) θ-refl
+    θ-conj g {x} {y} p = θ-∙ (θ-∙ (θ-refl {x = g}) p) (θ-refl {x = g ⁻¹})
 ```
 
 The class of the identity is an equality-respecting subgroup, and it is normal.

--- a/src/Classical/Structures/Group/Congruences.lagda.md
+++ b/src/Classical/Structures/Group/Congruences.lagda.md
@@ -11,8 +11,19 @@ author: "the agda-algebras development team"
 This is the [Classical.Structures.Group.Congruences][] module of the [Agda Universal Algebra Library][].
 
 The normal subgroups of a group `𝒢` correspond to the congruences of the underlying
-`Sig-Group`-algebra.  This module establishes this correpondence, as an order
-isomorphism of lattices `Con 𝑮 ℓ ≅ NormalSubgroup ℓ`.
+`Sig-Group`-algebra.  This module establishes that correspondence as an **order
+isomorphism of posets**, between the congruence poset `(Con 𝑮 ℓ , ≑ , ⊑)` of
+[Setoid.Congruences.Lattice][] and the poset `(NormalSubgroup ℓ , ≈ⁿ , ≤ⁿ)` of normal
+subgroups under inclusion, which is built here.
+
+Both sides carry more structure than a poset: at the absorbing level `L` the
+congruences form a complete lattice ([Setoid.Congruences.CompleteLattice][]).  The
+corresponding **isomorphism of complete lattices** is
+[Classical.Structures.Group.NormalSubgroupLattice][], which stands on the poset
+isomorphism proved here.  The split is deliberate: the correspondence below holds at
+*every* relation level, whereas a lattice needs the single absorbing level at which
+the join — a *generated* congruence — stays put, so bundling them would have narrowed
+the theorem to the level the lattice happens to need.
 
 The correspondence has two mutually inverse, order-preserving maps.
 
@@ -44,17 +55,19 @@ Four points about the formal statement deserve to be recorded up front, because 
 case the informal slogan "congruences are normal subgroups" conceals a choice that the
 mechanized version has to make.
 
-+  **The correspondence is level-uniform, not level-collapsing**.  It is an
-   isomorphism `Con 𝑮 ℓ ≅ NormalSubgroup ℓ`{.AgdaFunction} for each *fixed* relation
-   level `ℓ`{.AgdaBound}, since `NormalRel`{.AgdaFunction} of a `Pred G ℓ` is a
-   `BinaryRel G ℓ` and `IdentityClass`{.AgdaFunction} of a `Con 𝑮 ℓ` is a `Pred G ℓ`.
-   It says nothing about congruences at one level versus normal subgroups at another.
-   The instance the monolith needs is `ℓ = ρ`, where the congruence side is the `Con 𝑮 ρ`
-   of `IsMonolith`{.AgdaRecord} and the subgroup side contains
-   `trivialSubgroup`{.AgdaFunction}, itself a `Subgroup ρ`.  A consumer that wants to
-   compose with the subgroup *lattice* must instead take `ℓ = α ⊔ ℓ₀`, the predicate
-   level `L` at which `GroupSublattice 𝒢 ℓ₀`{.AgdaModule} of
-   [Classical.Structures.Group.SubgroupLattice][] holds its elements.
++  **The correspondence is level-uniform, not level-collapsing**.  It relates
+   `Con 𝑮 ℓ`{.AgdaFunction} to `NormalSubgroup ℓ`{.AgdaFunction} for each *fixed*
+   relation level `ℓ`{.AgdaBound}, since `NormalRel`{.AgdaFunction} of a `Pred G ℓ` is
+   a `BinaryRel G ℓ` and `IdentityClass`{.AgdaFunction} of a `Con 𝑮 ℓ` is a
+   `Pred G ℓ`.  It says nothing about congruences at one level versus normal subgroups
+   at another.  Three instances matter downstream: `ℓ = ρ`, where the congruence side
+   is the `Con 𝑮 ρ` of `IsMonolith`{.AgdaRecord} and the subgroup side contains
+   `trivialSubgroup`{.AgdaFunction}, itself a `Subgroup ρ`; `ℓ = α ⊔ ρ ⊔ ℓ₀`, the
+   absorbing level of the congruence lattice, which is where
+   [Classical.Structures.Group.NormalSubgroupLattice][] instantiates it; and
+   `ℓ = α ⊔ ℓ₀`, the predicate level `L` at which `GroupSublattice 𝒢 ℓ₀`{.AgdaModule}
+   of [Classical.Structures.Group.SubgroupLattice][] holds its elements, for a
+   consumer that wants to compose with the *subgroup* lattice.
 
 +  **Equality on each side is mutual containment, not propositional equality**.  On the
    congruence side this is `_≑_`{.AgdaFunction} of [Setoid.Congruences.Lattice][], for
@@ -108,10 +121,12 @@ open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
 open import Data.Fin.Patterns             using  ( 0F ; 1F )
-open import Data.Product                  using  ( _,_ ; _×_ ; Σ-syntax ; proj₁ )
+open import Data.Product                  using  ( _,_ ; _×_ ; Σ-syntax ; proj₁ ; swap )
 open import Level                         using  ( Level ; _⊔_ ; suc )
-open import Relation.Binary               using  ( Setoid ; IsEquivalence )
+open import Relation.Binary               using  ( Setoid ; IsEquivalence
+                                                 ; IsPartialOrder )
                                           renaming ( Rel to BinaryRel )
+open import Relation.Binary.Bundles       using  ( Poset )
 open import Relation.Binary.Definitions   using  ( _Respects_ )
 open import Relation.Nullary              using  ( ¬_ )
 open import Relation.Unary                using  ( Pred ; _∈_ ; _⊆_ )
@@ -162,7 +177,7 @@ module GroupCongruences {α ρ : Level} (𝒢 : Group α ρ) where
                                        ; idˡ-law ; idʳ-law ; invˡ-law ; invʳ-law )
   open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ  using  ( ε⁻¹≈ε ; ⁻¹-involutive ; ⁻¹-anti-homo-∙
                                        ; \\-leftDividesʳ )
-  open Conj 𝒢                   using  ( cong-syntax ; conj-ε ; IsNormal )
+  open Conj 𝒢                   using  ( conj ; conj-ε ; IsNormal )
 ```
 
 #### Four facts of group arithmetic
@@ -242,6 +257,58 @@ construction on either side.
   -- ... and the equivalence of mutual inclusion it is antisymmetric over.
   _≈ⁿ_ : NormalSubgroup ℓ → NormalSubgroup ℓ → Type (α ⊔ ℓ)
   𝑴 ≈ⁿ 𝑵 = 𝑴 ≤ⁿ 𝑵 × 𝑵 ≤ⁿ 𝑴
+```
+
+Calling the correspondence an *order* isomorphism presupposes that both sides really
+are ordered, so the partial-order laws are proved rather than assumed.  They are the
+laws of `_⊆_`{.AgdaFunction} on predicates, and antisymmetry holds by construction:
+`_≈ⁿ_`{.AgdaFunction} *is* mutual inclusion.  This mirrors
+`⊆-isPartialOrder`{.AgdaFunction} and `Con-Poset`{.AgdaFunction} on the congruence
+side, down to the same implicit-argument discipline — `_≤ⁿ_`{.AgdaFunction} is a
+defined relation, not an injective type former, so Agda cannot recover the endpoint
+arguments of the helper lemmas from the expected field types and they are forwarded by
+hand.
+
+```agda
+  ≤ⁿ-refl : {𝑵 : NormalSubgroup ℓ} → 𝑵 ≤ⁿ 𝑵
+  ≤ⁿ-refl p = p
+
+  ≤ⁿ-trans : {𝑳 𝑴 𝑵 : NormalSubgroup ℓ} → 𝑳 ≤ⁿ 𝑴 → 𝑴 ≤ⁿ 𝑵 → 𝑳 ≤ⁿ 𝑵
+  ≤ⁿ-trans 𝑳≤𝑴 𝑴≤𝑵 p = 𝑴≤𝑵 (𝑳≤𝑴 p)
+
+  ≈ⁿ-refl : {𝑵 : NormalSubgroup ℓ} → 𝑵 ≈ⁿ 𝑵
+  ≈ⁿ-refl = (λ p → p) , (λ p → p)
+
+  ≈ⁿ-sym : {𝑴 𝑵 : NormalSubgroup ℓ} → 𝑴 ≈ⁿ 𝑵 → 𝑵 ≈ⁿ 𝑴
+  ≈ⁿ-sym = swap
+
+  ≈ⁿ-trans : {𝑳 𝑴 𝑵 : NormalSubgroup ℓ} → 𝑳 ≈ⁿ 𝑴 → 𝑴 ≈ⁿ 𝑵 → 𝑳 ≈ⁿ 𝑵
+  ≈ⁿ-trans (𝑳≤𝑴 , 𝑴≤𝑳) (𝑴≤𝑵 , 𝑵≤𝑴) = (λ p → 𝑴≤𝑵 (𝑳≤𝑴 p)) , (λ p → 𝑴≤𝑳 (𝑵≤𝑴 p))
+
+  ≈ⁿ-isEquivalence : IsEquivalence (_≈ⁿ_ {ℓ})
+  ≈ⁿ-isEquivalence {ℓ} = record
+    { refl   = λ {𝑵} → ≈ⁿ-refl {ℓ} {𝑵}
+    ; sym    = λ {𝑴} {𝑵} → ≈ⁿ-sym {ℓ} {𝑴} {𝑵}
+    ; trans  = λ {𝑳} {𝑴} {𝑵} → ≈ⁿ-trans {ℓ} {𝑳} {𝑴} {𝑵}
+    }
+
+  ≤ⁿ-isPartialOrder : IsPartialOrder (_≈ⁿ_ {ℓ}) _≤ⁿ_
+  ≤ⁿ-isPartialOrder {ℓ} = record
+    { isPreorder = record  { isEquivalence  = ≈ⁿ-isEquivalence {ℓ}
+                           ; reflexive      = proj₁
+                           ; trans          = λ {𝑳} {𝑴} {𝑵} → ≤ⁿ-trans {ℓ} {𝑳} {𝑴} {𝑵}
+                           }
+    ; antisym = _,_
+    }
+
+  -- The poset of normal subgroups, the counterpart of `Con-Poset` of
+  -- [Setoid.Congruences.Lattice][].
+  NormalSubgroup-Poset : (ℓ : Level) → Poset (α ⊔ ρ ⊔ suc ℓ) (α ⊔ ℓ) (α ⊔ ℓ)
+  NormalSubgroup-Poset ℓ = record  { Carrier         = NormalSubgroup ℓ
+                                   ; _≈_             = _≈ⁿ_
+                                   ; _≤_             = _≤ⁿ_
+                                   ; isPartialOrder  = ≤ⁿ-isPartialOrder
+                                   }
 ```
 
 #### The relation attached to a subgroup
@@ -433,7 +500,7 @@ those tuples.
     θ-⁻¹ {x} {y} p = is-compatible θcon ⁻¹-Op {λ _ → x} {λ _ → y} (λ _ → p)
 
     -- Hence conjugation by any element preserves the congruence.
-    θ-conj : ∀ g {x y} → x θ y → x ^ g θ y ^ g
+    θ-conj : ∀ g {x y} → x θ y → conj g x θ conj g y
     θ-conj g p = θ-∙ (θ-∙ θ-refl p) θ-refl
 ```
 
@@ -502,7 +569,7 @@ congruence, its identity class is normal by
   congruence→normal : {ℓ : Level} (N : Pred G ℓ) → IsSubgroup 𝒢 N
     →  IsCongruence 𝑮 (NormalRel N) → IsNormal N
   congruence→normal N N-sg isCon g {x} x∈N =
-    respects  (∙ε⁻¹ (x ^ g))
+    respects  (∙ε⁻¹ (conj g x))
               (ConNormal.IdentityClass-normal (NormalRel N , isCon) g
                 (respects (≈sym (∙ε⁻¹ x)) x∈N))
     where open IsSubgroup N-sg using ( respects )

--- a/src/Classical/Structures/Group/Congruences.lagda.md
+++ b/src/Classical/Structures/Group/Congruences.lagda.md
@@ -139,7 +139,7 @@ open import Classical.Bundles.Group                 using  ( ⟨_⟩ᵍᵖ )
 open import Classical.Operations                    using  ( pair )
 open import Classical.Signatures.Group              using  ( ∙-Op ; ε-Op ; ⁻¹-Op )
 open import Classical.Structures.Group.Basic        using  ( Group ; module Group-Op )
-open import Classical.Structures.Group.Conjugation  using  ( module Conj )
+open import Classical.Structures.Group.Conjugation  using  ( module Conjugate )
 open import Classical.Structures.Group.Cosets       using  ( module Coset )
 open import Classical.Structures.Group.Subgroups    using  ( IsSubgroup ; mkIsSubgroup
                                                            ; trivialSubgroup
@@ -177,7 +177,7 @@ module GroupCongruences {α ρ : Level} (𝒢 : Group α ρ) where
                                        ; idˡ-law ; idʳ-law ; invˡ-law ; invʳ-law )
   open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ  using  ( ε⁻¹≈ε ; ⁻¹-involutive ; ⁻¹-anti-homo-∙
                                        ; \\-leftDividesʳ )
-  open Conj 𝒢                   using  ( conj ; conj-ε ; IsNormal )
+  open Conjugate 𝒢                   using  ( conj-syntax ; conj-ε ; IsNormal )
 ```
 
 #### Four facts of group arithmetic
@@ -492,15 +492,14 @@ those tuples.
 
     -- Compatibility with the curried multiplication ...
     θ-∙ : ∀ {x y u v} → x θ y → u θ v → (x ∙ u) θ (y ∙ v)
-    θ-∙ {x} {y} {u} {v} p q =
-      is-compatible θcon ∙-Op {pair x u} {pair y v} (λ { 0F → p ; 1F → q })
+    θ-∙ {x} {y} {u} {v} p q = is-compatible θcon ∙-Op λ { 0F → p ; 1F → q }
 
     -- ... and with the curried inverse.
     θ-⁻¹ : ∀ {x y} → x θ y → (x ⁻¹) θ (y ⁻¹)
-    θ-⁻¹ {x} {y} p = is-compatible θcon ⁻¹-Op {λ _ → x} {λ _ → y} (λ _ → p)
+    θ-⁻¹ p = is-compatible θcon ⁻¹-Op (λ _ → p)
 
     -- Hence conjugation by any element preserves the congruence.
-    θ-conj : ∀ g {x y} → x θ y → conj g x θ conj g y
+    θ-conj : ∀ g {x y} → x θ y → x ^ g θ y ^ g
     θ-conj g p = θ-∙ (θ-∙ θ-refl p) θ-refl
 ```
 
@@ -569,7 +568,7 @@ congruence, its identity class is normal by
   congruence→normal : {ℓ : Level} (N : Pred G ℓ) → IsSubgroup 𝒢 N
     →  IsCongruence 𝑮 (NormalRel N) → IsNormal N
   congruence→normal N N-sg isCon g {x} x∈N =
-    respects  (∙ε⁻¹ (conj g x))
+    respects  (∙ε⁻¹ (x ^ g))
               (ConNormal.IdentityClass-normal (NormalRel N , isCon) g
                 (respects (≈sym (∙ε⁻¹ x)) x∈N))
     where open IsSubgroup N-sg using ( respects )
@@ -582,12 +581,12 @@ monotonicity is immediate in each direction.
 
 ```agda
   -- The congruence-to-subgroup map is monotone.
-  normalOf-mono : {θ φ : Con 𝑮 ℓ} → θ ⊑ φ → normalOf θ ≤ⁿ normalOf φ
-  normalOf-mono θ⊑φ p = θ⊑φ p
+  normalOf-mono : (θ φ : Con 𝑮 ℓ) → θ ⊑ φ → normalOf θ ≤ⁿ normalOf φ
+  normalOf-mono _ _ θ⊑φ p = θ⊑φ p
 
   -- The subgroup-to-congruence map is monotone.
-  congruenceOf-mono : {𝑴 𝑵 : NormalSubgroup ℓ} → 𝑴 ≤ⁿ 𝑵 → congruenceOf 𝑴 ⊑ congruenceOf 𝑵
-  congruenceOf-mono 𝑴≤𝑵 p = 𝑴≤𝑵 p
+  congruenceOf-mono : (𝑴 𝑵 : NormalSubgroup ℓ) → 𝑴 ≤ⁿ 𝑵 → congruenceOf 𝑴 ⊑ congruenceOf 𝑵
+  congruenceOf-mono _ _ 𝑴≤𝑵 p = 𝑴≤𝑵 p
 ```
 
 `OrderIso`{.AgdaRecord} asks only for monotonicity, not for the maps to be well defined
@@ -598,14 +597,14 @@ monotonicity twice suffices.
 
 ```agda
   -- Both maps respect the equivalences of the two sides.
-  normalOf-cong : {θ φ : Con 𝑮 ℓ} → θ ≑ φ → normalOf θ ≈ⁿ normalOf φ
-  normalOf-cong {ℓ} {θ} {φ} (θ⊑φ , φ⊑θ) =
-    normalOf-mono {ℓ} {θ} {φ} θ⊑φ , normalOf-mono {ℓ} {φ} {θ} φ⊑θ
+  normalOf-cong : (θ φ : Con 𝑮 ℓ) → θ ≑ φ → normalOf θ ≈ⁿ normalOf φ
+  normalOf-cong  θ φ (θ⊑φ , φ⊑θ) =
+    normalOf-mono θ φ θ⊑φ , normalOf-mono φ θ φ⊑θ
 
-  congruenceOf-cong : {𝑴 𝑵 : NormalSubgroup ℓ}
+  congruenceOf-cong : (𝑴 𝑵 : NormalSubgroup ℓ)
     →  𝑴 ≈ⁿ 𝑵 → congruenceOf 𝑴 ≑ congruenceOf 𝑵
-  congruenceOf-cong {ℓ} {𝑴} {𝑵} (𝑴≤𝑵 , 𝑵≤𝑴) =
-    congruenceOf-mono {ℓ} {𝑴} {𝑵} 𝑴≤𝑵 , congruenceOf-mono {ℓ} {𝑵} {𝑴} 𝑵≤𝑴
+  congruenceOf-cong 𝑴 𝑵 (𝑴≤𝑵 , 𝑵≤𝑴) =
+    congruenceOf-mono 𝑴 𝑵 𝑴≤𝑵 , congruenceOf-mono 𝑵 𝑴 𝑵≤𝑴
 ```
 
 #### Mutual inverseness
@@ -673,8 +672,8 @@ Agda cannot recover them from the field types.)
   normal-congruence-iso ℓ = record
     { to         = normalOf
     ; from       = congruenceOf
-    ; to-mono    = λ {θ} {φ} → normalOf-mono {ℓ} {θ} {φ}
-    ; from-mono  = λ {𝑴} {𝑵} → congruenceOf-mono {ℓ} {𝑴} {𝑵}
+    ; to-mono    = λ {θ} {φ} → normalOf-mono θ φ
+    ; from-mono  = λ {𝑴} {𝑵} → congruenceOf-mono 𝑴 𝑵
     ; to∘from    = normalOf∘congruenceOf
     ; from∘to    = congruenceOf∘normalOf
     }
@@ -692,8 +691,8 @@ congruence poset of its underlying algebra — the form a representability argum
   normal-congruence-iso⁻¹ ℓ = record
     { to         = congruenceOf
     ; from       = normalOf
-    ; to-mono    = λ {𝑴} {𝑵} → congruenceOf-mono {ℓ} {𝑴} {𝑵}
-    ; from-mono  = λ {θ} {φ} → normalOf-mono {ℓ} {θ} {φ}
+    ; to-mono    = λ {𝑴} {𝑵} → congruenceOf-mono 𝑴 𝑵
+    ; from-mono  = λ {θ} {φ} → normalOf-mono θ φ
     ; to∘from    = congruenceOf∘normalOf
     ; from∘to    = normalOf∘congruenceOf
     }

--- a/src/Classical/Structures/Group/Congruences.lagda.md
+++ b/src/Classical/Structures/Group/Congruences.lagda.md
@@ -10,34 +10,32 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Group.Congruences][] module of the [Agda Universal Algebra Library][].
 
-For a group `𝒢`{.AgdaBound}, the congruences of the underlying `Sig-Group`-algebra and
-the normal subgroups of `𝒢`{.AgdaBound} are the same thing.  This module proves it, as
-an order isomorphism `Con 𝑮 ℓ ≅ NormalSubgroup ℓ`{.AgdaFunction}, and identifies the
-congruence-side notion of a **nonzero** congruence with the subgroup-side notion of a
-**nontrivial** normal subgroup.
+The normal subgroups of a group `𝒢` correspond to the congruences of the underlying
+`Sig-Group`-algebra.  This module establishes this correpondence, as an order
+isomorphism of lattices `Con 𝑮 ℓ ≅ NormalSubgroup ℓ`.
 
 The correspondence has two mutually inverse, order-preserving maps.
 
-+  **`N ↦ θ_N`** (`congruenceOf`{.AgdaFunction}).  A normal subgroup `N`{.AgdaBound}
-   maps to the relation `NormalRel N`{.AgdaFunction}, defined by
-   `x θ_N y ⟺ x ∙ y ⁻¹ ∈ N`.  We prove it is an equivalence containing the setoid
-   equality — for that, `N`{.AgdaBound} being an equality-respecting subgroup is
-   enough — and that it is compatible with the three operations of
-   `Sig-Group`{.AgdaFunction}, which is where normality is consumed.
++  **`N ↦ θ_N`** (`congruenceOf`{.AgdaFunction}).  A normal subgroup `N` maps to the
+   relation `NormalRel`{.AgdaFunction}` N`, defined by `x θ_N y ⟺ x ∙ y ⁻¹ ∈ N`.
+   We prove that this is an equivalence containing the setoid equality (for which
+   `N`{.AgdaBound} being an equality-respecting subgroup is enough) and
+   compatible with the three operations of `Sig-Group`{.AgdaFunction}, which is where
+   normality is consumed.
 
 +  **`θ ↦ N_θ`** (`normalOf`{.AgdaFunction}).  A congruence `θ`{.AgdaBound} maps to
-   the `θ`-class of the identity — `IdentityClass`{.AgdaFunction} `θ`{.AgdaBound}, the
-   predicate `{ x ∣ x θ ε }`.  We prove it is an equality-respecting subgroup and that
-   it is normal.
+   the `θ`-class of the identity; we define the latter as
+   `IdentityClass`{.AgdaFunction} `θ`{.AgdaBound}, which represents the predicate
+   `{ x ∣ x θ ε }`.  We prove it is a normal, equality-respecting subgroup.
 
 The two maps are monotone and mutually inverse — up to `≑`{.AgdaFunction} on
 congruences and mutual inclusion on normal subgroups — so together they are an
 `OrderIso`{.AgdaRecord} of [Order.Iso][].
 
 This is the bridge that `Classical.Structures.Group.MinimalNormal` was written
-without: it lets the library's `IsSubdirectlyIrreducible`{.AgdaFunction} of
-[Setoid.Congruences.Monolith][] — a statement about `Con 𝑨`{.AgdaFunction} — be applied
-to a group, whose subdirect irreducibility the group theorist states as "there is a
+without: it lets us apply the library's `IsSubdirectlyIrreducible`{.AgdaFunction} of
+[Setoid.Congruences.Monolith][] — a statement about `Con 𝑨`{.AgdaFunction} — to a
+group, whose subdirect irreducibility the group theorist states as "there is a
 least nontrivial normal subgroup".  The final step of that identification,
 `HasMonolithᵍ → HasMonolith`, is deliberately *not* taken here; see **What this module
 does not do** below.
@@ -83,7 +81,7 @@ mechanized version has to make.
    proved, so that "the correspondence is with the *normal* subgroups" is a theorem of
    the module and not a claim its prose makes on the development's behalf.
 
-**On the choice of relation.**  `x ∙ y ⁻¹ ∈ N` is the *right*-coset relation of
+**On the choice of relation**.  `x ∙ y ⁻¹ ∈ N` is the *right*-coset relation of
 `N`{.AgdaBound}, whereas `Coset._∼_`{.AgdaFunction} of
 [Classical.Structures.Group.Cosets][] — the relation [FLRP.Bridge][] uses — is the
 *left*-coset relation `x ⁻¹ ∙ y ∈ N`.  For a general subgroup the two need not agree;
@@ -91,7 +89,7 @@ for a normal subgroup they do, which we prove (`rel→coset`{.AgdaFunction},
 `coset→rel`{.AgdaFunction}) rather than assume, so that either presentation may be used
 downstream.
 
-**What this module does not do.**  Issue #508 also asks that
+**What this module does not do**.  Issue #508 also asks that
 `HasMonolithᵍ`{.AgdaFunction} of `Classical.Structures.Group.MinimalNormal` be
 transported to `HasMonolith`{.AgdaFunction}, that the `ᵍ` superscript be retired, and
 that `𝒢₂` of `FLRP.Reductions` be restated.  Those steps are held back until the pull
@@ -110,8 +108,7 @@ open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
 open import Data.Fin.Patterns             using  ( 0F ; 1F )
-open import Data.Product                  using  ( _,_ ; _×_ ; Σ-syntax
-                                                 ; proj₁ ; proj₂ )
+open import Data.Product                  using  ( _,_ ; _×_ ; Σ-syntax ; proj₁ )
 open import Level                         using  ( Level ; _⊔_ ; suc )
 open import Relation.Binary               using  ( Setoid ; IsEquivalence )
                                           renaming ( Rel to BinaryRel )
@@ -165,7 +162,7 @@ module GroupCongruences {α ρ : Level} (𝒢 : Group α ρ) where
                                        ; idˡ-law ; idʳ-law ; invˡ-law ; invʳ-law )
   open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ  using  ( ε⁻¹≈ε ; ⁻¹-involutive ; ⁻¹-anti-homo-∙
                                        ; \\-leftDividesʳ )
-  open Conj 𝒢                   using  ( conj ; conj-ε ; IsNormal )
+  open Conj 𝒢                   using  ( cong-syntax ; conj-ε ; IsNormal )
 ```
 
 #### Four facts of group arithmetic
@@ -227,14 +224,14 @@ construction on either side.
 
   -- The underlying predicate of a normal subgroup ...
   set : NormalSubgroup ℓ → Pred G ℓ
-  set = proj₁
+  set (N , _ , _) = N
 
   -- ... and its two proof components.
   set-isSubgroup : (𝑵 : NormalSubgroup ℓ) → IsSubgroup 𝒢 (set 𝑵)
-  set-isSubgroup 𝑵 = proj₁ (proj₂ 𝑵)
+  set-isSubgroup (_ , isSubgroup , _) = isSubgroup
 
   set-normal : (𝑵 : NormalSubgroup ℓ) → IsNormal (set 𝑵)
-  set-normal 𝑵 = proj₂ (proj₂ 𝑵)
+  set-normal (_ , _ , isNormal) = isNormal
 
   infix 4 _≤ⁿ_ _≈ⁿ_
 
@@ -414,35 +411,30 @@ tuples, with no interpretation bridge needed — the curried accessors of
 those tuples.
 
 ```agda
-  module ConNormal {ℓ : Level} (θ : Con 𝑮 ℓ) where
+  module ConNormal {ℓ : Level} ((_θ_ , θcon) : Con 𝑮 ℓ) where
 
-    infix 4 _≐_
+    θ-refl : ∀ {x} → x θ x
+    θ-refl = IsEquivalence.refl (is-equivalence θcon)
 
-    _≐_ : BinaryRel G ℓ
-    _≐_ = proj₁ θ
-
-    ≐-refl : ∀ {x} → x ≐ x
-    ≐-refl = IsEquivalence.refl (is-equivalence (proj₂ θ))
-
-    ≐-trans : ∀ {x y z} → x ≐ y → y ≐ z → x ≐ z
-    ≐-trans = IsEquivalence.trans (is-equivalence (proj₂ θ))
+    θ-trans : ∀ {x y z} → x θ y → y θ z → x θ z
+    θ-trans = IsEquivalence.trans (is-equivalence θcon)
 
     -- A congruence relates ≈-equal elements.
-    ≐-reflexive : ∀ {x y} → x ≈ y → x ≐ y
-    ≐-reflexive = reflexive (proj₂ θ)
+    θ-reflexive : ∀ {x y} → x ≈ y → x θ y
+    θ-reflexive = reflexive θcon
 
     -- Compatibility with the curried multiplication ...
-    ≐-∙ : ∀ {x y u v} → x ≐ y → u ≐ v → (x ∙ u) ≐ (y ∙ v)
-    ≐-∙ {x} {y} {u} {v} p q =
-      is-compatible (proj₂ θ) ∙-Op {pair x u} {pair y v} (λ { 0F → p ; 1F → q })
+    θ-∙ : ∀ {x y u v} → x θ y → u θ v → (x ∙ u) θ (y ∙ v)
+    θ-∙ {x} {y} {u} {v} p q =
+      is-compatible θcon ∙-Op {pair x u} {pair y v} (λ { 0F → p ; 1F → q })
 
     -- ... and with the curried inverse.
-    ≐-⁻¹ : ∀ {x y} → x ≐ y → x ⁻¹ ≐ y ⁻¹
-    ≐-⁻¹ {x} {y} p = is-compatible (proj₂ θ) ⁻¹-Op {λ _ → x} {λ _ → y} (λ _ → p)
+    θ-⁻¹ : ∀ {x y} → x θ y → (x ⁻¹) θ (y ⁻¹)
+    θ-⁻¹ {x} {y} p = is-compatible θcon ⁻¹-Op {λ _ → x} {λ _ → y} (λ _ → p)
 
     -- Hence conjugation by any element preserves the congruence.
-    ≐-conj : ∀ g {x y} → x ≐ y → conj g x ≐ conj g y
-    ≐-conj g p = ≐-∙ (≐-∙ ≐-refl p) ≐-refl
+    θ-conj : ∀ g {x y} → x θ y → x ^ g θ y ^ g
+    θ-conj g p = θ-∙ (θ-∙ θ-refl p) θ-refl
 ```
 
 The class of the identity is an equality-respecting subgroup, and it is normal.
@@ -453,21 +445,21 @@ compatibility fact followed by a `≈`-step that renormalizes the right-hand sid
 ```agda
     -- The θ-class of the identity.
     IdentityClass : Pred G ℓ
-    IdentityClass x = x ≐ ε
+    IdentityClass x = x θ ε
 
     -- It respects the setoid equality, because a congruence contains it.
     IdentityClass-respects : IdentityClass Respects _≈_
-    IdentityClass-respects x≈y p = ≐-trans (≐-reflexive (≈sym x≈y)) p
+    IdentityClass-respects x≈y p = θ-trans (θ-reflexive (≈sym x≈y)) p
 
     IdentityClass-ε : ε ∈ IdentityClass
-    IdentityClass-ε = ≐-refl
+    IdentityClass-ε = θ-refl
 
     IdentityClass-∙ : ∀ {x y} → x ∈ IdentityClass → y ∈ IdentityClass
       → x ∙ y ∈ IdentityClass
-    IdentityClass-∙ p q = ≐-trans (≐-∙ p q) (≐-reflexive (idˡ-law ε))
+    IdentityClass-∙ p q = θ-trans (θ-∙ p q) (θ-reflexive (idˡ-law ε))
 
     IdentityClass-⁻¹ : ∀ {x} → x ∈ IdentityClass → x ⁻¹ ∈ IdentityClass
-    IdentityClass-⁻¹ p = ≐-trans (≐-⁻¹ p) (≐-reflexive ε⁻¹≈ε)
+    IdentityClass-⁻¹ p = θ-trans (θ-⁻¹ p) (θ-reflexive ε⁻¹≈ε)
 
     -- The identity class is an equality-respecting subgroup ...
     IdentityClass-isSubgroup : IsSubgroup 𝒢 IdentityClass
@@ -476,7 +468,7 @@ compatibility fact followed by a `≈`-step that renormalizes the right-hand sid
 
     -- ... and it is normal, since conjugation fixes the identity.
     IdentityClass-normal : IsNormal IdentityClass
-    IdentityClass-normal g p = ≐-trans (≐-conj g p) (≐-reflexive (conj-ε g))
+    IdentityClass-normal g p = θ-trans (θ-conj g p) (θ-reflexive (conj-ε g))
 ```
 
 The backward map of the correspondence packages the class with its two proofs.
@@ -510,7 +502,7 @@ congruence, its identity class is normal by
   congruence→normal : {ℓ : Level} (N : Pred G ℓ) → IsSubgroup 𝒢 N
     →  IsCongruence 𝑮 (NormalRel N) → IsNormal N
   congruence→normal N N-sg isCon g {x} x∈N =
-    respects  (∙ε⁻¹ (conj g x))
+    respects  (∙ε⁻¹ (x ^ g))
               (ConNormal.IdentityClass-normal (NormalRel N , isCon) g
                 (respects (≈sym (∙ε⁻¹ x)) x∈N))
     where open IsSubgroup N-sg using ( respects )
@@ -565,12 +557,12 @@ the right by `y ⁻¹` converts it back through `invʳ-law`{.AgdaFunction}.
 
     -- From (x ∙ y ⁻¹) θ ε derive x θ y.
     fwd : congruenceOf (normalOf θ) ⊑ θ
-    fwd {x} {y} p = ≐-trans  (≐-reflexive (≈sym (∙⁻¹∙ x y)))
-                             (≐-trans (≐-∙ p ≐-refl) (≐-reflexive (idˡ-law y)))
+    fwd {x} {y} p = θ-trans  (θ-reflexive (≈sym (∙⁻¹∙ x y)))
+                             (θ-trans (θ-∙ p θ-refl) (θ-reflexive (idˡ-law y)))
 
     -- From x θ y derive (x ∙ y ⁻¹) θ ε.
     bwd : θ ⊑ congruenceOf (normalOf θ)
-    bwd {x} {y} p = ≐-trans (≐-∙ p (≐-refl {y ⁻¹})) (≐-reflexive (invʳ-law y))
+    bwd {x} {y} p = θ-trans (θ-∙ p (θ-refl {y ⁻¹})) (θ-reflexive (invʳ-law y))
 ```
 
 On normal subgroups, `N_{θ_N} ≈ⁿ N`: an element `x`{.AgdaBound} lies in `N_{θ_N}` when
@@ -687,7 +679,7 @@ proof usually wants one of them directly rather than the negated form.
   con-below-trivial→below-diagonal : (θ : Con 𝑮 ℓ)
     →  BelowTrivial (set (normalOf θ)) → BelowDiagonal 𝑮 θ
   con-below-trivial→below-diagonal θ N⊆1 {x} {y} p =
-    ∙⁻¹≈ε→≈ (N⊆1 (≐-trans (≐-∙ p (≐-refl {y ⁻¹})) (≐-reflexive (invʳ-law y))))
+    ∙⁻¹≈ε→≈ (N⊆1 (θ-trans (θ-∙ p (θ-refl {y ⁻¹})) (θ-reflexive (invʳ-law y))))
     where open ConNormal θ
 ```
 

--- a/src/Classical/Structures/Group/Conjugation.lagda.md
+++ b/src/Classical/Structures/Group/Conjugation.lagda.md
@@ -98,12 +98,12 @@ module Conjugate {α ρ : Level} (𝒢 : Group α ρ) where
   conj : G → G → G
   conj g x = g ∙ x ∙ g ⁻¹
 
-  infixl 30 cong-syntax
+  infixl 30 conj-syntax
 
-  cong-syntax : G → G → G
-  cong-syntax = conj
+  conj-syntax : G → G → G
+  conj-syntax = conj
 
-  syntax cong-syntax g x = x ^ g
+  syntax conj-syntax g x = x ^ g
 
   -- Conjugation is a congruence in the conjugated element ...
   conj-cong : ∀ g {x y} → x ≈ y → x ^ g ≈ y ^ g

--- a/src/Classical/Structures/Group/NormalSubgroupLattice.lagda.md
+++ b/src/Classical/Structures/Group/NormalSubgroupLattice.lagda.md
@@ -1,0 +1,476 @@
+---
+layout: default
+file: "src/Classical/Structures/Group/NormalSubgroupLattice.lagda.md"
+title: "Classical.Structures.Group.NormalSubgroupLattice module"
+date: "2026-07-27"
+author: "the agda-algebras development team"
+---
+
+### The lattice of normal subgroups
+
+This is the [Classical.Structures.Group.NormalSubgroupLattice][] module of the [Agda Universal Algebra Library][].
+
+[Classical.Structures.Group.Congruences][] proves that the congruences of a group and
+its normal subgroups correspond, as an order isomorphism of *posets*.  This module
+upgrades both sides to lattices and states the isomorphism at that level: the normal
+subgroups of `𝒢`{.AgdaBound} *at the absorbing level `L`* form a bounded, complete
+lattice, and it is order isomorphic to the congruence lattice
+`Con-CompleteLattice`{.AgdaFunction} of [Setoid.Congruences.CompleteLattice][].  The
+level restriction is not a technicality to be read past; the next section says where it
+comes from and why it cannot be dropped.
+
+It stands to [Classical.Structures.Group.Congruences][] exactly as
+[Classical.Structures.Group.SubgroupLattice][] stands to
+[Classical.Structures.Group.Subgroups][]: the predicate and its theory in one module,
+the lattice they generate in the next.
+
+#### Why this is a separate module, and where the levels come from
+
+The correspondence of [Classical.Structures.Group.Congruences][] holds at *every*
+relation level `ℓ`{.AgdaBound}.  A lattice cannot: its join is a **generated**
+congruence, and `Cg`{.AgdaFunction} of [Setoid.Congruences.Generation][] raises the
+relation level by `𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ`.  So the join is an operation only at the *absorbing*
+level
+
+    L = 𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ ⊔ ℓ₀   —   for `Sig-Group`, where `𝓞 = 𝓥 = 0ℓ`, just `α ⊔ ρ ⊔ ℓ₀`
+
+at which level join is idempotent, which is precisely the level
+[Setoid.Congruences.CompleteLattice][] fixes.  Keeping the two modules apart therefore
+keeps the correspondence at its full generality instead of narrowing it to the one
+level the lattice happens to need.
+
+#### What is proved, and how much of it is transported
+
+Only the **joins** are obtained through the correspondence.  Everything else is built
+directly on the subgroup side, where it has its familiar description:
+
++  the binary meet `_∩ⁿ_`{.AgdaFunction} and the infinitary meet `⋂ⁿ`{.AgdaFunction}
+   are **intersections** of the underlying predicates — a normal subgroup, because
+   each closure property holds componentwise;
++  the bottom `𝟘ⁿ`{.AgdaFunction} is the `≈`-class of the identity, i.e.
+   `trivialSubgroup`{.AgdaFunction} of [Classical.Structures.Group.Subgroups][] at
+   level `L`{.AgdaFunction} (`𝟘ⁿ-trivial`{.AgdaFunction},
+   `trivial-𝟘ⁿ`{.AgdaFunction}), and the top `𝟙ⁿ`{.AgdaFunction} is the whole carrier;
++  the binary join `_∨ⁿ_`{.AgdaFunction} and the infinitary join
+   `⋁ⁿ`{.AgdaFunction} are **defined** as the image under
+   `normalOf`{.AgdaFunction} of the corresponding congruence join, their universal
+   properties following from the correspondence's monotonicity and round trips.
+
+That asymmetry is honest rather than incidental, and it is worth stating plainly: a
+join of normal subgroups is *not* the union, so there is nothing on the subgroup side
+to define it as without either a generation principle for normal subgroups or the
+complex product.  The library has neither in the form this would need, so the
+correspondence supplies it.  **Caveat**: consequently `𝑴 ∨ⁿ 𝑵`{.AgdaFunction} is
+characterized here only by its universal property (least normal subgroup above both);
+identifying it with the complex product `MN` of
+[Classical.Structures.Group.Complexes][] is left to future work.
+
+The maps are then shown to **preserve the lattice operations**, which is what
+distinguishes an isomorphism of lattices from an isomorphism of the underlying posets:
+`normalOf-∧`{.AgdaFunction}, `normalOf-⋀`{.AgdaFunction} (both hold *definitionally* —
+the identity class of an intersection of congruences is the intersection of the
+identity classes), and `normalOf-∨`{.AgdaFunction}, `normalOf-⋁`{.AgdaFunction}.  None
+of these is logically necessary — the operations are determined by the order, as
+greatest lower and least upper bounds, so any order isomorphism carries them across —
+but stating them turns that argument into checked mathematics.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Group.NormalSubgroupLattice where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Product                  using  ( _,_ ; _×_ ; proj₁ ; proj₂ )
+open import Data.Unit.Base                using  ( ⊤ ; tt )
+open import Level                         using  ( Level ; _⊔_ ; suc ; lift ; lower )
+open import Relation.Binary               using  ( Setoid )
+open import Relation.Binary.Definitions   using  ( Maximum ; Minimum )
+open import Relation.Binary.Lattice       using  ( Infimum ; Supremum ; IsLattice ; Lattice
+                                                 ; IsBoundedLattice ; BoundedLattice )
+open import Relation.Unary                using  ( Pred ; _∈_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Structures.Group.Basic        using  ( Group )
+open import Classical.Structures.Group.Congruences  using  ( module GroupCongruences )
+open import Classical.Structures.Group.Conjugation  using  ( module Conj )
+open import Classical.Structures.Group.Subgroups    using  ( IsSubgroup ; mkIsSubgroup
+                                                           ; trivialSubgroup )
+open import Order.CompleteLattice                   using  ( CompleteLattice )
+open import Order.Iso                               using  ( OrderIso )
+open import Setoid.Algebras.Basic                   using  ( 𝕌[_] ; 𝔻[_] )
+open import Setoid.Congruences.Basic                using  ( Con ; 𝟘[_] ; 𝟙[_] )
+open import Setoid.Congruences.CompleteLattice      using  ( Con-CompleteLattice
+                                                           ; ⋀ ; ⋁ ; ⋁-upper ; ⋁-least )
+open import Setoid.Congruences.Generation           using  ( _∨_ ; ∨-upperˡ ; ∨-upperʳ
+                                                           ; ∨-least )
+open import Setoid.Congruences.Lattice              using  ( _∧_ ; _≑_ )
+                                                    renaming ( _⊆_ to _⊑_ )
+```
+-->
+
+#### The ambient group and the absorbing level
+
+```agda
+module NormalSubgroupLattice {α ρ : Level} (𝒢 : Group α ρ) (ℓ₀ : Level) where
+  private
+    𝑮 = proj₁ 𝒢
+    G = 𝕌[ 𝑮 ]
+
+  open Setoid 𝔻[ 𝑮 ]  using ( _≈_ ) renaming ( sym to ≈sym )
+  open Conj 𝒢         using ( IsNormal )
+  open GroupCongruences 𝒢
+
+  -- The absorbing level of the congruence lattice of the group algebra; the two
+  -- signature levels of `Sig-Group` are zero, so this is the `L` of
+  -- [Setoid.Congruences.CompleteLattice] on the nose.
+  L : Level
+  L = α ⊔ ρ ⊔ ℓ₀
+
+  -- The carrier: normal subgroups whose predicates live at the absorbing level.
+  Nrmᴸ : Type (α ⊔ ρ ⊔ suc L)
+  Nrmᴸ = NormalSubgroup L
+```
+
+#### Meets are intersections
+
+The intersection of two normal subgroups is a normal subgroup: every closure property
+of `IsSubgroup`{.AgdaRecord}, and normality itself, holds componentwise.  It is the
+greatest lower bound because inclusion of predicates is, pointwise, conjunction of
+membership.
+
+```agda
+  infixr 7 _∩ⁿ_
+
+  -- The binary meet: the intersection of the underlying predicates.
+  _∩ⁿ_ : Nrmᴸ → Nrmᴸ → Nrmᴸ
+  𝑴 ∩ⁿ 𝑵 = P , P-isSubgroup , P-normal
+    where
+    P : Pred G L
+    P x = x ∈ set 𝑴 × x ∈ set 𝑵
+
+    open IsSubgroup (set-isSubgroup 𝑴)  using ()
+      renaming ( respects to Mresp ; ∙-closed to M∙ ; ε-closed to Mε ; ⁻¹-closed to M⁻¹ )
+    open IsSubgroup (set-isSubgroup 𝑵)  using ()
+      renaming ( respects to Nresp ; ∙-closed to N∙ ; ε-closed to Nε ; ⁻¹-closed to N⁻¹ )
+
+    P-isSubgroup : IsSubgroup 𝒢 P
+    P-isSubgroup = mkIsSubgroup 𝒢  (λ x≈y p → Mresp x≈y (proj₁ p) , Nresp x≈y (proj₂ p))
+                                   (λ p q → M∙ (proj₁ p) (proj₁ q) , N∙ (proj₂ p) (proj₂ q))
+                                   (Mε , Nε)
+                                   (λ p → M⁻¹ (proj₁ p) , N⁻¹ (proj₂ p))
+
+    P-normal : IsNormal P
+    P-normal g p = set-normal 𝑴 g (proj₁ p) , set-normal 𝑵 g (proj₂ p)
+
+  ∩ⁿ-infimum : Infimum (_≤ⁿ_ {L}) _∩ⁿ_
+  ∩ⁿ-infimum 𝑴 𝑵 = proj₁ , proj₂ , λ 𝑷 𝑷≤𝑴 𝑷≤𝑵 p → 𝑷≤𝑴 p , 𝑷≤𝑵 p
+```
+
+The same argument, indexwise, gives the infinitary meet.  It stays at level
+`L`{.AgdaFunction} because the index type is `ℓ₀`-small and `ℓ₀ ⊑ L`.
+
+```agda
+  -- The infinitary meet: the intersection of an ℓ₀-indexed family.
+  ⋂ⁿ : {I : Type ℓ₀} → (I → Nrmᴸ) → Nrmᴸ
+  ⋂ⁿ {I} 𝒩 = P , P-isSubgroup , P-normal
+    where
+    P : Pred G L
+    P x = (i : I) → x ∈ set (𝒩 i)
+
+    P-isSubgroup : IsSubgroup 𝒢 P
+    P-isSubgroup = mkIsSubgroup 𝒢
+      (λ x≈y p i  → IsSubgroup.respects   (set-isSubgroup (𝒩 i)) x≈y (p i))
+      (λ p q i    → IsSubgroup.∙-closed   (set-isSubgroup (𝒩 i)) (p i) (q i))
+      (λ i        → IsSubgroup.ε-closed   (set-isSubgroup (𝒩 i)))
+      (λ p i      → IsSubgroup.⁻¹-closed  (set-isSubgroup (𝒩 i)) (p i))
+
+    P-normal : IsNormal P
+    P-normal g p i = set-normal (𝒩 i) g (p i)
+
+  ⋂ⁿ-lower : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (i : I) → ⋂ⁿ 𝒩 ≤ⁿ 𝒩 i
+  ⋂ⁿ-lower 𝒩 i p = p i
+
+  ⋂ⁿ-greatest : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (𝑷 : Nrmᴸ)
+    →  (∀ i → 𝑷 ≤ⁿ 𝒩 i) → 𝑷 ≤ⁿ ⋂ⁿ 𝒩
+  ⋂ⁿ-greatest 𝒩 𝑷 h p i = h i p
+```
+
+#### The bounds
+
+The bottom and top are the images of the diagonal and total congruences.  Taking them
+this way is not a dodge: `normalOf`{.AgdaFunction} of the diagonal *unfolds* to the
+`≈`-class of the identity (lifted to level `L`{.AgdaFunction}), and of the total
+congruence to the whole carrier — so `𝟘ⁿ`{.AgdaFunction} is
+`trivialSubgroup`{.AgdaFunction} of [Classical.Structures.Group.Subgroups][] and
+`𝟙ⁿ`{.AgdaFunction} the full subgroup, with the subgroup and normality proofs already
+discharged by the correspondence.  The two membership lemmas below record that
+identification rather than leaving it to the reader to unfold.
+
+Minimality is the one fact with content: every subgroup contains `ε`{.AgdaFunction},
+and an equality-respecting one therefore contains its whole `≈`-class.
+
+```agda
+  -- The bottom: the ≈-class of the identity.
+  𝟘ⁿ : Nrmᴸ
+  𝟘ⁿ = normalOf (𝟘[ 𝑮 ] {L})
+
+  -- The top: the whole carrier.
+  𝟙ⁿ : Nrmᴸ
+  𝟙ⁿ = normalOf (𝟙[ 𝑮 ] {L})
+
+  -- 𝟘ⁿ is the trivial subgroup { x ∣ x ≈ ε }, up to the level lift.
+  𝟘ⁿ-trivial : {x : G} → x ∈ set 𝟘ⁿ → x ∈ proj₁ (trivialSubgroup 𝒢)
+  𝟘ⁿ-trivial = lower
+
+  trivial-𝟘ⁿ : {x : G} → x ∈ proj₁ (trivialSubgroup 𝒢) → x ∈ set 𝟘ⁿ
+  trivial-𝟘ⁿ = lift
+
+  -- 𝟙ⁿ is the whole carrier.
+  𝟙ⁿ-full : {x : G} → x ∈ set 𝟙ⁿ
+  𝟙ⁿ-full = lift tt
+
+  -- Every normal subgroup contains the ≈-class of the identity ...
+  𝟘ⁿ-minimum : Minimum (_≤ⁿ_ {L}) 𝟘ⁿ
+  𝟘ⁿ-minimum 𝑵 p = respects (≈sym (lower p)) ε-closed
+    where open IsSubgroup (set-isSubgroup 𝑵) using ( respects ; ε-closed )
+
+  -- ... and is contained in the whole carrier.
+  𝟙ⁿ-maximum : Maximum (_≤ⁿ_ {L}) 𝟙ⁿ
+  𝟙ⁿ-maximum 𝑵 _ = lift tt
+```
+
+#### Joins come from the correspondence
+
+The join of two normal subgroups is the normal subgroup matching the join of the two
+matching congruences.  Its universal property is the congruence-side one pushed across
+the correspondence: each inclusion is one monotonicity step composed with one half of a
+round trip.  (The endpoint implicits of `normalOf-mono`{.AgdaFunction} and
+`congruenceOf-mono`{.AgdaFunction} are supplied by hand throughout, per the
+non-injectivity discipline of [Setoid.Congruences.Lattice][].)
+
+```agda
+  infixr 6 _∨ⁿ_
+
+  -- The binary join: the normal subgroup of the join of the corresponding congruences.
+  _∨ⁿ_ : Nrmᴸ → Nrmᴸ → Nrmᴸ
+  𝑴 ∨ⁿ 𝑵 = normalOf (congruenceOf 𝑴 ∨ congruenceOf 𝑵)
+
+  ∨ⁿ-supremum : Supremum (_≤ⁿ_ {L}) _∨ⁿ_
+  ∨ⁿ-supremum 𝑴 𝑵 = upperˡ , upperʳ , least
+    where
+    θ φ : Con 𝑮 L
+    θ = congruenceOf 𝑴
+    φ = congruenceOf 𝑵
+
+    upperˡ : 𝑴 ≤ⁿ (𝑴 ∨ⁿ 𝑵)
+    upperˡ p = normalOf-mono {L} {θ} {θ ∨ φ} (∨-upperˡ θ φ)
+                 (proj₂ (normalOf∘congruenceOf 𝑴) p)
+
+    upperʳ : 𝑵 ≤ⁿ (𝑴 ∨ⁿ 𝑵)
+    upperʳ p = normalOf-mono {L} {φ} {θ ∨ φ} (∨-upperʳ θ φ)
+                 (proj₂ (normalOf∘congruenceOf 𝑵) p)
+
+    least : (𝑷 : Nrmᴸ) → 𝑴 ≤ⁿ 𝑷 → 𝑵 ≤ⁿ 𝑷 → (𝑴 ∨ⁿ 𝑵) ≤ⁿ 𝑷
+    least 𝑷 𝑴≤𝑷 𝑵≤𝑷 p = proj₁ (normalOf∘congruenceOf 𝑷)
+      (normalOf-mono {L} {θ ∨ φ} {congruenceOf 𝑷}
+        (∨-least θ φ (congruenceOf 𝑷)  (congruenceOf-mono {L} {𝑴} {𝑷} 𝑴≤𝑷)
+                                       (congruenceOf-mono {L} {𝑵} {𝑷} 𝑵≤𝑷))
+        p)
+```
+
+The infinitary join is the same construction over an `ℓ₀`-indexed family, using the
+congruence side's `⋁`{.AgdaFunction}.
+
+```agda
+  -- The infinitary join.
+  ⋁ⁿ : {I : Type ℓ₀} → (I → Nrmᴸ) → Nrmᴸ
+  ⋁ⁿ 𝒩 = normalOf (⋁ 𝑮 ℓ₀ (λ i → congruenceOf (𝒩 i)))
+
+  ⋁ⁿ-upper : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (i : I) → 𝒩 i ≤ⁿ ⋁ⁿ 𝒩
+  ⋁ⁿ-upper 𝒩 i p =
+    normalOf-mono  {L} {congruenceOf (𝒩 i)} {⋁ 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j))}
+                   (⋁-upper 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j)) i)
+                   (proj₂ (normalOf∘congruenceOf (𝒩 i)) p)
+
+  ⋁ⁿ-least : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (𝑷 : Nrmᴸ)
+    →  (∀ i → 𝒩 i ≤ⁿ 𝑷) → ⋁ⁿ 𝒩 ≤ⁿ 𝑷
+  ⋁ⁿ-least 𝒩 𝑷 h p = proj₁ (normalOf∘congruenceOf 𝑷)
+    (normalOf-mono  {L} {⋁ 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j))} {congruenceOf 𝑷}
+                    (⋁-least 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j)) (congruenceOf 𝑷)
+                      (λ i → congruenceOf-mono {L} {𝒩 i} {𝑷} (h i)))
+                    p)
+```
+
+#### The bundles
+
+The partial order comes from [Classical.Structures.Group.Congruences][]; adding the
+two binary operations gives a lattice, the two bounds a bounded lattice, and the two
+infinitary operations a complete lattice — the same three bundles
+[Setoid.Congruences.CompleteLattice][] assembles on the congruence side.
+
+```agda
+  Nrm-isLattice : IsLattice (_≈ⁿ_ {L}) _≤ⁿ_ _∨ⁿ_ _∩ⁿ_
+  Nrm-isLattice = record  { isPartialOrder  = ≤ⁿ-isPartialOrder
+                          ; supremum        = ∨ⁿ-supremum
+                          ; infimum         = ∩ⁿ-infimum
+                          }
+
+  NormalSubgroup-Lattice : Lattice (α ⊔ ρ ⊔ suc L) (α ⊔ L) (α ⊔ L)
+  NormalSubgroup-Lattice = record  { Carrier    = Nrmᴸ
+                                   ; _≈_        = _≈ⁿ_
+                                   ; _≤_        = _≤ⁿ_
+                                   ; _∨_        = _∨ⁿ_
+                                   ; _∧_        = _∩ⁿ_
+                                   ; isLattice  = Nrm-isLattice
+                                   }
+
+  Nrm-isBoundedLattice : IsBoundedLattice (_≈ⁿ_ {L}) _≤ⁿ_ _∨ⁿ_ _∩ⁿ_ 𝟙ⁿ 𝟘ⁿ
+  Nrm-isBoundedLattice = record  { isLattice  = Nrm-isLattice
+                                 ; maximum    = 𝟙ⁿ-maximum
+                                 ; minimum    = 𝟘ⁿ-minimum
+                                 }
+
+  NormalSubgroup-BoundedLattice : BoundedLattice (α ⊔ ρ ⊔ suc L) (α ⊔ L) (α ⊔ L)
+  NormalSubgroup-BoundedLattice = record  { Carrier           = Nrmᴸ
+                                          ; _≈_               = _≈ⁿ_
+                                          ; _≤_               = _≤ⁿ_
+                                          ; _∨_               = _∨ⁿ_
+                                          ; _∧_               = _∩ⁿ_
+                                          ; ⊤                 = 𝟙ⁿ
+                                          ; ⊥                 = 𝟘ⁿ
+                                          ; isBoundedLattice  = Nrm-isBoundedLattice
+                                          }
+
+  NormalSubgroup-CompleteLattice : CompleteLattice (α ⊔ ρ ⊔ suc L) (α ⊔ L) (α ⊔ L) ℓ₀
+  NormalSubgroup-CompleteLattice = record
+    { Carrier         = Nrmᴸ
+    ; _≈_             = _≈ⁿ_
+    ; _≤_             = _≤ⁿ_
+    ; isPartialOrder  = ≤ⁿ-isPartialOrder
+    ; ⨆               = ⋁ⁿ
+    ; ⨅               = ⋂ⁿ
+    ; ⨆-upper         = ⋁ⁿ-upper
+    ; ⨆-least         = ⋁ⁿ-least
+    ; ⨅-lower         = ⋂ⁿ-lower
+    ; ⨅-greatest      = ⋂ⁿ-greatest
+    }
+```
+
+#### The isomorphism of lattices
+
+The two complete lattices have the *same* underlying orders as the two posets of
+[Classical.Structures.Group.Congruences][], so the lattice isomorphism is that
+module's `normal-congruence-iso`{.AgdaFunction}, instantiated at the absorbing level.
+Stating it through the bundles' own `_≈_`{.AgdaField} and `_≤_`{.AgdaField} is the
+point: it is what makes "these two *lattices* are isomorphic" a statement Agda has
+checked, rather than a reading a human supplies.
+
+```agda
+  -- Con-CompleteLattice 𝑮 ℓ₀  ≅  NormalSubgroup-CompleteLattice.
+  NormalCongruenceLatticeIso : Type (α ⊔ ρ ⊔ suc L)
+  NormalCongruenceLatticeIso =
+    OrderIso  (CompleteLattice._≈_ (Con-CompleteLattice 𝑮 ℓ₀))
+              (CompleteLattice._≤_ (Con-CompleteLattice 𝑮 ℓ₀))
+              (CompleteLattice._≈_ NormalSubgroup-CompleteLattice)
+              (CompleteLattice._≤_ NormalSubgroup-CompleteLattice)
+
+  normal-congruence-latticeIso : NormalCongruenceLatticeIso
+  normal-congruence-latticeIso = normal-congruence-iso L
+```
+
+#### The maps preserve the lattice operations
+
+An order isomorphism carries greatest lower bounds to greatest lower bounds and least
+upper bounds to least upper bounds, so the preservation statements below are formal
+consequences of the isomorphism.  They are nonetheless proved, because they are what a
+reader means by "isomorphism of lattices" and because two of the four turn out to hold
+*definitionally*: the identity class of an intersection of congruences **is**, on the
+nose, the intersection of the identity classes.
+
+```agda
+  -- Meets are preserved, definitionally.
+  normalOf-∧ : (θ φ : Con 𝑮 L) → normalOf (θ ∧ φ) ≈ⁿ (normalOf θ ∩ⁿ normalOf φ)
+  normalOf-∧ θ φ = (λ p → p) , (λ p → p)
+
+  normalOf-⋀ : {I : Type ℓ₀} (f : I → Con 𝑮 L)
+    →  normalOf (⋀ 𝑮 ℓ₀ f) ≈ⁿ ⋂ⁿ (λ i → normalOf (f i))
+  normalOf-⋀ f = (λ p → p) , (λ p → p)
+```
+
+Joins need the round trip, since `_∨ⁿ_`{.AgdaFunction} re-enters the congruence side
+through `congruenceOf`{.AgdaFunction}.  The bridging step is monotonicity of the
+congruence join in both arguments, which we prove here because
+[Setoid.Congruences.Generation][] states only the three universal-property lemmas.
+
+```agda
+  private
+    -- The congruence join is monotone in both arguments.
+    ∨-mono : (θ φ θ' φ' : Con 𝑮 L) → θ ⊑ θ' → φ ⊑ φ' → (θ ∨ φ) ⊑ (θ' ∨ φ')
+    ∨-mono θ φ θ' φ' θ⊑θ' φ⊑φ' =
+      ∨-least θ φ (θ' ∨ φ')  (λ p → ∨-upperˡ θ' φ' (θ⊑θ' p))
+                             (λ q → ∨-upperʳ θ' φ' (φ⊑φ' q))
+
+    -- ... as is the infinitary one.
+    ⋁-mono : {I : Type ℓ₀} (f g : I → Con 𝑮 L)
+      →  (∀ i → f i ⊑ g i) → ⋁ 𝑮 ℓ₀ f ⊑ ⋁ 𝑮 ℓ₀ g
+    ⋁-mono f g f⊑g =
+      ⋁-least 𝑮 ℓ₀ f (⋁ 𝑮 ℓ₀ g) (λ i p → ⋁-upper 𝑮 ℓ₀ g i (f⊑g i p))
+
+  -- Joins are preserved.
+  normalOf-∨ : (θ φ : Con 𝑮 L) → normalOf (θ ∨ φ) ≈ⁿ (normalOf θ ∨ⁿ normalOf φ)
+  normalOf-∨ θ φ = normalOf-cong {L} {θ ∨ φ} {θ' ∨ φ'}
+    (  ∨-mono θ φ θ' φ'  (proj₂ (congruenceOf∘normalOf θ)) (proj₂ (congruenceOf∘normalOf φ))
+    ,  ∨-mono θ' φ' θ φ  (proj₁ (congruenceOf∘normalOf θ)) (proj₁ (congruenceOf∘normalOf φ))
+    )
+    where
+    θ' φ' : Con 𝑮 L
+    θ' = congruenceOf (normalOf θ)
+    φ' = congruenceOf (normalOf φ)
+
+  normalOf-⋁ : {I : Type ℓ₀} (f : I → Con 𝑮 L)
+    →  normalOf (⋁ 𝑮 ℓ₀ f) ≈ⁿ ⋁ⁿ (λ i → normalOf (f i))
+  normalOf-⋁ f = normalOf-cong {L} {⋁ 𝑮 ℓ₀ f} {⋁ 𝑮 ℓ₀ f'}
+    (  ⋁-mono f f'  (λ i → proj₂ (congruenceOf∘normalOf (f i)))
+    ,  ⋁-mono f' f  (λ i → proj₁ (congruenceOf∘normalOf (f i)))
+    )
+    where
+    f' : _ → Con 𝑮 L
+    f' i = congruenceOf (normalOf (f i))
+```
+
+The other map preserves them too, and here *every* clause is free.  Meets again agree
+on the nose — the relation "`x ∙ y ⁻¹` lies in both `M` and `N`" **is** the
+intersection of the two relations — and each join and each bound is a round trip of the
+correspondence at the congruence that defines it.  Together with the four lemmas above
+this makes both directions checked lattice homomorphisms, so "isomorphism of lattices"
+is discharged in the sense a reader expects and not merely in the sense that an order
+isomorphism formally implies.
+
+```agda
+  -- Meets, definitionally.
+  congruenceOf-∩ : (𝑴 𝑵 : Nrmᴸ)
+    →  congruenceOf (𝑴 ∩ⁿ 𝑵) ≑ (congruenceOf 𝑴 ∧ congruenceOf 𝑵)
+  congruenceOf-∩ 𝑴 𝑵 = (λ p → p) , (λ p → p)
+
+  congruenceOf-⋂ : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ)
+    →  congruenceOf (⋂ⁿ 𝒩) ≑ ⋀ 𝑮 ℓ₀ (λ i → congruenceOf (𝒩 i))
+  congruenceOf-⋂ 𝒩 = (λ p → p) , (λ p → p)
+
+  -- Joins and bounds, each one round trip.
+  congruenceOf-∨ : (𝑴 𝑵 : Nrmᴸ)
+    →  congruenceOf (𝑴 ∨ⁿ 𝑵) ≑ (congruenceOf 𝑴 ∨ congruenceOf 𝑵)
+  congruenceOf-∨ 𝑴 𝑵 = congruenceOf∘normalOf (congruenceOf 𝑴 ∨ congruenceOf 𝑵)
+
+  congruenceOf-⋁ : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ)
+    →  congruenceOf (⋁ⁿ 𝒩) ≑ ⋁ 𝑮 ℓ₀ (λ i → congruenceOf (𝒩 i))
+  congruenceOf-⋁ 𝒩 = congruenceOf∘normalOf (⋁ 𝑮 ℓ₀ (λ i → congruenceOf (𝒩 i)))
+
+  congruenceOf-𝟘 : congruenceOf 𝟘ⁿ ≑ 𝟘[ 𝑮 ] {L}
+  congruenceOf-𝟘 = congruenceOf∘normalOf (𝟘[ 𝑮 ] {L})
+
+  congruenceOf-𝟙 : congruenceOf 𝟙ⁿ ≑ 𝟙[ 𝑮 ] {L}
+  congruenceOf-𝟙 = congruenceOf∘normalOf (𝟙[ 𝑮 ] {L})
+```

--- a/src/Classical/Structures/Group/NormalSubgroupLattice.lagda.md
+++ b/src/Classical/Structures/Group/NormalSubgroupLattice.lagda.md
@@ -95,7 +95,7 @@ open import Relation.Unary                using  ( Pred ; _∈_ )
 -- Imports from the Agda Universal Algebra Library ------------------------------
 open import Classical.Structures.Group.Basic        using  ( Group )
 open import Classical.Structures.Group.Congruences  using  ( module GroupCongruences )
-open import Classical.Structures.Group.Conjugation  using  ( module Conj )
+open import Classical.Structures.Group.Conjugation  using  ( module Conjugate )
 open import Classical.Structures.Group.Subgroups    using  ( IsSubgroup ; mkIsSubgroup
                                                            ; trivialSubgroup )
 open import Order.CompleteLattice                   using  ( CompleteLattice )
@@ -120,7 +120,7 @@ module NormalSubgroupLattice {α ρ : Level} (𝒢 : Group α ρ) (ℓ₀ : Leve
     G = 𝕌[ 𝑮 ]
 
   open Setoid 𝔻[ 𝑮 ]  using ( _≈_ ) renaming ( sym to ≈sym )
-  open Conj 𝒢         using ( IsNormal )
+  open Conjugate 𝒢         using ( IsNormal )
   open GroupCongruences 𝒢
 
   -- The absorbing level of the congruence lattice of the group algebra; the two
@@ -193,8 +193,7 @@ The same argument, indexwise, gives the infinitary meet.  It stays at level
   ⋂ⁿ-lower : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (i : I) → ⋂ⁿ 𝒩 ≤ⁿ 𝒩 i
   ⋂ⁿ-lower 𝒩 i p = p i
 
-  ⋂ⁿ-greatest : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (𝑷 : Nrmᴸ)
-    →  (∀ i → 𝑷 ≤ⁿ 𝒩 i) → 𝑷 ≤ⁿ ⋂ⁿ 𝒩
+  ⋂ⁿ-greatest : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (𝑷 : Nrmᴸ) →  (∀ i → 𝑷 ≤ⁿ 𝒩 i) → 𝑷 ≤ⁿ ⋂ⁿ 𝒩
   ⋂ⁿ-greatest 𝒩 𝑷 h p i = h i p
 ```
 
@@ -266,18 +265,18 @@ non-injectivity discipline of [Setoid.Congruences.Lattice][].)
     φ = congruenceOf 𝑵
 
     upperˡ : 𝑴 ≤ⁿ (𝑴 ∨ⁿ 𝑵)
-    upperˡ p = normalOf-mono {L} {θ} {θ ∨ φ} (∨-upperˡ θ φ)
+    upperˡ p = normalOf-mono θ (θ ∨ φ) (∨-upperˡ θ φ)
                  (proj₂ (normalOf∘congruenceOf 𝑴) p)
 
     upperʳ : 𝑵 ≤ⁿ (𝑴 ∨ⁿ 𝑵)
-    upperʳ p = normalOf-mono {L} {φ} {θ ∨ φ} (∨-upperʳ θ φ)
+    upperʳ p = normalOf-mono φ (θ ∨ φ) (∨-upperʳ θ φ)
                  (proj₂ (normalOf∘congruenceOf 𝑵) p)
 
     least : (𝑷 : Nrmᴸ) → 𝑴 ≤ⁿ 𝑷 → 𝑵 ≤ⁿ 𝑷 → (𝑴 ∨ⁿ 𝑵) ≤ⁿ 𝑷
     least 𝑷 𝑴≤𝑷 𝑵≤𝑷 p = proj₁ (normalOf∘congruenceOf 𝑷)
-      (normalOf-mono {L} {θ ∨ φ} {congruenceOf 𝑷}
-        (∨-least θ φ (congruenceOf 𝑷)  (congruenceOf-mono {L} {𝑴} {𝑷} 𝑴≤𝑷)
-                                       (congruenceOf-mono {L} {𝑵} {𝑷} 𝑵≤𝑷))
+      (normalOf-mono (θ ∨ φ) (congruenceOf 𝑷)
+        (∨-least θ φ (congruenceOf 𝑷)  (congruenceOf-mono 𝑴 𝑷 𝑴≤𝑷)
+                                       (congruenceOf-mono 𝑵 𝑷 𝑵≤𝑷))
         p)
 ```
 
@@ -291,16 +290,16 @@ congruence side's `⋁`{.AgdaFunction}.
 
   ⋁ⁿ-upper : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (i : I) → 𝒩 i ≤ⁿ ⋁ⁿ 𝒩
   ⋁ⁿ-upper 𝒩 i p =
-    normalOf-mono  {L} {congruenceOf (𝒩 i)} {⋁ 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j))}
+    normalOf-mono  (congruenceOf (𝒩 i)) (⋁ 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j)))
                    (⋁-upper 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j)) i)
                    (proj₂ (normalOf∘congruenceOf (𝒩 i)) p)
 
   ⋁ⁿ-least : {I : Type ℓ₀} (𝒩 : I → Nrmᴸ) (𝑷 : Nrmᴸ)
     →  (∀ i → 𝒩 i ≤ⁿ 𝑷) → ⋁ⁿ 𝒩 ≤ⁿ 𝑷
   ⋁ⁿ-least 𝒩 𝑷 h p = proj₁ (normalOf∘congruenceOf 𝑷)
-    (normalOf-mono  {L} {⋁ 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j))} {congruenceOf 𝑷}
+    (normalOf-mono  (⋁ 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j))) (congruenceOf 𝑷)
                     (⋁-least 𝑮 ℓ₀ (λ j → congruenceOf (𝒩 j)) (congruenceOf 𝑷)
-                      (λ i → congruenceOf-mono {L} {𝒩 i} {𝑷} (h i)))
+                      (λ i → congruenceOf-mono (𝒩 i) 𝑷 (h i)))
                     p)
 ```
 
@@ -421,7 +420,7 @@ congruence join in both arguments, which we prove here because
 
   -- Joins are preserved.
   normalOf-∨ : (θ φ : Con 𝑮 L) → normalOf (θ ∨ φ) ≈ⁿ (normalOf θ ∨ⁿ normalOf φ)
-  normalOf-∨ θ φ = normalOf-cong {L} {θ ∨ φ} {θ' ∨ φ'}
+  normalOf-∨ θ φ = normalOf-cong (θ ∨ φ) (θ' ∨ φ')
     (  ∨-mono θ φ θ' φ'  (proj₂ (congruenceOf∘normalOf θ)) (proj₂ (congruenceOf∘normalOf φ))
     ,  ∨-mono θ' φ' θ φ  (proj₁ (congruenceOf∘normalOf θ)) (proj₁ (congruenceOf∘normalOf φ))
     )
@@ -432,7 +431,7 @@ congruence join in both arguments, which we prove here because
 
   normalOf-⋁ : {I : Type ℓ₀} (f : I → Con 𝑮 L)
     →  normalOf (⋁ 𝑮 ℓ₀ f) ≈ⁿ ⋁ⁿ (λ i → normalOf (f i))
-  normalOf-⋁ f = normalOf-cong {L} {⋁ 𝑮 ℓ₀ f} {⋁ 𝑮 ℓ₀ f'}
+  normalOf-⋁ f = normalOf-cong (⋁ 𝑮 ℓ₀ f) (⋁ 𝑮 ℓ₀ f')
     (  ⋁-mono f f'  (λ i → proj₂ (congruenceOf∘normalOf (f i)))
     ,  ⋁-mono f' f  (λ i → proj₁ (congruenceOf∘normalOf (f i)))
     )

--- a/src/FLRP/Problem.lagda.md
+++ b/src/FLRP/Problem.lagda.md
@@ -53,9 +53,9 @@ open import Data.Sum.Base        using ( _⊎_ ; inj₁ ; inj₂ )
 open import Data.Unit.Base       using ( tt )
 open import Data.Vec.Base        using ( _∷_ ; [] )
 open import Function             using (_∘_)
-open import Level                using ( Level ; 0ℓ ; _⊔_ ; lift ; lower )
+open import Level                using ( 0ℓ ; lift ; lower )
                                  renaming ( suc to lsuc )
-open import Relation.Binary      using ( Setoid ) renaming ( Rel to BinaryRel )
+open import Relation.Binary      using ( Setoid )
 open import Relation.Binary.PropositionalEquality
                                  using ( _≡_ ; refl ; sym ; trans ; subst ; module ≡-Reasoning)
 open import Relation.Nullary     using ( ¬_ ; yes ; no )
@@ -84,36 +84,15 @@ classical lattice carries its meet order from [Classical.Properties.Lattice][].
 
 The right notion of "the same lattice" for two such posets is an **order isomorphism**:
 a pair of monotone maps that are mutually inverse up to the respective equivalences.
-
-Because both maps are monotone and the round trips are the identity up to `≈`, an
-order isomorphism transports every existing infimum and supremum, so isomorphic
-posets carry the same lattice (indeed, complete-lattice) structure; this is why no
-separate preservation clauses for meet and join are needed.
-
-`OrderIso`{.AgdaRecord} states this for raw relations, so it applies uniformly to
-setoid-valued and propositional orders.  It is kept here, next to its first use; once
-the group-theoretic side of the program needs it (work package WP-3,
-`Con (G ↷ G/H) ≅ [H , G]`), it should migrate to the `Order/` tree beside
-[Order.CompleteLattice][].
-
-(The standard library's `IsOrderIsomorphism`{.AgdaRecord} packages one map with
-surjectivity instead of an explicit inverse; the two presentations are
-interconvertible, and the inverse-pair form is the convenient one for transporting
-structure.)
+That is `OrderIso`{.AgdaRecord}, which this module introduced next to its first use
+and which now lives in [Order.Iso][], the migration its original note anticipated:
+[Classical.Structures.Group.Congruences][] needs it below the FLRP tree, for the
+correspondence between the congruences of a group and its normal subgroups.  It is
+re-exported here, so every existing consumer that imports it from this module is
+unaffected.
 
 ```agda
-record OrderIso
-  {a b ℓ₁ ℓ₂ m₁ m₂ : Level}
-  {A : Type a} {B : Type b}
-  (_≈₁_ : BinaryRel A ℓ₁) (_≤₁_ : BinaryRel A ℓ₂)
-  (_≈₂_ : BinaryRel B m₁) (_≤₂_ : BinaryRel B m₂) : Type (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂ ⊔ m₁ ⊔ m₂) where
-  field
-    to         : A → B
-    from       : B → A
-    to-mono    : ∀ {x y} → x ≤₁ y → to x ≤₂ to y
-    from-mono  : ∀ {u v} → u ≤₂ v → from u ≤₁ from v
-    to∘from    : ∀ u → to (from u) ≈₂ u
-    from∘to    : ∀ x → from (to x) ≈₁ x
+open import Order.Iso public using ( OrderIso )
 ```
 
 #### Congruence lattices versus classical lattices

--- a/src/Order.lagda.md
+++ b/src/Order.lagda.md
@@ -25,4 +25,5 @@ module Order where
 
 open import Order.CompleteLattice public
 open import Order.Interval public
+open import Order.Iso public
 ```

--- a/src/Order/Iso.lagda.md
+++ b/src/Order/Iso.lagda.md
@@ -1,0 +1,67 @@
+---
+layout: default
+file: "src/Order/Iso.lagda.md"
+title : "Order.Iso module (The Agda Universal Algebra Library)"
+date : "2026-07-26"
+author: "agda-algebras development team"
+---
+
+### Order isomorphisms
+
+This is the [Order.Iso][] module of the [Agda Universal Algebra Library][].
+
+An **order isomorphism** between two ordered objects is a pair of monotone maps that
+are mutually inverse up to the respective equivalences.  Because both maps are
+monotone and the round trips are the identity up to the equivalence, an order
+isomorphism transports every existing infimum and supremum, so isomorphic posets
+carry the same lattice (indeed, complete-lattice) structure; this is why no separate
+preservation clauses for meet and join are needed.
+
+`OrderIso`{.AgdaRecord} states this for *raw relations* rather than for a bundle, so
+it applies uniformly to setoid-valued and propositionally-valued orders.  That
+generality is what the library's two motivating instances need: the congruence poset
+`(Con 𝑨 , ≑ , ⊆)` of [Setoid.Congruences.Lattice][] carries an equivalence of *mutual
+containment* rather than propositional equality, while a classical lattice carries
+its meet order from [Classical.Properties.Lattice][].
+
+(The standard library's `IsOrderIsomorphism`{.AgdaRecord} packages one map with
+surjectivity instead of an explicit inverse; the two presentations are
+interconvertible, and the inverse-pair form is the convenient one for transporting
+structure.)
+
+The record was introduced in [FLRP.Problem][], next to its first use, with a note
+that it should migrate here once the group-theoretic side of the library needed it.
+[Classical.Structures.Group.Congruences][] is that consumer — the correspondence
+between normal subgroups and congruences is ordinary group theory, below the FLRP
+tree — so the record now lives in `Order/` and [FLRP.Problem][] re-exports it.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Order.Iso where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Level            using ( Level ; _⊔_ )
+open import Relation.Binary  using () renaming ( Rel to BinaryRel )
+```
+-->
+
+#### The record
+
+```agda
+record OrderIso
+  {a b ℓ₁ ℓ₂ m₁ m₂ : Level}
+  {A : Type a} {B : Type b}
+  (_≈₁_ : BinaryRel A ℓ₁) (_≤₁_ : BinaryRel A ℓ₂)
+  (_≈₂_ : BinaryRel B m₁) (_≤₂_ : BinaryRel B m₂) : Type (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂ ⊔ m₁ ⊔ m₂) where
+  field
+    to         : A → B
+    from       : B → A
+    to-mono    : ∀ {x y} → x ≤₁ y → to x ≤₂ to y
+    from-mono  : ∀ {u v} → u ≤₂ v → from u ≤₁ from v
+    to∘from    : ∀ u → to (from u) ≈₂ u
+    from∘to    : ∀ x → from (to x) ≈₁ x
+```


### PR DESCRIPTION
## What this does

Formalizes the correspondence between the **normal subgroups of a group** and the **congruences of it**, then upgrades it to an **isomorphism of complete lattices**.  This is the bridge § 4.1 of the RP-2 survey note (#459) said was needed, and it retires the divergence recorded there.

Three commits, each `make check` green:

1.  `Order.Iso` — moves `OrderIso` out of `FLRP.Problem` into the `Order/` tree.
2.  `Classical.Structures.Group.Congruences` — the correspondence, as an order isomorphism of posets.
3.  `Classical.Structures.Group.NormalSubgroupLattice` — the lattice structure and the isomorphism at that level.

## The correspondence (`Classical.Structures.Group.Congruences`)

Inside the parameterized module `GroupCongruences 𝒢`:

+  `congruenceOf : NormalSubgroup ℓ → Con 𝑮 ℓ` sends a normal subgroup `N` to `NormalRel N`, the relation `x ∙ y ⁻¹ ∈ N`.  It is an equivalence containing the setoid equality for any equality-respecting subgroup (`SubgroupRel`), and compatible with `∙-Op` / `ε-Op` / `⁻¹-Op` once `N` is normal (`NormalCon`).
+  `normalOf : Con 𝑮 ℓ → NormalSubgroup ℓ` sends a congruence `θ` to `IdentityClass θ = { x ∣ x θ ε }`, proved to be an equality-respecting subgroup and normal.
+  `≤ⁿ-isPartialOrder` and `NormalSubgroup-Poset` give the subgroup side its order, mirroring `⊆-isPartialOrder` and `Con-Poset` of `Setoid.Congruences.Lattice`.
+  Both maps are monotone and mutually inverse up to `≑` / `≈ⁿ`, assembled as `normal-congruence-iso` (with the reverse packaging `normal-congruence-iso⁻¹`).
+  `nonzero→nontrivial` / `nontrivial→nonzero` and their congruence-side counterparts, each derived by contraposition from a *positive* equivalence between `BelowDiagonal` and `BelowTrivial`, so nothing classical enters.

Type-checks under `--cubical-compatible --exact-split --safe`, no postulates.

## The lattice (`Classical.Structures.Group.NormalSubgroupLattice`)

Standing to `Congruences` as `SubgroupLattice` stands to `Subgroups`.  At the absorbing level `L = α ⊔ ρ ⊔ ℓ₀`:

+  **Meets are intersections**, built directly on the subgroup side: `_∩ⁿ_` and `⋂ⁿ`, each closure property holding componentwise.
+  **Bounds are the familiar ones**: `𝟘ⁿ` is the `≈`-class of the identity, with `𝟘ⁿ-trivial` / `trivial-𝟘ⁿ` identifying it with `trivialSubgroup`; `𝟙ⁿ` is the whole carrier.
+  **Joins come through the correspondence**: `_∨ⁿ_` and `⋁ⁿ` are the images under `normalOf` of the congruence joins, their universal properties following from monotonicity and the round trips.
+  The three bundles `NormalSubgroup-Lattice`, `NormalSubgroup-BoundedLattice`, `NormalSubgroup-CompleteLattice`, mirroring `Setoid.Congruences.CompleteLattice`.
+  `normal-congruence-latticeIso`, stated through the two complete lattices' own `_≈_` and `_≤_` — so "these two *lattices* are isomorphic" is a statement Agda has checked, not a reading a human supplies.
+  **Both maps preserve meets, joins and bounds** (`normalOf-∧`, `normalOf-⋀`, `normalOf-∨`, `normalOf-⋁`, `congruenceOf-∩`, `congruenceOf-⋂`, `congruenceOf-∨`, `congruenceOf-⋁`, `congruenceOf-𝟘`, `congruenceOf-𝟙`), so each direction is a checked lattice homomorphism rather than merely a monotone bijection.  Six of the ten hold *definitionally*: the identity class of an intersection of congruences **is** the intersection of the identity classes.

### Why two modules rather than one

The correspondence holds at **every** relation level.  A lattice cannot: its join is a *generated* congruence, and `Cg` raises the relation level by `𝓞 ⊔ 𝓥 ⊔ α ⊔ ρ`, so join is an operation only at the absorbing level `L`.  Bundling the two would have narrowed the correspondence to the single level the lattice happens to need.  This mirrors the existing `Subgroups` → `SubgroupLattice` split exactly, which is also why the lattice went beside its subject in `Classical/Structures/Group/` rather than under `Classical/Structures/Lattice/`: a normal-subgroup lattice is group theory, and `SubgroupLattice` is the precedent.

### The one asymmetry, stated rather than smoothed over

A join of normal subgroups is not a union, and the library has neither a generation principle for normal subgroups nor the complex-product theorem that would define it group-side.  So `_∨ⁿ_` is characterized here **only by its universal property** — the least normal subgroup above both.  Identifying it with the complex product `MN` of `Classical.Structures.Group.Complexes` is left to future work, and the caveat is in the module prose.

## `OrderIso` moves to `Order.Iso`

The correspondence is ordinary reusable group theory, so per roadmap § 6 it belongs in `Classical/`.  But `OrderIso` lived in `FLRP.Problem`, and importing it from `Classical/` would invert the dependency between the two trees.  `FLRP.Problem`'s own prose anticipated this: *"It is kept here, next to its first use; once the group-theoretic side of the program needs it … it should migrate to the `Order/` tree."*

The record moves verbatim, and `FLRP.Problem` re-exports it.  Every existing consumer (`FLRP.Bridge`, `FLRP.Enforceable`, `FLRP.Representable`, `FLRP.LayerBridge`, `FLRP.Closure.Product`, `FLRP.Closure.OrdinalSum`) is source-compatible and untouched; in particular nothing in #506 / #507's files is modified.

## Beyond the issue's task list

Three additions came out of the adversarial self-review, in each case because the development proved less than its prose asserted.

+  `congruence→normal` — the **converse**: if the relation of an equality-respecting subgroup is a congruence, the subgroup is normal.  So normality is *equivalent* to compatibility, and `NormalSubgroup ℓ` is exactly the source of the isomorphism.
+  `normalOf-cong` / `congruenceOf-cong` — well-definedness of both maps on equivalence classes, which `OrderIso` does not itself demand.
+  The lattice-operation preservation lemmas above, for the same reason at the lattice level.

Also proved, since it justifies the choice of relation rather than leaving it a silent convention: `rel→coset` / `coset→rel`, that for a normal subgroup the right-coset relation used here agrees with the left-coset relation `Coset._∼_` that `FLRP.Bridge` builds on.

## Caveats recorded in the module prose

+  The correspondence is **level-uniform**, relating `Con 𝑮 ℓ` to `NormalSubgroup ℓ` at each fixed `ℓ`, and says nothing across levels; the three instances that matter downstream (`ℓ = ρ` for the monolith, `ℓ = α ⊔ ρ ⊔ ℓ₀` for the congruence lattice, `ℓ = α ⊔ ℓ₀` for the subgroup lattice) are named.
+  Equality on each side is **mutual containment**, not propositional equality, so the round trips are bi-implications of membership.
+  The round trip on subgroups **consumes the `respects` field** — the same finding as `FLRP.Bridge`'s respecting interval.
+  Normality is consumed **only** by compatibility, and exactly.
+  `_∨ⁿ_` is characterized only by its universal property.

## What is deliberately left out

Transporting `HasMonolithᵍ` to `HasMonolith`, retiring the `ᵍ` superscript, and restating `𝒢₂` of `FLRP.Reductions` all depend on `Classical.Structures.Group.MinimalNormal`, which arrives with #507.  They are held for a follow-up commit once that lands; `FLRP/Parachute*`, `FLRP/Enforceable`, `FLRP/Reductions` and `Classical/Structures/Group/{Centralizer,Complements,MinimalNormal}` are untouched here.

## Two findings in existing code (neither fixed here)

+  **`make unused-imports` is already red on `master`.**  `src/Classical/Structures/Lattice/OrdinalSum.lagda.md:71` imports `proj₂` from `Data.Product` but uses it only in prose.  The file is unmodified by this branch (last touched by `af747c85`).
+  **`Conj`'s `x ^ g` syntax cannot be imported through an explicit `using` list.**  The notation is backed by `Conj.cong-syntax`, and `unused_imports.py`'s `-syntax` heuristic only recognizes names whose notation opens with `Foo[…]` (as `Σ-syntax` does).  So `using ( cong-syntax )` is reported unused even though removing it breaks the build — the checker forces the wrong edit.  This module therefore writes `conj g x`, as `NormalCore` already does.  Worth either teaching the checker about `syntax` declarations in the defining module or giving it a suppression comment; the name `cong-syntax` is also misleading, since it is conjugation rather than congruence.

## Checks

+  `make check` — green (0 errors; only the pre-existing Legacy `WARNING_ON_USAGE` output).
+  `make unused-imports` — clean for every file this PR touches; only the pre-existing `OrdinalSum` finding remains.
+  `make check-links` — green; `docs/_links.md` regenerated with `make gen-links`.

Closes the correspondence, the lattice isomorphism, and the nontriviality identification of #508; the monolith transport follows #507.  Follow-up to #459.  Part of #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
