### PR TITLE
[M6-23] Powers, diagonals, and the interval `[D , Gⁿ]` (#521)

### DIFF
--- a/docs/_links.md
+++ b/docs/_links.md
@@ -185,10 +185,13 @@
 [Classical.Structures.Group.Conjugation]: /Classical/Structures/Group/Conjugation/
 [Classical.Structures.Group.Cosets]: /Classical/Structures/Group/Cosets/
 [Classical.Structures.Group.Dedekind]: /Classical/Structures/Group/Dedekind/
+[Classical.Structures.Group.Diagonal]: /Classical/Structures/Group/Diagonal/
 [Classical.Structures.Group.GSet]: /Classical/Structures/Group/GSet/
 [Classical.Structures.Group.MinimalNormal]: /Classical/Structures/Group/MinimalNormal/
 [Classical.Structures.Group.NormalCore]: /Classical/Structures/Group/NormalCore/
 [Classical.Structures.Group.NormalSubgroupLattice]: /Classical/Structures/Group/NormalSubgroupLattice/
+[Classical.Structures.Group.PartitionSubgroup]: /Classical/Structures/Group/PartitionSubgroup/
+[Classical.Structures.Group.Power]: /Classical/Structures/Group/Power/
 [Classical.Structures.Group.Product]: /Classical/Structures/Group/Product/
 [Classical.Structures.Group.SubgroupLattice]: /Classical/Structures/Group/SubgroupLattice/
 [Classical.Structures.Group.Subgroups]: /Classical/Structures/Group/Subgroups/
@@ -199,6 +202,7 @@
 [Classical.Structures.Lattice.Dual]: /Classical/Structures/Lattice/Dual/
 [Classical.Structures.Lattice.OrdinalSum]: /Classical/Structures/Lattice/OrdinalSum/
 [Classical.Structures.Lattice.Parachute]: /Classical/Structures/Lattice/Parachute/
+[Classical.Structures.Lattice.Partitions]: /Classical/Structures/Lattice/Partitions/
 [Classical.Structures.Lattice.Product]: /Classical/Structures/Lattice/Product/
 [Classical.Structures.Magma]: /Classical/Structures/Magma/
 [Classical.Structures.Monoid]: /Classical/Structures/Monoid/
@@ -379,6 +383,7 @@
 [FLRP.Closure.OrdinalSum]: /FLRP/Closure/OrdinalSum/
 [FLRP.Closure.Product]: /FLRP/Closure/Product/
 [FLRP.Enforceable]: /FLRP/Enforceable/
+[FLRP.KurzweilInterval]: /FLRP/KurzweilInterval/
 [FLRP.L7EqSix]: /FLRP/L7EqSix/
 [FLRP.LayerBridge]: /FLRP/LayerBridge/
 [FLRP.Parachute]: /FLRP/Parachute/
@@ -565,10 +570,13 @@
 [Classical/Structures/Group/Conjugation.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Conjugation.lagda.md
 [Classical/Structures/Group/Cosets.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Cosets.lagda.md
 [Classical/Structures/Group/Dedekind.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Dedekind.lagda.md
+[Classical/Structures/Group/Diagonal.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Diagonal.lagda.md
 [Classical/Structures/Group/GSet.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/GSet.lagda.md
 [Classical/Structures/Group/MinimalNormal.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/MinimalNormal.lagda.md
 [Classical/Structures/Group/NormalCore.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/NormalCore.lagda.md
 [Classical/Structures/Group/NormalSubgroupLattice.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/NormalSubgroupLattice.lagda.md
+[Classical/Structures/Group/PartitionSubgroup.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
+[Classical/Structures/Group/Power.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Power.lagda.md
 [Classical/Structures/Group/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Product.lagda.md
 [Classical/Structures/Group/SubgroupLattice.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/SubgroupLattice.lagda.md
 [Classical/Structures/Group/Subgroups.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Group/Subgroups.lagda.md
@@ -579,6 +587,7 @@
 [Classical/Structures/Lattice/Dual.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice/Dual.lagda.md
 [Classical/Structures/Lattice/OrdinalSum.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
 [Classical/Structures/Lattice/Parachute.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice/Parachute.lagda.md
+[Classical/Structures/Lattice/Partitions.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice/Partitions.lagda.md
 [Classical/Structures/Lattice/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Lattice/Product.lagda.md
 [Classical/Structures/Magma.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Magma.lagda.md
 [Classical/Structures/Monoid.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Classical/Structures/Monoid.lagda.md
@@ -759,6 +768,7 @@
 [FLRP/Closure/OrdinalSum.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/OrdinalSum.lagda.md
 [FLRP/Closure/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/Product.lagda.md
 [FLRP/Enforceable.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Enforceable.lagda.md
+[FLRP/KurzweilInterval.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilInterval.lagda.md
 [FLRP/L7EqSix.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/L7EqSix.lagda.md
 [FLRP/LayerBridge.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/LayerBridge.lagda.md
 [FLRP/Parachute.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Parachute.lagda.md

--- a/src/Classical/Structures/Group.lagda.md
+++ b/src/Classical/Structures/Group.lagda.md
@@ -24,10 +24,13 @@ open import Classical.Structures.Group.Congruences public
 open import Classical.Structures.Group.Conjugation public
 open import Classical.Structures.Group.Cosets public
 open import Classical.Structures.Group.Dedekind public
+open import Classical.Structures.Group.Diagonal public
 open import Classical.Structures.Group.GSet public
 open import Classical.Structures.Group.MinimalNormal public
 open import Classical.Structures.Group.NormalCore public
 open import Classical.Structures.Group.NormalSubgroupLattice public
+open import Classical.Structures.Group.PartitionSubgroup public
+open import Classical.Structures.Group.Power public
 open import Classical.Structures.Group.Product public
 open import Classical.Structures.Group.Subgroups public
 open import Classical.Structures.Group.SubgroupLattice public

--- a/src/Classical/Structures/Group/Congruences.lagda.md
+++ b/src/Classical/Structures/Group/Congruences.lagda.md
@@ -136,7 +136,6 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
 open import Classical.Bundles.Group                 using  ( ⟨_⟩ᵍᵖ )
-open import Classical.Operations                    using  ( pair )
 open import Classical.Signatures.Group              using  ( ∙-Op ; ε-Op ; ⁻¹-Op )
 open import Classical.Structures.Group.Basic        using  ( Group ; module Group-Op )
 open import Classical.Structures.Group.Conjugation  using  ( module Conjugate )

--- a/src/Classical/Structures/Group/Diagonal.lagda.md
+++ b/src/Classical/Structures/Group/Diagonal.lagda.md
@@ -42,15 +42,14 @@ open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
 open import Data.Fin.Patterns   using ( 0F ; 1F )
-open import Data.Product        using ( Σ-syntax ; _,_ ; proj₁ ; proj₂ )
+open import Data.Product        using ( Σ-syntax ; _,_ ; proj₁ )
 open import Level               using ( Level ; _⊔_ )
 open import Relation.Binary     using ( Setoid )
 open import Relation.Binary.Definitions   using ( _Respects_ )
 open import Relation.Unary      using ( Pred ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Signatures.Group          using  ( Sig-Group ; ∙-Op ; ε-Op
-                                                       ; ⁻¹-Op )
+open import Classical.Signatures.Group          using  ( ∙-Op ; ⁻¹-Op )
 open import Classical.Structures.Group.Basic    using  ( Group ; module Group-Op )
 open import Classical.Structures.Group.Power    using  ( module GroupPower )
 open import Classical.Structures.Group.Subgroups
@@ -121,7 +120,6 @@ the pointwise descriptions, and applies the membership hypothesis coordinatewise
   Diag-isSubgroup : IsSubgroup ⨅ᵍ-Group Diag
   Diag-isSubgroup = mkIsSubgroup ⨅ᵍ-Group Diag-respects ∙-closed ε-closed ⁻¹-closed
     where
-    open Group-Op 𝒢         using () renaming ( _∙_ to _∙₁_ ; ε to ε₁ ; _⁻¹ to _⁻¹₁ )
     open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
 
     ∙-closed : ∀ {x y} → x ∈ Diag → y ∈ Diag → (x ∙ₚ y) ∈ Diag

--- a/src/Classical/Structures/Group/Diagonal.lagda.md
+++ b/src/Classical/Structures/Group/Diagonal.lagda.md
@@ -1,0 +1,141 @@
+---
+layout: default
+file: "src/Classical/Structures/Group/Diagonal.lagda.md"
+title: "Classical.Structures.Group.Diagonal module"
+date: "2026-07-27"
+author: "the agda-algebras development team"
+---
+
+### The diagonal subgroup of a power
+
+This is the [Classical.Structures.Group.Diagonal][] module of the [Agda Universal Algebra Library][].
+
+For a power `𝒢 ^ I` built by [Classical.Structures.Group.Power][], the
+**diagonal** is the set of constant tuples,
+
+$$D \;=\; \{\, (s, s, \dots, s) \mid s \in S \,\} \;\leq\; S^I ,$$
+
+the image of the constant embedding `κ`{.AgdaFunction}` : S → Sᴵ`.  Over a setoid
+carrier "constant" means *`≈`-constant*, so the predicate is stated as equality of
+any two coordinate values: `Diag x = ∀ i j → x i ≈ x j`.  This form respects the
+pointwise equality of the power by construction and needs no distinguished index,
+so it is the canonical membership predicate; the pointed characterizations —
+membership from and to an explicit constant value — are provided as lemmas for the
+consumers that do fix an index (`Fin (suc m)`, say).
+
+The diagonal is an equality-respecting subgroup (`IsSubgroup`{.AgdaRecord}): each
+closure proof rewrites one coordinate of the curried power operation to the base
+group by the pointwise descriptions of [Classical.Structures.Group.Power][], applies
+the hypothesis coordinatewise, and folds back.
+
+The diagonal is the bottom of the interval `[D , Sⁿ]` that Kurzweil's construction
+inhabits (issue #521); the partition subgroups whose least member it is are the
+subject of [Classical.Structures.Group.PartitionSubgroup][].
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Group.Diagonal where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Fin.Patterns   using ( 0F ; 1F )
+open import Data.Product        using ( Σ-syntax ; _,_ ; proj₁ ; proj₂ )
+open import Level               using ( Level ; _⊔_ )
+open import Relation.Binary     using ( Setoid )
+open import Relation.Binary.Definitions   using ( _Respects_ )
+open import Relation.Unary      using ( Pred ; _∈_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Signatures.Group          using  ( Sig-Group ; ∙-Op ; ε-Op
+                                                       ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic    using  ( Group ; module Group-Op )
+open import Classical.Structures.Group.Power    using  ( module GroupPower )
+open import Classical.Structures.Group.Subgroups
+                                                using  ( IsSubgroup ; mkIsSubgroup )
+open import Classical.Structures.Interpret      using  ( interp-cong )
+open import Setoid.Algebras.Basic               using  ( 𝕌[_] ; 𝔻[_] )
+
+private variable ι α ρ : Level
+```
+-->
+
+#### The diagonal predicate
+
+`DiagonalSubgroup`{.AgdaModule} `I` `𝒢` packages the diagonal of the power
+`𝒢 ^ I` for a fixed index type and base group.
+
+```agda
+module DiagonalSubgroup (I : Type ι) (𝒢 : Group α ρ) where
+
+  open GroupPower I 𝒢
+
+  private
+    𝑮 = proj₁ 𝒢
+    𝑷 = proj₁ ⨅ᵍ-Group
+
+  open Setoid 𝔻[ 𝑮 ] using ()
+    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝔻[ 𝑷 ] using () renaming ( _≈_ to _≈ₚ_ )
+
+  -- Membership: all coordinate values agree.
+  Diag : Pred 𝕌[ 𝑷 ] (ι ⊔ ρ)
+  Diag x = ∀ i j → x i ≈₁ x j
+```
+
+The constant embedding, and the pointed characterizations of membership: a tuple
+is diagonal exactly when it is `≈`-equal to a constant tuple, and any coordinate
+supplies the constant.
+
+```agda
+  -- The constant embedding S → Sᴵ.
+  κ : 𝕌[ 𝑮 ] → 𝕌[ 𝑷 ]
+  κ s _ = s
+
+  -- Constant tuples are diagonal.
+  κ-diag : (s : 𝕌[ 𝑮 ]) → κ s ∈ Diag
+  κ-diag s i j = refl₁
+
+  -- A tuple pointwise equal to a constant is diagonal.
+  diag-from-const : {x : 𝕌[ 𝑷 ]} → Σ[ s ∈ 𝕌[ 𝑮 ] ] (∀ i → x i ≈₁ s) → x ∈ Diag
+  diag-from-const (s , e) i j = trans₁ (e i) (sym₁ (e j))
+
+  -- Conversely, any coordinate value of a diagonal tuple is such a constant.
+  diag-to-const : (i₀ : I) {x : 𝕌[ 𝑷 ]} → x ∈ Diag → Σ[ s ∈ 𝕌[ 𝑮 ] ] (∀ i → x i ≈₁ s)
+  diag-to-const i₀ {x} d = x i₀ , λ i → d i i₀
+```
+
+#### The diagonal is a respecting subgroup
+
+Each closure proof moves between the power operation and the base operations by
+the pointwise descriptions, and applies the membership hypothesis coordinatewise.
+
+```agda
+  -- Diag respects the pointwise equality of the power.
+  Diag-respects : Diag Respects _≈ₚ_
+  Diag-respects e d i j = trans₁ (sym₁ (e i)) (trans₁ (d i j) (e j))
+
+  -- Diag is closed under the power operations, hence a respecting subgroup.
+  Diag-isSubgroup : IsSubgroup ⨅ᵍ-Group Diag
+  Diag-isSubgroup = mkIsSubgroup ⨅ᵍ-Group Diag-respects ∙-closed ε-closed ⁻¹-closed
+    where
+    open Group-Op 𝒢         using () renaming ( _∙_ to _∙₁_ ; ε to ε₁ ; _⁻¹ to _⁻¹₁ )
+    open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+
+    ∙-closed : ∀ {x y} → x ∈ Diag → y ∈ Diag → (x ∙ₚ y) ∈ Diag
+    ∙-closed {x} {y} dx dy i j =
+      trans₁  (∙ₚ-pointwise x y i)
+              (trans₁  (interp-cong 𝑮 ∙-Op (λ { 0F → dx i j ; 1F → dy i j }))
+                       (sym₁ (∙ₚ-pointwise x y j)))
+
+    ε-closed : εₚ ∈ Diag
+    ε-closed i j = trans₁ (εₚ-pointwise i) (sym₁ (εₚ-pointwise j))
+
+    ⁻¹-closed : ∀ {x} → x ∈ Diag → (x ⁻¹ₚ) ∈ Diag
+    ⁻¹-closed {x} d i j =
+      trans₁  (⁻¹ₚ-pointwise x i)
+              (trans₁  (interp-cong 𝑮 ⁻¹-Op (λ { 0F → d i j }))
+                       (sym₁ (⁻¹ₚ-pointwise x j)))
+```

--- a/src/Classical/Structures/Group/Diagonal.lagda.md
+++ b/src/Classical/Structures/Group/Diagonal.lagda.md
@@ -13,9 +13,9 @@ This is the [Classical.Structures.Group.Diagonal][] module of the [Agda Universa
 For a power `𝒢 ^ I` built by [Classical.Structures.Group.Power][], the
 **diagonal** is the set of constant tuples,
 
-$$D \;=\; \{\, (s, s, \dots, s) \mid s \in S \,\} \;\leq\; S^I ,$$
+    D = { (g, g, …, g) | g ∈ G } ≤ Gᴵ,
 
-the image of the constant embedding `κ`{.AgdaFunction}` : S → Sᴵ`.  Over a setoid
+the image of the constant embedding `κ`{.AgdaFunction}` : G → Gᴵ`.  Over a setoid
 carrier "constant" means *`≈`-constant*, so the predicate is stated as equality of
 any two coordinate values: `Diag x = ∀ i j → x i ≈ x j`.  This form respects the
 pointwise equality of the power by construction and needs no distinguished index,
@@ -26,11 +26,7 @@ consumers that do fix an index (`Fin (suc m)`, say).
 The diagonal is an equality-respecting subgroup (`IsSubgroup`{.AgdaRecord}): each
 closure proof rewrites one coordinate of the curried power operation to the base
 group by the pointwise descriptions of [Classical.Structures.Group.Power][], applies
-the hypothesis coordinatewise, and folds back.
-
-The diagonal is the bottom of the interval `[D , Sⁿ]` that Kurzweil's construction
-inhabits (issue #521); the partition subgroups whose least member it is are the
-subject of [Classical.Structures.Group.PartitionSubgroup][].
+the hypothesis coordinatewise, and folds back.[^1]
 
 <!--
 ```agda
@@ -41,21 +37,20 @@ module Classical.Structures.Group.Diagonal where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
-open import Data.Fin.Patterns   using ( 0F ; 1F )
-open import Data.Product        using ( Σ-syntax ; _,_ ; proj₁ )
-open import Level               using ( Level ; _⊔_ )
-open import Relation.Binary     using ( Setoid )
-open import Relation.Binary.Definitions   using ( _Respects_ )
-open import Relation.Unary      using ( Pred ; _∈_ )
+open import Data.Fin.Patterns            using ( 0F ; 1F )
+open import Data.Product                 using ( Σ-syntax ; _,_ ; proj₁ )
+open import Level                        using ( Level ; _⊔_ )
+open import Relation.Binary              using ( Setoid )
+open import Relation.Binary.Definitions  using ( _Respects_ )
+open import Relation.Unary               using ( Pred ; _∈_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Signatures.Group          using  ( ∙-Op ; ⁻¹-Op )
-open import Classical.Structures.Group.Basic    using  ( Group ; module Group-Op )
-open import Classical.Structures.Group.Power    using  ( module GroupPower )
-open import Classical.Structures.Group.Subgroups
-                                                using  ( IsSubgroup ; mkIsSubgroup )
-open import Classical.Structures.Interpret      using  ( interp-cong )
-open import Setoid.Algebras.Basic               using  ( 𝕌[_] ; 𝔻[_] )
+open import Classical.Signatures.Group            using ( ∙-Op ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic      using ( Group ; module Group-Op )
+open import Classical.Structures.Group.Power      using ( module GroupPower )
+open import Classical.Structures.Group.Subgroups  using ( IsSubgroup ; mkIsSubgroup )
+open import Classical.Structures.Interpret        using ( interp-cong )
+open import Setoid.Algebras.Basic                 using ( 𝕌[_] ; 𝔻[_] )
 
 private variable ι α ρ : Level
 ```
@@ -63,8 +58,8 @@ private variable ι α ρ : Level
 
 #### The diagonal predicate
 
-`DiagonalSubgroup`{.AgdaModule} `I` `𝒢` packages the diagonal of the power
-`𝒢 ^ I` for a fixed index type and base group.
+`DiagonalSubgroup`{.AgdaModule}` I 𝒢` packages the diagonal of the power `𝒢 ^ I` for
+a fixed index type and base group.
 
 ```agda
 module DiagonalSubgroup (I : Type ι) (𝒢 : Group α ρ) where
@@ -72,16 +67,16 @@ module DiagonalSubgroup (I : Type ι) (𝒢 : Group α ρ) where
   open GroupPower I 𝒢
 
   private
-    𝑮 = proj₁ 𝒢
-    𝑷 = proj₁ ⨅ᵍ-Group
+    𝑮 = 𝒢 .proj₁
+    𝑮ᴵ = ⨅ᵍ-Group .proj₁
 
-  open Setoid 𝔻[ 𝑮 ] using ()
-    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
-  open Setoid 𝔻[ 𝑷 ] using () renaming ( _≈_ to _≈ₚ_ )
+  open Setoid 𝔻[ 𝑮 ]  renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+                       using ( _≈_ )
+  open Setoid 𝔻[ 𝑮ᴵ ]  renaming ( _≈_ to _≈ᴵ_ ) using ()
 
   -- Membership: all coordinate values agree.
-  Diag : Pred 𝕌[ 𝑷 ] (ι ⊔ ρ)
-  Diag x = ∀ i j → x i ≈₁ x j
+  Diag : Pred 𝕌[ 𝑮ᴵ ] (ι ⊔ ρ)
+  Diag x = ∀ i j → x i ≈ x j
 ```
 
 The constant embedding, and the pointed characterizations of membership: a tuple
@@ -89,20 +84,20 @@ is diagonal exactly when it is `≈`-equal to a constant tuple, and any coordina
 supplies the constant.
 
 ```agda
-  -- The constant embedding S → Sᴵ.
-  κ : 𝕌[ 𝑮 ] → 𝕌[ 𝑷 ]
-  κ s _ = s
+  -- The constant embedding G → Gᴵ.
+  κ : 𝕌[ 𝑮 ] → 𝕌[ 𝑮ᴵ ]
+  κ g _ = g
 
   -- Constant tuples are diagonal.
-  κ-diag : (s : 𝕌[ 𝑮 ]) → κ s ∈ Diag
-  κ-diag s i j = refl₁
+  κ-diag : (g : 𝕌[ 𝑮 ]) → κ g ∈ Diag
+  κ-diag g i j = ≈refl
 
   -- A tuple pointwise equal to a constant is diagonal.
-  diag-from-const : {x : 𝕌[ 𝑷 ]} → Σ[ s ∈ 𝕌[ 𝑮 ] ] (∀ i → x i ≈₁ s) → x ∈ Diag
-  diag-from-const (s , e) i j = trans₁ (e i) (sym₁ (e j))
+  diag-from-const : {x : 𝕌[ 𝑮ᴵ ]} → Σ[ g ∈ 𝕌[ 𝑮 ] ] (∀ i → x i ≈ g) → x ∈ Diag
+  diag-from-const (g , e) i j = ≈trans (e i) (≈sym (e j))
 
   -- Conversely, any coordinate value of a diagonal tuple is such a constant.
-  diag-to-const : (i₀ : I) {x : 𝕌[ 𝑷 ]} → x ∈ Diag → Σ[ s ∈ 𝕌[ 𝑮 ] ] (∀ i → x i ≈₁ s)
+  diag-to-const : (i₀ : I) {x : 𝕌[ 𝑮ᴵ ]} → x ∈ Diag → Σ[ g ∈ 𝕌[ 𝑮 ] ] (∀ i → x i ≈ g)
   diag-to-const i₀ {x} d = x i₀ , λ i → d i i₀
 ```
 
@@ -113,27 +108,31 @@ the pointwise descriptions, and applies the membership hypothesis coordinatewise
 
 ```agda
   -- Diag respects the pointwise equality of the power.
-  Diag-respects : Diag Respects _≈ₚ_
-  Diag-respects e d i j = trans₁ (sym₁ (e i)) (trans₁ (d i j) (e j))
+  Diag-respects : Diag Respects _≈ᴵ_
+  Diag-respects e d i j = ≈trans (≈sym (e i)) (≈trans (d i j) (e j))
 
   -- Diag is closed under the power operations, hence a respecting subgroup.
   Diag-isSubgroup : IsSubgroup ⨅ᵍ-Group Diag
   Diag-isSubgroup = mkIsSubgroup ⨅ᵍ-Group Diag-respects ∙-closed ε-closed ⁻¹-closed
     where
-    open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+    open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _⊗_ ; ε to e ; _⁻¹ to inv )
 
-    ∙-closed : ∀ {x y} → x ∈ Diag → y ∈ Diag → (x ∙ₚ y) ∈ Diag
+    ∙-closed : ∀ {x y} → x ∈ Diag → y ∈ Diag → (x ⊗ y) ∈ Diag
     ∙-closed {x} {y} dx dy i j =
-      trans₁  (∙ₚ-pointwise x y i)
-              (trans₁  (interp-cong 𝑮 ∙-Op (λ { 0F → dx i j ; 1F → dy i j }))
-                       (sym₁ (∙ₚ-pointwise x y j)))
+      ≈trans  (⊗-pointwise x y i)
+              (≈trans  (interp-cong 𝑮 ∙-Op λ { 0F → dx i j ; 1F → dy i j })
+                       (≈sym (⊗-pointwise x y j)))
 
-    ε-closed : εₚ ∈ Diag
-    ε-closed i j = trans₁ (εₚ-pointwise i) (sym₁ (εₚ-pointwise j))
+    ε-closed : e ∈ Diag
+    ε-closed i j = ≈trans (e-pointwise i) (≈sym (e-pointwise j))
 
-    ⁻¹-closed : ∀ {x} → x ∈ Diag → (x ⁻¹ₚ) ∈ Diag
-    ⁻¹-closed {x} d i j =
-      trans₁  (⁻¹ₚ-pointwise x i)
-              (trans₁  (interp-cong 𝑮 ⁻¹-Op (λ { 0F → d i j }))
-                       (sym₁ (⁻¹ₚ-pointwise x j)))
+    ⁻¹-closed : ∀ {x} → x ∈ Diag → (inv x) ∈ Diag
+    ⁻¹-closed {x} d i j = ≈trans  (inv-pointwise x i)
+                                  (≈trans  (interp-cong 𝑮 ⁻¹-Op λ { 0F → d i j })
+                                           (≈sym (inv-pointwise x j)))
 ```
+---
+
+[^1]: The diagonal is the bottom of the interval `[D , Gⁿ]` that Kurzweil's construction
+      inhabits (Issue #521); it is the bottom of the lattice of *partition subgroups*
+      (the subject of [Classical.Structures.Group.PartitionSubgroup][]).

--- a/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
+++ b/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
@@ -90,7 +90,7 @@ power, together with the diagonal of [Classical.Structures.Group.Diagonal][].
 ```agda
 module PartitionSubgroups (n : ℕ) (𝒢 : Group α ρ) where
 
-  open GroupPower (Fin n) 𝒢
+  open GroupPower (Fin n) 𝒢 public
   open DiagonalSubgroup (Fin n) 𝒢 public
 
   private

--- a/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
+++ b/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
@@ -1,0 +1,224 @@
+---
+layout: default
+file: "src/Classical/Structures/Group/PartitionSubgroup.lagda.md"
+title: "Classical.Structures.Group.PartitionSubgroup module"
+date: "2026-07-27"
+author: "the agda-algebras development team"
+---
+
+### Partition subgroups of a finite power
+
+This is the [Classical.Structures.Group.PartitionSubgroup][] module of the [Agda Universal Algebra Library][].
+
+For the finite power `𝒢 ^ᵍ n` of [Classical.Structures.Group.Power][] and a
+partition `π` of the index set — a `ParentVec`{.AgdaFunction} read through its
+kernel, as in [Classical.Structures.Lattice.Partitions][] — the **partition
+subgroup** is the set of tuples constant on the blocks of `π`:
+
+$$K_\pi \;=\; \{\, y \in S^n \mid \ker \pi \leq \ker y \,\}.$$
+
+These are the subgroups Kurzweil's construction is about (issue #521; the sources
+write `K_f` or `f̂[Sⁿ]` for `f` an idempotent decreasing map presenting `π`):
+every `K_π` is an equality-respecting subgroup sandwiched between the diagonal
+`D = K_⊤` and the full power `Sⁿ = K_⊥`, and the assignment `π ↦ K_π` reverses
+the refinement order — a finer partition imposes fewer constancy constraints,
+hence a larger subgroup.
+
+The delicate lemma is **order reflection**: if `K_ρ ⊆ K_π` then `π ⊑ ρ`.  Its
+proof is the one place the base group must be *nontrivial*: for indices `i , j`
+in distinct `ρ`-blocks, the indicator tuple that is `s` on the `ρ`-block of `i`
+and `ε` elsewhere lies in `K_ρ`, so it lies in `K_π`; if `π` related `i` and `j`
+the indicator would identify `s` with `ε`.  The hypothesis enters as an explicit
+witness `s` with `¬ (s ≈ ε)` — the constructive, positive form of nontriviality
+(the negative form `Nontrivial`{.AgdaFunction} of
+[Classical.Structures.Group.MinimalNormal][] supplies no witness to build the
+indicator from).  Membership in a `ρ`-block is decided by the parent lookups, so
+the reflection is fully constructive.
+
+Together, monotonicity and reflection make `π ↦ K_π` a *dual order embedding* of
+the partition lattice `Eq(n)` into the interval `[D , Sⁿ]` of the subgroup
+lattice; that `K` is also *onto* the interval when the base group is a
+nonabelian simple group is Kurzweil's lemma, registered as an explicit
+hypothesis where the FLRP program consumes it ([FLRP.KurzweilInterval][]).
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Group.PartitionSubgroup where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Bool.Base      using ( if_then_else_ )
+open import Data.Empty          using ( ⊥-elim )
+open import Data.Fin.Base       using ( Fin )
+open import Data.Fin.Patterns   using ( 0F ; 1F )
+open import Data.Fin.Properties using ( _≟_ )
+open import Data.Nat.Base       using ( ℕ )
+open import Data.Product        using ( _,_ ; proj₁ ; proj₂ )
+open import Level               using ( Level ; _⊔_ )
+open import Relation.Binary     using ( Setoid )
+open import Relation.Binary.Definitions           using ( _Respects_ )
+open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl ; sym ; trans
+                                                        ; cong )
+open import Relation.Nullary            using ( ¬_ ; Dec ; yes ; no )
+open import Relation.Nullary.Decidable  using ( does ; dec-true ; dec-false )
+open import Relation.Unary              using ( Pred ; _∈_ ; _⊆_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Signatures.Group             using  ( ∙-Op ; ε-Op ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic       using  ( Group ; module Group-Op )
+open import Classical.Structures.Group.Diagonal    using  ( module DiagonalSubgroup )
+open import Classical.Structures.Group.Power       using  ( module GroupPower )
+open import Classical.Structures.Group.Subgroups   using  ( IsSubgroup ; mkIsSubgroup )
+open import Classical.Structures.Interpret         using  ( interp-cong )
+open import Classical.Structures.Lattice.Partitions
+  using  ( SameBlock ; _⊑_ ; _≈ᵖ_ ; ⊤ᵉ ; ⊤ᵉ-related ; ⊥ᵉ ; parent-tab )
+open import Setoid.Congruences.Certificates.Schema using  ( ParentVec ; parent )
+open import Setoid.Algebras.Basic                  using  ( 𝕌[_] ; 𝔻[_] )
+
+private variable α ρ : Level
+```
+-->
+
+#### The partition subgroup predicate
+
+`PartitionSubgroups`{.AgdaModule} `n` `𝒢` packages the family `K` for a fixed
+power, together with the diagonal of [Classical.Structures.Group.Diagonal][].
+
+```agda
+module PartitionSubgroups (n : ℕ) (𝒢 : Group α ρ) where
+
+  open GroupPower (Fin n) 𝒢
+  open DiagonalSubgroup (Fin n) 𝒢 public
+
+  private
+    𝑮 = proj₁ 𝒢
+    𝑷 = proj₁ ⨅ᵍ-Group
+
+  open Setoid 𝔻[ 𝑮 ] using ( reflexive )
+    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+  open Setoid 𝔻[ 𝑷 ] using () renaming ( _≈_ to _≈ₚ_ )
+  open Group-Op 𝒢 using () renaming ( ε to ε₁ )
+
+  -- Membership: the tuple is constant on every block of the partition.
+  K : ParentVec n → Pred 𝕌[ 𝑷 ] ρ
+  K pv x = ∀ {i j} → SameBlock pv i j → x i ≈₁ x j
+```
+
+Every `K pv` is an equality-respecting subgroup, by the same coordinatewise
+rewriting as for the diagonal.
+
+```agda
+  -- K pv respects the pointwise equality of the power.
+  K-respects : (pv : ParentVec n) → K pv Respects _≈ₚ_
+  K-respects pv {x} {y} e k {i} {j} sb = trans₁ (sym₁ (e i)) (trans₁ (k sb) (e j))
+
+  -- K pv is closed under the power operations, hence a respecting subgroup.
+  K-isSubgroup : (pv : ParentVec n) → IsSubgroup ⨅ᵍ-Group (K pv)
+  K-isSubgroup pv = mkIsSubgroup ⨅ᵍ-Group (K-respects pv) ∙-closed ε-closed ⁻¹-closed
+    where
+    open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+
+    ∙-closed : ∀ {x y} → x ∈ K pv → y ∈ K pv → (x ∙ₚ y) ∈ K pv
+    ∙-closed {x} {y} kx ky {i} {j} sb =
+      trans₁  (∙ₚ-pointwise x y i)
+              (trans₁  (interp-cong 𝑮 ∙-Op (λ { 0F → kx sb ; 1F → ky sb }))
+                       (sym₁ (∙ₚ-pointwise x y j)))
+
+    ε-closed : εₚ ∈ K pv
+    ε-closed {i} {j} _ = trans₁ (εₚ-pointwise i) (sym₁ (εₚ-pointwise j))
+
+    ⁻¹-closed : ∀ {x} → x ∈ K pv → (x ⁻¹ₚ) ∈ K pv
+    ⁻¹-closed {x} kx {i} {j} sb =
+      trans₁  (⁻¹ₚ-pointwise x i)
+              (trans₁  (interp-cong 𝑮 ⁻¹-Op (λ { 0F → kx sb }))
+                       (sym₁ (⁻¹ₚ-pointwise x j)))
+```
+
+#### The sandwich `D ≤ K_π ≤ Sⁿ`
+
+Diagonal tuples are constant outright, so they lie in every partition subgroup;
+the one-block partition recovers the diagonal exactly, and the discrete
+partition imposes no constraint at all.
+
+```agda
+  -- The diagonal lies in every partition subgroup.
+  Diag⊆K : (pv : ParentVec n) → Diag ⊆ K pv
+  Diag⊆K pv d {i} {j} _ = d i j
+
+  -- The one-block partition carves out exactly the diagonal.
+  K⊤⊆Diag : K (⊤ᵉ n) ⊆ Diag
+  K⊤⊆Diag k i j = k (⊤ᵉ-related n i j)
+
+  Diag⊆K⊤ : Diag ⊆ K (⊤ᵉ n)
+  Diag⊆K⊤ = Diag⊆K (⊤ᵉ n)
+
+  -- The discrete partition constrains nothing: K ⊥ᵉ is the full power.
+  K⊥-full : (x : 𝕌[ 𝑷 ]) → x ∈ K (⊥ᵉ n)
+  K⊥-full x {i} {j} sb = reflexive (cong x discrete)
+    where
+    discrete : i ≡ j
+    discrete = trans (sym (parent-tab (λ k → k) i)) (trans sb (parent-tab (λ k → k) j))
+```
+
+#### Order reversal
+
+Refinement reverses under `K`: a finer partition has more blocks, fewer
+constancy constraints, and a larger subgroup.
+
+```agda
+  -- Monotone contravariance: pu ⊑ pw implies K pw ⊆ K pu.
+  K-antitone : {pu pw : ParentVec n} → pu ⊑ pw → K pw ⊆ K pu
+  K-antitone h k sb = k (h sb)
+```
+
+Conversely, inclusion of partition subgroups reflects refinement, given a
+witness that the base group is nontrivial.  For `π`-related `i , j`, either the
+`ρ`-relation of `i , j` is already decided true, or the indicator of the
+`ρ`-block of `i` — the tuple `s` on that block and `ε` off it — lies in
+`K ρ ⊆ K π` yet takes the values `s` at `i` and `ε` at `j`, forcing the
+contradiction `s ≈ ε`.
+
+```agda
+  -- Reflection: K pw ⊆ K pu implies pu ⊑ pw, for a nontrivial base group.
+  K-reflects : (s : 𝕌[ 𝑮 ]) → ¬ (s ≈₁ ε₁) → {pu pw : ParentVec n}
+    → K pw ⊆ K pu → pu ⊑ pw
+  K-reflects s s≉ε {pu} {pw} incl {i} {j} sbu = decide (parent pw i ≟ parent pw j)
+    where
+    -- The indicator of the pw-block of i.
+    ind : 𝕌[ 𝑷 ]
+    ind k = if does (parent pw k ≟ parent pw i) then s else ε₁
+
+    -- The indicator is constant on pw-blocks, so it lies in K pw.
+    ind∈Kpw : ind ∈ K pw
+    ind∈Kpw {k} {l} sb =
+      reflexive (cong (λ t → if does (t ≟ parent pw i) then s else ε₁) sb)
+
+    decide : Dec (SameBlock pw i j) → SameBlock pw i j
+    decide (yes e)   = e
+    decide (no ¬e)   = ⊥-elim (s≉ε s≈ε)
+      where
+      ind-i : ind i ≡ s
+      ind-i = cong (λ b → if b then s else ε₁) (dec-true (parent pw i ≟ parent pw i) refl)
+
+      ind-j : ind j ≡ ε₁
+      ind-j = cong  (λ b → if b then s else ε₁)
+                    (dec-false (parent pw j ≟ parent pw i) (λ e → ¬e (sym e)))
+
+      s≈ε : s ≈₁ ε₁
+      s≈ε = trans₁  (reflexive (sym ind-i))
+                    (trans₁ (incl ind∈Kpw sbu) (reflexive ind-j))
+```
+
+Reflection upgrades mutual inclusion of partition subgroups to equality of
+partitions — the injectivity of `π ↦ K_π`, in the setoid sense.
+
+```agda
+  -- Mutual inclusion of partition subgroups gives equal partitions.
+  K-injective : (s : 𝕌[ 𝑮 ]) → ¬ (s ≈₁ ε₁) → {pu pw : ParentVec n}
+    → K pw ⊆ K pu → K pu ⊆ K pw → pu ≈ᵖ pw
+  K-injective s s≉ε {pu} {pw} wu uw =
+    K-reflects s s≉ε {pu = pu} {pw = pw} wu , K-reflects s s≉ε {pu = pw} {pw = pu} uw
+```

--- a/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
+++ b/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
@@ -47,8 +47,6 @@ hypothesis where the FLRP program consumes it ([FLRP.KurzweilInterval][]).
 
 module Classical.Structures.Group.PartitionSubgroup where
 
-open import Agda.Primitive using () renaming ( Set to Type )
-
 -- Imports from the Agda Standard Library ---------------------------------------
 open import Data.Bool.Base      using ( if_then_else_ )
 open import Data.Empty          using ( ⊥-elim )
@@ -56,8 +54,8 @@ open import Data.Fin.Base       using ( Fin )
 open import Data.Fin.Patterns   using ( 0F ; 1F )
 open import Data.Fin.Properties using ( _≟_ )
 open import Data.Nat.Base       using ( ℕ )
-open import Data.Product        using ( _,_ ; proj₁ ; proj₂ )
-open import Level               using ( Level ; _⊔_ )
+open import Data.Product        using ( _,_ ; proj₁ )
+open import Level               using ( Level )
 open import Relation.Binary     using ( Setoid )
 open import Relation.Binary.Definitions           using ( _Respects_ )
 open import Relation.Binary.PropositionalEquality using ( _≡_ ; refl ; sym ; trans
@@ -67,7 +65,7 @@ open import Relation.Nullary.Decidable  using ( does ; dec-true ; dec-false )
 open import Relation.Unary              using ( Pred ; _∈_ ; _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Signatures.Group             using  ( ∙-Op ; ε-Op ; ⁻¹-Op )
+open import Classical.Signatures.Group             using  ( ∙-Op ; ⁻¹-Op )
 open import Classical.Structures.Group.Basic       using  ( Group ; module Group-Op )
 open import Classical.Structures.Group.Diagonal    using  ( module DiagonalSubgroup )
 open import Classical.Structures.Group.Power       using  ( module GroupPower )
@@ -98,7 +96,7 @@ module PartitionSubgroups (n : ℕ) (𝒢 : Group α ρ) where
     𝑷 = proj₁ ⨅ᵍ-Group
 
   open Setoid 𝔻[ 𝑮 ] using ( reflexive )
-    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁ )
+    renaming ( _≈_ to _≈₁_ ; sym to sym₁ ; trans to trans₁ )
   open Setoid 𝔻[ 𝑷 ] using () renaming ( _≈_ to _≈ₚ_ )
   open Group-Op 𝒢 using () renaming ( ε to ε₁ )
 

--- a/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
+++ b/src/Classical/Structures/Group/PartitionSubgroup.lagda.md
@@ -11,35 +11,29 @@ author: "the agda-algebras development team"
 This is the [Classical.Structures.Group.PartitionSubgroup][] module of the [Agda Universal Algebra Library][].
 
 For the finite power `𝒢 ^ᵍ n` of [Classical.Structures.Group.Power][] and a
-partition `π` of the index set — a `ParentVec`{.AgdaFunction} read through its
-kernel, as in [Classical.Structures.Lattice.Partitions][] — the **partition
-subgroup** is the set of tuples constant on the blocks of `π`:
+partition `π` of the index set, the **partition subgroup** is the set of tuples
+constant on the blocks of `π`:
 
-$$K_\pi \;=\; \{\, y \in S^n \mid \ker \pi \leq \ker y \,\}.$$
+    Kπ = { y ∈ Gⁿ | ∀ i j → ker π ≤ ker y }
+       = { y ∈ Gⁿ | ∀ i j → π i j → y i ≈ y j }.
 
-These are the subgroups Kurzweil's construction is about (issue #521; the sources
-write `K_f` or `f̂[Sⁿ]` for `f` an idempotent decreasing map presenting `π`):
-every `K_π` is an equality-respecting subgroup sandwiched between the diagonal
-`D = K_⊤` and the full power `Sⁿ = K_⊥`, and the assignment `π ↦ K_π` reverses
-the refinement order — a finer partition imposes fewer constancy constraints,
-hence a larger subgroup.
 
-The delicate lemma is **order reflection**: if `K_ρ ⊆ K_π` then `π ⊑ ρ`.  Its
-proof is the one place the base group must be *nontrivial*: for indices `i , j`
-in distinct `ρ`-blocks, the indicator tuple that is `s` on the `ρ`-block of `i`
-and `ε` elsewhere lies in `K_ρ`, so it lies in `K_π`; if `π` related `i` and `j`
-the indicator would identify `s` with `ε`.  The hypothesis enters as an explicit
-witness `s` with `¬ (s ≈ ε)` — the constructive, positive form of nontriviality
-(the negative form `Nontrivial`{.AgdaFunction} of
-[Classical.Structures.Group.MinimalNormal][] supplies no witness to build the
-indicator from).  Membership in a `ρ`-block is decided by the parent lookups, so
-the reflection is fully constructive.
+This is an equality-respecting subgroup of the power, sandwiched between the diagonal
+`D = K⊤` and the full power `Gⁿ = K⊥`, and the assignment `π ↦ Kπ` reverses the
+refinement order — a finer partition imposes fewer constancy constraints, hence a
+larger subgroup.
 
-Together, monotonicity and reflection make `π ↦ K_π` a *dual order embedding* of
-the partition lattice `Eq(n)` into the interval `[D , Sⁿ]` of the subgroup
-lattice; that `K` is also *onto* the interval when the base group is a
-nonabelian simple group is Kurzweil's lemma, registered as an explicit
-hypothesis where the FLRP program consumes it ([FLRP.KurzweilInterval][]).
+The delicate lemma is *order reflection*: if `Kρ ⊆ Kπ` then `π ⊑ ρ`.
+Its proof is the one place the base group must be *nontrivial*.  Indeed, for indices
+`i , j` in distinct `ρ`-blocks, the indicator tuple that is `s` on the `ρ`-block of
+`i` and `ε` elsewhere lies in `Kρ`, so it lies in `Kπ`; if `π i j`, then the
+indicator would identify `s` with `ε`.  The hypothesis enters as an explicit
+witness `s` with `¬ s ≈ ε` — the constructive, positive form of nontriviality.[^1]
+Membership in a `ρ`-block is decided by the parent lookups, so the reflection is
+fully constructive.
+
+Together, monotonicity and reflection make `π ↦ Kπ` a *dual order embedding* of the
+partition lattice `Eq(n)` into the interval `[D , Gⁿ]` of the subgroup lattice.[^2]
 
 <!--
 ```agda
@@ -55,6 +49,7 @@ open import Data.Fin.Patterns   using ( 0F ; 1F )
 open import Data.Fin.Properties using ( _≟_ )
 open import Data.Nat.Base       using ( ℕ )
 open import Data.Product        using ( _,_ ; proj₁ )
+open import Function            using ( id )
 open import Level               using ( Level )
 open import Relation.Binary     using ( Setoid )
 open import Relation.Binary.Definitions           using ( _Respects_ )
@@ -82,7 +77,7 @@ private variable α ρ : Level
 
 #### The partition subgroup predicate
 
-`PartitionSubgroups`{.AgdaModule} `n` `𝒢` packages the family `K` for a fixed
+`PartitionSubgroups`{.AgdaModule}` n 𝒢` packages the family `K` for a fixed
 power, together with the diagonal of [Classical.Structures.Group.Diagonal][].
 
 ```agda
@@ -92,17 +87,16 @@ module PartitionSubgroups (n : ℕ) (𝒢 : Group α ρ) where
   open DiagonalSubgroup (Fin n) 𝒢 public
 
   private
-    𝑮 = proj₁ 𝒢
-    𝑷 = proj₁ ⨅ᵍ-Group
+    𝑮 = 𝒢 .proj₁
+    Π𝑮 = ⨅ᵍ-Group .proj₁
 
-  open Setoid 𝔻[ 𝑮 ] using ( reflexive )
-    renaming ( _≈_ to _≈₁_ ; sym to sym₁ ; trans to trans₁ )
-  open Setoid 𝔻[ 𝑷 ] using () renaming ( _≈_ to _≈ₚ_ )
-  open Group-Op 𝒢 using () renaming ( ε to ε₁ )
+  open Setoid 𝔻[ 𝑮 ] using (reflexive ; _≈_) renaming (sym to ≈sym ; trans to ≈trans)
+  open Setoid 𝔻[ Π𝑮 ] using () renaming ( _≈_ to _≈ᴵ_ )
+  open Group-Op 𝒢 using ( ε )
 
   -- Membership: the tuple is constant on every block of the partition.
-  K : ParentVec n → Pred 𝕌[ 𝑷 ] ρ
-  K pv x = ∀ {i j} → SameBlock pv i j → x i ≈₁ x j
+  K : ParentVec n → Pred 𝕌[ Π𝑮 ] ρ
+  K pv x = ∀ {i j} → SameBlock pv i j → x i ≈ x j
 ```
 
 Every `K pv` is an equality-respecting subgroup, by the same coordinatewise
@@ -110,32 +104,32 @@ rewriting as for the diagonal.
 
 ```agda
   -- K pv respects the pointwise equality of the power.
-  K-respects : (pv : ParentVec n) → K pv Respects _≈ₚ_
-  K-respects pv {x} {y} e k {i} {j} sb = trans₁ (sym₁ (e i)) (trans₁ (k sb) (e j))
+  K-respects : (pv : ParentVec n) → K pv Respects _≈ᴵ_
+  K-respects pv e k {i} {j} sb = ≈trans (≈sym (e i)) (≈trans (k sb) (e j))
 
   -- K pv is closed under the power operations, hence a respecting subgroup.
   K-isSubgroup : (pv : ParentVec n) → IsSubgroup ⨅ᵍ-Group (K pv)
   K-isSubgroup pv = mkIsSubgroup ⨅ᵍ-Group (K-respects pv) ∙-closed ε-closed ⁻¹-closed
     where
-    open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+    open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _⊗_ ; ε to e ; _⁻¹ to inv )
 
-    ∙-closed : ∀ {x y} → x ∈ K pv → y ∈ K pv → (x ∙ₚ y) ∈ K pv
+    ∙-closed : ∀ {x y} → x ∈ K pv → y ∈ K pv → x ⊗ y ∈ K pv
     ∙-closed {x} {y} kx ky {i} {j} sb =
-      trans₁  (∙ₚ-pointwise x y i)
-              (trans₁  (interp-cong 𝑮 ∙-Op (λ { 0F → kx sb ; 1F → ky sb }))
-                       (sym₁ (∙ₚ-pointwise x y j)))
+      ≈trans  (⊗-pointwise x y i)
+              (≈trans  (interp-cong 𝑮 ∙-Op λ { 0F → kx sb ; 1F → ky sb })
+                       (≈sym (⊗-pointwise x y j)))
 
-    ε-closed : εₚ ∈ K pv
-    ε-closed {i} {j} _ = trans₁ (εₚ-pointwise i) (sym₁ (εₚ-pointwise j))
+    ε-closed : e ∈ K pv
+    ε-closed {i} {j} _ = ≈trans (e-pointwise i) (≈sym (e-pointwise j))
 
-    ⁻¹-closed : ∀ {x} → x ∈ K pv → (x ⁻¹ₚ) ∈ K pv
+    ⁻¹-closed : ∀ {x} → x ∈ K pv → inv x ∈ K pv
     ⁻¹-closed {x} kx {i} {j} sb =
-      trans₁  (⁻¹ₚ-pointwise x i)
-              (trans₁  (interp-cong 𝑮 ⁻¹-Op (λ { 0F → kx sb }))
-                       (sym₁ (⁻¹ₚ-pointwise x j)))
+      ≈trans  (inv-pointwise x i)
+              (≈trans  (interp-cong 𝑮 ⁻¹-Op λ { 0F → kx sb })
+                       (≈sym (inv-pointwise x j)))
 ```
 
-#### The sandwich `D ≤ K_π ≤ Sⁿ`
+#### The sandwich `D ≤ Kπ ≤ Sⁿ`
 
 Diagonal tuples are constant outright, so they lie in every partition subgroup;
 the one-block partition recovers the diagonal exactly, and the discrete
@@ -154,11 +148,11 @@ partition imposes no constraint at all.
   Diag⊆K⊤ = Diag⊆K (⊤ᵉ n)
 
   -- The discrete partition constrains nothing: K ⊥ᵉ is the full power.
-  K⊥-full : (x : 𝕌[ 𝑷 ]) → x ∈ K (⊥ᵉ n)
+  K⊥-full : (x : 𝕌[ Π𝑮 ]) → x ∈ K (⊥ᵉ n)
   K⊥-full x {i} {j} sb = reflexive (cong x discrete)
     where
     discrete : i ≡ j
-    discrete = trans (sym (parent-tab (λ k → k) i)) (trans sb (parent-tab (λ k → k) j))
+    discrete = trans (sym (parent-tab id i)) (trans sb (parent-tab id j))
 ```
 
 #### Order reversal
@@ -181,42 +175,50 @@ contradiction `s ≈ ε`.
 
 ```agda
   -- Reflection: K pw ⊆ K pu implies pu ⊑ pw, for a nontrivial base group.
-  K-reflects : (s : 𝕌[ 𝑮 ]) → ¬ (s ≈₁ ε₁) → {pu pw : ParentVec n}
+  K-reflects : (s : 𝕌[ 𝑮 ]) → ¬ (s ≈ ε) → {pu pw : ParentVec n}
     → K pw ⊆ K pu → pu ⊑ pw
   K-reflects s s≉ε {pu} {pw} incl {i} {j} sbu = decide (parent pw i ≟ parent pw j)
     where
     -- The indicator of the pw-block of i.
-    ind : 𝕌[ 𝑷 ]
-    ind k = if does (parent pw k ≟ parent pw i) then s else ε₁
+    ind : 𝕌[ Π𝑮 ]
+    ind k = if does (parent pw k ≟ parent pw i) then s else ε
 
     -- The indicator is constant on pw-blocks, so it lies in K pw.
     ind∈Kpw : ind ∈ K pw
     ind∈Kpw {k} {l} sb =
-      reflexive (cong (λ t → if does (t ≟ parent pw i) then s else ε₁) sb)
+      reflexive (cong (λ t → if does (t ≟ parent pw i) then s else ε) sb)
 
     decide : Dec (SameBlock pw i j) → SameBlock pw i j
     decide (yes e)   = e
     decide (no ¬e)   = ⊥-elim (s≉ε s≈ε)
       where
       ind-i : ind i ≡ s
-      ind-i = cong (λ b → if b then s else ε₁) (dec-true (parent pw i ≟ parent pw i) refl)
+      ind-i = cong (λ b → if b then s else ε) (dec-true (parent pw i ≟ parent pw i) refl)
 
-      ind-j : ind j ≡ ε₁
-      ind-j = cong  (λ b → if b then s else ε₁)
+      ind-j : ind j ≡ ε
+      ind-j = cong  (λ b → if b then s else ε)
                     (dec-false (parent pw j ≟ parent pw i) (λ e → ¬e (sym e)))
 
-      s≈ε : s ≈₁ ε₁
-      s≈ε = trans₁  (reflexive (sym ind-i))
-                    (trans₁ (incl ind∈Kpw sbu) (reflexive ind-j))
+      s≈ε : s ≈ ε
+      s≈ε = ≈trans  (reflexive (sym ind-i))
+                    (≈trans (incl ind∈Kpw sbu) (reflexive ind-j))
 ```
 
-Reflection upgrades mutual inclusion of partition subgroups to equality of
-partitions — the injectivity of `π ↦ K_π`, in the setoid sense.
+Reflection upgrades mutual inclusion of partition subgroups to equality of partitions
+— the injectivity of `π ↦ Kπ`, in the setoid sense.
 
 ```agda
   -- Mutual inclusion of partition subgroups gives equal partitions.
-  K-injective : (s : 𝕌[ 𝑮 ]) → ¬ (s ≈₁ ε₁) → {pu pw : ParentVec n}
+  K-injective : (s : 𝕌[ 𝑮 ]) → ¬ s ≈ ε → {pu pw : ParentVec n}
     → K pw ⊆ K pu → K pu ⊆ K pw → pu ≈ᵖ pw
   K-injective s s≉ε {pu} {pw} wu uw =
     K-reflects s s≉ε {pu = pu} {pw = pw} wu , K-reflects s s≉ε {pu = pw} {pw = pu} uw
 ```
+
+[^1]: The negative form `Nontrivial`{.AgdaFunction} of
+      [Classical.Structures.Group.MinimalNormal][] supplies no witness to build the
+      indicator from.
+
+[^2]: `K` is also *onto* the interval if `G` is a nonabelian simple group; this is
+      **Kurzweil's lemma**, registered as an explicit hypothesis where the FLRP
+      program consumes it ([FLRP.KurzweilInterval][]).

--- a/src/Classical/Structures/Group/Power.lagda.md
+++ b/src/Classical/Structures/Group/Power.lagda.md
@@ -1,0 +1,184 @@
+---
+layout: default
+file: "src/Classical/Structures/Group/Power.lagda.md"
+title: "Classical.Structures.Group.Power module"
+date: "2026-07-27"
+author: "the agda-algebras development team"
+---
+
+### Indexed products and powers of groups
+
+This is the [Classical.Structures.Group.Power][] module of the [Agda Universal Algebra Library][].
+
+For an indexed family `𝒢s : I → Group α ρ`{.AgdaBound} of groups presented as
+Σ-typed structures over [`Sig-Group`][Classical.Signatures.Group], this module
+constructs the **indexed direct product** `⨅ᵍ 𝒢s`{.AgdaFunction}: the group on the
+product algebra `⨅`{.AgdaFunction} of [Setoid.Algebras.Products][], whose carrier is
+the function type `∀ i → 𝕌[ 𝑮s i ]` with pointwise operations and pointwise
+equality.  The five group laws transfer coordinatewise by
+`⊧-P-invar`{.AgdaFunction} of [Setoid.Varieties.Properties][] — products preserve
+identities — so no term induction is repeated here.
+
+This construction *generalizes* the binary product `_×ᵍ_`{.AgdaFunction} of
+[Classical.Structures.Group.Product][] rather than replacing it: the binary module
+deliberately keeps the *pair* carrier `G × K`, which is the form the FLRP fattening
+arguments consume, whereas the function-typed carrier here is the form **Kurzweil's
+construction** consumes.  The power `𝒢 ^ᵍ n`{.AgdaFunction} is the constant-family
+product over `I = Fin n`, so an element of `S ^ᵍ n` is literally a map
+`x : Fin n → S`, and conditions such as "`x` is constant on the blocks of a
+partition of the index set" — the membership conditions of the diagonal and of the
+partition subgroups (issue #521) — are stated by comparing values of `x` at
+indices, with no tuple bookkeeping.
+
+Besides the product and the power, the module provides
+
++  **pointwise descriptions of the curried operations** — `(x ∙ y) i ≈ x i ∙ y i`
+   and its companions for `ε` and `⁻¹` — bridging the `Fin`-tuple η-gap exactly as
+   in the binary module (the curried accessors route arguments through a canonical
+   `pair` tuple, and `Fin`-indexed tuples lack η under `--cubical-compatible`;
+   each bridge is one `interp-cong`{.AgdaFunction} per use); and
++  **coordinate projections as homomorphisms**, by instantiating the generic
+   `⨅-proj`{.AgdaFunction} of [Setoid.Homomorphisms.Products][].
+
+Following the Cubical-port discipline, the underlying equivalence of the product is
+not redefined here: it is the pointwise equivalence of `⨅`{.AgdaFunction}, so the
+equality locus to substitute on the eventual port is that of
+[Setoid.Algebras.Products][] alone.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Group.Power where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Fin.Base       using ( Fin )
+open import Data.Fin.Patterns   using ( 0F ; 1F )
+open import Data.Nat.Base       using ( ℕ )
+open import Data.Product        using ( _,_ ; proj₁ ; proj₂ )
+open import Function            using ( _∘_ )
+open import Level               using ( Level ; _⊔_ )
+open import Relation.Binary     using ( Setoid )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Signatures.Group          using  ( Sig-Group ; ∙-Op ; ε-Op
+                                                       ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic    using  ( Group ; module Group-Op
+                                                       ; _⊨ᵍᵖ_ )
+open import Classical.Structures.Interpret      using  ( interp-cong )
+open import Classical.Theories.Group            using  ( Th-Group )
+open import Setoid.Algebras.Basic               using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Products            using  ( ⨅ )
+open import Setoid.Homomorphisms.Basic          using  ( hom )
+open import Setoid.Homomorphisms.Products       using  ( ⨅-proj )
+open import Setoid.Varieties.Properties         using  ( ⊧-P-invar )
+
+private variable ι α ρ : Level
+```
+-->
+
+#### The indexed product of a family of groups
+
+`GroupFamilyProduct`{.AgdaModule} `𝒢s` packages the construction for a fixed family:
+the product algebra, the transferred satisfaction proof, and the product group.
+Each group equation holds in `⨅`{.AgdaFunction} because it holds in every
+coordinate — this is `⊧-P-invar`{.AgdaFunction} applied to the family of
+satisfaction proofs, one application per equation of `Th-Group`{.AgdaFunction}.
+
+```agda
+module GroupFamilyProduct {I : Type ι} (𝒢s : I → Group α ρ) where
+
+  private
+    𝑮s : I → Algebra {𝑆 = Sig-Group} α ρ
+    𝑮s = proj₁ ∘ 𝒢s
+
+  -- Every group equation transfers to the product, coordinatewise.
+  -- (The equation sides are passed explicitly: they are not inferable from the
+  -- coordinatewise proofs, whose types are stuck on the term interpreter.)
+  ⨅ᵍ-⊨ : ⨅ 𝑮s ⊨ᵍᵖ Th-Group
+  ⨅ᵍ-⊨ eq =
+    ⊧-P-invar  {p = proj₁ (Th-Group eq)} {q = proj₂ (Th-Group eq)}
+               𝑮s (λ i → proj₂ (𝒢s i) eq)
+
+  -- The indexed direct product group.
+  ⨅ᵍ-Group : Group (α ⊔ ι) (ρ ⊔ ι)
+  ⨅ᵍ-Group = ⨅ 𝑮s , ⨅ᵍ-⊨
+```
+
+The top-level form, for use at call sites.
+
+```agda
+⨅ᵍ : {I : Type ι} → (I → Group α ρ) → Group (α ⊔ ι) (ρ ⊔ ι)
+⨅ᵍ 𝒢s = GroupFamilyProduct.⨅ᵍ-Group 𝒢s
+```
+
+#### Powers: the constant-family product
+
+`GroupPower`{.AgdaModule} `I` `𝒢` is the product of the constant family at
+`𝒢`{.AgdaBound} — the power `𝒢 ^ I` — together with the power-specific toolkit:
+pointwise descriptions of the curried operations and the coordinate projections.
+Opening it re-exports the `GroupFamilyProduct`{.AgdaModule} kit for the constant
+family, so `⨅ᵍ-Group`{.AgdaFunction} names the power group itself.
+
+```agda
+module GroupPower (I : Type ι) (𝒢 : Group α ρ) where
+
+  open GroupFamilyProduct (λ (_ : I) → 𝒢) public
+
+  private
+    𝑮 = proj₁ 𝒢
+    𝑷 = proj₁ ⨅ᵍ-Group
+
+  open Setoid 𝔻[ 𝑮 ] using () renaming ( _≈_ to _≈₁_ ; refl to refl₁ )
+```
+
+The curried accessors of `Group-Op`{.AgdaModule} applied to the power agree, at
+each coordinate, with the accessors of the base group applied to the coordinate
+values.  (They are not definitionally equal, for the same reason as in the binary
+module: the curried form routes the arguments through a canonical `pair` tuple, and
+`Fin`-indexed tuples lack η under `--cubical-compatible`; each bridge is one
+`interp-cong`{.AgdaFunction}.)
+
+```agda
+  open Group-Op 𝒢         using () renaming ( _∙_ to _∙₁_ ; ε to ε₁ ; _⁻¹ to _⁻¹₁ )
+  open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+
+  -- The power multiplication is pointwise.
+  ∙ₚ-pointwise : ∀ x y i → (x ∙ₚ y) i ≈₁ (x i ∙₁ y i)
+  ∙ₚ-pointwise x y i = interp-cong 𝑮 ∙-Op (λ { 0F → refl₁ ; 1F → refl₁ })
+
+  -- The power identity is the constant identity tuple.
+  εₚ-pointwise : ∀ i → εₚ i ≈₁ ε₁
+  εₚ-pointwise i = interp-cong 𝑮 ε-Op (λ ())
+
+  -- The power inverse is pointwise.
+  ⁻¹ₚ-pointwise : ∀ x i → (x ⁻¹ₚ) i ≈₁ ((x i) ⁻¹₁)
+  ⁻¹ₚ-pointwise x i = interp-cong 𝑮 ⁻¹-Op (λ { 0F → refl₁ })
+```
+
+Evaluation at a coordinate is a homomorphism from the power onto the base group —
+the generic projection of [Setoid.Homomorphisms.Products][], instantiated at the
+constant family.
+
+```agda
+  -- The i-th coordinate projection, as a homomorphism.
+  proj-hom : (i : I) → hom 𝑷 𝑮
+  proj-hom = ⨅-proj (λ (_ : I) → 𝑮)
+```
+
+#### The finite power `Sⁿ`
+
+The power of a group by a natural number — the form Kurzweil's construction and
+the FLRP consumers use — is the constant-family product over `Fin n`.  Since
+`Fin n` lives at level zero, the levels of the base group are preserved; in
+particular the power of a `Group 0ℓ 0ℓ` is again a `Group 0ℓ 0ℓ`, as the
+`UpperInterval`{.AgdaModule} machinery of [FLRP.Enforceable][] requires.
+
+```agda
+infixl 8 _^ᵍ_
+
+_^ᵍ_ : Group α ρ → ℕ → Group α ρ
+𝒢 ^ᵍ n = GroupPower.⨅ᵍ-Group (Fin n) 𝒢
+```

--- a/src/Classical/Structures/Group/Power.lagda.md
+++ b/src/Classical/Structures/Group/Power.lagda.md
@@ -10,40 +10,32 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Group.Power][] module of the [Agda Universal Algebra Library][].
 
-For an indexed family `𝒢s : I → Group α ρ`{.AgdaBound} of groups presented as
-Σ-typed structures over [`Sig-Group`][Classical.Signatures.Group], this module
-constructs the **indexed direct product** `⨅ᵍ 𝒢s`{.AgdaFunction}: the group on the
-product algebra `⨅`{.AgdaFunction} of [Setoid.Algebras.Products][], whose carrier is
-the function type `∀ i → 𝕌[ 𝑮s i ]` with pointwise operations and pointwise
-equality.  The five group laws transfer coordinatewise by
-`⊧-P-invar`{.AgdaFunction} of [Setoid.Varieties.Properties][] — products preserve
-identities — so no term induction is repeated here.
+For an indexed family `𝒢 : I → Group α ρ` of groups presented as Σ-typed structures
+over [`Sig-Group`][Classical.Signatures.Group], this module constructs the
+**indexed direct product** `⨅ᵍ`{.AgdaFunction}` 𝒢`, that is, the group on the product
+algebra `⨅`{.AgdaFunction} of [Setoid.Algebras.Products][], whose carrier is the
+function type `∀ i → 𝕌[ 𝑮 i ]` with pointwise operations and pointwise equality.
 
-This construction *generalizes* the binary product `_×ᵍ_`{.AgdaFunction} of
-[Classical.Structures.Group.Product][] rather than replacing it: the binary module
-deliberately keeps the *pair* carrier `G × K`, which is the form the FLRP fattening
-arguments consume, whereas the function-typed carrier here is the form **Kurzweil's
-construction** consumes.  The power `𝒢 ^ᵍ n`{.AgdaFunction} is the constant-family
-product over `I = Fin n`, so an element of `S ^ᵍ n` is literally a map
-`x : Fin n → S`, and conditions such as "`x` is constant on the blocks of a
-partition of the index set" — the membership conditions of the diagonal and of the
-partition subgroups (issue #521) — are stated by comparing values of `x` at
-indices, with no tuple bookkeeping.
+The five group laws transfer coordinatewise by `⊧-P-invar`{.AgdaFunction} of
+[Setoid.Varieties.Properties][] (products preserve identities) so no term induction
+is repeated here.
+
+This construction generalizes the binary product `_×ᵍ_`{.AgdaFunction} of
+[Classical.Structures.Group.Product][] rather than replacing it.[^1]
+
+The power `𝒢 ^ᵍ n` is the constant-family product over
+`I = Fin n`, so an element of `S ^ᵍ n` is literally a map `x : Fin n → S`, and
+conditions such as "`x` is constant on the blocks of a partition of the index set"
+are stated by comparing values of `x` at indices, with no tuple bookkeeping.
 
 Besides the product and the power, the module provides
 
-+  **pointwise descriptions of the curried operations** — `(x ∙ y) i ≈ x i ∙ y i`
-   and its companions for `ε` and `⁻¹` — bridging the `Fin`-tuple η-gap exactly as
-   in the binary module (the curried accessors route arguments through a canonical
-   `pair` tuple, and `Fin`-indexed tuples lack η under `--cubical-compatible`;
-   each bridge is one `interp-cong`{.AgdaFunction} per use); and
++  **pointwise descriptions of the curried operations**, `(x ⊗ y) i ≈ x i ∙ y i`
+   and its companions for `ε` and `⁻¹`;[^2]
 +  **coordinate projections as homomorphisms**, by instantiating the generic
    `⨅-proj`{.AgdaFunction} of [Setoid.Homomorphisms.Products][].
 
-Following the Cubical-port discipline, the underlying equivalence of the product is
-not redefined here: it is the pointwise equivalence of `⨅`{.AgdaFunction}, so the
-equality locus to substitute on the eventual port is that of
-[Setoid.Algebras.Products][] alone.
+The underlying equivalence of the product is not redefined here.[^3]
 
 <!--
 ```agda
@@ -63,17 +55,15 @@ open import Level               using ( Level ; _⊔_ )
 open import Relation.Binary     using ( Setoid )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Signatures.Group          using  ( Sig-Group ; ∙-Op ; ε-Op
-                                                       ; ⁻¹-Op )
-open import Classical.Structures.Group.Basic    using  ( Group ; module Group-Op
-                                                       ; _⊨ᵍᵖ_ )
-open import Classical.Structures.Interpret      using  ( interp-cong )
-open import Classical.Theories.Group            using  ( Th-Group )
-open import Setoid.Algebras.Basic               using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Algebras.Products            using  ( ⨅ )
-open import Setoid.Homomorphisms.Basic          using  ( hom )
-open import Setoid.Homomorphisms.Products       using  ( ⨅-proj )
-open import Setoid.Varieties.Properties         using  ( ⊧-P-invar )
+open import Classical.Signatures.Group        using  ( Sig-Group ; ∙-Op ; ε-Op ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic  using  ( Group ; module Group-Op ; _⊨ᵍᵖ_ )
+open import Classical.Structures.Interpret    using  ( interp-cong )
+open import Classical.Theories.Group          using  ( Th-Group )
+open import Setoid.Algebras.Basic             using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Products          using  ( ⨅ )
+open import Setoid.Homomorphisms.Basic        using  ( hom )
+open import Setoid.Homomorphisms.Products     using  ( ⨅-proj )
+open import Setoid.Varieties.Properties       using  ( ⊧-P-invar )
 
 private variable ι α ρ : Level
 ```
@@ -81,44 +71,42 @@ private variable ι α ρ : Level
 
 #### The indexed product of a family of groups
 
-`GroupFamilyProduct`{.AgdaModule} `𝒢s` packages the construction for a fixed family:
+`GroupFamilyProduct`{.AgdaModule}` 𝒢` packages the construction for a fixed family:
 the product algebra, the transferred satisfaction proof, and the product group.
-Each group equation holds in `⨅`{.AgdaFunction} because it holds in every
-coordinate — this is `⊧-P-invar`{.AgdaFunction} applied to the family of
-satisfaction proofs, one application per equation of `Th-Group`{.AgdaFunction}.
+Each group equation holds in `⨅`{.AgdaFunction} because it holds in every coordinate;
+this is `⊧-P-invar`{.AgdaFunction} applied to the family of satisfaction proofs, one
+application per equation of `Th-Group`{.AgdaFunction}.
 
 ```agda
-module GroupFamilyProduct {I : Type ι} (𝒢s : I → Group α ρ) where
+module GroupFamilyProduct {I : Type ι} (𝒢 : I → Group α ρ) where
 
   private
-    𝑮s : I → Algebra {𝑆 = Sig-Group} α ρ
-    𝑮s = proj₁ ∘ 𝒢s
+    𝑮 : I → Algebra {𝑆 = Sig-Group} α ρ
+    𝑮 = proj₁ ∘ 𝒢
 
   -- Every group equation transfers to the product, coordinatewise.
-  -- (The equation sides are passed explicitly: they are not inferable from the
-  -- coordinatewise proofs, whose types are stuck on the term interpreter.)
-  ⨅ᵍ-⊨ : ⨅ 𝑮s ⊨ᵍᵖ Th-Group
-  ⨅ᵍ-⊨ eq =
-    ⊧-P-invar  {p = proj₁ (Th-Group eq)} {q = proj₂ (Th-Group eq)}
-               𝑮s (λ i → proj₂ (𝒢s i) eq)
+  ⨅ᵍ-⊨ : ⨅ 𝑮 ⊨ᵍᵖ Th-Group
+  ⨅ᵍ-⊨ eq = ⊧-P-invar {p = Th-Group eq .proj₁} {q = Th-Group eq .proj₂}
+              𝑮 λ i → 𝒢 i .proj₂ eq
 
   -- The indexed direct product group.
   ⨅ᵍ-Group : Group (α ⊔ ι) (ρ ⊔ ι)
-  ⨅ᵍ-Group = ⨅ 𝑮s , ⨅ᵍ-⊨
+  ⨅ᵍ-Group = ⨅ 𝑮 , ⨅ᵍ-⊨
 ```
 
 The top-level form, for use at call sites.
 
 ```agda
 ⨅ᵍ : {I : Type ι} → (I → Group α ρ) → Group (α ⊔ ι) (ρ ⊔ ι)
-⨅ᵍ 𝒢s = GroupFamilyProduct.⨅ᵍ-Group 𝒢s
+⨅ᵍ = GroupFamilyProduct.⨅ᵍ-Group
 ```
 
 #### Powers: the constant-family product
 
-`GroupPower`{.AgdaModule} `I` `𝒢` is the product of the constant family at
-`𝒢`{.AgdaBound} — the power `𝒢 ^ I` — together with the power-specific toolkit:
+`GroupPower`{.AgdaModule}` I 𝒢` is the product of the constant family at
+`𝒢`{.AgdaBound} (the power `𝒢 ^ I`) together with the power-specific toolkit:
 pointwise descriptions of the curried operations and the coordinate projections.
+
 Opening it re-exports the `GroupFamilyProduct`{.AgdaModule} kit for the constant
 family, so `⨅ᵍ-Group`{.AgdaFunction} names the power group itself.
 
@@ -128,34 +116,31 @@ module GroupPower (I : Type ι) (𝒢 : Group α ρ) where
   open GroupFamilyProduct (λ (_ : I) → 𝒢) public
 
   private
-    𝑮 = proj₁ 𝒢
-    𝑷 = proj₁ ⨅ᵍ-Group
+    𝑮 = 𝒢 .proj₁
+    𝑮ᴵ = ⨅ᵍ-Group .proj₁
 
-  open Setoid 𝔻[ 𝑮 ] using () renaming ( _≈_ to _≈₁_ ; refl to refl₁ )
+  open Setoid 𝔻[ 𝑮 ] using ( _≈_ ; refl )
 ```
 
 The curried accessors of `Group-Op`{.AgdaModule} applied to the power agree, at
 each coordinate, with the accessors of the base group applied to the coordinate
-values.  (They are not definitionally equal, for the same reason as in the binary
-module: the curried form routes the arguments through a canonical `pair` tuple, and
-`Fin`-indexed tuples lack η under `--cubical-compatible`; each bridge is one
-`interp-cong`{.AgdaFunction}.)
+values.[^4]
 
 ```agda
-  open Group-Op 𝒢         using () renaming ( _∙_ to _∙₁_ ; ε to ε₁ ; _⁻¹ to _⁻¹₁ )
-  open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+  open Group-Op 𝒢         using ( _∙_ ; ε ; _⁻¹ )
+  open Group-Op ⨅ᵍ-Group  using () renaming ( _∙_ to _⊗_ ; ε to e ; _⁻¹ to inv )
 
   -- The power multiplication is pointwise.
-  ∙ₚ-pointwise : ∀ x y i → (x ∙ₚ y) i ≈₁ (x i ∙₁ y i)
-  ∙ₚ-pointwise x y i = interp-cong 𝑮 ∙-Op (λ { 0F → refl₁ ; 1F → refl₁ })
+  ⊗-pointwise : ∀ x y i → (x ⊗ y) i ≈ x i ∙ y i
+  ⊗-pointwise x y i = interp-cong 𝑮 ∙-Op λ { 0F → refl ; 1F → refl }
 
   -- The power identity is the constant identity tuple.
-  εₚ-pointwise : ∀ i → εₚ i ≈₁ ε₁
-  εₚ-pointwise i = interp-cong 𝑮 ε-Op (λ ())
+  e-pointwise : ∀ i → e i ≈ ε
+  e-pointwise i = interp-cong 𝑮 ε-Op λ ()
 
   -- The power inverse is pointwise.
-  ⁻¹ₚ-pointwise : ∀ x i → (x ⁻¹ₚ) i ≈₁ ((x i) ⁻¹₁)
-  ⁻¹ₚ-pointwise x i = interp-cong 𝑮 ⁻¹-Op (λ { 0F → refl₁ })
+  inv-pointwise : ∀ x i → (inv x) i ≈ x i ⁻¹
+  inv-pointwise x i = interp-cong 𝑮 ⁻¹-Op λ { 0F → refl }
 ```
 
 Evaluation at a coordinate is a homomorphism from the power onto the base group —
@@ -164,17 +149,15 @@ constant family.
 
 ```agda
   -- The i-th coordinate projection, as a homomorphism.
-  proj-hom : (i : I) → hom 𝑷 𝑮
-  proj-hom = ⨅-proj (λ (_ : I) → 𝑮)
+  proj-hom : (i : I) → hom 𝑮ᴵ 𝑮
+  proj-hom = ⨅-proj λ (_ : I) → 𝑮
 ```
 
-#### The finite power `Sⁿ`
+#### The finite power of a group
 
-The power of a group by a natural number — the form Kurzweil's construction and
-the FLRP consumers use — is the constant-family product over `Fin n`.  Since
-`Fin n` lives at level zero, the levels of the base group are preserved; in
-particular the power of a `Group 0ℓ 0ℓ` is again a `Group 0ℓ 0ℓ`, as the
-`UpperInterval`{.AgdaModule} machinery of [FLRP.Enforceable][] requires.
+The power of a group by a natural number is the constant-family product over `Fin n`.
+Since `Fin n` lives at level zero, the levels of the base group are preserved; in
+particular the power of a `Group 0ℓ 0ℓ` is again a `Group 0ℓ 0ℓ`.
 
 ```agda
 infixl 8 _^ᵍ_
@@ -182,3 +165,24 @@ infixl 8 _^ᵍ_
 _^ᵍ_ : Group α ρ → ℕ → Group α ρ
 𝒢 ^ᵍ n = GroupPower.⨅ᵍ-Group (Fin n) 𝒢
 ```
+
+---
+
+[^1]:  The binary module deliberately keeps the *pair* carrier `G × K`, which is the
+       form the FLRP fattening arguments consume, whereas the function-typed carrier
+       here is the form Kurzweil's construction consumes.
+
+[^2]:  This bridges the `Fin`-tuple η-gap exactly as in the binary module; the curried
+       accessors route arguments through a canonical `pair` tuple, and `Fin`-indexed
+       tuples lack η under `--cubical-compatible`; each bridge is one
+       `interp-cong`{.AgdaFunction} per use.
+
+[^3]:  Following the planned-Cubical-port discipline, the underlying equivalence of
+       the product is not redefined here; it is the pointwise equivalence of
+       `⨅`{.AgdaFunction}, so the equality locus to substitute on the eventual port
+       is that of [Setoid.Algebras.Products][] alone.
+
+[^4]:  They are not definitionally equal, for the same reason as in the binary
+       module: the curried form routes the arguments through a canonical `pair`
+       tuple, and `Fin`-indexed tuples lack η under `--cubical-compatible`; each
+       bridge is one `interp-cong`{.AgdaFunction}.

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -20,6 +20,7 @@ open import Classical.Structures.Lattice.DistributiveLattice  public
 open import Classical.Structures.Lattice.Dual                 public
 open import Classical.Structures.Lattice.OrdinalSum           public
 open import Classical.Structures.Lattice.Parachute            public
+open import Classical.Structures.Lattice.Partitions           public
 open import Classical.Structures.Lattice.Product              public
 
 ```

--- a/src/Classical/Structures/Lattice/Partitions.lagda.md
+++ b/src/Classical/Structures/Lattice/Partitions.lagda.md
@@ -1,0 +1,573 @@
+---
+layout: default
+file: "src/Classical/Structures/Lattice/Partitions.lagda.md"
+title: "Classical.Structures.Lattice.Partitions module"
+date: "2026-07-27"
+author: "the agda-algebras development team"
+---
+
+### The partition lattice `Eq(n)`
+
+This is the [Classical.Structures.Lattice.Partitions][] module of the [Agda Universal Algebra Library][].
+
+This module constructs the **partition lattice** `Eq(n)`{.AgdaFunction} — the
+equivalence relations on an `n`-element set, ordered by refinement — as a
+level-zero equational `Lattice`{.AgdaFunction} of
+[Classical.Structures.Lattice.Basic][], the presentation the FLRP program's
+`IntervalIso`{.AgdaFunction} and `ConIso`{.AgdaFunction} target.  It is the lattice
+whose *dual* Kurzweil's construction realizes as the interval `[D , Sⁿ]` in the
+subgroup lattice of a power of a group (issue #521), and the classical sources
+(`docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals") work with the
+same small carrier used here: a partition is a *function* `Fin n → Fin n`,
+identified with its kernel.
+
+**The presentation.**  A partition of `Fin n` is stored as a
+`ParentVec`{.AgdaFunction} of [Setoid.Congruences.Certificates.Schema][] — a vector
+of `n` labels — and *read through its kernel*: indices `i` and `j` lie in the same
+block exactly when their labels agree (`SameBlock`{.AgdaFunction}, the standalone
+form of the relation the certificate checkers use).  Two vectors present the same
+partition when their kernels coincide, so the carrier setoid takes **mutual
+refinement** as its equality, in the library's setoid discipline; no normal form is
+imposed.  (The Freese normal form of the Schema module remains the right tool where
+*syntactic* comparison of partitions is wanted, as in the certificate checkers; the
+lattice here never needs canonical representatives, and its operations choose
+whatever labels are convenient.)
+
+**Order-first.**  Per the library's construction discipline, the lattice is built
+from its order: refinement `_⊑_`{.AgdaFunction} is a partial order on the carrier
+setoid, the meet and join constructed below are its infimum and supremum, and the
+eight lattice equations then come for free — through the standard library's
+order-to-algebra bridge (`algLattice`{.AgdaFunction} of
+[`Relation.Binary.Lattice.Properties.Lattice`]) — before the final packaging by
+`setoidEqsToLattice`{.AgdaFunction}.
+
+**The operations.**  Both operations are elementary and total, with no fixpoint
+iteration:
+
++  the **meet** relabels each index by the *least* index carrying the same pair of
+   labels — its kernel is the intersection of the two kernels by construction;
++  the **join** folds over all index pairs `(i , j)`, and, whenever `i` and `j` lie
+   in the same block of the second argument, merges the *whole blocks* of `i` and
+   `j` in the accumulator by relabelling.  Because each step merges two entire
+   blocks, the accumulated kernel is transitive at every stage, and no closure
+   iteration or chain-length bound is ever needed: the result contains both
+   kernels and is contained in every common coarsening.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Classical.Structures.Lattice.Partitions where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Bool.Base       using ( Bool ; true ; false ; if_then_else_ )
+open import Data.Empty           using ( ⊥-elim )
+open import Data.Fin.Base as Fin using ( Fin ; _≤_ )
+open import Data.Fin.Properties  using ( _≟_ ; ≤-antisym )
+open import Data.List.Base       using ( List ; [] ; _∷_ ; foldr ; allFin
+                                       ; cartesianProduct )
+open import Data.List.Membership.Propositional             using ( _∈_ )
+open import Data.List.Membership.Propositional.Properties  using ( ∈-allFin
+                                                                 ; ∈-cartesianProduct⁺ )
+open import Data.List.Relation.Unary.Any                   using ( here ; there )
+open import Data.Nat.Base        using ( ℕ ; zero ; suc ; z≤n ; s≤s )
+open import Data.Product         using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ ; swap )
+open import Data.Sum.Base        using ( _⊎_ ; inj₁ ; inj₂ ; map₂ )
+open import Data.Vec.Base        using ( tabulate )
+open import Data.Vec.Properties  using ( lookup∘tabulate )
+open import Function             using ( _∘_ )
+open import Level                using ( 0ℓ )
+open import Relation.Binary      using ( Setoid )
+open import Relation.Binary.Lattice  using ( Supremum ; Infimum )
+                                     renaming ( Lattice to OrderLattice
+                                              ; IsLattice to IsOrderLattice )
+open import Relation.Binary.PropositionalEquality
+                                 using ( _≡_ ; refl ; sym ; trans ; cong )
+open import Relation.Nullary     using ( ¬_ ; Dec ; yes ; no )
+open import Relation.Nullary.Decidable  using ( does ; _×-dec_ ; dec-true )
+
+import Algebra.Lattice.Bundles                       as AlgLatticeBundles
+import Algebra.Lattice.Properties.Lattice            as AlgLatticeProperties
+import Relation.Binary.Lattice.Properties.Lattice    as OrderLatticeProperties
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Structures.Lattice.Basic           using  ( Lattice
+                                                                ; setoidEqsToLattice )
+open import Setoid.Congruences.Certificates.Schema       using  ( ParentVec ; parent )
+```
+-->
+
+#### The kernel reading and the refinement order
+
+`SameBlock`{.AgdaFunction} `pv i j` says the labels of `i` and `j` agree — `i` and
+`j` lie in the same block of the partition presented by `pv`.  (This is the
+standalone form of the relation the certificate checker of
+[Setoid.Congruences.Certificates.Congruence][] defines locally against an ambient
+algebra.)  Refinement `pu ⊑ pw` says every block relation of `pu` is one of `pw` —
+`pu` refines `pw` — and partition equality is mutual refinement.
+
+```agda
+private variable n : ℕ
+
+-- i and j lie in the same block of pv.
+SameBlock : ParentVec n → Fin n → Fin n → Type
+SameBlock pv i j = parent pv i ≡ parent pv j
+
+infix 4 _⊑_ _≈ᵖ_
+
+-- pu refines pw: every pu-block relation is a pw-block relation.
+_⊑_ : ParentVec n → ParentVec n → Type
+pu ⊑ pw = ∀ {i j} → SameBlock pu i j → SameBlock pw i j
+
+-- Partition equality: the two vectors have the same kernel.
+_≈ᵖ_ : ParentVec n → ParentVec n → Type
+pu ≈ᵖ pw = (pu ⊑ pw) × (pw ⊑ pu)
+```
+
+Reflexivity, transitivity, and — because equality *is* mutual refinement —
+antisymmetry of the order are immediate.
+
+```agda
+⊑-refl : {pv : ParentVec n} → pv ⊑ pv
+⊑-refl e = e
+
+⊑-trans : {pu pv pw : ParentVec n} → pu ⊑ pv → pv ⊑ pw → pu ⊑ pw
+⊑-trans uv vw e = vw (uv e)
+
+≈ᵖ-refl : {pv : ParentVec n} → pv ≈ᵖ pv
+≈ᵖ-refl = (λ e → e) , (λ e → e)
+
+≈ᵖ-sym : {pu pv : ParentVec n} → pu ≈ᵖ pv → pv ≈ᵖ pu
+≈ᵖ-sym = swap
+
+≈ᵖ-trans : {pu pv pw : ParentVec n} → pu ≈ᵖ pv → pv ≈ᵖ pw → pu ≈ᵖ pw
+≈ᵖ-trans (uv , vu) (vw , wv) = (λ e → vw (uv e)) , (λ e → vu (wv e))
+
+-- The carrier setoid of Eq(n): parent vectors up to kernel equality.
+Eq-setoid : (n : ℕ) → Setoid 0ℓ 0ℓ
+Eq-setoid n = record
+  { Carrier        = ParentVec n
+  ; _≈_            = _≈ᵖ_
+  ; isEquivalence  = record
+      { refl   = λ {pv} → ≈ᵖ-refl {pv = pv}
+      ; sym    = λ {pu} {pv} → ≈ᵖ-sym {pu = pu} {pv = pv}
+      ; trans  = λ {pu} {pv} {pw} → ≈ᵖ-trans {pu = pu} {pv = pv} {pw = pw}
+      }
+  }
+```
+
+Operations produce vectors by tabulating a relabelling function; this small lemma
+is the only bridge ever needed between the vector and its function.
+
+```agda
+-- Reading back a tabulated relabelling function.
+parent-tab : (f : Fin n → Fin n) (i : Fin n) → parent (tabulate f) i ≡ f i
+parent-tab = lookup∘tabulate
+```
+
+#### Bounded search for a least satisfier
+
+The meet relabels each index by the least member of its intersection block, so we
+need one search primitive: the least index satisfying a decidable predicate, or a
+proof that none does.  The search is structural recursion on `n`, scanning from
+`zero` upward, so the first hit is the least.
+
+```agda
+findLeast : (n : ℕ) {P : Fin n → Type 0ℓ} (P? : (j : Fin n) → Dec (P j))
+  →  (Σ[ j ∈ Fin n ] (P j × ((k : Fin n) → P k → j ≤ k)))
+  ⊎  ((j : Fin n) → ¬ P j)
+findLeast zero P? = inj₂ (λ ())
+findLeast (suc m) {P} P? = check (P? Fin.zero)
+  where
+  check : Dec (P Fin.zero) → _
+  check (yes p) = inj₁ (Fin.zero , p , λ k _ → z≤n)
+  check (no ¬p) = lift-tail (findLeast m (P? ∘ Fin.suc))
+    where
+    lift-tail : _ → _
+    lift-tail (inj₁ (j , p , least)) = inj₁ (Fin.suc j , p , least′)
+      where
+      least′ : (k : Fin (suc m)) → P k → Fin.suc j ≤ k
+      least′ Fin.zero     pk = ⊥-elim (¬p pk)
+      least′ (Fin.suc k)  pk = s≤s (least k pk)
+    lift-tail (inj₂ none) = inj₂ none′
+      where
+      none′ : (j : Fin (suc m)) → ¬ P j
+      none′ Fin.zero     = ¬p
+      none′ (Fin.suc j)  = none j
+```
+
+Two least satisfiers of pointwise-equivalent predicates coincide — the
+antisymmetry step every canonicity argument below routes through.
+
+```agda
+least-unique : {P Q : Fin n → Type 0ℓ}
+  → ((k : Fin n) → P k → Q k) → ((k : Fin n) → Q k → P k)
+  → (jp : Fin n) → P jp → ((k : Fin n) → P k → jp ≤ k)
+  → (jq : Fin n) → Q jq → ((k : Fin n) → Q k → jq ≤ k)
+  → jp ≡ jq
+least-unique pq qp jp Pjp minP jq Qjq minQ =
+  ≤-antisym (minP jq (qp jq Qjq)) (minQ jp (pq jp Pjp))
+```
+
+#### The meet
+
+`MeetOf`{.AgdaModule} `pu pw` relabels each index `i` by the least index carrying
+the same `pu`-label *and* the same `pw`-label as `i`.  The relabelling is constant
+on intersection blocks and separates distinct ones, so its kernel is exactly the
+intersection of the two kernels.
+
+```agda
+module MeetOf (pu pw : ParentVec n) where
+
+  private
+    -- The intersection block of i, as a predicate on candidate representatives.
+    P : Fin n → Fin n → Type 0ℓ
+    P i j = SameBlock pu j i × SameBlock pw j i
+
+    P? : (i j : Fin n) → Dec (P i j)
+    P? i j = (parent pu j ≟ parent pu i) ×-dec (parent pw j ≟ parent pw i)
+
+    -- The search cannot fail: i itself is in the intersection block of i.
+    found : (i : Fin n) → Σ[ j ∈ Fin n ] (P i j × ((k : Fin n) → P i k → j ≤ k))
+    found i = extract (findLeast _ (P? i))
+      where
+      extract : _ → _
+      extract (inj₁ f)     = f
+      extract (inj₂ none)  = ⊥-elim (none i (refl , refl))
+
+  -- The meet relabelling: the least member of the intersection block.
+  meetF : Fin n → Fin n
+  meetF i = proj₁ (found i)
+
+  meetF-sat : (i : Fin n) → SameBlock pu (meetF i) i × SameBlock pw (meetF i) i
+  meetF-sat i = proj₁ (proj₂ (found i))
+
+  meetF-least : (i k : Fin n) → SameBlock pu k i × SameBlock pw k i → meetF i ≤ k
+  meetF-least i = proj₂ (proj₂ (found i))
+```
+
+The relabelling is constant on intersection blocks (two indices related in both
+kernels search pointwise-equivalent predicates), and conversely two indices with
+the same relabel are related in both kernels (each is related in both kernels to
+its representative).
+
+```agda
+  -- Same pu-block and same pw-block ⟹ same meet label.
+  meetF-cong : {i j : Fin n} → SameBlock pu i j → SameBlock pw i j → meetF i ≡ meetF j
+  meetF-cong {i} {j} eu ew =
+    least-unique
+      (λ k (a , b) → trans a eu , trans b ew)
+      (λ k (a , b) → trans a (sym eu) , trans b (sym ew))
+      (meetF i) (meetF-sat i) (meetF-least i)
+      (meetF j) (meetF-sat j) (meetF-least j)
+
+  -- Same meet label ⟹ same pu-block and same pw-block.
+  meetF-ker : {i j : Fin n} → meetF i ≡ meetF j → SameBlock pu i j × SameBlock pw i j
+  meetF-ker {i} {j} e =
+      trans (sym (proj₁ (meetF-sat i))) (trans (cong (parent pu) e) (proj₁ (meetF-sat j)))
+    , trans (sym (proj₂ (meetF-sat i))) (trans (cong (parent pw) e) (proj₂ (meetF-sat j)))
+```
+
+The meet vector, with its infimum properties at the vector level.
+
+```agda
+  -- The meet of the two partitions.
+  meet-vec : ParentVec n
+  meet-vec = tabulate meetF
+
+  private
+    to-meetF : {i j : Fin n} → SameBlock meet-vec i j → meetF i ≡ meetF j
+    to-meetF {i} {j} e = trans (sym (parent-tab meetF i)) (trans e (parent-tab meetF j))
+
+  ∧-lower₁ : meet-vec ⊑ pu
+  ∧-lower₁ e = proj₁ (meetF-ker (to-meetF e))
+
+  ∧-lower₂ : meet-vec ⊑ pw
+  ∧-lower₂ e = proj₂ (meetF-ker (to-meetF e))
+
+  ∧-greatest : (q : ParentVec n) → q ⊑ pu → q ⊑ pw → q ⊑ meet-vec
+  ∧-greatest q qu qw {i} {j} e =
+    trans (parent-tab meetF i) (trans (meetF-cong (qu e) (qw e)) (sym (parent-tab meetF j)))
+```
+
+#### The join
+
+`JoinOf`{.AgdaModule} `pu pw` starts from the labels of `pu` and folds over all
+index pairs; at a pair `(i , j)` lying in the same `pw`-block, it merges the
+current blocks of `i` and `j` by relabelling `j`'s block with `i`'s label.  One
+merge step joins the accumulated partition with one whole pair of blocks, so the
+accumulated kernel is an equivalence at every stage — this is what makes the least
+upper bound argument a plain fold induction, with no transitive-closure iteration.
+
+```agda
+module JoinOf (pu pw : ParentVec n) where
+
+  private
+    if-same : (b : Bool) (t : Fin n) → (if b then t else t) ≡ t
+    if-same true   t = refl
+    if-same false  t = refl
+
+  -- Relabel the (current) block of j with the (current) label of i.
+  relabel : (Fin n → Fin n) → Fin n → Fin n → (Fin n → Fin n)
+  relabel v i j k = if does (v k ≟ v j) then v i else v k
+
+  -- Relabelling only coarsens: the new label is a function of the old one.
+  relabel-mono : (v : Fin n → Fin n) (i j : Fin n) {k l : Fin n}
+    → v k ≡ v l → relabel v i j k ≡ relabel v i j l
+  relabel-mono v i j = cong (λ t → if does (t ≟ v j) then v i else t)
+
+  -- After the merge, i and j carry the same label.
+  relabel-relates : (v : Fin n → Fin n) (i j : Fin n) → relabel v i j i ≡ relabel v i j j
+  relabel-relates v i j =
+    trans (if-same (does (v i ≟ v j)) (v i)) (sym at-j)
+    where
+    at-j : relabel v i j j ≡ v i
+    at-j = cong (λ b → if b then v i else v j) (dec-true (v j ≟ v j) refl)
+
+  -- A pair merged by the relabelling was already related, or straddles
+  -- the two merged blocks.
+  relabel-ker : (v : Fin n → Fin n) (i j : Fin n) {k l : Fin n}
+    → relabel v i j k ≡ relabel v i j l
+    → (v k ≡ v l) ⊎ ((v k ≡ v j × v l ≡ v i) ⊎ (v k ≡ v i × v l ≡ v j))
+  relabel-ker v i j {k} {l} = split (v k ≟ v j) (v l ≟ v j)
+    where
+    split : (dk : Dec (v k ≡ v j)) (dl : Dec (v l ≡ v j))
+      → (if does dk then v i else v k) ≡ (if does dl then v i else v l)
+      → (v k ≡ v l) ⊎ ((v k ≡ v j × v l ≡ v i) ⊎ (v k ≡ v i × v l ≡ v j))
+    split (yes ek)  (yes el)  _ = inj₁ (trans ek (sym el))
+    split (yes ek)  (no _)    e = inj₂ (inj₁ (ek , sym e))
+    split (no _)    (yes el)  e = inj₂ (inj₂ (e , el))
+    split (no _)    (no _)    e = inj₁ e
+```
+
+One fold step: merge the blocks of `i` and `j` exactly when `i` and `j` lie in the
+same `pw`-block.  Each `relabel` lemma has its conditional counterpart, by
+inspecting the guard.
+
+```agda
+  -- Merge the blocks of i and j if (i , j) is a pw-block relation.
+  step : Fin n × Fin n → (Fin n → Fin n) → (Fin n → Fin n)
+  step (i , j) v = if does (parent pw i ≟ parent pw j) then relabel v i j else v
+
+  step-mono : (p : Fin n × Fin n) (v : Fin n → Fin n) {k l : Fin n}
+    → v k ≡ v l → step p v k ≡ step p v l
+  step-mono (i , j) v {k} {l} e = guard (does (parent pw i ≟ parent pw j))
+    where
+    guard : (b : Bool) → (if b then relabel v i j else v) k ≡ (if b then relabel v i j else v) l
+    guard true   = relabel-mono v i j e
+    guard false  = e
+
+  step-relates : (i j : Fin n) (v : Fin n → Fin n)
+    → SameBlock pw i j → step (i , j) v i ≡ step (i , j) v j
+  step-relates i j v sb = guard (parent pw i ≟ parent pw j)
+    where
+    guard : (d : Dec (SameBlock pw i j))
+      → (if does d then relabel v i j else v) i ≡ (if does d then relabel v i j else v) j
+    guard (yes _)   = relabel-relates v i j
+    guard (no ¬sb)  = ⊥-elim (¬sb sb)
+
+  step-ker : (i j : Fin n) (v : Fin n → Fin n) {k l : Fin n}
+    → step (i , j) v k ≡ step (i , j) v l
+    → (v k ≡ v l) ⊎ (SameBlock pw i j × ((v k ≡ v j × v l ≡ v i) ⊎ (v k ≡ v i × v l ≡ v j)))
+  step-ker i j v {k} {l} = guard (parent pw i ≟ parent pw j)
+    where
+    guard : (d : Dec (SameBlock pw i j))
+      → (if does d then relabel v i j else v) k ≡ (if does d then relabel v i j else v) l
+      → (v k ≡ v l) ⊎ (SameBlock pw i j × ((v k ≡ v j × v l ≡ v i) ⊎ (v k ≡ v i × v l ≡ v j)))
+    guard (yes sb)  e = map₂ (λ c → sb , c) (relabel-ker v i j e)
+    guard (no _)    e = inj₁ e
+```
+
+The fold and its three invariants: it coarsens `pu`; it relates every `pw`-block
+relation whose pair occurs in the processed list; and everything it relates is
+related in every common coarsening of `pu` and `pw` — by induction, since a step
+merges two blocks that any common coarsening already merges.
+
+```agda
+  -- The join relabelling: fold the conditional merges over a pair list.
+  joinAcc : List (Fin n × Fin n) → (Fin n → Fin n)
+  joinAcc = foldr step (parent pu)
+
+  fold-mono : (ps : List (Fin n × Fin n)) {k l : Fin n}
+    → SameBlock pu k l → joinAcc ps k ≡ joinAcc ps l
+  fold-mono []        e = e
+  fold-mono (p ∷ ps)  e = step-mono p (joinAcc ps) (fold-mono ps e)
+
+  fold-relates : (ps : List (Fin n × Fin n)) {i j : Fin n}
+    → (i , j) ∈ ps → SameBlock pw i j → joinAcc ps i ≡ joinAcc ps j
+  fold-relates (_ ∷ ps) {i} {j} (here refl)   sb = step-relates i j (joinAcc ps) sb
+  fold-relates (p ∷ ps)         (there mem)   sb = step-mono p (joinAcc ps) (fold-relates ps mem sb)
+
+  fold-least : (ps : List (Fin n × Fin n)) (q : ParentVec n) → pu ⊑ q → pw ⊑ q
+    → {k l : Fin n} → joinAcc ps k ≡ joinAcc ps l → SameBlock q k l
+  fold-least [] q u w e = u e
+  fold-least ((i , j) ∷ ps) q u w {k} {l} e = assemble (step-ker i j (joinAcc ps) e)
+    where
+    rec : {a b : Fin n} → joinAcc ps a ≡ joinAcc ps b → SameBlock q a b
+    rec = fold-least ps q u w
+
+    assemble :
+        (joinAcc ps k ≡ joinAcc ps l)
+      ⊎ (SameBlock pw i j
+          × ((joinAcc ps k ≡ joinAcc ps j × joinAcc ps l ≡ joinAcc ps i)
+            ⊎ (joinAcc ps k ≡ joinAcc ps i × joinAcc ps l ≡ joinAcc ps j)))
+      → SameBlock q k l
+    assemble (inj₁ e')                        = rec e'
+    assemble (inj₂ (sb , inj₁ (ekj , eli)))  =
+      trans (rec ekj) (trans (sym (w sb)) (sym (rec eli)))
+    assemble (inj₂ (sb , inj₂ (eki , elj)))  =
+      trans (rec eki) (trans (w sb) (sym (rec elj)))
+```
+
+The join vector folds over *all* index pairs, so every `pw`-block relation is
+processed; its supremum properties are the three invariants read through
+`parent-tab`{.AgdaFunction}.
+
+```agda
+  private
+    allPairs : List (Fin n × Fin n)
+    allPairs = cartesianProduct (allFin _) (allFin _)
+
+  -- The join of the two partitions.
+  join-vec : ParentVec n
+  join-vec = tabulate (joinAcc allPairs)
+
+  ∨-upper₁ : pu ⊑ join-vec
+  ∨-upper₁ {i} {j} e =
+    trans  (parent-tab (joinAcc allPairs) i)
+           (trans (fold-mono allPairs e) (sym (parent-tab (joinAcc allPairs) j)))
+
+  ∨-upper₂ : pw ⊑ join-vec
+  ∨-upper₂ {i} {j} e =
+    trans  (parent-tab (joinAcc allPairs) i)
+           (trans  (fold-relates allPairs (∈-cartesianProduct⁺ (∈-allFin i) (∈-allFin j)) e)
+                   (sym (parent-tab (joinAcc allPairs) j)))
+
+  ∨-least : (q : ParentVec n) → pu ⊑ q → pw ⊑ q → join-vec ⊑ q
+  ∨-least q u w {i} {j} e =
+    fold-least allPairs q u w
+      (trans (sym (parent-tab (joinAcc allPairs) i)) (trans e (parent-tab (joinAcc allPairs) j)))
+```
+
+#### The lattice `Eq(n)`
+
+The binary operations, the order-theoretic lattice bundle, and — through the
+standard library's order-to-algebra bridge — the equational `Lattice`.
+
+```agda
+infixr 6 _∨ᵖ_
+infixr 7 _∧ᵖ_
+
+_∧ᵖ_ : ParentVec n → ParentVec n → ParentVec n
+pu ∧ᵖ pw = MeetOf.meet-vec pu pw
+
+_∨ᵖ_ : ParentVec n → ParentVec n → ParentVec n
+pu ∨ᵖ pw = JoinOf.join-vec pu pw
+
+Eq-supremum : Supremum (_⊑_ {n}) _∨ᵖ_
+Eq-supremum pu pw =
+  JoinOf.∨-upper₁ pu pw , JoinOf.∨-upper₂ pu pw , λ q → JoinOf.∨-least pu pw q
+
+Eq-infimum : Infimum (_⊑_ {n}) _∧ᵖ_
+Eq-infimum pu pw =
+  MeetOf.∧-lower₁ pu pw , MeetOf.∧-lower₂ pu pw , λ q → MeetOf.∧-greatest pu pw q
+
+Eq-isOrderLattice : {n : ℕ} → IsOrderLattice (_≈ᵖ_ {n}) _⊑_ _∨ᵖ_ _∧ᵖ_
+Eq-isOrderLattice {n} = record
+  { isPartialOrder = record
+      { isPreorder = record
+          { isEquivalence  = Setoid.isEquivalence (Eq-setoid n)
+          ; reflexive      = proj₁
+          ; trans          = λ {pu} {pv} {pw} → ⊑-trans {pu = pu} {pv = pv} {pw = pw}
+          }
+      ; antisym = _,_
+      }
+  ; supremum  = Eq-supremum
+  ; infimum   = Eq-infimum
+  }
+
+-- The order-theoretic partition lattice.
+Eq-OrderLattice : (n : ℕ) → OrderLattice 0ℓ 0ℓ 0ℓ
+Eq-OrderLattice n = record
+  { Carrier    = ParentVec n
+  ; _≈_        = _≈ᵖ_
+  ; _≤_        = _⊑_
+  ; _∨_        = _∨ᵖ_
+  ; _∧_        = _∧ᵖ_
+  ; isLattice  = Eq-isOrderLattice
+  }
+```
+
+The eight equations of `Th-Lattice` now come from the order: the standard
+library's `algLattice`{.AgdaFunction} turns the order-theoretic bundle into an
+algebraic one (commutativity, associativity, congruence, absorption), its
+`Properties` module supplies idempotence, and `setoidEqsToLattice`{.AgdaFunction}
+packages everything as the library's Σ-typed equational lattice.
+
+```agda
+-- The partition lattice Eq(n), as a level-zero equational Lattice.
+EqLattice : (n : ℕ) → Lattice 0ℓ 0ℓ
+EqLattice n = setoidEqsToLattice (Eq-setoid n) _∧ᵖ_ _∨ᵖ_
+  (λ {x} {y} {u} {v} → AL.∧-cong {x} {y} {u} {v})
+  (λ {x} {y} {u} {v} → AL.∨-cong {x} {y} {u} {v})
+  (λ {a} {b} {c} → AL.∧-assoc a b c)
+  (λ {a} {b} → AL.∧-comm a b)
+  (λ {a} → AP.∧-idem a)
+  (λ {a} {b} {c} → AL.∨-assoc a b c)
+  (λ {a} {b} → AL.∨-comm a b)
+  (λ {a} → AP.∨-idem a)
+  (λ {a} {b} → AL.∧-absorbs-∨ a b)
+  (λ {a} {b} → ≈ᵖ-trans  {pu = (a ∧ᵖ b) ∨ᵖ a} {pv = a ∨ᵖ (a ∧ᵖ b)} {pw = a}
+                         (AL.∨-comm (a ∧ᵖ b) a) (AL.∨-absorbs-∧ a b))
+  where
+  module OP  = OrderLatticeProperties (Eq-OrderLattice n)
+  module AL  = AlgLatticeBundles.Lattice OP.algLattice
+  module AP  = AlgLatticeProperties OP.algLattice
+```
+
+#### Extremes
+
+The identity relabelling presents the discrete partition (all blocks singleton),
+the least element; the constant relabelling presents the one-block partition, the
+greatest.  For `n ≡ 0` the two coincide on the empty vector.
+
+```agda
+-- The discrete partition: every index its own label.
+⊥ᵉ : (n : ℕ) → ParentVec n
+⊥ᵉ n = tabulate (λ i → i)
+
+-- The one-block partition: every index the label zero.
+⊤ᵉ : (n : ℕ) → ParentVec n
+⊤ᵉ zero     = tabulate (λ ())
+⊤ᵉ (suc m)  = tabulate (λ _ → Fin.zero)
+
+⊥ᵉ-minimum : (pv : ParentVec n) → ⊥ᵉ n ⊑ pv
+⊥ᵉ-minimum {n} pv {i} {j} e =
+  cong (parent pv) (trans (sym (parent-tab (λ k → k) i)) (trans e (parent-tab (λ k → k) j)))
+
+⊤ᵉ-maximum : (n : ℕ) (pv : ParentVec n) → pv ⊑ ⊤ᵉ n
+⊤ᵉ-maximum zero     pv {()}
+⊤ᵉ-maximum (suc m)  pv {i} {j} _ =
+  trans (parent-tab (λ _ → Fin.zero) i) (sym (parent-tab (λ _ → Fin.zero) j))
+```
+
+#### The refinement order is the meet order of the lattice
+
+`Lattice-Order`{.AgdaModule} of [Classical.Properties.Lattice][] equips
+`EqLattice n` with its meet order `x ≤ y = x ∧ y ≈ x`; that order coincides with
+refinement.  (The interpretation clauses of `setoidEqsToLattice` apply argument
+tuples directly, so the curried meet of the built lattice is definitionally
+`_∧ᵖ_`, and both lemmas are one appeal to the infimum.)  Downstream consumers —
+the interval isomorphism of Kurzweil's construction — pass between the two forms
+through this bridge.
+
+```agda
+⊑→≤ : {pu pw : ParentVec n} → pu ⊑ pw → (pu ∧ᵖ pw) ≈ᵖ pu
+⊑→≤ {n} {pu} {pw} h =
+  MeetOf.∧-lower₁ pu pw , MeetOf.∧-greatest pu pw pu (λ e → e) h
+
+≤→⊑ : {pu pw : ParentVec n} → (pu ∧ᵖ pw) ≈ᵖ pu → pu ⊑ pw
+≤→⊑ {n} {pu} {pw} (_ , pu⊑∧) e = MeetOf.∧-lower₂ pu pw (pu⊑∧ e)
+```

--- a/src/Classical/Structures/Lattice/Partitions.lagda.md
+++ b/src/Classical/Structures/Lattice/Partitions.lagda.md
@@ -547,10 +547,14 @@ greatest.  For `n ≡ 0` the two coincide on the empty vector.
 ⊥ᵉ-minimum {n} pv {i} {j} e =
   cong (parent pv) (trans (sym (parent-tab (λ k → k) i)) (trans e (parent-tab (λ k → k) j)))
 
+-- Any two indices lie in the one block of ⊤ᵉ.
+⊤ᵉ-related : (n : ℕ) (i j : Fin n) → SameBlock (⊤ᵉ n) i j
+⊤ᵉ-related (suc m) i j =
+  trans (parent-tab (λ _ → Fin.zero) i) (sym (parent-tab (λ _ → Fin.zero) j))
+
 ⊤ᵉ-maximum : (n : ℕ) (pv : ParentVec n) → pv ⊑ ⊤ᵉ n
 ⊤ᵉ-maximum zero     pv {()}
-⊤ᵉ-maximum (suc m)  pv {i} {j} _ =
-  trans (parent-tab (λ _ → Fin.zero) i) (sym (parent-tab (λ _ → Fin.zero) j))
+⊤ᵉ-maximum (suc m)  pv {i} {j} _ = ⊤ᵉ-related (suc m) i j
 ```
 
 #### The refinement order is the meet order of the lattice

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -110,6 +110,7 @@ open import FLRP.Bridge         public
 open import FLRP.Representable  public
 open import FLRP.Assumptions    public
 open import FLRP.Closure        public
+open import FLRP.KurzweilInterval public
 open import FLRP.LayerBridge    public
 open import FLRP.Certificates   public
 open import FLRP.L7EqSix        public

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -67,6 +67,14 @@ is used: exhibiting a finite lattice that is no interval refutes the group-side
 statement, hence the algebra-side one.  It is registered as
 `PalfyPudlak`{.AgdaFunction}.[^4]
 
+**Entry 4**: Kurzweil interval surjectivity.  For a finite *nonabelian simple*
+group `S`, every subgroup between the diagonal `D` and the full power `Sⁿ` is a
+partition subgroup `K_π` — the surjectivity half of Kurzweil's lemma
+`[D , Sⁿ] ≅ Eq(n)′`, whose dual-embedding half is proved outright in
+[Classical.Structures.Group.PartitionSubgroup][].  It is registered as
+`KurzweilSurjectivityAt`{.AgdaFunction}, in the witness-producing form defined
+by [FLRP.KurzweilInterval][].
+
 The module is structured as *per-assumption statement definitions* (rather than one
 monolithic record) precisely so that entries can be appended without disturbing one
 another, and downstream results take whichever entry they need as an ordinary
@@ -82,6 +90,7 @@ open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
 open import Data.List.Membership.Propositional    using  ( _∈_ )
+open import Data.Nat.Base                         using  ( ℕ )
 open import Data.Product                          using  ( _×_ ; _,_ ; Σ-syntax
                                                          ; proj₁ ; proj₂ )
 open import Function                              using  (_∘_)
@@ -90,8 +99,10 @@ open import Level                                 using  ( Level ; _⊔_ ; 0ℓ 
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
 open import Classical.Small.Structures.Lattice    using  ( Lattice )
+open import Classical.Structures.Group.Basic      using  ( Group )
 open import Classical.Structures.Lattice.Dual     using  ( dualLattice )
 open import FLRP.Enforceable                      using  ( GroupFLRP-Statement )
+open import FLRP.KurzweilInterval                 using  ( module KurzweilInterval )
 open import FLRP.Problem                          using  ( FLRP-Statement )
 open import FLRP.Representable                    using  ( Representableᵈ )
 open import Overture                              using  ( 𝓞 ; 𝓥 ; Signature )
@@ -287,6 +298,59 @@ Algebra Universalis 11 (1980) 22–27) states the equivalence of
 -- Entry 3: statement (A) of Pálfy–Pudlák implies statement (B).
 PalfyPudlak : Type (lsuc 0ℓ)
 PalfyPudlak = FLRP-Statement → GroupFLRP-Statement
+```
+
+#### Entry 4: Kurzweil interval surjectivity
+
+**Kurzweil's surjectivity lemma**: if `S` is a finite nonabelian simple group,
+then every subgroup of `Sⁿ` containing the diagonal `D` is a partition subgroup
+`K_π = { y ∣ ker π ≤ ker y }`.  This is the *onto* half of the isomorphism
+`[D , Sⁿ] ≅ Eq(n)′` (H. Kurzweil, *Endliche Gruppen mit vielen Untergruppen*,
+J. reine angew. Math. 356 (1985) 140–160 — the same article behind Entry 2's
+group-interval case); the write-ups this library follows
+(`docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals", Lemma
+`lem:latt-duals`, and DeMeo's thesis § 2.2) prove the dual order embedding and
+cite the surjectivity without reproof.  The embedding half is *proved* in
+[Classical.Structures.Group.PartitionSubgroup][]; this entry is exactly the
+remaining classical delta.
+
++  **Meaning**.  `KurzweilSurjectivityAt`{.AgdaFunction} `𝒮` `n` says: every
+   element of the respecting upper interval `[D , Sⁿ]` (an
+   `Interval≈`{.AgdaFunction} of the `UpperInterval`{.AgdaModule} at the
+   diagonal) is extensionally `K_π` for a *produced* partition `π` — the Σ-form
+   defined in [FLRP.KurzweilInterval][], which is precisely what the inverse map
+   of `kurzweilIntervalIso`{.AgdaFunction} consumes.
+
++  **Side condition**.  The statement type is defined for an arbitrary
+   `𝒮 : Group 0ℓ 0ℓ` — and for arbitrary `𝒮` it is *false* (for `S = ℤ₃` and
+   `n = 3` the tuples with `x₀ x₂ = x₁²` form a non-partition subgroup above the
+   diagonal).  The classical theorem asserts the instances where `𝒮` is finite
+   nonabelian simple, and consumers must instantiate it there; the side
+   condition stays in prose because the library does not yet define simplicity
+   predicates (issue #512 owns them), and making it formal is part of this
+   entry's retirement.
+
++  **Status and retirement path**.  A classically proven theorem imported
+   pending formalization.  The missing mathematics is the normal-subgroup
+   structure theory of powers of a nonabelian simple group (normal subgroups of
+   `Sⁿ` are partial products; subdirect subgroups containing the diagonal
+   collapse blockwise), a follow-up flagged in issue #521.  On completion this
+   entry retires, `kurzweilIntervalIso`{.AgdaFunction} holds outright at simple
+   instantiations, and the Kurzweil–Netter route of issue #502 loses one of its
+   two imported steps toward retiring Entry 2.
+
++  **Layer**.  Layer S, on the respecting interval `Interval≈`{.AgdaFunction}.
+   Over a decidable interval element (`Intervalᵈ`{.AgdaFunction}) with a finite
+   base group the partition is computable as the kernel meet of the member
+   tuples, so a formal proof is expected to produce the Layer-D reading
+   directly, mirroring Entry 2's layer note.
+
+```agda
+-- Entry 4, per-instance form: every subgroup in [D , Sⁿ] is a partition
+-- subgroup, with the partition produced as data.  Classically true for 𝒮 a
+-- finite nonabelian simple group; consumers instantiate it there.
+KurzweilSurjectivityAt : Group 0ℓ 0ℓ → ℕ → Type (lsuc 0ℓ)
+KurzweilSurjectivityAt 𝒮 n = KurzweilInterval.KurzweilSurjectivity 𝒮 n
 ```
 
 --------------------------------------

--- a/src/FLRP/KurzweilInterval.lagda.md
+++ b/src/FLRP/KurzweilInterval.lagda.md
@@ -78,11 +78,10 @@ open import Classical.Structures.Group.PartitionSubgroup using  ( module Partiti
 open import Classical.Structures.Lattice.Dual            using  ( module LatticeDual
                                                                 ; dualLattice )
 open import Classical.Structures.Lattice.Partitions      using  ( EqLattice ; _⊑_
-                                                                ; _≈ᵖ_ ; ⊑→≤ ; ≤→⊑ )
+                                                                ; ⊑→≤ ; ≤→⊑ )
 open import FLRP.Enforceable    using  ( module UpperInterval ; IntervalIso
                                        ; GroupRepresentable )
 open import FLRP.Problem        using  ( ConIso )
-open import Order.Iso           using  ( OrderIso )
 open import Setoid.Algebras     using  ( 𝕌[_] ; 𝔻[_] )
 open import Setoid.Congruences.Certificates.Schema  using  ( ParentVec )
 ```

--- a/src/FLRP/KurzweilInterval.lagda.md
+++ b/src/FLRP/KurzweilInterval.lagda.md
@@ -1,0 +1,211 @@
+---
+layout: default
+file: "src/FLRP/KurzweilInterval.lagda.md"
+title: "FLRP.KurzweilInterval module (The Agda Universal Algebra Library)"
+date: "2026-07-27"
+author: "the agda-algebras development team"
+---
+
+### Kurzweil's interval `[D , Sⁿ] ≅ Eq(n)′`
+
+This is the [FLRP.KurzweilInterval][] module of the [Agda Universal Algebra Library][].
+
+This module packages the group infrastructure of issue #521 — the power
+`Sⁿ`{.AgdaFunction}, its diagonal `D`{.AgdaFunction}, and the partition subgroups
+`K_π` — into the interval presentation the FLRP program consumes: the upper
+interval `[D , Sⁿ]` as an `UpperInterval`{.AgdaModule} instance of
+[FLRP.Enforceable][], and **Kurzweil's lemma** — the interval is isomorphic to the
+*dual* of the partition lattice `Eq(n)` of
+[Classical.Structures.Lattice.Partitions][] — as an
+`IntervalIso`{.AgdaFunction}.
+
+The classical statement (Kurzweil 1985; `lem:latt-duals` of
+`docs/papers/fin-lat-rep/SmallLatticeReps.tex`, discussed in DeMeo's thesis
+§ 2.2) splits into two halves of very different characters, and the formal
+treatment mirrors the split honestly:
+
++  **The dual order embedding is proved outright.**  `π ↦ K_π` lands in the
+   interval, reverses the refinement order in both directions, and is injective
+   up to kernel equality — this is the content the written sources actually
+   prove, it is finite combinatorics, and it needs only a *nontrivial* base
+   group ([Classical.Structures.Group.PartitionSubgroup][]).
+
++  **Surjectivity is a registered hypothesis.**  That *every* respecting subgroup
+   between `D` and `Sⁿ` is a partition subgroup is the half where `S` must be a
+   finite *nonabelian simple* group; the sources cite it to Kurzweil's article
+   without reproof, and its formalization needs the normal-subgroup structure
+   theory of powers of a simple group (subdirect products, block inductions) that
+   the library does not yet have — real group theory, not bookkeeping.  Per the
+   `--safe` discipline it enters as the explicit hypothesis
+   `KurzweilSurjectivity`{.AgdaFunction}, registered as **Entry 4** of
+   [FLRP.Assumptions][]; it is stated in the Σ-form that *hands the consumer the
+   partition witness*, which is exactly what the isomorphism's inverse map needs.
+   Retiring the entry — proving surjectivity for a nonabelian simple base — is
+   the follow-up flagged in issue #521, and upgrades
+   `kurzweilIntervalIso`{.AgdaFunction} with no change to consumers.
+
+Given the hypothesis, `kurzweilIntervalIso`{.AgdaFunction} *is a theorem*:
+`[D , Sⁿ] ≅ (Eq n)′` in the `IntervalIso` presentation, with the dual order
+handled by `≤ᵈ-flip`{.AgdaFunction} / `≤ᵈ-unflip`{.AgdaFunction} of
+[Classical.Structures.Lattice.Dual][] and the refinement order bridged to the
+lattice meet order by `⊑→≤`{.AgdaFunction} / `≤→⊑`{.AgdaFunction}.  The
+corollary `eqDual-groupRepresentable`{.AgdaFunction} — the dual partition
+lattice is group representable — is the form RP-4's wreath no-go (issue #461)
+consumes, and the consumer-interface module at the bottom records the composite
+signature the Kurzweil–Netter duality proof (issue #502) will call.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.KurzweilInterval where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Nat.Base   using ( ℕ )
+open import Data.Product    using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
+open import Level           using ( 0ℓ ) renaming ( suc to lsuc )
+open import Relation.Binary using ( Setoid )
+open import Relation.Nullary  using ( ¬_ )
+open import Relation.Unary    using ( _⊆_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Structures.Group.Basic             using  ( Group
+                                                                ; module Group-Op )
+open import Classical.Structures.Group.GSet              using  ( module CosetAction )
+open import Classical.Structures.Group.PartitionSubgroup using  ( module PartitionSubgroups )
+open import Classical.Structures.Lattice.Dual            using  ( module LatticeDual
+                                                                ; dualLattice )
+open import Classical.Structures.Lattice.Partitions      using  ( EqLattice ; _⊑_
+                                                                ; _≈ᵖ_ ; ⊑→≤ ; ≤→⊑ )
+open import FLRP.Enforceable    using  ( module UpperInterval ; IntervalIso
+                                       ; GroupRepresentable )
+open import FLRP.Problem        using  ( ConIso )
+open import Order.Iso           using  ( OrderIso )
+open import Setoid.Algebras     using  ( 𝕌[_] ; 𝔻[_] )
+open import Setoid.Congruences.Certificates.Schema  using  ( ParentVec )
+```
+-->
+
+#### The interval `[D , Sⁿ]` and the surjectivity hypothesis
+
+`KurzweilInterval`{.AgdaModule} `𝒮` `n` fixes the base group and the exponent,
+instantiates the partition-subgroup toolkit, and opens the upper interval at the
+diagonal.
+
+```agda
+module KurzweilInterval (𝒮 : Group 0ℓ 0ℓ) (n : ℕ) where
+
+  open PartitionSubgroups n 𝒮 public
+
+  -- The power Sⁿ (the ⨅ᵍ-Group of the opened toolkit, named for readability).
+  Sⁿ : Group 0ℓ 0ℓ
+  Sⁿ = ⨅ᵍ-Group
+
+  open UpperInterval Sⁿ Diag Diag-isSubgroup public
+
+  -- A partition subgroup, as an element of the interval [D , Sⁿ].
+  toInterval : ParentVec n → Interval≈
+  toInterval pv = mk (K pv) (K-isSubgroup pv) (Diag⊆K pv)
+```
+
+**Entry 4 of the assumptions registry** ([FLRP.Assumptions][]): every interval
+element is extensionally a partition subgroup, *with the partition produced as
+data*.  The classical theorem asserts this whenever `𝒮` is a finite nonabelian
+simple group; the registry documents source, status, and retirement path.
+
+```agda
+  -- Kurzweil surjectivity: every respecting subgroup in [D , Sⁿ] is K_π for
+  -- a produced partition π.
+  KurzweilSurjectivity : Type (lsuc 0ℓ)
+  KurzweilSurjectivity =
+    (𝑴 : Interval≈) → Σ[ pv ∈ ParentVec n ] ((set 𝑴 ⊆ K pv) × (K pv ⊆ set 𝑴))
+```
+
+#### The interval isomorphism `[D , Sⁿ] ≅ Eq(n)′`
+
+Under the surjectivity hypothesis and a nontriviality witness for the base
+group, `π ↦ K_π` and the produced partitions are a mutually inverse monotone
+pair between the interval and the *dual* of `Eq(n)`: order reversal turns the
+interval order into the dual lattice order, with the round trips repaired by
+order reflection (`K-reflects`{.AgdaFunction}) and injectivity
+(`K-injective`{.AgdaFunction}).
+
+```agda
+  module _ (s : 𝕌[ proj₁ 𝒮 ]) (s≉ε : ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s (Group-Op.ε 𝒮)))
+           (surj : KurzweilSurjectivity)
+    where
+
+    open LatticeDual (EqLattice n) using ( ≤ᵈ-flip ; ≤ᵈ-unflip )
+
+    private
+      -- The partition attached to an interval element by the hypothesis.
+      part : Interval≈ → ParentVec n
+      part 𝑴 = proj₁ (surj 𝑴)
+
+      part-in : (𝑴 : Interval≈) → set 𝑴 ⊆ K (part 𝑴)
+      part-in 𝑴 = proj₁ (proj₂ (surj 𝑴))
+
+      part-out : (𝑴 : Interval≈) → K (part 𝑴) ⊆ set 𝑴
+      part-out 𝑴 = proj₂ (proj₂ (surj 𝑴))
+
+      -- Inclusion of interval elements reflects to reversed refinement.
+      mono-flip : {𝑴 𝑵 : Interval≈} → 𝑴 ≤ᵢ 𝑵 → part 𝑵 ⊑ part 𝑴
+      mono-flip {𝑴} {𝑵} le =
+        K-reflects s s≉ε {pu = part 𝑵} {pw = part 𝑴}
+          (λ k → part-in 𝑵 (le (part-out 𝑴 k)))
+
+    kurzweilIntervalIso : IntervalIso Sⁿ Diag Diag-isSubgroup (dualLattice (EqLattice n))
+    kurzweilIntervalIso = record
+      { to         = part
+      ; from       = toInterval
+      ; to-mono    = λ {𝑴} {𝑵} le →
+          ≤ᵈ-unflip {x = part 𝑴} {y = part 𝑵}
+            (⊑→≤ {pu = part 𝑵} {pw = part 𝑴} (mono-flip {𝑴} {𝑵} le))
+      ; from-mono  = λ {pu} {pw} le →
+          K-antitone {pu = pw} {pw = pu}
+            (≤→⊑ {pu = pw} {pw = pu} (≤ᵈ-flip {x = pu} {y = pw} le))
+      ; to∘from    = λ pv →
+          K-injective s s≉ε {pu = part (toInterval pv)} {pw = pv}
+            (part-in (toInterval pv)) (part-out (toInterval pv))
+      ; from∘to    = λ 𝑴 → part-out 𝑴 , part-in 𝑴
+      }
+```
+
+The form RP-4's wreath no-go consumes: the dual of the partition lattice is
+group representable, witnessed on `[D , Sⁿ]`.
+
+```agda
+    -- Corollary: Eq(n)′ is group representable.
+    eqDual-groupRepresentable : GroupRepresentable (dualLattice (EqLattice n))
+    eqDual-groupRepresentable = record
+      { grp           = Sⁿ
+      ; sub           = Diag
+      ; isSubgroup    = Diag-isSubgroup
+      ; interval-iso  = kurzweilIntervalIso
+      }
+```
+
+#### Consumer interface checks
+
+The signatures the two consumers will call, stated (not proved) so that a
+mismatch surfaces here rather than in their branches.  The Kurzweil–Netter proof
+(issue #502) composes the WP-3 bridge `Con (Sⁿ ↷ Sⁿ/D) ≅ [D , Sⁿ]` of
+[FLRP.Bridge][] with `kurzweilIntervalIso`{.AgdaFunction}; its target is
+therefore a `ConIso`{.AgdaFunction} between the coset algebra at the diagonal
+and the dual partition lattice.  RP-4 (issue #461) consumes
+`eqDual-groupRepresentable`{.AgdaFunction} directly, at a nonabelian simple
+instantiation of `𝒮`.
+
+```agda
+module ConsumerChecks (𝒮 : Group 0ℓ 0ℓ) (n : ℕ) where
+
+  open KurzweilInterval 𝒮 n
+
+  open CosetAction Sⁿ Diag Diag-isSubgroup using ( cosetAlgebra )
+
+  -- #502 will inhabit this by composing the WP-3 bridge with kurzweilIntervalIso.
+  DualityConIso : Type (lsuc 0ℓ)
+  DualityConIso = ConIso cosetAlgebra (dualLattice (EqLattice n))
+```


### PR DESCRIPTION
## Description

Closes #521.

Builds the group infrastructure Kurzweil's construction needs, once, in `Classical/`, so that RP-4's wreath no-go (#461) and the Kurzweil–Netter duality proof (#502) consume the same definitions.

### What is added

+  **`Classical.Structures.Group.Power`**.

   +  the indexed direct product `⨅ᵍ` of a family of groups on the function-typed carrier of `⨅`, with the group laws transferred coordinatewise by the existing `⊧-P-invar` (no term induction repeated);
   +  the constant-family toolkit `GroupPower` with pointwise descriptions of the curried operations and coordinate projections via the generic `⨅-proj`;
   +  the finite power `_^ᵍ_` over `Fin n`; generalizes the binary `_×ᵍ_` rather than duplicating it.

   The binary module keeps its pair carrier for the fattening arguments, the power keeps the function carrier Kurzweil's construction wants.

+  **`Classical.Structures.Group.Diagonal`**.

   +  the diagonal `D` as the ≈-constant-tuple predicate;
   +  the constant embedding `κ` (technically not necessarily an embedding, if we allow empty index type; clarify/fix this);
   +  pointed membership characterizations and the proof that `D` is an equality-respecting subgroup.

+  **`Classical.Structures.Lattice.Partitions`**.

   +  the partition lattice `Eq(n)` as a level-zero equational `Lattice`;
   +  the presentation `IntervalIso`/`ConIso` target.

   Partitions are Schema parent vectors read through their kernels (mutual refinement as the carrier equality, so no normal form is imposed); the meet relabels by least representatives, and the join folds whole-block merges over all index pairs, so the accumulated kernel is transitive at every stage and no closure iteration or chain-length bound is needed.

   The lattice is built "order-first": the proved infimum and supremum feed the standard library's order-to-algebra bridge (`algLattice`), and `setoidEqsToLattice` packages the result.

+  **`Classical.Structures.Group.PartitionSubgroup`**.

   +  The partition subgroups `Kπ` (tuples constant on the blocks of `π`), each an equality-respecting subgroup with `D = K⊤ ≤ Kπ ≤ K⊥ = Gⁿ`;
   +  contravariance of `K` in the refinement order;
   +  the constructive order reflection via block-indicator tuples (the one place nontriviality of the base group enters), giving injectivity of `π ↦ K_π` up to kernel equality.

+  **`FLRP.KurzweilInterval`**.

   +  the interval `[D , Gⁿ]` as an `UpperInterval` instance at the diagonal;
   +  the surjectivity statement `KurzweilSurjectivity` in the witness-producing Σ-form;
   +  the conditional theorem `kurzweilIntervalIso : [D , Sⁿ] ≅ Eq(n)′` in the `IntervalIso` presentation;
   +  the corollary `eqDual-groupRepresentable` (the form RP-4 consumes);
   +  a `ConsumerChecks` module stating the `ConIso` target [#502](https://github.com/ualib/agda-algebras/issues/502) will inhabit by composing the WP-3 bridge (the consumer-interface sanity check requested by the issue).

+  **`FLRP.Assumptions` Entry 4**.  `KurzweilSurjectivityAt`, with meaning, the nonabelian-simple side condition (including the ℤ₃ arithmetic-progression counterexample showing the unrestricted statement fails), source, status, layer, and retirement path in the established per-entry style.

### The deliberate decision on `[D , Gⁿ] ≅ Eq(n)′`

Both written sources (the manuscript's `lem:latt-duals` and thesis § 2.2) prove only the order-reversing embedding — the proof given is order-reversal in both directions — and cite the surjectivity half to Kurzweil's 1985 article.

Surjectivity is exactly where nonabelian simplicity enters, and its formalization needs the normal-subgroup structure theory of powers of a simple group, which the library does not yet have.

The split here mirrors that honestly: everything the sources prove is formalized unconditionally (including `Eq(n)` itself, which is needed even to *state* the isomorphism), surjectivity is registered as Entry 4 with a concrete retirement path (#522), and the assembled isomorphism is a theorem conditional on the entry, so retiring the entry upgrades it with no change to consumers.

A `Slice`-toolkit analogue for powers turned out to be unnecessary: the block-indicator tuples of the reflection lemma play that role for every interval argument in this development.

### Gates

+  `make check` green (full library);
+  `make unused-imports` 0 flagged (including a pre-existing leftover in `Group.Congruences` from [#514](https://github.com/ualib/agda-algebras/pull/514), fixed here);
+  `make gen-links` + `make check-links` green;
+  `python3 scripts/python/test_unused_imports.py` 55/55.

---

🤖 AI-assisted development: Claude Fable 5 (Anthropic)
