### PR TITLE
∃-syntax follow-ups: drop a redundant import, correct a stale docstring

### DIFF
--- a/scripts/python/unused_imports.py
+++ b/scripts/python/unused_imports.py
@@ -352,9 +352,11 @@ def parse_syntax_decl(code_line: str) -> Optional[tuple[str, frozenset[str]]]:
     The literal tokens are those of the notation that are not bound on the left of
     the ``=``.  A declaration whose notation is all placeholders yields ``None``:
     there would be nothing to look for.  A declaration whose notation mentions a
-    name that is *not* among its parameters (``∃-syntax`` in ``Overture.Basic``
-    does) yields an over-strict entry, which simply never matches; the ``Foo[``
-    fallback in :func:`is_used` then applies, so the outcome is still correct."""
+    name that is *not* among its parameters yields an over-strict entry — such a
+    name is a literal token as far as Agda is concerned, and no use site can
+    contain it — which simply never matches; the ``Foo[`` fallback in
+    :func:`is_used` then applies, so the outcome is still correct.  (A `syntax`
+    declaration in that shape is usually a mistake in the declaration itself.)"""
     m = _SYNTAX_DECL.match(code_line)
     if m is None:
         return None
@@ -369,7 +371,13 @@ def harvest_syntax_notations(sources: Iterable[tuple[Path, str]]) -> dict[str, f
     global here rather than per-module: two modules declaring the same
     syntax-backing name are rare, and on collision we keep the *intersection* of
     the literal tokens, which can only make a name easier to count as used —
-    the safe direction for a gate that must not raise false alarms."""
+    the safe direction for a gate that must not raise false alarms.
+
+    The same bare-name keying is a known limitation: when a corpus module and a
+    library outside the corpus both export ``Foo-syntax`` with *different*
+    notations, an import of the outside one is judged by the corpus notation, so
+    a redundant import of the twin can go unreported.  The failure direction is
+    again under-reporting, never a false alarm."""
     found: dict[str, frozenset[str]] = {}
     for _, text in sources:
         for line in file_code_lines(text):

--- a/src/FLRP/Enforceable.lagda.md
+++ b/src/FLRP/Enforceable.lagda.md
@@ -69,7 +69,7 @@ open import Data.Empty                              using  ( ⊥ )
 open import Data.Fin.Base                           using  ( Fin )
 open import Data.Nat.Base renaming ( _≤_ to _≤ⁿ_ )  using  ( ℕ ; _+_ )
 open import Data.Product                            using  ( _,_ ; _×_ ; Σ-syntax
-                                                           ; ∃-syntax ; proj₁ ; proj₂ )
+                                                           ; proj₁ ; proj₂ )
 open import Data.Unit.Base                          using  ( tt )
 open import Function                                using  ( _∘_ )
 open import Level         renaming ( suc to lsuc )  using  ( Level ; 0ℓ ; _⊔_


### PR DESCRIPTION
Rebased onto `master` after #506 merged.  **The `∃-syntax` fix and the `unused_imports` notation registry this PR was opened for are already on `master`** — they went in with #506, which was merged whole rather than after the split — so the rebase dropped that commit as already upstream.  What remains is the two-file follow-up that #506 did not carry: Copilot's review of this PR, both findings correct.

+  **`FLRP.Enforceable` imported `∃-syntax` twice**, from `Data.Product` and from `Overture`.  Every existential in the module uses the domain-explicit notation, so the standard-library one is dead; removed.

+  **`parse_syntax_decl`'s docstring cited `∃-syntax` in `Overture.Basic`** as an example of a notation mentioning an unbound name — which the same branch fixes, so the example sent readers hunting for something no longer there.  It now describes the shape without naming a victim.

The reviewer's second observation — that the duplicate import *masks* a genuinely unused one — is also right, and is a limitation of the registry rather than of that file: it is keyed by bare name, so an import of the standard library's `∃-syntax` is judged by the notation harvested for `Overture.Basic`'s.  Reproduced by restoring the duplicate: the analyzer reports nothing.  The failure direction is under-reporting, never a false alarm; `harvest_syntax_notations`'s docstring now says so, and the notation-independent fix is filed as #519.

`make check`, `make unused-imports` (0 flagged), and the linter suite (55/55) verified on the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
