### PR TITLE
Keep the landing-page corpus stats current at build time

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,12 @@ every commit.
 </div>
 
 <div class="ualib-stats">
-  <div class="ualib-stat"><span class="ualib-stat__num">283</span><span class="ualib-stat__label">literate modules</span></div>
-  <div class="ualib-stat"><span class="ualib-stat__num">38k</span><span class="ualib-stat__label">lines of Agda</span></div>
+  <!-- The two figures below are recomputed from the src/ tree on every build by
+       scripts/python/mkdocs_hooks.py (via the ualib:stat markers).  The values
+       here are only a fallback for non-MkDocs (e.g. GitHub) views — do not
+       hand-tune them; run `make site` and they refresh. -->
+  <div class="ualib-stat"><span class="ualib-stat__num"><!-- ualib:stat:modules -->302<!-- /ualib:stat:modules --></span><span class="ualib-stat__label">literate modules</span></div>
+  <div class="ualib-stat"><span class="ualib-stat__num"><!-- ualib:stat:loc -->60k<!-- /ualib:stat:loc --></span><span class="ualib-stat__label">lines of Agda</span></div>
   <div class="ualib-stat"><span class="ualib-stat__num">100%</span><span class="ualib-stat__label">machine-checked</span></div>
   <div class="ualib-stat"><span class="ualib-stat__num">2.8.0</span><span class="ualib-stat__label">Agda · stdlib 2.3</span></div>
 </div>

--- a/scripts/python/mkdocs_hooks.py
+++ b/scripts/python/mkdocs_hooks.py
@@ -134,9 +134,12 @@ def on_files(files, config):
 # docs/index.md advertises "<N> literate modules, <M>k lines of Agda".  Rather
 # than let those drift, the hook recomputes them from the tree and substitutes
 # them into the `<!-- ualib:stat:… -->` markers on that one page.  It is a single
-# pass over the ~280 canonical modules (~0.5 s), run only when rendering index.md.
+# pass over the canonical (non-Legacy) modules — a few hundred files, ~50 ms —
+# run only when rendering index.md, so it adds nothing meaningful to the build.
 SRC = Path("src")
-STAT = re.compile(r"<!-- ualib:stat:(\w+) -->.*?<!-- /ualib:stat:\1 -->")
+# DOTALL so the markers keep matching even if index.md is reformatted with the
+# open/close comments on separate lines; the \1 backreference pins each pair.
+STAT = re.compile(r"<!-- ualib:stat:(\w+) -->.*?<!-- /ualib:stat:\1 -->", re.DOTALL)
 
 
 def _agda_loc(text: str) -> int:
@@ -168,7 +171,9 @@ def _corpus_stats() -> tuple[int, int]:
 def _fill_corpus_stats(markdown: str) -> str:
     """Replace the landing page's stat markers with freshly counted values."""
     mods, loc = _corpus_stats()
-    values = {"modules": str(mods), "loc": f"{round(loc / 1000)}k"}
+    # Half-up rounding to thousands (round() would round ties to even, e.g.
+    # 60_500 → "60k"; readers of a "…k" stat expect 60_500 → "61k").
+    values = {"modules": str(mods), "loc": f"{(loc + 500) // 1000}k"}
     log.info(f"📊  corpus stats: {values['modules']} modules, {values['loc']} lines of Agda")
     return STAT.sub(lambda m: values.get(m.group(1), m.group(0)), markdown)
 

--- a/scripts/python/mkdocs_hooks.py
+++ b/scripts/python/mkdocs_hooks.py
@@ -130,10 +130,56 @@ def on_files(files, config):
     return files
 
 
+# --- Landing-page corpus stats, kept current at build time -------------------
+# docs/index.md advertises "<N> literate modules, <M>k lines of Agda".  Rather
+# than let those drift, the hook recomputes them from the tree and substitutes
+# them into the `<!-- ualib:stat:… -->` markers on that one page.  It is a single
+# pass over the ~280 canonical modules (~0.5 s), run only when rendering index.md.
+SRC = Path("src")
+STAT = re.compile(r"<!-- ualib:stat:(\w+) -->.*?<!-- /ualib:stat:\1 -->")
+
+
+def _agda_loc(text: str) -> int:
+    """Lines inside the module's ```agda fenced blocks — its actual Agda code
+    (the hidden import scaffolding counts; prose and the fence lines do not)."""
+    n, in_agda = 0, False
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            if in_agda:
+                in_agda = False
+            elif stripped[3:].strip().lower().startswith("agda"):
+                in_agda = True
+            continue
+        if in_agda:
+            n += 1
+    return n
+
+
+def _corpus_stats() -> tuple[int, int]:
+    """(literate-module count, Agda-code lines) over src/ minus the frozen
+    Legacy/ tree — the canonical library the landing page advertises."""
+    mods = [p for p in SRC.rglob("*.lagda.md")
+            if p.relative_to(SRC).parts[0] != "Legacy"]
+    loc = sum(_agda_loc(p.read_text(encoding="utf-8")) for p in mods)
+    return len(mods), loc
+
+
+def _fill_corpus_stats(markdown: str) -> str:
+    """Replace the landing page's stat markers with freshly counted values."""
+    mods, loc = _corpus_stats()
+    values = {"modules": str(mods), "loc": f"{round(loc / 1000)}k"}
+    log.info(f"📊  corpus stats: {values['modules']} modules, {values['loc']} lines of Agda")
+    return STAT.sub(lambda m: values.get(m.group(1), m.group(0)), markdown)
+
+
 def on_page_markdown(markdown: str, *, page=None, config=None, files=None) -> str:
     global _done
     _done += 1
     where = f"[{_done}/{_total}]" if _total else f"[{_done}]"
+
+    if getattr(getattr(page, "file", None), "src_uri", None) == "index.md":
+        markdown = _fill_corpus_stats(markdown)
 
     out: list[str] = []
     in_code = False


### PR DESCRIPTION
## Summary

The landing page (`docs/index.md`) advertised **"283 literate modules, 38k lines of Agda"**, and both had drifted — the canonical tree is now **302 modules / ~60k lines**.  This teaches the existing render hook to recompute those two figures from the `src/` tree on every build and substitute them into `<!-- ualib:stat:… -->` markers on the landing page, so they never go stale again.

## Related issues

None — standalone follow-up to the merged #496.  No open issue to close.

## Is it cheap?  Yes

That was the deciding question.  Computing the stats is a single pass over the ~300 canonical (non-Legacy) `.lagda.md` files — **~50 ms**, measured — and it runs **only when rendering `index.md`**, on a build that already takes minutes and already walks `src/`.  It adds nothing meaningful to build time, so it's worth wiring up rather than updating by hand.

## What changed

+  **`scripts/python/mkdocs_hooks.py`** — adds `_corpus_stats()` (counts non-Legacy `.lagda.md` modules and the lines inside their ` ```agda ` fences) and, in `on_page_markdown`, fills the landing page's stat markers.  Guarded on `page.file.src_uri == "index.md"`, so the `src/` walk happens once per build, not per page.
+  **`docs/index.md`** — wraps the two numbers in `<!-- ualib:stat:modules -->` / `<!-- ualib:stat:loc -->` markers.  The values in the file (now `302` / `60k`) are a fallback for non-MkDocs (e.g. GitHub) rendering; the hook overwrites them in the built site.  The markers are HTML comments, so they're stripped from the rendered HTML — the tiles show a clean number.

## Metric definition

+  **"literate modules"** = `.lagda.md` files under `src/` excluding the frozen `Legacy/` tree — the canonical library (what `Everything.agda` type-checks).  Matches the original intent (the old `283` ≈ today's canonical count).
+  **"lines of Agda"** = lines inside ` ```agda ` fenced blocks across those modules (hidden import scaffolding included; prose and fence lines excluded), rounded to `k`.

## Verification

+  Unit-checked the substitution against the real `index.md`: the two tiles render `302` and `60k`, the other two tiles (`100%`, `2.8.0`) are untouched, and no markers leak into the HTML.
+  `mkdocs build --strict` renders the landing page cleanly (the hook logs `📊  corpus stats: …` once per build).

## Type of change

- [ ] Bug fix
- [ ] New definition, theorem, or feature
- [ ] Refactor / cleanup (user-facing/API change)
- [ ] Refactor / cleanup (no user-facing change)
- [x] Documentation
- [x] Infrastructure (CI, Nix, build)
- [ ] Other

## Checklist

- [x] `make check` passes locally under `nix develop` — n/a to this change (no `src/` Agda touched; only the render hook and the landing page's HTML).
- [x] New public definitions have prose comment blocks — the new hook helpers are documented.
- [x] Commits are coherent and have explanatory messages.
- [x] If this PR touches `src/`, it targets a supported area — n/a (no `src/` changes).
- [x] If this PR introduces new notation, it doesn't conflict — n/a.

## Notes for reviewers

+  The fallback numbers in `docs/index.md` will themselves drift slowly (they only matter for GitHub's raw rendering of that file); the *site* is always exact.  If that bothers you, they can be dropped to a placeholder like `—`, but keeping a real recent number reads better on GitHub.
+  Adding another auto-stat later is a two-line change: add a `<!-- ualib:stat:NAME -->` marker in `index.md` and a `NAME` key in `_fill_corpus_stats`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GGoMgZ4mXFT3Q6RT86856

---
_Generated by [Claude Code](https://claude.ai/code/session_015GGoMgZ4mXFT3Q6RT86856)_