### PR TITLE
[M6-16] Kurzweil–Netter duality theorem (#502)

### DIFF
--- a/docs/_links.md
+++ b/docs/_links.md
@@ -32,7 +32,9 @@
 [Setoid.Algebras]: /Setoid/Algebras/
 [Setoid.Algebras.Basic]: /Setoid/Algebras/Basic/
 [Setoid.Algebras.Finite]: /Setoid/Algebras/Finite/
+[Setoid.Algebras.Finite.Irredundant]: /Setoid/Algebras/Finite/Irredundant/
 [Setoid.Algebras.Products]: /Setoid/Algebras/Products/
+[Setoid.Algebras.Products.Finite]: /Setoid/Algebras/Products/Finite/
 [Setoid.Algebras.Reduct]: /Setoid/Algebras/Reduct/
 [Setoid.Categories]: /Setoid/Categories/
 [Setoid.Categories.Adjunction]: /Setoid/Categories/Adjunction/
@@ -386,6 +388,12 @@
 [FLRP.Closure.Product]: /FLRP/Closure/Product/
 [FLRP.Enforceable]: /FLRP/Enforceable/
 [FLRP.KurzweilInterval]: /FLRP/KurzweilInterval/
+[FLRP.KurzweilNetter]: /FLRP/KurzweilNetter/
+[FLRP.KurzweilNetter.Blocks]: /FLRP/KurzweilNetter/Blocks/
+[FLRP.KurzweilNetter.Duality]: /FLRP/KurzweilNetter/Duality/
+[FLRP.KurzweilNetter.Expansion]: /FLRP/KurzweilNetter/Expansion/
+[FLRP.KurzweilNetter.Invariance]: /FLRP/KurzweilNetter/Invariance/
+[FLRP.KurzweilNetter.Translations]: /FLRP/KurzweilNetter/Translations/
 [FLRP.L7EqSix]: /FLRP/L7EqSix/
 [FLRP.LayerBridge]: /FLRP/LayerBridge/
 [FLRP.Parachute]: /FLRP/Parachute/
@@ -420,7 +428,9 @@
 [Setoid/Algebras.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras.lagda.md
 [Setoid/Algebras/Basic.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Basic.lagda.md
 [Setoid/Algebras/Finite.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Finite.lagda.md
+[Setoid/Algebras/Finite/Irredundant.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Finite/Irredundant.lagda.md
 [Setoid/Algebras/Products.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Products.lagda.md
+[Setoid/Algebras/Products/Finite.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Products/Finite.lagda.md
 [Setoid/Algebras/Reduct.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Reduct.lagda.md
 [Setoid/Categories.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Categories.lagda.md
 [Setoid/Categories/Adjunction.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Categories/Adjunction.lagda.md
@@ -774,6 +784,12 @@
 [FLRP/Closure/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/Product.lagda.md
 [FLRP/Enforceable.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Enforceable.lagda.md
 [FLRP/KurzweilInterval.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilInterval.lagda.md
+[FLRP/KurzweilNetter.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter.lagda.md
+[FLRP/KurzweilNetter/Blocks.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Blocks.lagda.md
+[FLRP/KurzweilNetter/Duality.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Duality.lagda.md
+[FLRP/KurzweilNetter/Expansion.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Expansion.lagda.md
+[FLRP/KurzweilNetter/Invariance.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Invariance.lagda.md
+[FLRP/KurzweilNetter/Translations.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Translations.lagda.md
 [FLRP/L7EqSix.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/L7EqSix.lagda.md
 [FLRP/LayerBridge.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/LayerBridge.lagda.md
 [FLRP/Parachute.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Parachute.lagda.md

--- a/docs/_links.md
+++ b/docs/_links.md
@@ -32,7 +32,9 @@
 [Setoid.Algebras]: /Setoid/Algebras/
 [Setoid.Algebras.Basic]: /Setoid/Algebras/Basic/
 [Setoid.Algebras.Finite]: /Setoid/Algebras/Finite/
+[Setoid.Algebras.Finite.Irredundant]: /Setoid/Algebras/Finite/Irredundant/
 [Setoid.Algebras.Products]: /Setoid/Algebras/Products/
+[Setoid.Algebras.Products.Finite]: /Setoid/Algebras/Products/Finite/
 [Setoid.Algebras.Reduct]: /Setoid/Algebras/Reduct/
 [Setoid.Categories]: /Setoid/Categories/
 [Setoid.Categories.Adjunction]: /Setoid/Categories/Adjunction/
@@ -384,6 +386,12 @@
 [FLRP.Closure.Product]: /FLRP/Closure/Product/
 [FLRP.Enforceable]: /FLRP/Enforceable/
 [FLRP.KurzweilInterval]: /FLRP/KurzweilInterval/
+[FLRP.KurzweilNetter]: /FLRP/KurzweilNetter/
+[FLRP.KurzweilNetter.Blocks]: /FLRP/KurzweilNetter/Blocks/
+[FLRP.KurzweilNetter.Duality]: /FLRP/KurzweilNetter/Duality/
+[FLRP.KurzweilNetter.Expansion]: /FLRP/KurzweilNetter/Expansion/
+[FLRP.KurzweilNetter.Invariance]: /FLRP/KurzweilNetter/Invariance/
+[FLRP.KurzweilNetter.Translations]: /FLRP/KurzweilNetter/Translations/
 [FLRP.L7EqSix]: /FLRP/L7EqSix/
 [FLRP.LayerBridge]: /FLRP/LayerBridge/
 [FLRP.Parachute]: /FLRP/Parachute/
@@ -417,7 +425,9 @@
 [Setoid/Algebras.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras.lagda.md
 [Setoid/Algebras/Basic.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Basic.lagda.md
 [Setoid/Algebras/Finite.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Finite.lagda.md
+[Setoid/Algebras/Finite/Irredundant.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Finite/Irredundant.lagda.md
 [Setoid/Algebras/Products.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Products.lagda.md
+[Setoid/Algebras/Products/Finite.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Products/Finite.lagda.md
 [Setoid/Algebras/Reduct.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Algebras/Reduct.lagda.md
 [Setoid/Categories.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Categories.lagda.md
 [Setoid/Categories/Adjunction.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/Setoid/Categories/Adjunction.lagda.md
@@ -769,6 +779,12 @@
 [FLRP/Closure/Product.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Closure/Product.lagda.md
 [FLRP/Enforceable.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Enforceable.lagda.md
 [FLRP/KurzweilInterval.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilInterval.lagda.md
+[FLRP/KurzweilNetter.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter.lagda.md
+[FLRP/KurzweilNetter/Blocks.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Blocks.lagda.md
+[FLRP/KurzweilNetter/Duality.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Duality.lagda.md
+[FLRP/KurzweilNetter/Expansion.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Expansion.lagda.md
+[FLRP/KurzweilNetter/Invariance.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Invariance.lagda.md
+[FLRP/KurzweilNetter/Translations.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/KurzweilNetter/Translations.lagda.md
 [FLRP/L7EqSix.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/L7EqSix.lagda.md
 [FLRP/LayerBridge.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/LayerBridge.lagda.md
 [FLRP/Parachute.lagda]: https://github.com/ualib/agda-algebras/blob/master/src/FLRP/Parachute.lagda.md

--- a/docs/notes/flrp-slr-census.md
+++ b/docs/notes/flrp-slr-census.md
@@ -34,11 +34,11 @@ Every artifact is a deterministic function of the manuscript source, via `script
 | `L15` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR15` |
 | `L16` | 7 | group representation (Sub(C2.A6), 180 points); pending #454/#487 |
 | `L17` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR17` |
-| `L18` | 7 | dual of L19; assumption-conditional via Kurzweil–Netter duality (#456) |
+| `L18` | 7 | dual of L19; conditional corollary of the Kurzweil–Netter theorem (#502) — rests on Entry 4 (Kurzweil surjectivity, #522) and a simple-group instantiation (#527) |
 | `L19` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR19` |
 | `L20` | 7 | group representation (filter-ideal in SmallGroup(216,153)); pending #454/#487 |
 | `L21` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR21` |
-| `L22` | 7 | dual of L23; assumption-conditional via Kurzweil–Netter duality (#456) |
+| `L22` | 7 | dual of L23; conditional corollary of the Kurzweil–Netter theorem (#502) — rests on Entry 4 (Kurzweil surjectivity, #522) and a simple-group instantiation (#527) |
 | `L23` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR23` |
 | `L24` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR24` |
 | `L25` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR25` |
@@ -53,7 +53,7 @@ Every artifact is a deterministic function of the manuscript source, via `script
 | `L34` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR34` |
 | `L35` | 7 | certified — `FLRP.Certificates.SmallLatticeReps.SLR35` |
 
-Tally: **27 certified** (21 in batch 1, 6 more once the batch-2 renderer landed), **4 parked on the group route** (#454/#487), **2 assumption-conditional duals** (#456), **1 open** (#484), **1 candidate erratum**.
+Tally: **27 certified** (21 in batch 1, 6 more once the batch-2 renderer landed), **4 parked on the group route** (#454/#487), **2 conditional duals** (corollaries of the #502 theorem, resting on Entry 4), **1 open** (#484), **1 candidate erratum**.
 
 ## 3. The parked entries, in detail
 
@@ -63,7 +63,7 @@ Tally: **27 certified** (21 in batch 1, 6 more once the batch-2 renderer landed)
    +  **`L11`** — the manuscript's filter-ideal construction reproduced in `SmallGroup(216,153)` (`bin/filter_ideal_216.g`): the pentagon filter `[H, G] ≅ N5` together with the order-3 minimal subgroup `K` (index 72, below β but neither α nor γ), `l11_filter_ideal_216_153.json`.
    +  **`L16`** — **not reproduced as printed**: the manuscript's "upper interval in `Sub(C2.A6)`, index 180" does not appear in `C2.A6 = 2.A6 = SL(2,9)`; recorded as candidate erratum E2 below.
    +  **`L20`** — filter-ideal in `SmallGroup(216,153)`; the 2016-06-10 draft states the method but prints no explicit construction, so only the group is pinned, with the pentagon/subgroup data of `L11` in hand for a fuller reproduction.
-+  **`L18`, `L22`** — duals of `L19` and `L23`, with no explicit small algebras in the manuscript.  Both duals' partners are now **certified** (`SLR19`, `SLR23`), so once WP-5 (#456) registers Kurzweil–Netter duality as a named assumption, `L18` and `L22` become assumption-conditional corollaries; explicit algebras may also be found by the #486 search tooling (their lattice stanzas `slr18_lattice.json`, `slr22_lattice.json` are committed as ready-made `eqsearch.py` targets).
++  **`L18`, `L22`** — duals of `L19` and `L23`, with no explicit small algebras in the manuscript.  Both duals' partners are now **certified** (`SLR19`, `SLR23`), and the Kurzweil–Netter duality theorem is now proved from the simple-group package (#502, `FLRP.KurzweilNetter`), so `L18` and `L22` are corollaries conditional on Entry 4 (Kurzweil surjectivity, retirement tracked by #522) and a concrete simple-group instantiation (#527) — no longer on the full duality theorem as an assumption (the former #456 route).  Explicit algebras may also be found by the #486 search tooling (their lattice stanzas `slr18_lattice.json`, `slr22_lattice.json` are committed as ready-made `eqsearch.py` targets).
 
 ## 4. Erratum log
 

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -57,13 +57,20 @@ Two standing warnings apply to everything under this namespace.
 +  [FLRP.Assumptions][]: the registry of classical theorems imported as
    explicit hypotheses (never postulates), keeping the tree honest under
    `--safe`; Entry 1 is the congruence-completeness bridge
-   `CongruenceCompleteness`, the single Layer-S→Layer-D assumption of ADR-008,
-   and Entry 2 is Kurzweil–Netter duality, consumed by the WP-5 closure
-   toolkit.
+   `CongruenceCompleteness`, the single Layer-S→Layer-D assumption of ADR-008;
+   Entry 2 (Kurzweil–Netter duality) is retired — proved in
+   [FLRP.KurzweilNetter][] — leaving Entry 4 (Kurzweil surjectivity) as the
+   construction's residual classical content.
 +  [FLRP.Closure][]: the WP-5 closure toolkit: product and ordinal-sum
    closure of `Representableᵈ` (issue #456), the adjoin-a-new-extremum
-   corollaries at `chain₂`, and the duality corollary `dual-Representableᵈ`
-   conditional on the registry's Entry 2.
+   corollaries at `chain₂`, and the duality theorem `dual-Representableᵈ`,
+   rewired from the retired Entry 2 to the Kurzweil–Netter proof.
++  [FLRP.KurzweilNetter][]: the formal Kurzweil–Netter duality proof (issue
+   #502): irredundant carrier enumerations, the basic-translation criterion
+   for congruences, the expansion of the coset algebra on `Sᵐ/D` by lifted
+   translations, and the assembled theorem `kurzweilNetterDuality`,
+   parameterized by exactly the properties of the simple group the argument
+   uses.
 +  [FLRP.LayerBridge][]: the cross-layer bridge: under the congruence-completeness
    assumption, the semantic and decidable congruence posets are order-isomorphic
    (`conDecIso`), whence `Representable 𝑳 ↔ Representableᵈ 𝑳`.
@@ -121,6 +128,7 @@ open import FLRP.Representable  public
 open import FLRP.Assumptions    public
 open import FLRP.Closure        public
 open import FLRP.KurzweilInterval public
+open import FLRP.KurzweilNetter public
 open import FLRP.LayerBridge    public
 open import FLRP.WreathNoGo     public
 open import FLRP.Certificates   public

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -57,13 +57,20 @@ Two standing warnings apply to everything under this namespace.
 +  [FLRP.Assumptions][] — the registry of classical theorems imported as
    explicit hypotheses (never postulates), keeping the tree honest under
    `--safe`; Entry 1 is the congruence-completeness bridge
-   `CongruenceCompleteness`, the single Layer-S→Layer-D assumption of ADR-008,
-   and Entry 2 is Kurzweil–Netter duality, consumed by the WP-5 closure
-   toolkit.
+   `CongruenceCompleteness`, the single Layer-S→Layer-D assumption of ADR-008;
+   Entry 2 (Kurzweil–Netter duality) is retired — proved in
+   [FLRP.KurzweilNetter][] — leaving Entry 4 (Kurzweil surjectivity) as the
+   construction's residual classical content.
 +  [FLRP.Closure][] — the WP-5 closure toolkit: product and ordinal-sum
    closure of `Representableᵈ` (issue #456), the adjoin-a-new-extremum
-   corollaries at `chain₂`, and the duality corollary `dual-Representableᵈ`
-   conditional on the registry's Entry 2.
+   corollaries at `chain₂`, and the duality theorem `dual-Representableᵈ`,
+   rewired from the retired Entry 2 to the Kurzweil–Netter proof.
++  [FLRP.KurzweilNetter][] — the formal Kurzweil–Netter duality proof (issue
+   #502): irredundant carrier enumerations, the basic-translation criterion
+   for congruences, the expansion of the coset algebra on `Sᵐ/D` by lifted
+   translations, and the assembled theorem `kurzweilNetterDuality`,
+   parameterized by exactly the properties of the simple group the argument
+   uses.
 +  [FLRP.LayerBridge][] — the cross-layer bridge: under the congruence-completeness
    assumption, the semantic and decidable congruence posets are order-isomorphic
    (`conDecIso`), whence `Representable 𝑳 ↔ Representableᵈ 𝑳`.
@@ -111,6 +118,7 @@ open import FLRP.Representable  public
 open import FLRP.Assumptions    public
 open import FLRP.Closure        public
 open import FLRP.KurzweilInterval public
+open import FLRP.KurzweilNetter public
 open import FLRP.LayerBridge    public
 open import FLRP.Certificates   public
 open import FLRP.L7EqSix        public

--- a/src/FLRP.lagda.md
+++ b/src/FLRP.lagda.md
@@ -58,9 +58,9 @@ Two standing warnings apply to everything under this namespace.
    explicit hypotheses (never postulates), keeping the tree honest under
    `--safe`; Entry 1 is the congruence-completeness bridge
    `CongruenceCompleteness`, the single Layer-S→Layer-D assumption of ADR-008;
-   Entry 2 (Kurzweil–Netter duality) is retired — proved in
-   [FLRP.KurzweilNetter][] — leaving Entry 4 (Kurzweil surjectivity) as the
-   construction's residual classical content.
+   Entry 2 (Kurzweil–Netter duality) is reduced to Entry 4 (Kurzweil
+   surjectivity) by the proof in [FLRP.KurzweilNetter][], and no longer enters
+   anywhere as an independent hypothesis.
 +  [FLRP.Closure][]: the WP-5 closure toolkit: product and ordinal-sum
    closure of `Representableᵈ` (issue #456), the adjoin-a-new-extremum
    corollaries at `chain₂`, and the duality theorem `dual-Representableᵈ`,

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -51,13 +51,15 @@ free constructive data reconstitutes the full semantic
 `FiniteCongruences`{.AgdaRecord}, so the assumption is exactly the classical delta
 between the two layers, no more, no less.
 
-**Entry 2**: Kurzweil–Netter duality.  The class of representable lattices is
-closed under dualization — proved by Kurzweil (1985) for intervals in solvable
-groups and by Netter (1986) in general, the latter possibly never published.  The
-closure toolkit of work package WP-5 ([FLRP.Closure][]) proves product and
-ordinal-sum closure outright; duality enters as this registry's second entry,
-`KurzweilNetterDuality`{.AgdaFunction}, an explicit hypothesis pending a formal
-reproof.[^3]
+**Entry 2** (*retired*): Kurzweil–Netter duality.  The class of representable
+lattices is closed under dualization — proved by Kurzweil (1985) for intervals
+in solvable groups and by Netter (1986) in general, the latter possibly never
+published.  Registered here as `KurzweilNetterDuality`{.AgdaFunction} while a
+formal reproof was pending, the entry is **retired as an assumption**: issue
+#502's [FLRP.KurzweilNetter.Duality][] proves the statement outright from the
+properties of the base group the argument actually uses, the only remaining
+classical ingredient being Entry 4.  The statement types remain here as the
+theorem's canonical name.[^3]
 
 **Entry 3**: the Pálfy–Pudlák theorem.  Every finite lattice is a congruence
 lattice of a finite algebra *if and only if* every finite lattice is an interval in
@@ -206,14 +208,14 @@ transitivity.
       φ≑e = d≑e .proj₁ ∘ φ≑d .proj₁ , φ≑d .proj₂ ∘ d≑e .proj₂
 ```
 
-#### Entry 2: Kurzweil–Netter duality
+#### Entry 2: Kurzweil–Netter duality (retired)
 
 The **theorem of Kurzweil and Netter**: if a finite lattice is representable as
 the congruence lattice of a finite algebra, then so is its dual.  Kurzweil proved
 the group-interval case (H. Kurzweil, *Endliche Gruppen mit vielen Untergruppen*,
 J. reine angew. Math. 356 (1985) 140–160); his student Netter proved the general
 statement (R. Netter, 1986), in an article that may never have been published.
-The argument this library targets is the one presented in
+The formalized argument is the one presented in
 `docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals: the theorem of
 Kurzweil and Netter", following Pálfy's 2009 lectures: represent the dual of
 `Eq(n)` as the interval `[D , Sⁿ]` in the subgroup lattice of a power of a
@@ -225,36 +227,40 @@ algebra with lifted operations.
    decidable representation of `𝑳`{.AgdaBound}, one can produce a decidable
    representation of `dualLattice 𝑳`{.AgdaFunction}
    ([Classical.Structures.Lattice.Dual][]).  The ∀-form
-   `KurzweilNetterDuality`{.AgdaFunction} is the full theorem.  The per-lattice
-   form is the useful granularity downstream: a consumer may assume duality at
-   exactly the lattice it dualizes (the small-lattice census, issue #485, needs it
-   only at the certified partners of its two dual entries).
+   `KurzweilNetterDuality`{.AgdaFunction} is the full theorem.
 
-+  **Source and status**.  Unlike Entry 1 — an axiom-calibrated *bridge* whose
-   strength is pinned between WLEM and LEM — this entry is a *classically proven
-   theorem* imported pending formalization.  Its proof route needs the powers
-   `Sⁿ` of a finite simple group, the interval `[D , Sⁿ]`, and the transitive
-   G-set congruence bridge of work package WP-3, none of which is formalized yet;
-   when the stretch goal of issue #456 lands, this entry retires and
-   `dual-Representableᵈ`{.AgdaFunction} of [FLRP.Closure][] becomes a theorem.
++  **Status: retired as an assumption** (issue #502).
+   `kurzweilNetterDuality`{.AgdaFunction} of [FLRP.KurzweilNetter.Duality][]
+   *proves* `KurzweilNetterDuality`{.AgdaFunction} outright, parameterized by
+   the properties of the base group the argument actually uses — a finite
+   carrier with decidable equality, a nontriviality witness, and Entry 4's
+   surjectivity family — and `dual-Representableᵈ`{.AgdaFunction} of
+   [FLRP.Closure][] is rewired to that theorem.  Nothing consumes this entry
+   as a hypothesis any more; the definitions below remain as the canonical
+   *statement* of the theorem (they are its conclusion's type).  The residual
+   classical content is exactly Entry 4 (retirement tracked by issue #522)
+   plus the instantiation of `𝒮` at a concrete finite nonabelian simple group
+   (tracked separately; `A₅` needs the simplicity predicates of issue #512).
 
-+  **Layer**.  The entry is registered at Layer D (`Representableᵈ`{.AgdaRecord}),
++  **Layer**.  The statement is at Layer D (`Representableᵈ`{.AgdaRecord}),
    the program's working notion per [ADR-008][]; the classical statement is the
-   Layer-S reading, and the two coincide classically through Entry 1.  A formal
-   Kurzweil–Netter proof would in any case produce the Layer-D form: the
-   construction is finite and explicit.
+   Layer-S reading, and the two coincide classically through Entry 1.  As
+   anticipated at registration, the formal proof produces the Layer-D form
+   directly: the construction is finite and explicit.
 
 +  **Size**.  The construction represents the dual on an algebra of
    `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹` elements (for an `n`-element original), which is why the
-   census keeps dual entries assumption-conditional rather than materializing
-   concrete certificate algebras.
+   census keeps dual entries conditional rather than materializing concrete
+   certificate algebras: the theorem makes their *statements* assumption-free
+   (modulo Entry 4) without bringing the certificates in reach.
 
 ```agda
--- Entry 2, per-lattice form: a decidable representation of 𝑳 yields one of its dual.
+-- Entry 2, per-lattice form: a decidable representation of 𝑳 yields one of its
+-- dual.  Proved by FLRP.KurzweilNetter.Duality; retained as the statement type.
 KurzweilNetterDualityAt : Lattice → Type (lsuc 0ℓ)
 KurzweilNetterDualityAt 𝑳 = Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
 
--- The full theorem of Kurzweil (1985) and Netter (1986), as an explicit hypothesis.
+-- The theorem of Kurzweil (1985) and Netter (1986), as a statement.
 KurzweilNetterDuality : Type (lsuc 0ℓ)
 KurzweilNetterDuality = (𝑳 : Lattice) → KurzweilNetterDualityAt 𝑳
 ```
@@ -364,7 +370,10 @@ KurzweilSurjectivityAt 𝒮 n = KurzweilInterval.KurzweilSurjectivity 𝒮 n
       decidable representability outright in [FLRP.Closure][] and registered
       duality here as Entry 2 (see
       [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7
-      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456).
+      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456)).
+      The work package's stretch goal — the formal reproof — landed with GitHub
+      [Issue #502](https://github.com/ualib/agda-algebras/issues/502), retiring
+      the entry.
 
 [^4]: Registered by **RP-1** (GitHub
       [Issue #458](https://github.com/ualib/agda-algebras/issues/458)), which needs it

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -53,11 +53,14 @@ constructive data reconstitutes the full semantic
 `FiniteCongruences`{.AgdaRecord}, so the assumption is exactly the classical delta
 between the two layers, no more, no less.
 
-**Entry 2**: Kurzweil–Netter duality.  The class of representable lattices is
-closed under dualization.[^3] The closure toolkit of work package WP-5
-([FLRP.Closure][]) proves product and ordinal-sum closure outright; duality enters
-as this registry's second entry, `KurzweilNetterDuality`{.AgdaFunction}, an
-explicit hypothesis pending a formal reproof.[^4]
+**Entry 2** (*retired*): Kurzweil–Netter duality.  The class of representable
+lattices is closed under dualization.[^3]  Registered here as
+`KurzweilNetterDuality`{.AgdaFunction} while a formal reproof was pending, the
+entry is **retired as an assumption**: issue #502's
+[FLRP.KurzweilNetter.Duality][] proves the statement outright from the
+properties of the base group the argument actually uses, the only remaining
+classical ingredient being Entry 4.  The statement types remain here as the
+theorem's canonical name.[^4]
 
 **Entry 3**: the Pálfy–Pudlák theorem.  Every finite lattice is a congruence
 lattice of a finite algebra *if and only if* every finite lattice is an interval in
@@ -212,7 +215,7 @@ completeness `completeᵈ`{.AgdaField} by transitivity.
       φ≑e = d≑e .proj₁ ∘ φ≑d .proj₁ , φ≑d .proj₂ ∘ d≑e .proj₂
 ```
 
-#### Entry 2: Kurzweil–Netter duality
+#### Entry 2: Kurzweil–Netter duality (retired)
 
 **The theorem of Kurzweil and Netter**.  If a finite lattice is representable as
 the congruence lattice of a finite algebra, then so is its dual.
@@ -222,7 +225,7 @@ Kurzweil proved the group-interval case (H. Kurzweil,
 140–160); his student Netter proved the general statement (R. Netter, 1986), in an
 article that may never have been published.
 
-The argument this library targets is the one presented in
+The formalized argument is the one presented in
 `docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals: the theorem of
 Kurzweil and Netter", following Pálfy's 2009 lectures: represent the dual of
 `Eq(n)` as the interval `[D , Sⁿ]` in the subgroup lattice of a power of a
@@ -234,34 +237,40 @@ algebra with lifted operations.
    decidable representation of `𝑳`{.AgdaBound}, one can produce a decidable
    representation of `dualLattice 𝑳`{.AgdaFunction}
    ([Classical.Structures.Lattice.Dual][]).  The ∀-form
-   `KurzweilNetterDuality`{.AgdaFunction} is the full theorem.  The per-lattice
-   form is the useful granularity downstream: a consumer may assume duality at
-   exactly the lattice it dualizes (the small-lattice census, issue #485, needs it
-   only at the certified partners of its two dual entries).
+   `KurzweilNetterDuality`{.AgdaFunction} is the full theorem.
 
-+  **Source and status**.  Unlike Entry 1 (an axiom-calibrated bridge whose
-   strength is pinned between WLEM and LEM) this entry is a classically proven
-   theorem imported pending formalization.  Its proof route needs the powers
-   `Sⁿ` of a finite simple group, the interval `[D , Sⁿ]`, and the transitive
-   G-set congruence bridge (work package WP-3), none of which is formalized yet.[^6]
++  **Status: retired as an assumption** (issue #502).
+   `kurzweilNetterDuality`{.AgdaFunction} of [FLRP.KurzweilNetter.Duality][]
+   *proves* `KurzweilNetterDuality`{.AgdaFunction} outright, parameterized by
+   the properties of the base group the argument actually uses — a finite
+   carrier with decidable equality, a nontriviality witness, and Entry 4's
+   surjectivity family — and `dual-Representableᵈ`{.AgdaFunction} of
+   [FLRP.Closure][] is rewired to that theorem.  Nothing consumes this entry
+   as a hypothesis any more; the definitions below remain as the canonical
+   *statement* of the theorem (they are its conclusion's type).  The residual
+   classical content is exactly Entry 4 (retirement tracked by issue #522)
+   plus the instantiation of `𝒮` at a concrete finite nonabelian simple group
+   (tracked separately; `A₅` needs the simplicity predicates of issue #512).
 
-+  **Layer**.  The entry is registered at Layer D (`Representableᵈ`{.AgdaRecord}),
++  **Layer**.  The statement is at Layer D (`Representableᵈ`{.AgdaRecord}),
    the program's working notion per [ADR-008][]; the classical statement is the
-   Layer-S reading, and the two coincide classically through Entry 1.  A formal
-   Kurzweil–Netter proof would in any case produce the Layer-D form: the
-   construction is finite and explicit.
+   Layer-S reading, and the two coincide classically through Entry 1.  As
+   anticipated at registration, the formal proof produces the Layer-D form
+   directly: the construction is finite and explicit.
 
 +  **Size**.  The construction represents the dual on an algebra of
    `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹` elements (for an `n`-element original), which is why the
-   census keeps dual entries assumption-conditional rather than materializing
-   concrete certificate algebras.
+   census keeps dual entries conditional rather than materializing concrete
+   certificate algebras: the theorem makes their *statements* assumption-free
+   (modulo Entry 4) without bringing the certificates in reach.
 
 ```agda
--- Entry 2, per-lattice form: a decidable representation of 𝑳 yields one of its dual.
+-- Entry 2, per-lattice form: a decidable representation of 𝑳 yields one of its
+-- dual.  Proved by FLRP.KurzweilNetter.Duality; retained as the statement type.
 KurzweilNetterDualityAt : Lattice → Type (lsuc 0ℓ)
 KurzweilNetterDualityAt 𝑳 = Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
 
--- The full theorem of Kurzweil (1985) and Netter (1986), as an explicit hypothesis.
+-- The theorem of Kurzweil (1985) and Netter (1986), as a statement.
 KurzweilNetterDuality : Type (lsuc 0ℓ)
 KurzweilNetterDuality = (𝑳 : Lattice) → KurzweilNetterDualityAt 𝑳
 ```
@@ -467,12 +476,12 @@ KurzweilWreathIntervalAt 𝒮 = KurzweilWreathInterval 𝒮
       decidable representability outright in [FLRP.Closure][] and registered
       duality here as Entry 2 (see
       [`docs/notes/flrp-research-roadmap.md`](docs/notes/flrp-research-roadmap.md) § 7
-      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456).
+      and GitHub [Issue #456](https://github.com/ualib/agda-algebras/issues/456)).
+      The work package's stretch goal — the formal reproof — landed with GitHub
+      [Issue #502](https://github.com/ualib/agda-algebras/issues/502), retiring
+      the entry.
 
 [^5]: Registered by **RP-1** (GitHub
       [Issue #458](https://github.com/ualib/agda-algebras/issues/458)), which needs it
       for the strategy meta-theorem of [FLRP.Parachute.Theorems][]; see
       [`docs/notes/flrp-rp1-parachutes.md`](docs/notes/flrp-rp1-parachutes.md).
-
-[^6]: When the stretch goal of issue #456 lands, this entry retires and
-      `dual-Representableᵈ`{.AgdaFunction} of [FLRP.Closure][] becomes a theorem.

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -53,14 +53,14 @@ constructive data reconstitutes the full semantic
 `FiniteCongruences`{.AgdaRecord}, so the assumption is exactly the classical delta
 between the two layers, no more, no less.
 
-**Entry 2** (*retired*): Kurzweil–Netter duality.  The class of representable
-lattices is closed under dualization.[^3]  Registered here as
+**Entry 2** (*reduced to Entry 4*): Kurzweil–Netter duality.  The class of
+representable lattices is closed under dualization.[^3]  Registered here as
 `KurzweilNetterDuality`{.AgdaFunction} while a formal reproof was pending, the
-entry is **retired as an assumption**: issue #502's
-[FLRP.KurzweilNetter.Duality][] proves the statement outright from the
-properties of the base group the argument actually uses, the only remaining
-classical ingredient being Entry 4.  The statement types remain here as the
-theorem's canonical name.[^4]
+entry is **retired as an independent assumption**: issue #502's
+[FLRP.KurzweilNetter.Duality][] proves the statement from a package of
+properties of the base group the argument actually uses, so the closed result
+is *conditional*; the only remaining classical ingredient is Entry 4.  The
+statement types remain here as the theorem's canonical name.[^4]
 
 **Entry 3**: the Pálfy–Pudlák theorem.  Every finite lattice is a congruence
 lattice of a finite algebra *if and only if* every finite lattice is an interval in
@@ -215,7 +215,7 @@ completeness `completeᵈ`{.AgdaField} by transitivity.
       φ≑e = d≑e .proj₁ ∘ φ≑d .proj₁ , φ≑d .proj₂ ∘ d≑e .proj₂
 ```
 
-#### Entry 2: Kurzweil–Netter duality (retired)
+#### Entry 2: Kurzweil–Netter duality (reduced to Entry 4)
 
 **The theorem of Kurzweil and Netter**.  If a finite lattice is representable as
 the congruence lattice of a finite algebra, then so is its dual.
@@ -239,18 +239,21 @@ algebra with lifted operations.
    ([Classical.Structures.Lattice.Dual][]).  The ∀-form
    `KurzweilNetterDuality`{.AgdaFunction} is the full theorem.
 
-+  **Status: retired as an assumption** (issue #502).
++  **Status: reduced to Entry 4** (issue #502).
    `kurzweilNetterDuality`{.AgdaFunction} of [FLRP.KurzweilNetter.Duality][]
-   *proves* `KurzweilNetterDuality`{.AgdaFunction} outright, parameterized by
-   the properties of the base group the argument actually uses — a finite
-   carrier with decidable equality, a nontriviality witness, and Entry 4's
-   surjectivity family — and `dual-Representableᵈ`{.AgdaFunction} of
-   [FLRP.Closure][] is rewired to that theorem.  Nothing consumes this entry
-   as a hypothesis any more; the definitions below remain as the canonical
-   *statement* of the theorem (they are its conclusion's type).  The residual
-   classical content is exactly Entry 4 (retirement tracked by issue #522)
-   plus the instantiation of `𝒮` at a concrete finite nonabelian simple group
-   (tracked separately; `A₅` needs the simplicity predicates of issue #512).
+   proves `KurzweilNetterDuality`{.AgdaFunction} *from a package of witnesses*
+   for the base group (a finite carrier with decidable equality, a
+   nontriviality witness, and Entry 4's surjectivity family), and
+   `dual-Representableᵈ`{.AgdaFunction} of [FLRP.Closure][] is rewired to that
+   proof, taking the same package.  So the library holds no *closed* inhabitant
+   of `KurzweilNetterDuality`{.AgdaFunction} — the closed form of the proof
+   quantifies over the package — and the result stays conditional exactly on
+   Entry 4 plus the instantiation of `𝒮` at a concrete finite nonabelian
+   simple group.  What is retired is Entry 2's role as an *independent*
+   hypothesis: nothing consumes it any more, and the definitions below remain
+   as the canonical *statement* of the theorem (they are its conclusion's
+   type).  The residue is tracked by issue #522 (Entry 4) and issue #527
+   (the `A₅` instantiation, needing the simplicity predicates of issue #512).
 
 +  **Layer**.  The statement is at Layer D (`Representableᵈ`{.AgdaRecord}),
    the program's working notion per [ADR-008][]; the classical statement is the

--- a/src/FLRP/Closure/Basic.lagda.md
+++ b/src/FLRP/Closure/Basic.lagda.md
@@ -10,38 +10,33 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.Closure.Basic][] module of the [Agda Universal Algebra Library][].
 
-The class of representable lattices is closed under a catalogue of operations
-(the roadmap's § 3; `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure
-properties).  This module is work package WP-5's umbrella over that catalogue at
-Layer D, re-exporting the two proved closure theorems and deriving the rest:
+The class of representable lattices is closed under a catalogue of operations.[^1]
+This module is work package WP-5's umbrella over that catalogue at Layer D,
+re-exporting the two proved closure theorems and deriving the rest:
 
-+  **finite direct products**. `product-Representableᵈ`{.AgdaFunction}
++  **finite direct products**: `product-Representableᵈ`{.AgdaFunction}
    ([FLRP.Closure.Product][], after Tůma);
-+  **ordinal sums**. `ordinalSum-Representableᵈ`{.AgdaFunction}
++  **ordinal sums**: `ordinalSum-Representableᵈ`{.AgdaFunction}
    ([FLRP.Closure.OrdinalSum][], after McKenzie and Snow); the *unglued* sum is
    the derived composite with `chain₂` glued in the middle;
-+  **adjoining a new bottom or top**. `adjoinBottom-Representableᵈ`{.AgdaFunction}
-   / `adjoinTop-Representableᵈ`{.AgdaFunction} below: *corollaries* of
-   ordinal-sum closure, not fresh results, obtained by instantiating one summand
-   at the two-element chain (whose Layer-D representation
-   `chain₂-Representableᵈ`{.AgdaFunction} is the constructive centerpiece of
-   [FLRP.Representable][]);
-+  **lattice duals**. `dual-Representableᵈ`{.AgdaFunction} below: the
-   Kurzweil–Netter duality theorem, *proved* in
-   [FLRP.KurzweilNetter.Duality][] (issue #502) and consumed here through the
-   simple-group package that parameterizes the proof — a finite nontrivial
-   group together with the Kurzweil-surjectivity family, Entry 4 of
-   [FLRP.Assumptions][].  Entry 2 of the registry (the duality theorem as an
-   *imported* hypothesis) is retired; what remains classical is exactly
-   Entry 4 and the choice of a concrete nonabelian simple instantiation.
++  **adjoining a new bottom or top**: `adjoinBottom-Representableᵈ`{.AgdaFunction}
+   / `adjoinTop-Representableᵈ`{.AgdaFunction}, *corollaries* of ordinal-sum
+   closure, obtained by instantiating one summand at the two-element chain (whose
+   Layer-D representation `chain₂-Representableᵈ`{.AgdaFunction} is the
+   constructive centerpiece of [FLRP.Representable][]);
++  **lattice duals**: `dual-Representableᵈ`{.AgdaFunction}, the Kurzweil–Netter
+   duality theorem, proved in [FLRP.KurzweilNetter.Duality][] and consumed here
+   through the simple-group package that parameterizes the proof with a finite
+   nontrivial group together with the Kurzweil-surjectivity family, Entry 4 of
+   [FLRP.Assumptions][]; Entry 2 of the registry (the duality theorem as an
+   *imported* hypothesis) is retired; what remains classical is exactly Entry 4
+   and the choice of a concrete nonabelian simple instantiation.
 
 The payoff downstream: the two dual entries of the small-lattice census
-(`L18` and `L22`, duals of the certified `SLR19` and `SLR23`) now rest on
-Entry 4 and an instantiation rather than on the full duality theorem;
-materializing those conditional certificates is issue #485's concern, not
-this module's — and remains computationally out of reach in any case, since
-the construction represents an `n`-element algebra's dual on `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹`
-elements.
+(`L18` and `L22`, duals of the certified `SLR19` and `SLR23`) now rest on Entry 4
+and an instantiation rather than on the full duality theorem; materializing those
+conditional certificates remains computationally out of reach, since the
+construction represents an `n`-element algebra's dual on `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹` elements.
 
 <!--
 ```agda
@@ -51,10 +46,9 @@ module FLRP.Closure.Basic where
 
 -- Imports from the Agda Standard Library -----------------------------------
 open import Data.Fin.Patterns                      using  ( 0F ; 1F )
-open import Data.Nat.Base                          using  ( ℕ )
-open import Data.Product                           using  ( _,_ ; proj₁ )
+open import Data.Product                           using  ( _,_ )
 open import Level                                  using  ( 0ℓ )
-open import Relation.Binary                       using  ( Setoid )
+open import Relation.Binary                        using  ( Setoid )
 open import Relation.Binary.PropositionalEquality  using  ( refl )
 open import Relation.Nullary                       using  ( ¬_ )
 
@@ -90,15 +84,13 @@ chain₂-bot : BottomOf chain₂-lattice
 chain₂-bot = 0F , λ { 0F → refl ; 1F → refl }
 ```
 
-Adjoining a fresh extremum to a lattice is the special case of the glued
-ordinal sum in which one summand is the two-element chain: gluing `chain₂`'s
-top onto `𝑳`'s bottom leaves exactly one new element below everything
-(`adjoinBottom`), and mirrored for `adjoinTop`.  These are the roadmap § 3
-catalogue's "adjoining a new top or bottom", each a one-application corollary
-of `ordinalSum-Representableᵈ`{.AgdaFunction} at
-`chain₂-Representableᵈ`{.AgdaFunction} — a deliberate design check that the
-ordinal-sum statement carries no hidden nontriviality assumptions on its
-summands.
+Adjoining a fresh extremum to a lattice is the special case of the glued ordinal
+sum in which one summand is the two-element chain: gluing `chain₂`'s top onto
+`𝑳`'s bottom leaves exactly one new element below everything (`adjoinBottom`), and
+mirrored for `adjoinTop`.  Each is a one-application corollary of
+`ordinalSum-Representableᵈ`{.AgdaFunction} at `chain₂-Representableᵈ`{.AgdaFunction},
+confirming that the ordinal-sum statement carries no hidden nontriviality
+assumptions on its summands.
 
 ```agda
 -- Adjoin a new bottom: chain₂ glued below 𝑳, at 𝑳's chosen bottom.
@@ -116,23 +108,28 @@ adjoinTop-Representableᵈ t r =
 
 #### Duality
 
-Closure under dualization — the Kurzweil–Netter theorem, rewired from the
-retired Entry 2 to the proof of [FLRP.KurzweilNetter.Duality][].  The
-parameters are the simple-group package of the proof module: a finite group
-with a nontriviality witness and the Kurzweil-surjectivity family (Entry 4 of
-[FLRP.Assumptions][], classically true for `𝒮` finite nonabelian simple).
-Every consumer displays its remaining classical debt — Entry 4 at the chosen
-group — in its own type, exactly as the registry discipline demands.
+Here we prove closure under dualization (the Kurzweil–Netter theorem) using
+[FLRP.KurzweilNetter.Duality][].  The parameters are the simple-group package of
+the proof module: a finite group with a nontriviality witness and the
+Kurzweil-surjectivity family (Entry 4 of [FLRP.Assumptions][], classically true
+for `𝒮` finite nonabelian simple).
+
+Every consumer displays its remaining classical debt (Entry 4 at the chosen group)
+in its own type, exactly as the registry discipline demands.
 
 ```agda
--- The Kurzweil–Netter closure, from the simple-group package of the proof.
-dual-Representableᵈ :
-    (𝒮 : Group 0ℓ 0ℓ) (𝑭ₛ : FiniteAlgebra (proj₁ 𝒮)) (s₀ : 𝕌[ proj₁ 𝒮 ])
-  → ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s₀ (Group-Op.ε 𝒮))
-  → ((n : ℕ) → KurzweilSurjectivityAt 𝒮 n)
-  → (𝑳 : Lattice) → Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
-dual-Representableᵈ 𝒮 𝑭ₛ s₀ s₀≉ε surj =
-  KurzweilNetterProof.kurzweilNetterDuality 𝒮 𝑭ₛ s₀ s₀≉ε surj
+module _ ((𝑺 , eqns) : Group 0ℓ 0ℓ) where
+  open Setoid 𝔻[ 𝑺 ] using (_≈_)
+  open Group-Op (𝑺 , eqns) using (ε)
+  -- The Kurzweil–Netter closure, from the simple-group package of the proof.
+  dual-Representableᵈ : (𝑭ₛ : FiniteAlgebra 𝑺) (s₀ : 𝕌[ 𝑺 ])
+    → ¬ s₀ ≈ ε → (∀ n → KurzweilSurjectivityAt (𝑺 , eqns) n)
+    → (𝑳 : Lattice) → Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
+  dual-Representableᵈ 𝑭ₛ s₀ s₀≉ε surj =
+    KurzweilNetterProof.kurzweilNetterDuality (𝑺 , eqns) 𝑭ₛ s₀ s₀≉ε surj
 ```
 
 --------------------------------------
+
+
+[^1]: See the roadmap's § 3; `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure properties.

--- a/src/FLRP/Closure/Basic.lagda.md
+++ b/src/FLRP/Closure/Basic.lagda.md
@@ -26,17 +26,22 @@ Layer D, re-exporting the two proved closure theorems and deriving the rest:
    at the two-element chain (whose Layer-D representation
    `chain₂-Representableᵈ`{.AgdaFunction} is the constructive centerpiece of
    [FLRP.Representable][]);
-+  **lattice duals**. `dual-Representableᵈ`{.AgdaFunction} below, *conditional*
-   on the Kurzweil–Netter entry of the assumptions registry
-   ([FLRP.Assumptions][], Entry 2): the theorem is classically proved but not yet
-   formalized, so it is threaded as an explicit hypothesis, keeping `--safe`
-   honest.  Once the planned formal reproof lands, the hypothesis discharges and
-   the corollary becomes a theorem.
++  **lattice duals**. `dual-Representableᵈ`{.AgdaFunction} below: the
+   Kurzweil–Netter duality theorem, *proved* in
+   [FLRP.KurzweilNetter.Duality][] (issue #502) and consumed here through the
+   simple-group package that parameterizes the proof — a finite nontrivial
+   group together with the Kurzweil-surjectivity family, Entry 4 of
+   [FLRP.Assumptions][].  Entry 2 of the registry (the duality theorem as an
+   *imported* hypothesis) is retired; what remains classical is exactly
+   Entry 4 and the choice of a concrete nonabelian simple instantiation.
 
-The payoff downstream: with Entry 2 in place, the two dual entries of the
-small-lattice census (`L18` and `L22`, duals of the certified `SLR19` and
-`SLR23`) become assumption-conditional corollaries; materializing those
-conditional certificates is issue #485's concern, not this module's.
+The payoff downstream: the two dual entries of the small-lattice census
+(`L18` and `L22`, duals of the certified `SLR19` and `SLR23`) now rest on
+Entry 4 and an instantiation rather than on the full duality theorem;
+materializing those conditional certificates is issue #485's concern, not
+this module's — and remains computationally out of reach in any case, since
+the construction represents an `n`-element algebra's dual on `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹`
+elements.
 
 <!--
 ```agda
@@ -46,18 +51,26 @@ module FLRP.Closure.Basic where
 
 -- Imports from the Agda Standard Library -----------------------------------
 open import Data.Fin.Patterns                      using  ( 0F ; 1F )
-open import Data.Product                           using  ( _,_ )
+open import Data.Nat.Base                          using  ( ℕ )
+open import Data.Product                           using  ( _,_ ; proj₁ )
+open import Level                                  using  ( 0ℓ )
+open import Relation.Binary                       using  ( Setoid )
 open import Relation.Binary.PropositionalEquality  using  ( refl )
+open import Relation.Nullary                       using  ( ¬_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
 open import Classical.Properties.Lattice              using  ( TopOf ; BottomOf )
 open import Classical.Small.Structures.Lattice        using  ( Lattice )
+open import Classical.Structures.Group.Basic          using  ( Group ; module Group-Op )
 open import Classical.Structures.Lattice.Dual         using  ( dualLattice )
 open import Classical.Structures.Lattice.OrdinalSum   using  ( ordinalSum )
-open import FLRP.Assumptions                          using  ( KurzweilNetterDuality )
+open import FLRP.Assumptions                          using  ( KurzweilSurjectivityAt )
+open import FLRP.KurzweilNetter.Duality               using  ( module KurzweilNetterProof )
 open import FLRP.Problem                              using  ( chain₂-lattice )
 open import FLRP.Representable                        using  ( Representableᵈ
                                                              ; chain₂-Representableᵈ )
+open import Setoid.Algebras.Basic                     using  ( 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite                    using  ( FiniteAlgebra )
 
 open import FLRP.Closure.Product     public
 open import FLRP.Closure.OrdinalSum  public
@@ -101,18 +114,25 @@ adjoinTop-Representableᵈ t r =
   ordinalSum-Representableᵈ t chain₂-bot r chain₂-Representableᵈ
 ```
 
-#### Duality, conditionally
+#### Duality
 
-Closure under dualization, threaded through the registry's Entry 2.  The body
-is instantiation — deliberately so: the mathematical content lives in the
-*named, cited* hypothesis, and every consumer of this corollary displays its
-classical debt in its own type.
+Closure under dualization — the Kurzweil–Netter theorem, rewired from the
+retired Entry 2 to the proof of [FLRP.KurzweilNetter.Duality][].  The
+parameters are the simple-group package of the proof module: a finite group
+with a nontriviality witness and the Kurzweil-surjectivity family (Entry 4 of
+[FLRP.Assumptions][], classically true for `𝒮` finite nonabelian simple).
+Every consumer displays its remaining classical debt — Entry 4 at the chosen
+group — in its own type, exactly as the registry discipline demands.
 
 ```agda
--- The Kurzweil–Netter closure, conditional on the registered assumption.
-dual-Representableᵈ : KurzweilNetterDuality
+-- The Kurzweil–Netter closure, from the simple-group package of the proof.
+dual-Representableᵈ :
+    (𝒮 : Group 0ℓ 0ℓ) (𝑭ₛ : FiniteAlgebra (proj₁ 𝒮)) (s₀ : 𝕌[ proj₁ 𝒮 ])
+  → ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s₀ (Group-Op.ε 𝒮))
+  → ((n : ℕ) → KurzweilSurjectivityAt 𝒮 n)
   → (𝑳 : Lattice) → Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
-dual-Representableᵈ knd 𝑳 = knd 𝑳
+dual-Representableᵈ 𝒮 𝑭ₛ s₀ s₀≉ε surj =
+  KurzweilNetterProof.kurzweilNetterDuality 𝒮 𝑭ₛ s₀ s₀≉ε surj
 ```
 
 --------------------------------------

--- a/src/FLRP/KurzweilInterval.lagda.md
+++ b/src/FLRP/KurzweilInterval.lagda.md
@@ -10,49 +10,50 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.KurzweilInterval][] module of the [Agda Universal Algebra Library][].
 
-This module packages the group infrastructure of issue #521 — the power
-`Sⁿ`{.AgdaFunction}, its diagonal `D`{.AgdaFunction}, and the partition subgroups
-`K_π` — into the interval presentation the FLRP program consumes: the upper
-interval `[D , Sⁿ]` as an `UpperInterval`{.AgdaModule} instance of
-[FLRP.Enforceable][], and **Kurzweil's lemma** — the interval is isomorphic to the
-*dual* of the partition lattice `Eq(n)` of
-[Classical.Structures.Lattice.Partitions][] — as an
-`IntervalIso`{.AgdaFunction}.
+This module packages the group infrastructure of
 
-The classical statement (Kurzweil 1985; `lem:latt-duals` of
-`docs/papers/fin-lat-rep/SmallLatticeReps.tex`, discussed in DeMeo's thesis
-§ 2.2) splits into two halves of very different characters, and the formal
-treatment mirrors the split honestly:
++ the power `Sⁿ`{.AgdaFunction},
++ the diagonal subgroup `D`{.AgdaFunction} of `Sⁿ`{.AgdaFunction}, and
++ the partition subgroups `K_π`,
 
-+  **The dual order embedding is proved outright.**  `π ↦ K_π` lands in the
+into the interval presentation the FLRP research program consumes.
+
+The package consists of the subgroup lattice interval `[D , Sⁿ]`, as an
+`UpperInterval`{.AgdaModule} instance of [FLRP.Enforceable][], and
+**Kurzweil's lemma** asserting that the interval is isomorphic to the dual of the
+partition lattice `Eq(n)` as an `IntervalIso`{.AgdaFunction}.
+
+The classical statement (Kurzweil 1985) splits into two halves of very different
+characters, and the formal treatment mirrors the split honestly:[^1]
+
++  **The dual order embedding is proved outright**.  `π ↦ K_π` lands in the
    interval, reverses the refinement order in both directions, and is injective
-   up to kernel equality — this is the content the written sources actually
+   up to kernel equality; this is the content the written sources actually
    prove, it is finite combinatorics, and it needs only a *nontrivial* base
    group ([Classical.Structures.Group.PartitionSubgroup][]).
 
-+  **Surjectivity is a registered hypothesis.**  That *every* respecting subgroup
++  **Surjectivity is a registered hypothesis**.  That every respecting subgroup
    between `D` and `Sⁿ` is a partition subgroup is the half where `S` must be a
-   finite *nonabelian simple* group; the sources cite it to Kurzweil's article
+   finite nonabelian simple group; the sources cite it to Kurzweil's article
    without reproof, and its formalization needs the normal-subgroup structure
    theory of powers of a simple group (subdirect products, block inductions) that
-   the library does not yet have — real group theory, not bookkeeping.  Per the
-   `--safe` discipline it enters as the explicit hypothesis
-   `KurzweilSurjectivity`{.AgdaFunction}, registered as **Entry 4** of
-   [FLRP.Assumptions][]; it is stated in the Σ-form that *hands the consumer the
-   partition witness*, which is exactly what the isomorphism's inverse map needs.
-   Retiring the entry — proving surjectivity for a nonabelian simple base — is
-   the follow-up flagged in issue #521, and upgrades
+   the library does not yet have.  Per the `--safe` discipline it enters as the
+   explicit hypothesis `KurzweilSurjectivity`{.AgdaFunction}, registered as
+   **Entry 4** of [FLRP.Assumptions][]; it is stated in the Σ-form that
+   *hands the consumer the partition witness*, which is exactly what the
+   isomorphism's inverse map needs.  Retiring the entry, proving surjectivity for
+   a nonabelian simple base, is follow-up work, and will upgrade
    `kurzweilIntervalIso`{.AgdaFunction} with no change to consumers.
 
-Given the hypothesis, `kurzweilIntervalIso`{.AgdaFunction} *is a theorem*:
+Given the hypothesis, `kurzweilIntervalIso`{.AgdaFunction} is a theorem:
 `[D , Sⁿ] ≅ (Eq n)′` in the `IntervalIso` presentation, with the dual order
 handled by `≤ᵈ-flip`{.AgdaFunction} / `≤ᵈ-unflip`{.AgdaFunction} of
 [Classical.Structures.Lattice.Dual][] and the refinement order bridged to the
-lattice meet order by `⊑→≤`{.AgdaFunction} / `≤→⊑`{.AgdaFunction}.  The
-corollary `eqDual-groupRepresentable`{.AgdaFunction} — the dual partition
-lattice is group representable — is the form RP-4's wreath no-go (issue #461)
-consumes, and the consumer-interface module at the bottom records the composite
-signature the Kurzweil–Netter duality proof (issue #502) will call.
+lattice meet order by `⊑→≤`{.AgdaFunction} / `≤→⊑`{.AgdaFunction}.  The corollary
+`eqDual-groupRepresentable`{.AgdaFunction}, asserting that the dual partition
+lattice is group representable, is the form RP-4's wreath "no go" consumes, and
+the consumer-interface module at the bottom records the composite signature the
+Kurzweil–Netter duality proof will call.
 
 <!--
 ```agda
@@ -63,10 +64,10 @@ module FLRP.KurzweilInterval where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
-open import Data.Nat.Base   using ( ℕ )
-open import Data.Product    using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
-open import Level           using ( 0ℓ ) renaming ( suc to lsuc )
-open import Relation.Binary using ( Setoid )
+open import Data.Nat.Base     using ( ℕ )
+open import Data.Product      using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
+open import Level             using ( 0ℓ ) renaming ( suc to lsuc )
+open import Relation.Binary   using ( Setoid )
 open import Relation.Nullary  using ( ¬_ )
 open import Relation.Unary    using ( _⊆_ )
 
@@ -79,30 +80,34 @@ open import Classical.Structures.Lattice.Dual            using  ( module Lattice
                                                                 ; dualLattice )
 open import Classical.Structures.Lattice.Partitions      using  ( EqLattice ; _⊑_
                                                                 ; ⊑→≤ ; ≤→⊑ )
-open import FLRP.Enforceable    using  ( module UpperInterval ; IntervalIso
-                                       ; GroupRepresentable )
-open import FLRP.Problem        using  ( ConIso )
-open import Setoid.Algebras     using  ( 𝕌[_] ; 𝔻[_] )
-open import Setoid.Congruences.Certificates.Schema  using  ( ParentVec )
+open import FLRP.Enforceable                             using  ( module UpperInterval
+                                                                ; IntervalIso
+                                                                ; GroupRepresentable )
+open import FLRP.Problem                                 using  ( ConIso )
+open import Setoid.Algebras                              using  ( 𝕌[_] ; 𝔻[_] ; Algebra)
+open import Setoid.Congruences.Certificates.Schema       using  ( ParentVec )
 ```
 -->
 
 #### The interval `[D , Sⁿ]` and the surjectivity hypothesis
 
-`KurzweilInterval`{.AgdaModule} `𝒮` `n` fixes the base group and the exponent,
+`KurzweilInterval`{.AgdaModule}` 𝒮 n` fixes the base group and the exponent,
 instantiates the partition-subgroup toolkit, and opens the upper interval at the
 diagonal.
 
 ```agda
-module KurzweilInterval (𝒮 : Group 0ℓ 0ℓ) (n : ℕ) where
+module KurzweilInterval (𝒮@(𝑺 , _) : Group 0ℓ 0ℓ) (n : ℕ) where
 
+  open Setoid 𝔻[ 𝑺 ] using ( _≈_ )
+  open Group-Op 𝒮 using ( ε )
   open PartitionSubgroups n 𝒮 public
 
-  -- The power Sⁿ (the ⨅ᵍ-Group of the opened toolkit, named for readability).
-  Sⁿ : Group 0ℓ 0ℓ
-  Sⁿ = ⨅ᵍ-Group
-
-  open UpperInterval Sⁿ Diag Diag-isSubgroup public
+  -- The power 𝑺ⁿ (the ⨅ᵍ-Group of the opened toolkit, named for readability).
+  𝑺ⁿ : Group 0ℓ 0ℓ
+  𝑺ⁿ = ⨅ᵍ-Group
+  Sⁿ : Algebra 0ℓ 0ℓ
+  Sⁿ = 𝑺ⁿ .proj₁
+  open UpperInterval 𝑺ⁿ Diag Diag-isSubgroup public
 
   -- A partition subgroup, as an element of the interval [D , Sⁿ].
   toInterval : ParentVec n → Interval≈
@@ -132,8 +137,7 @@ order reflection (`K-reflects`{.AgdaFunction}) and injectivity
 (`K-injective`{.AgdaFunction}).
 
 ```agda
-  module _ (s : 𝕌[ proj₁ 𝒮 ]) (s≉ε : ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s (Group-Op.ε 𝒮)))
-           (surj : KurzweilSurjectivity)
+  module _ (s : 𝕌[ 𝑺 ]) (s≉ε : ¬ s ≈ ε) (surj : KurzweilSurjectivity)
     where
 
     open LatticeDual (EqLattice n) using ( ≤ᵈ-flip ; ≤ᵈ-unflip )
@@ -141,45 +145,42 @@ order reflection (`K-reflects`{.AgdaFunction}) and injectivity
     private
       -- The partition attached to an interval element by the hypothesis.
       part : Interval≈ → ParentVec n
-      part 𝑴 = proj₁ (surj 𝑴)
+      part 𝑴 = surj 𝑴 .proj₁
 
       part-in : (𝑴 : Interval≈) → set 𝑴 ⊆ K (part 𝑴)
-      part-in 𝑴 = proj₁ (proj₂ (surj 𝑴))
+      part-in 𝑴 = surj 𝑴 .proj₂ .proj₁
 
       part-out : (𝑴 : Interval≈) → K (part 𝑴) ⊆ set 𝑴
-      part-out 𝑴 = proj₂ (proj₂ (surj 𝑴))
+      part-out 𝑴 = surj 𝑴 .proj₂ .proj₂
 
       -- Inclusion of interval elements reflects to reversed refinement.
       mono-flip : {𝑴 𝑵 : Interval≈} → 𝑴 ≤ᵢ 𝑵 → part 𝑵 ⊑ part 𝑴
       mono-flip {𝑴} {𝑵} le =
         K-reflects s s≉ε {pu = part 𝑵} {pw = part 𝑴}
-          (λ k → part-in 𝑵 (le (part-out 𝑴 k)))
+          λ k → part-in 𝑵 (le (part-out 𝑴 k))
 
-    kurzweilIntervalIso : IntervalIso Sⁿ Diag Diag-isSubgroup (dualLattice (EqLattice n))
+    kurzweilIntervalIso : IntervalIso 𝑺ⁿ Diag Diag-isSubgroup (dualLattice (EqLattice n))
     kurzweilIntervalIso = record
       { to         = part
       ; from       = toInterval
-      ; to-mono    = λ {𝑴} {𝑵} le →
-          ≤ᵈ-unflip {x = part 𝑴} {y = part 𝑵}
-            (⊑→≤ {pu = part 𝑵} {pw = part 𝑴} (mono-flip {𝑴} {𝑵} le))
-      ; from-mono  = λ {pu} {pw} le →
-          K-antitone {pu = pw} {pw = pu}
-            (≤→⊑ {pu = pw} {pw = pu} (≤ᵈ-flip {x = pu} {y = pw} le))
-      ; to∘from    = λ pv →
-          K-injective s s≉ε {pu = part (toInterval pv)} {pw = pv}
-            (part-in (toInterval pv)) (part-out (toInterval pv))
+      ; to-mono    = λ {𝑴} {𝑵} le → ≤ᵈ-unflip ( ⊑→≤ {pu = part 𝑵} {pw = part 𝑴}
+                                                   ( mono-flip {𝑴} {𝑵} le ) )
+      ; from-mono  = λ {pu} {pw} le → K-antitone {pu = pw} {pw = pu}
+                                        ( ≤→⊑ (≤ᵈ-flip {x = pu} {y = pw} le) )
+      ; to∘from    = λ pv → K-injective s s≉ε {pu = part (toInterval pv)} {pw = pv}
+                              ( part-in (toInterval pv)) (part-out (toInterval pv) )
       ; from∘to    = λ 𝑴 → part-out 𝑴 , part-in 𝑴
       }
 ```
 
-The form RP-4's wreath no-go consumes: the dual of the partition lattice is
+**The form RP-4's wreath "no go" consumes**.  The dual of the partition lattice is
 group representable, witnessed on `[D , Sⁿ]`.
 
 ```agda
     -- Corollary: Eq(n)′ is group representable.
     eqDual-groupRepresentable : GroupRepresentable (dualLattice (EqLattice n))
     eqDual-groupRepresentable = record
-      { grp           = Sⁿ
+      { grp           = 𝑺ⁿ
       ; sub           = Diag
       ; isSubgroup    = Diag-isSubgroup
       ; interval-iso  = kurzweilIntervalIso
@@ -188,23 +189,27 @@ group representable, witnessed on `[D , Sⁿ]`.
 
 #### Consumer interface checks
 
-The signatures the two consumers will call, stated (not proved) so that a
-mismatch surfaces here rather than in their branches.  The Kurzweil–Netter proof
-(issue #502) composes the WP-3 bridge `Con (Sⁿ ↷ Sⁿ/D) ≅ [D , Sⁿ]` of
-[FLRP.Bridge][] with `kurzweilIntervalIso`{.AgdaFunction}; its target is
-therefore a `ConIso`{.AgdaFunction} between the coset algebra at the diagonal
-and the dual partition lattice.  RP-4 (issue #461) consumes
-`eqDual-groupRepresentable`{.AgdaFunction} directly, at a nonabelian simple
-instantiation of `𝒮`.
+**The signatures the two consumers will call**.  This is stated (not proved) so
+that a mismatch surfaces here rather than in their branches.
+
+The Kurzweil–Netter proof composes the WP-3 bridge `Con (Sⁿ ↷ Sⁿ/D) ≅ [D , Sⁿ]` of
+[FLRP.Bridge][] with `kurzweilIntervalIso`{.AgdaFunction}; its target is therefore
+a `ConIso`{.AgdaFunction} between the coset algebra at the diagonal and the dual
+partition lattice.  RP-4 consumes `eqDual-groupRepresentable`{.AgdaFunction}
+directly, at a nonabelian simple instantiation of `𝒮`.
 
 ```agda
 module ConsumerChecks (𝒮 : Group 0ℓ 0ℓ) (n : ℕ) where
-
   open KurzweilInterval 𝒮 n
+  open CosetAction 𝑺ⁿ Diag Diag-isSubgroup using ( cosetAlgebra )
 
-  open CosetAction Sⁿ Diag Diag-isSubgroup using ( cosetAlgebra )
-
-  -- #502 will inhabit this by composing the WP-3 bridge with kurzweilIntervalIso.
+  -- The Kurzweil-etter proof inhabits this by composing the WP-3 bridge with
+  -- kurzweilIntervalIso.
   DualityConIso : Type (lsuc 0ℓ)
   DualityConIso = ConIso cosetAlgebra (dualLattice (EqLattice n))
 ```
+
+---
+
+[^1]: See also `docs/papers/fin-lat-rep/SmallLatticeReps.tex` (`lem:latt-duals`)
+      and DeMeo's thesis § 2.2.

--- a/src/FLRP/KurzweilNetter.lagda.md
+++ b/src/FLRP/KurzweilNetter.lagda.md
@@ -12,7 +12,7 @@ This is the [FLRP.KurzweilNetter][] module of the [Agda Universal Algebra Librar
 
 The formal proof of the **Kurzweil–Netter duality theorem** — the class of
 decidably representable lattices is closed under dualization — assembled from
-four submodules (issue #502; the argument of
+five submodules (issue #502; the argument of
 `docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals", after
 Pálfy's 2009 lectures):
 

--- a/src/FLRP/KurzweilNetter.lagda.md
+++ b/src/FLRP/KurzweilNetter.lagda.md
@@ -10,28 +10,24 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.KurzweilNetter][] module of the [Agda Universal Algebra Library][].
 
-The formal proof of the **Kurzweil–Netter duality theorem** — the class of
-decidably representable lattices is closed under dualization — assembled from
-five submodules (issue #502; the argument of
-`docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals", after
-Pálfy's 2009 lectures):
+This module develops the formal proof of the **Kurzweil–Netter duality theorem**,
+which asserts that the class of decidably representable lattices is closed under
+the taking of lattice duals.  It is assembled from the following submodules:
 
-+  [FLRP.KurzweilNetter.Invariance][] — partitions invariant under an index
-   map, the notion where the algebra side and the group side of the
-   construction meet;
-+  [FLRP.KurzweilNetter.Blocks][] — decidable congruences of a finite carrier
-   as partitions of its (irredundantly enumerated) index set, at the relation
-   level;
-+  [FLRP.KurzweilNetter.Translations][] — the basic translations of a finite
-   finitary algebra, and the Mal'cev-style translation criterion identifying
-   the congruences with the invariant partitions;
-+  [FLRP.KurzweilNetter.Expansion][] — the expansion step: the coset algebra
-   on `Sᵐ/D`, expanded by a family of lifted index maps, has decidable
-   congruence poset dually isomorphic to the family-invariant partitions;
-+  [FLRP.KurzweilNetter.Duality][] — the composite theorem
++  [FLRP.KurzweilNetter.Invariance][]: partitions invariant under an index map,
+   the notion where the algebra side and the group side of the construction meet;
++  [FLRP.KurzweilNetter.Blocks][]: decidable congruences of a finite carrier as
+   partitions of its (irredundantly enumerated) index set, at the relation level;
++  [FLRP.KurzweilNetter.Translations][]: the basic translations of a finite
+   finitary algebra, and the Mal'cev-style translation criterion identifying the
+   congruences with the invariant partitions;
++  [FLRP.KurzweilNetter.Expansion][]: the expansion step showing the coset algebra
+   on `Sᵐ/D`, expanded by a family of lifted index maps, has decidable congruence
+   lattice that is dually isomorphic to the family-invariant partitions;
++  [FLRP.KurzweilNetter.Duality][]: the composite theorem
    `kurzweilNetterDuality`{.AgdaFunction}, retiring Entry 2 of
-   [FLRP.Assumptions][] to a proof from Entry 4 and the properties of a
-   finite nontrivial group.
+   [FLRP.Assumptions][] to a proof from Entry 4 and the properties of a finite
+   nontrivial group.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/FLRP/KurzweilNetter.lagda.md
+++ b/src/FLRP/KurzweilNetter.lagda.md
@@ -1,0 +1,48 @@
+---
+layout: default
+file: "src/FLRP/KurzweilNetter.lagda.md"
+title: "FLRP.KurzweilNetter module (The Agda Universal Algebra Library)"
+date: "2026-07-28"
+author: "the agda-algebras development team"
+---
+
+### Kurzweil–Netter duality
+
+This is the [FLRP.KurzweilNetter][] module of the [Agda Universal Algebra Library][].
+
+The formal proof of the **Kurzweil–Netter duality theorem** — the class of
+decidably representable lattices is closed under dualization — assembled from
+four submodules (issue #502; the argument of
+`docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals", after
+Pálfy's 2009 lectures):
+
++  [FLRP.KurzweilNetter.Invariance][] — partitions invariant under an index
+   map, the notion where the algebra side and the group side of the
+   construction meet;
++  [FLRP.KurzweilNetter.Blocks][] — decidable congruences of a finite carrier
+   as partitions of its (irredundantly enumerated) index set, at the relation
+   level;
++  [FLRP.KurzweilNetter.Translations][] — the basic translations of a finite
+   finitary algebra, and the Mal'cev-style translation criterion identifying
+   the congruences with the invariant partitions;
++  [FLRP.KurzweilNetter.Expansion][] — the expansion step: the coset algebra
+   on `Sᵐ/D`, expanded by a family of lifted index maps, has decidable
+   congruence poset dually isomorphic to the family-invariant partitions;
++  [FLRP.KurzweilNetter.Duality][] — the composite theorem
+   `kurzweilNetterDuality`{.AgdaFunction}, retiring Entry 2 of
+   [FLRP.Assumptions][] to a proof from Entry 4 and the properties of a
+   finite nontrivial group.
+
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.KurzweilNetter where
+
+open import FLRP.KurzweilNetter.Invariance    public
+open import FLRP.KurzweilNetter.Blocks        public
+open import FLRP.KurzweilNetter.Translations  public
+open import FLRP.KurzweilNetter.Expansion     public
+open import FLRP.KurzweilNetter.Duality       public
+```
+
+--------------------------------------

--- a/src/FLRP/KurzweilNetter/Blocks.lagda.md
+++ b/src/FLRP/KurzweilNetter/Blocks.lagda.md
@@ -10,40 +10,39 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.KurzweilNetter.Blocks][] module of the [Agda Universal Algebra Library][].
 
-The Kurzweil–Netter construction (issue #502) represents the dual of
-`Con 𝑨` on a power of a simple group *indexed by the carrier* of the finite
-algebra `𝑨`{.AgdaBound}.  The traffic between the two sides runs through the
-partition lattice `Eq(m)` of [Classical.Structures.Lattice.Partitions][]: a
-decidable congruence of `𝑨`{.AgdaBound} must become a partition of
-`Fin m`{.AgdaDatatype}, and a partition must become a decidable relation on the
-carrier.  This module provides exactly that dictionary, *at the relation level*
-— no operations of `𝑨`{.AgdaBound} appear, so everything here is about
-decidable equivalences; the interaction with the operations (which partitions
-arise from congruences) is the business of
+For a finite algebra `𝑨`{.AgdaBound}, the Kurzweil–Netter construction represents
+the dual of `Con 𝑨` on a power of a simple group *indexed by the carrier* of `𝑨`{.AgdaBound}.
+
+The traffic between the two sides runs through the partition lattice `Eq(m)` of
+[Classical.Structures.Lattice.Partitions][]: a decidable congruence of
+`𝑨`{.AgdaBound} must become a partition of `Fin m`{.AgdaDatatype}, and a partition
+must become a decidable relation on the carrier.  This module provides exactly
+that dictionary, at the relation level; no operations of `𝑨`{.AgdaBound} appear,
+so everything here is about decidable equivalences.  The interaction with the
+operations (which partitions arise from congruences) is handled in
 [FLRP.KurzweilNetter.Translations][].
 
 Throughout, the carrier is presented by an *irredundant* enumeration
-([Setoid.Algebras.Finite.Irredundant][]): `ienum : Fin m → 𝕌[ 𝑨 ]` hits every
+([Setoid.Algebras.Finite.Irredundant][]): `ienum[_] : Fin m → 𝕌[ 𝑨 ]` hits every
 `≈`-class exactly once.  Irredundancy is not a convenience but a correctness
-condition — with a redundant index the partitions of `Fin m` could separate two
+condition; with a redundant index the partitions of `Fin m` could separate two
 copies of one carrier element, and the correspondence below would fail to be a
 bijection.
 
-The two directions:
+**The two directions**.
 
-+  **`pvOf`** sends a decidable congruence `d` to the partition of the index
-   set by `d`-classes, presented as a `ParentVec`{.AgdaFunction}: index `i` is
-   labelled by the *least* index `d`-related to it, computed by the bounded
-   search `findLeast`{.AgdaFunction}.  Its kernel is exactly the restriction of
-   `d` to enumerated values (`pvOf-sound`{.AgdaFunction} /
-   `pvOf-complete`{.AgdaFunction}).
++  **`pvOf`** sends a decidable congruence `d` to the partition of the index set
+   by `d`-classes, presented as a `ParentVec`{.AgdaFunction}: index `i` is
+   labelled by the *least* index `d`-related to it, computed by the bounded search
+   `findLeast`{.AgdaFunction}; its kernel is exactly the restriction of `d` to
+   enumerated values (`pvOf-sound`{.AgdaFunction} / `pvOf-complete`{.AgdaFunction}).
 
 +  **`blockRel`** sends a partition `pv` to the relation identifying carrier
-   elements whose indices share a block.  It is a decidable equivalence
-   respecting `≈`{.AgdaFunction}, by irredundancy of the enumeration.
+   elements whose indices share a block; it is a decidable equivalence respecting
+   `≈`{.AgdaFunction}, by irredundancy of the enumeration.
 
-The module closes with the monotonicity of both maps and the two round trips,
-each stated against an arbitrary relation-equivalent presentation so that the
+The module closes with the monotonicity of both maps and the two round trips, each
+stated against an arbitrary relation-equivalent presentation so that the
 downstream isomorphisms can consume them without definitional coincidences.
 
 <!--
@@ -53,28 +52,33 @@ downstream isomorphisms can consume them without definitional coincidences.
 module FLRP.KurzweilNetter.Blocks where
 
 -- Imports from the Agda Standard Library ---------------------------------------
-open import Data.Empty          using ( ⊥-elim )
-open import Data.Fin.Base       using ( Fin ) renaming ( _≤_ to _≤ᶠ_ )
-open import Data.Fin.Properties using () renaming ( _≟_ to _≟ᶠ_ )
-open import Data.Product        using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
-open import Data.Sum.Base       using ( _⊎_ ; inj₁ ; inj₂ )
-open import Data.Vec.Base       using ( tabulate )
-open import Level               using ( 0ℓ )
-open import Relation.Binary     using ( Setoid ; IsEquivalence )
-                                renaming ( Rel to BinaryRel )
-open import Relation.Binary.PropositionalEquality
-                                using ( _≡_ ; refl ; sym ; trans ; cong ; subst ; subst₂ )
-open import Relation.Nullary    using ( ¬_ ; Dec )
+open import Data.Empty                               using  ( ⊥-elim )
+open import Data.Fin.Base                            using  ( Fin )
+                                                     renaming ( _≤_ to _≤ᶠ_ )
+open import Data.Fin.Properties                      using  ()
+                                                     renaming ( _≟_ to _≟ᶠ_ )
+open import Data.Product                             using  ( Σ-syntax ; _×_ ; _,_
+                                                            ; proj₁ ; proj₂ )
+open import Data.Sum.Base                            using  ( _⊎_ ; inj₁ ; inj₂ )
+open import Data.Vec.Base                            using  ( tabulate )
+open import Function                                 using  ( _∘_ )
+open import Level                                    using  ( 0ℓ )
+open import Relation.Binary                          using  ( Setoid ; IsEquivalence )
+                                                     renaming ( Rel to BinaryRel )
+open import Relation.Binary.PropositionalEquality    using  ( _≡_ ; refl ; sym ; trans
+                                                            ; cong ; subst ; subst₂ )
+open import Relation.Nullary                         using  ( ¬_ ; Dec )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Structures.Lattice.Partitions
-  using ( SameBlock ; _⊑_ ; _≈ᵖ_ ; parent-tab ; findLeast ; least-unique )
-open import Overture                             using ( Signature )
-open import Setoid.Algebras.Basic                using ( Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Algebras.Finite.Irredundant   using ( IrredundantEnumeration )
-open import Setoid.Congruences.Basic             using ( reflexive ; is-equivalence )
-open import Setoid.Congruences.Certificates.Schema  using ( ParentVec ; parent )
-open import Setoid.Congruences.Finite.Basic      using ( DecCon ; ConRel )
+open import Classical.Structures.Lattice.Partitions  using  ( SameBlock ; _⊑_ ; _≈ᵖ_
+                                                            ; parent-tab ; findLeast
+                                                            ; least-unique )
+open import Overture                                 using  ( Signature )
+open import Setoid.Algebras.Basic                    using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite.Irredundant       using  ( IrredundantEnumeration )
+open import Setoid.Congruences.Basic                 using  ( reflexive ; is-equivalence )
+open import Setoid.Congruences.Certificates.Schema   using  ( ParentVec ; parent )
+open import Setoid.Congruences.Finite.Basic          using  ( DecCon ; ConRel )
 ```
 -->
 
@@ -82,17 +86,18 @@ open import Setoid.Congruences.Finite.Basic      using ( DecCon ; ConRel )
 
 `KNBlocks`{.AgdaModule} fixes the algebra and an irredundant enumeration of its
 carrier.  Nothing here looks at the operations, but the ambient algebra is kept
-(rather than a bare setoid) because the input and output of the dictionary are
-`DecCon`{.AgdaFunction}s.
+(rather than a bare setoid) because the input and output of the dictionary inhabit
+`DecCon`{.AgdaFunction}.
 
 ```agda
-module KNBlocks {𝑆 : Signature 0ℓ 0ℓ} (𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ)
-                (𝑬 : IrredundantEnumeration 𝑨) where
+module KNBlocks
+  {𝑆 : Signature 0ℓ 0ℓ}
+  (𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ)
+  (𝑬 : IrredundantEnumeration 𝑨)
+  where
 
-  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
-    renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
-  open IrredundantEnumeration 𝑬 using ( ienum ; ienum-sur ; ienum-inj )
-    renaming ( icard to m )
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ) renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+  open IrredundantEnumeration 𝑬 using ( ienum[_] ; ienum-sur ; ienum-inj ) renaming ( icard to m )
 ```
 
 #### The index of a carrier element
@@ -104,86 +109,88 @@ of an enumerated value is its own position.
 ```agda
   -- The index of (the ≈-class of) a carrier element.
   eIdx : 𝕌[ 𝑨 ] → Fin m
-  eIdx x = proj₁ (ienum-sur x)
+  eIdx = proj₁ ∘ ienum-sur
 
   -- The enumerated value at the index of x is x, up to ≈.
-  eIdx-≈ : ∀ x → ienum (eIdx x) ≈ x
-  eIdx-≈ x = proj₂ (ienum-sur x)
+  eIdx-≈ : ∀ x → ienum[ eIdx x ] ≈ x
+  eIdx-≈ = proj₂ ∘ ienum-sur
 
   -- ≈-equal elements have equal indices (this is exactly irredundancy).
   eIdx-cong : ∀ {x y} → x ≈ y → eIdx x ≡ eIdx y
   eIdx-cong {x} {y} e = ienum-inj (≈trans (eIdx-≈ x) (≈trans e (≈sym (eIdx-≈ y))))
 
   -- The index of an enumerated value is its position.
-  eIdx-ienum : ∀ i → eIdx (ienum i) ≡ i
-  eIdx-ienum i = ienum-inj (eIdx-≈ (ienum i))
+  eIdx-ienum[_] : ∀ i → eIdx ienum[ i ] ≡ i
+  eIdx-ienum[_] = ienum-inj ∘ eIdx-≈ ∘ ienum[_]
 ```
 
 #### From a decidable congruence to a partition
 
-Fix a decidable congruence `d`.  Each index `i` is relabelled by the least
-index whose value is `d`-related to `ienum i`; the search cannot fail because
-`i` itself qualifies, by reflexivity of `d` over `≈`.
+Fix a decidable congruence `θ`.  Each index `i` is relabelled by the least index
+whose value is `θ`-related to `ienum[ i ]`; the search cannot fail because `i`
+itself qualifies, by reflexivity of `θ` over `_≈_`{.AgdaField}.
 
 ```agda
-  module _ (d : DecCon 𝑨 0ℓ) where
-
+  module _ (((_θ_ , θcon) , θdec) : DecCon 𝑨 0ℓ) where
     private
-      θ : BinaryRel 𝕌[ 𝑨 ] 0ℓ
-      θ = ConRel d
 
-      θ-refl≈ : ∀ {x y} → x ≈ y → θ x y
-      θ-refl≈ = reflexive (proj₂ (proj₁ d))
+      θ-refl≈ : ∀ {x y} → x ≈ y → x θ y
+      θ-refl≈ = reflexive θcon
 
-      θ-sym : ∀ {x y} → θ x y → θ y x
-      θ-sym = IsEquivalence.sym (is-equivalence (proj₂ (proj₁ d)))
+      θ-sym : ∀ {x y} → x θ y → y θ x
+      θ-sym = IsEquivalence.sym (is-equivalence θcon)
 
-      θ-trans : ∀ {x y z} → θ x y → θ y z → θ x z
-      θ-trans = IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+      θ-trans : ∀ {x y z} → x θ y → y θ z → x θ z
+      θ-trans = IsEquivalence.trans (is-equivalence θcon)
 
-      -- The least index of the d-class of ienum i, with its two certificates.
-      found : (i : Fin m)
-        → Σ[ j ∈ Fin m ] (θ (ienum j) (ienum i) × ((k : Fin m) → θ (ienum k) (ienum i) → j ≤ᶠ k))
-      found i = extract (findLeast m (λ j → proj₂ d (ienum j) (ienum i)))
+      -- The least index of the θ-class of ienum[ i ], with its two certificates.
+      found : (i : Fin m) → Σ[ j ∈ Fin m ] (ienum[ j ] θ ienum[ i ]
+                                           × ∀ k → ienum[ k ] θ ienum[ i ] → j ≤ᶠ k)
+
+      found i = extract (findLeast m (λ j → θdec ienum[ j ] ienum[ i ]))
         where
-        extract :
-             (Σ[ j ∈ Fin m ] (θ (ienum j) (ienum i) × ((k : Fin m) → θ (ienum k) (ienum i) → j ≤ᶠ k)))
-           ⊎ ((j : Fin m) → ¬ θ (ienum j) (ienum i))
-          → Σ[ j ∈ Fin m ] (θ (ienum j) (ienum i) × ((k : Fin m) → θ (ienum k) (ienum i) → j ≤ᶠ k))
-        extract (inj₁ w)     = w
-        extract (inj₂ none)  = ⊥-elim (none i (θ-refl≈ ≈refl))
+        extract :  Σ[ j ∈ Fin m ] ( ienum[ j ] θ ienum[ i ]
+                                    × ∀ k → ienum[ k ] θ ienum[ i ] → j ≤ᶠ k )
+                   ⊎ (∀ j → ¬ ienum[ j ] θ ienum[ i ])
+
+          → Σ[ j ∈ Fin m ] ( ienum[ j ] θ ienum[ i ]
+                             × ∀ k → ienum[ k ] θ ienum[ i ] → j ≤ᶠ k)
+
+        extract (inj₁ w) = w
+        extract (inj₂ none) = ⊥-elim (none i (θ-refl≈ ≈refl))
 
       -- The class representative (least related index).
       rep : Fin m → Fin m
-      rep i = proj₁ (found i)
+      rep i = found i .proj₁
 
-      rep-rel : (i : Fin m) → θ (ienum (rep i)) (ienum i)
-      rep-rel i = proj₁ (proj₂ (found i))
+      rep-rel : (i : Fin m) → ienum[ rep i ] θ ienum[ i ]
+      rep-rel i = found i .proj₂ .proj₁
 
-      rep-least : (i k : Fin m) → θ (ienum k) (ienum i) → rep i ≤ᶠ k
-      rep-least i = proj₂ (proj₂ (found i))
+      rep-least : (i k : Fin m) → ienum[ k ] θ ienum[ i ] → rep i ≤ᶠ k
+      rep-least i = found i .proj₂ .proj₂
 
-    -- The partition of the index set by d-classes.
+    -- The partition of the index set by θ-classes.
     pvOf : ParentVec m
     pvOf = tabulate rep
 ```
 
-The kernel of `pvOf`{.AgdaFunction} is the restriction of `d` to enumerated
+The kernel of `pvOf`{.AgdaFunction} is the restriction of `θ` to enumerated
 values: same label means related through the shared representative, and related
 values search pointwise-equivalent predicates, so their least representatives
 coincide.
 
 ```agda
-    -- Same pvOf-block implies d-related values.
-    pvOf-sound : ∀ {i j} → SameBlock pvOf i j → θ (ienum i) (ienum j)
+    -- Same pvOf-block implies θ-related values.
+    pvOf-sound : ∀ {i j} → SameBlock pvOf i j → ienum[ i ] θ ienum[ j ]
     pvOf-sound {i} {j} sb =
-      θ-trans (θ-sym (rep-rel i)) (subst (λ k → θ (ienum k) (ienum j)) (sym rep≡) (rep-rel j))
+      θ-trans (θ-sym (rep-rel i)) ( subst  (λ k → ienum[ k ] θ ienum[ j ])
+                                           (sym rep≡) (rep-rel j) )
       where
       rep≡ : rep i ≡ rep j
       rep≡ = trans (sym (parent-tab rep i)) (trans sb (parent-tab rep j))
 
-    -- d-related values imply same pvOf-block.
-    pvOf-complete : ∀ {i j} → θ (ienum i) (ienum j) → SameBlock pvOf i j
+    -- θ-related values imply same pvOf-block.
+    pvOf-complete : ∀ {i j} → ienum[ i ] θ ienum[ j ] → SameBlock pvOf i j
     pvOf-complete {i} {j} rel = trans (parent-tab rep i) (trans rep≡ (sym (parent-tab rep j)))
       where
       rep≡ : rep i ≡ rep j
@@ -198,7 +205,7 @@ coincide.
 `blockRel pv` identifies carrier elements whose indices share a `pv`-block.
 Because `SameBlock`{.AgdaFunction} is a propositional equality of labels, the
 equivalence laws are those of `_≡_`{.AgdaDatatype}; reflexivity over
-`≈`{.AgdaFunction} and decidability come from irredundancy and the decidable
+`_≈_`{.AgdaField} and decidability come from irredundancy and the decidable
 equality of `Fin`{.AgdaDatatype}.
 
 ```agda
@@ -221,8 +228,8 @@ equality of `Fin`{.AgdaDatatype}.
 
 #### Monotonicity
 
-Both maps are monotone for containment: refinement of partitions is inclusion
-of kernels, so `blockRel`{.AgdaFunction} forwards it verbatim, and
+Both maps are monotone for containment: refinement of partitions is inclusion of
+kernels, so `blockRel`{.AgdaFunction} forwards it verbatim, and
 `pvOf`{.AgdaFunction} forwards a congruence containment through the two kernel
 characterizations.
 
@@ -243,8 +250,8 @@ characterizations.
 Each round trip is stated against an arbitrary relation-equivalent
 presentation.  On the partition side: if the relation of `d` is pointwise
 equivalent to `blockRel pv`, then `pvOf d` and `pv` have the same kernel — the
-step from index `i` to carrier element `ienum i` and back is repaired by
-`eIdx-ienum`{.AgdaFunction}.
+step from index `i` to carrier element `ienum[ i ]` and back is repaired by
+`eIdx-ienum[_]`{.AgdaFunction}.
 
 ```agda
   -- Round trip on partitions: pvOf inverts blockRel, up to kernel equality.
@@ -256,11 +263,12 @@ step from index `i` to carrier element `ienum i` and back is repaired by
     where
     to-pv : pvOf d ⊑ pv
     to-pv {i} {j} sb =
-      subst₂ (SameBlock pv) (eIdx-ienum i) (eIdx-ienum j) (fwd (pvOf-sound d sb))
+      subst₂ (SameBlock pv) eIdx-ienum[ i ] eIdx-ienum[ j ] (fwd (pvOf-sound d sb))
 
     from-pv : pv ⊑ pvOf d
     from-pv {i} {j} sb =
-      pvOf-complete d (bwd (subst₂ (SameBlock pv) (sym (eIdx-ienum i)) (sym (eIdx-ienum j)) sb))
+      pvOf-complete d (bwd (subst₂ (SameBlock pv)  (sym eIdx-ienum[ i ])
+                                                   (sym eIdx-ienum[ j ]) sb))
 ```
 
 On the congruence side: the relation induced by the partition of a decidable
@@ -268,24 +276,23 @@ congruence is the congruence itself, the step from `x` to `ienum (eIdx x)` and
 back repaired by reflexivity over `≈`{.AgdaFunction} and transitivity.
 
 ```agda
-  -- Round trip on relations: blockRel inverts pvOf, up to mutual containment.
-  blockRel-pvOf-out : (d : DecCon 𝑨 0ℓ) → ∀ {x y} → blockRel (pvOf d) x y → ConRel d x y
-  blockRel-pvOf-out d {x} {y} sb = θ-trans (θ-sym (θ-refl≈ (eIdx-≈ x))) (θ-trans rel (θ-refl≈ (eIdx-≈ y)))
-    where
-    θ-refl≈  = reflexive (proj₂ (proj₁ d))
-    θ-sym    = IsEquivalence.sym (is-equivalence (proj₂ (proj₁ d)))
-    θ-trans  = IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+  module _ (d@((_θ_ , θcon) , _) : DecCon 𝑨 0ℓ) where
+    private
+      θ-refl≈  = reflexive θcon
+      θ-sym    = IsEquivalence.sym (is-equivalence θcon)
+      θ-trans  = IsEquivalence.trans (is-equivalence θcon)
 
-    rel : ConRel d (ienum (eIdx x)) (ienum (eIdx y))
-    rel = pvOf-sound d sb
+    -- Round trip on relations: blockRel inverts pvOf, up to mutual containment.
+    blockRel-pvOf-out : ∀ {x y} → blockRel (pvOf d) x y → ConRel d x y
+    blockRel-pvOf-out {x} {y} sb =
+      θ-trans (θ-sym (θ-refl≈ (eIdx-≈ x))) (θ-trans rel (θ-refl≈ (eIdx-≈ y)))
+      where
+      rel : ienum[ eIdx x ] θ ienum[ eIdx y ]
+      rel = pvOf-sound d sb
 
-  blockRel-pvOf-in : (d : DecCon 𝑨 0ℓ) → ∀ {x y} → ConRel d x y → blockRel (pvOf d) x y
-  blockRel-pvOf-in d {x} {y} rel =
-    pvOf-complete d (θ-trans (θ-refl≈ (eIdx-≈ x)) (θ-trans rel (θ-sym (θ-refl≈ (eIdx-≈ y)))))
-    where
-    θ-refl≈  = reflexive (proj₂ (proj₁ d))
-    θ-sym    = IsEquivalence.sym (is-equivalence (proj₂ (proj₁ d)))
-    θ-trans  = IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+    blockRel-pvOf-in : ∀ {x y} → ConRel d x y → blockRel (pvOf d) x y
+    blockRel-pvOf-in {x} {y} rel =
+      pvOf-complete d (θ-trans (θ-refl≈ (eIdx-≈ x)) (θ-trans rel (θ-sym (θ-refl≈ (eIdx-≈ y)))))
 ```
 
 --------------------------------------

--- a/src/FLRP/KurzweilNetter/Blocks.lagda.md
+++ b/src/FLRP/KurzweilNetter/Blocks.lagda.md
@@ -1,0 +1,291 @@
+---
+layout: default
+file: "src/FLRP/KurzweilNetter/Blocks.lagda.md"
+title: "FLRP.KurzweilNetter.Blocks module (The Agda Universal Algebra Library)"
+date: "2026-07-28"
+author: "the agda-algebras development team"
+---
+
+### Decidable equivalences of a finite carrier as partitions of its index set
+
+This is the [FLRP.KurzweilNetter.Blocks][] module of the [Agda Universal Algebra Library][].
+
+The Kurzweil–Netter construction (issue #502) represents the dual of
+`Con 𝑨` on a power of a simple group *indexed by the carrier* of the finite
+algebra `𝑨`{.AgdaBound}.  The traffic between the two sides runs through the
+partition lattice `Eq(m)` of [Classical.Structures.Lattice.Partitions][]: a
+decidable congruence of `𝑨`{.AgdaBound} must become a partition of
+`Fin m`{.AgdaDatatype}, and a partition must become a decidable relation on the
+carrier.  This module provides exactly that dictionary, *at the relation level*
+— no operations of `𝑨`{.AgdaBound} appear, so everything here is about
+decidable equivalences; the interaction with the operations (which partitions
+arise from congruences) is the business of
+[FLRP.KurzweilNetter.Translations][].
+
+Throughout, the carrier is presented by an *irredundant* enumeration
+([Setoid.Algebras.Finite.Irredundant][]): `ienum : Fin m → 𝕌[ 𝑨 ]` hits every
+`≈`-class exactly once.  Irredundancy is not a convenience but a correctness
+condition — with a redundant index the partitions of `Fin m` could separate two
+copies of one carrier element, and the correspondence below would fail to be a
+bijection.
+
+The two directions:
+
++  **`pvOf`** sends a decidable congruence `d` to the partition of the index
+   set by `d`-classes, presented as a `ParentVec`{.AgdaFunction}: index `i` is
+   labelled by the *least* index `d`-related to it, computed by the bounded
+   search `findLeast`{.AgdaFunction}.  Its kernel is exactly the restriction of
+   `d` to enumerated values (`pvOf-sound`{.AgdaFunction} /
+   `pvOf-complete`{.AgdaFunction}).
+
++  **`blockRel`** sends a partition `pv` to the relation identifying carrier
+   elements whose indices share a block.  It is a decidable equivalence
+   respecting `≈`{.AgdaFunction}, by irredundancy of the enumeration.
+
+The module closes with the monotonicity of both maps and the two round trips,
+each stated against an arbitrary relation-equivalent presentation so that the
+downstream isomorphisms can consume them without definitional coincidences.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.KurzweilNetter.Blocks where
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Empty          using ( ⊥-elim )
+open import Data.Fin.Base       using ( Fin ) renaming ( _≤_ to _≤ᶠ_ )
+open import Data.Fin.Properties using () renaming ( _≟_ to _≟ᶠ_ )
+open import Data.Product        using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
+open import Data.Sum.Base       using ( _⊎_ ; inj₁ ; inj₂ )
+open import Data.Vec.Base       using ( tabulate )
+open import Level               using ( 0ℓ )
+open import Relation.Binary     using ( Setoid ; IsEquivalence )
+                                renaming ( Rel to BinaryRel )
+open import Relation.Binary.PropositionalEquality
+                                using ( _≡_ ; refl ; sym ; trans ; cong ; subst ; subst₂ )
+open import Relation.Nullary    using ( ¬_ ; Dec )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Structures.Lattice.Partitions
+  using ( SameBlock ; _⊑_ ; _≈ᵖ_ ; parent-tab ; findLeast ; least-unique )
+open import Overture                             using ( Signature )
+open import Setoid.Algebras.Basic                using ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite.Irredundant   using ( IrredundantEnumeration )
+open import Setoid.Congruences.Basic             using ( reflexive ; is-equivalence )
+open import Setoid.Congruences.Certificates.Schema  using ( ParentVec ; parent )
+open import Setoid.Congruences.Finite.Basic      using ( DecCon ; ConRel )
+```
+-->
+
+#### The dictionary module
+
+`KNBlocks`{.AgdaModule} fixes the algebra and an irredundant enumeration of its
+carrier.  Nothing here looks at the operations, but the ambient algebra is kept
+(rather than a bare setoid) because the input and output of the dictionary are
+`DecCon`{.AgdaFunction}s.
+
+```agda
+module KNBlocks {𝑆 : Signature 0ℓ 0ℓ} (𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ)
+                (𝑬 : IrredundantEnumeration 𝑨) where
+
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
+    renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+  open IrredundantEnumeration 𝑬 using ( ienum ; ienum-sur ; ienum-inj )
+    renaming ( icard to m )
+```
+
+#### The index of a carrier element
+
+Irredundancy makes "the index of `x`" a function of the `≈`-class of `x`: any
+two `≈`-equal elements are sent to propositionally equal indices, and the index
+of an enumerated value is its own position.
+
+```agda
+  -- The index of (the ≈-class of) a carrier element.
+  eIdx : 𝕌[ 𝑨 ] → Fin m
+  eIdx x = proj₁ (ienum-sur x)
+
+  -- The enumerated value at the index of x is x, up to ≈.
+  eIdx-≈ : ∀ x → ienum (eIdx x) ≈ x
+  eIdx-≈ x = proj₂ (ienum-sur x)
+
+  -- ≈-equal elements have equal indices (this is exactly irredundancy).
+  eIdx-cong : ∀ {x y} → x ≈ y → eIdx x ≡ eIdx y
+  eIdx-cong {x} {y} e = ienum-inj (≈trans (eIdx-≈ x) (≈trans e (≈sym (eIdx-≈ y))))
+
+  -- The index of an enumerated value is its position.
+  eIdx-ienum : ∀ i → eIdx (ienum i) ≡ i
+  eIdx-ienum i = ienum-inj (eIdx-≈ (ienum i))
+```
+
+#### From a decidable congruence to a partition
+
+Fix a decidable congruence `d`.  Each index `i` is relabelled by the least
+index whose value is `d`-related to `ienum i`; the search cannot fail because
+`i` itself qualifies, by reflexivity of `d` over `≈`.
+
+```agda
+  module _ (d : DecCon 𝑨 0ℓ) where
+
+    private
+      θ : BinaryRel 𝕌[ 𝑨 ] 0ℓ
+      θ = ConRel d
+
+      θ-refl≈ : ∀ {x y} → x ≈ y → θ x y
+      θ-refl≈ = reflexive (proj₂ (proj₁ d))
+
+      θ-sym : ∀ {x y} → θ x y → θ y x
+      θ-sym = IsEquivalence.sym (is-equivalence (proj₂ (proj₁ d)))
+
+      θ-trans : ∀ {x y z} → θ x y → θ y z → θ x z
+      θ-trans = IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+
+      -- The least index of the d-class of ienum i, with its two certificates.
+      found : (i : Fin m)
+        → Σ[ j ∈ Fin m ] (θ (ienum j) (ienum i) × ((k : Fin m) → θ (ienum k) (ienum i) → j ≤ᶠ k))
+      found i = extract (findLeast m (λ j → proj₂ d (ienum j) (ienum i)))
+        where
+        extract :
+             (Σ[ j ∈ Fin m ] (θ (ienum j) (ienum i) × ((k : Fin m) → θ (ienum k) (ienum i) → j ≤ᶠ k)))
+           ⊎ ((j : Fin m) → ¬ θ (ienum j) (ienum i))
+          → Σ[ j ∈ Fin m ] (θ (ienum j) (ienum i) × ((k : Fin m) → θ (ienum k) (ienum i) → j ≤ᶠ k))
+        extract (inj₁ w)     = w
+        extract (inj₂ none)  = ⊥-elim (none i (θ-refl≈ ≈refl))
+
+      -- The class representative (least related index).
+      rep : Fin m → Fin m
+      rep i = proj₁ (found i)
+
+      rep-rel : (i : Fin m) → θ (ienum (rep i)) (ienum i)
+      rep-rel i = proj₁ (proj₂ (found i))
+
+      rep-least : (i k : Fin m) → θ (ienum k) (ienum i) → rep i ≤ᶠ k
+      rep-least i = proj₂ (proj₂ (found i))
+
+    -- The partition of the index set by d-classes.
+    pvOf : ParentVec m
+    pvOf = tabulate rep
+```
+
+The kernel of `pvOf`{.AgdaFunction} is the restriction of `d` to enumerated
+values: same label means related through the shared representative, and related
+values search pointwise-equivalent predicates, so their least representatives
+coincide.
+
+```agda
+    -- Same pvOf-block implies d-related values.
+    pvOf-sound : ∀ {i j} → SameBlock pvOf i j → θ (ienum i) (ienum j)
+    pvOf-sound {i} {j} sb =
+      θ-trans (θ-sym (rep-rel i)) (subst (λ k → θ (ienum k) (ienum j)) (sym rep≡) (rep-rel j))
+      where
+      rep≡ : rep i ≡ rep j
+      rep≡ = trans (sym (parent-tab rep i)) (trans sb (parent-tab rep j))
+
+    -- d-related values imply same pvOf-block.
+    pvOf-complete : ∀ {i j} → θ (ienum i) (ienum j) → SameBlock pvOf i j
+    pvOf-complete {i} {j} rel = trans (parent-tab rep i) (trans rep≡ (sym (parent-tab rep j)))
+      where
+      rep≡ : rep i ≡ rep j
+      rep≡ = least-unique
+        (λ k pk → θ-trans pk rel) (λ k qk → θ-trans qk (θ-sym rel))
+        (rep i) (rep-rel i) (rep-least i)
+        (rep j) (rep-rel j) (rep-least j)
+```
+
+#### From a partition to a decidable equivalence
+
+`blockRel pv` identifies carrier elements whose indices share a `pv`-block.
+Because `SameBlock`{.AgdaFunction} is a propositional equality of labels, the
+equivalence laws are those of `_≡_`{.AgdaDatatype}; reflexivity over
+`≈`{.AgdaFunction} and decidability come from irredundancy and the decidable
+equality of `Fin`{.AgdaDatatype}.
+
+```agda
+  -- The relation on the carrier induced by a partition of the index set.
+  blockRel : ParentVec m → BinaryRel 𝕌[ 𝑨 ] 0ℓ
+  blockRel pv x y = SameBlock pv (eIdx x) (eIdx y)
+
+  -- blockRel contains the setoid equality.
+  blockRel-refl≈ : (pv : ParentVec m) → ∀ {x y} → x ≈ y → blockRel pv x y
+  blockRel-refl≈ pv e = cong (parent pv) (eIdx-cong e)
+
+  -- blockRel is an equivalence (label equality is propositional equality).
+  blockRel-isEquivalence : (pv : ParentVec m) → IsEquivalence (blockRel pv)
+  blockRel-isEquivalence pv = record { refl = refl ; sym = sym ; trans = trans }
+
+  -- blockRel is decidable: compare the two labels.
+  blockRel-dec : (pv : ParentVec m) → ∀ x y → Dec (blockRel pv x y)
+  blockRel-dec pv x y = parent pv (eIdx x) ≟ᶠ parent pv (eIdx y)
+```
+
+#### Monotonicity
+
+Both maps are monotone for containment: refinement of partitions is inclusion
+of kernels, so `blockRel`{.AgdaFunction} forwards it verbatim, and
+`pvOf`{.AgdaFunction} forwards a congruence containment through the two kernel
+characterizations.
+
+```agda
+  -- Refinement of partitions gives containment of the induced relations.
+  blockRel-mono : {pu pw : ParentVec m} → pu ⊑ pw
+    → ∀ {x y} → blockRel pu x y → blockRel pw x y
+  blockRel-mono h = h
+
+  -- Containment of congruences gives refinement of the induced partitions.
+  pvOf-mono : (d e : DecCon 𝑨 0ℓ) → (∀ {x y} → ConRel d x y → ConRel e x y)
+    → pvOf d ⊑ pvOf e
+  pvOf-mono d e sub sb = pvOf-complete e (sub (pvOf-sound d sb))
+```
+
+#### The round trips
+
+Each round trip is stated against an arbitrary relation-equivalent
+presentation.  On the partition side: if the relation of `d` is pointwise
+equivalent to `blockRel pv`, then `pvOf d` and `pv` have the same kernel — the
+step from index `i` to carrier element `ienum i` and back is repaired by
+`eIdx-ienum`{.AgdaFunction}.
+
+```agda
+  -- Round trip on partitions: pvOf inverts blockRel, up to kernel equality.
+  pvOf-blockRel : (d : DecCon 𝑨 0ℓ) (pv : ParentVec m)
+    → (∀ {x y} → ConRel d x y → blockRel pv x y)
+    → (∀ {x y} → blockRel pv x y → ConRel d x y)
+    → pvOf d ≈ᵖ pv
+  pvOf-blockRel d pv fwd bwd = to-pv , from-pv
+    where
+    to-pv : pvOf d ⊑ pv
+    to-pv {i} {j} sb =
+      subst₂ (SameBlock pv) (eIdx-ienum i) (eIdx-ienum j) (fwd (pvOf-sound d sb))
+
+    from-pv : pv ⊑ pvOf d
+    from-pv {i} {j} sb =
+      pvOf-complete d (bwd (subst₂ (SameBlock pv) (sym (eIdx-ienum i)) (sym (eIdx-ienum j)) sb))
+```
+
+On the congruence side: the relation induced by the partition of a decidable
+congruence is the congruence itself, the step from `x` to `ienum (eIdx x)` and
+back repaired by reflexivity over `≈`{.AgdaFunction} and transitivity.
+
+```agda
+  -- Round trip on relations: blockRel inverts pvOf, up to mutual containment.
+  blockRel-pvOf-out : (d : DecCon 𝑨 0ℓ) → ∀ {x y} → blockRel (pvOf d) x y → ConRel d x y
+  blockRel-pvOf-out d {x} {y} sb = θ-trans (θ-sym (θ-refl≈ (eIdx-≈ x))) (θ-trans rel (θ-refl≈ (eIdx-≈ y)))
+    where
+    θ-refl≈  = reflexive (proj₂ (proj₁ d))
+    θ-sym    = IsEquivalence.sym (is-equivalence (proj₂ (proj₁ d)))
+    θ-trans  = IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+
+    rel : ConRel d (ienum (eIdx x)) (ienum (eIdx y))
+    rel = pvOf-sound d sb
+
+  blockRel-pvOf-in : (d : DecCon 𝑨 0ℓ) → ∀ {x y} → ConRel d x y → blockRel (pvOf d) x y
+  blockRel-pvOf-in d {x} {y} rel =
+    pvOf-complete d (θ-trans (θ-refl≈ (eIdx-≈ x)) (θ-trans rel (θ-sym (θ-refl≈ (eIdx-≈ y)))))
+    where
+    θ-refl≈  = reflexive (proj₂ (proj₁ d))
+    θ-sym    = IsEquivalence.sym (is-equivalence (proj₂ (proj₁ d)))
+    θ-trans  = IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+```
+
+--------------------------------------

--- a/src/FLRP/KurzweilNetter/Duality.lagda.md
+++ b/src/FLRP/KurzweilNetter/Duality.lagda.md
@@ -300,6 +300,13 @@ finite signature from the expansion module, and the composite isomorphism.
 property witnesses of the deliverable list, and instantiates the glue at the
 canonical irredundant enumeration of each representation.
 
+One reading note, so the module cannot overstate itself: the definitions below
+inhabit `KurzweilNetterDuality`{.AgdaFunction} *inside* this parameterized
+module, so their closed types quantify over the package — the library holds no
+closed inhabitant of the statement, and Entry 4's family is a genuine
+hypothesis of the result.  Entry 2 of [FLRP.Assumptions][] is thereby *reduced
+to Entry 4*, not discharged; the registry entry records the same reading.
+
 ```agda
 module KurzweilNetterProof
   (𝒮     : Group 0ℓ 0ℓ)
@@ -320,7 +327,7 @@ module KurzweilNetterProof
     𝑬ᵢ : IrredundantEnumeration algᵈ
     𝑬ᵢ = irredundantEnumeration finiteᵈ
 
-  -- The Kurzweil–Netter duality theorem.
+  -- The Kurzweil–Netter duality theorem, conditional on the module's package.
   kurzweilNetterDuality : KurzweilNetterDuality
   kurzweilNetterDuality 𝑳 = kurzweilNetterDualityAt 𝑳
 ```

--- a/src/FLRP/KurzweilNetter/Duality.lagda.md
+++ b/src/FLRP/KurzweilNetter/Duality.lagda.md
@@ -10,75 +10,72 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.KurzweilNetter.Duality][] module of the [Agda Universal Algebra Library][].
 
-**Theorem (Kurzweil 1985, Netter 1986).**  *If a finite lattice is decidably
-representable, then so is its dual.*
+**Theorem (Kurzweil 1985, Netter 1986)**.
+If a finite lattice is decidably representable, then so is its dual.
 
 This module assembles the formal proof from its three prepared stages,
 following the argument of `docs/papers/fin-lat-rep/SmallLatticeReps.tex`
 § "Lattice duals: the theorem of Kurzweil and Netter" (after Pálfy's 2009
-lectures).  Given a representation `𝑳 ≅ DecCon 𝑨`:
+lectures).  Given a representation `𝑳 ≅ DecCon 𝑨`, proceed as follows:
 
-1. present the carrier of `𝑨`{.AgdaBound} by an irredundant enumeration
-   `Fin m` ([Setoid.Algebras.Finite.Irredundant][]), and its congruences as
-   the partitions of `Fin m`{.AgdaDatatype} invariant under the basic
-   translations ([FLRP.KurzweilNetter.Blocks][],
-   [FLRP.KurzweilNetter.Translations][] — the translation criterion);
+1. present the carrier of `𝑨`{.AgdaBound} by an irredundant enumeration `Fin m`
+   ([Setoid.Algebras.Finite.Irredundant][]), and its congruences as the partitions
+   of `Fin m`{.AgdaDatatype} invariant under the basic translations
+   ([FLRP.KurzweilNetter.Blocks][], [FLRP.KurzweilNetter.Translations][], the
+   translation criterion);
 
-2. expand the coset algebra of the diagonal `D ≤ Sᵐ` by the lifted
-   translations; its decidable congruence poset is the *reversed* poset of
-   invariant partitions ([FLRP.KurzweilNetter.Expansion][], composing the
-   WP-3 bridge `DecCon (Sᵐ ↷ Sᵐ/D) ≅ [D , Sᵐ]` of [FLRP.Bridge][] with
-   Kurzweil's interval isomorphism `[D , Sᵐ] ≅ Eq(m)′` of
-   [FLRP.KurzweilInterval][]);
+2. expand the coset algebra of the diagonal `D ≤ Sᵐ` by the lifted translations;
+   its decidable congruence poset is the *reversed* poset of invariant partitions
+   ([FLRP.KurzweilNetter.Expansion][], composing the WP-3 bridge
+   `DecCon (Sᵐ ↷ Sᵐ/D) ≅ [D , Sᵐ]` of [FLRP.Bridge][] with Kurzweil's interval
+   isomorphism `[D , Sᵐ] ≅ Eq(m)′` of [FLRP.KurzweilInterval][]);
 
 3. compose the two, and the original representation, into
-   `DecCon 𝑬 ≅ dualLattice 𝑳` — the record
-   `dual-representation`{.AgdaFunction} below.
+   `DecCon 𝑬 ≅ dualLattice 𝑳`, the record `dual-representation`{.AgdaFunction} below.
 
 #### What the proof assumes of the simple group
 
-Per the scoping decision of issue #502, the theorem is *parameterized* by the
-group `S` rather than instantiated at a concrete simple group, and the module
-parameters are the deliverable list of properties the argument actually uses:
+For now, we parameterize by the group `S` rather than instantiated at a concrete
+simple group, and the module parameters are the deliverable list of properties the
+argument actually uses:
 
-+  **a finite carrier with decidable equality** (`𝑭ₛ`{.AgdaBound} `:`
-   `FiniteAlgebra`{.AgdaRecord}): for finiteness of the power `Sᵐ`, decidable
-   coset equality, and the membership deciders of the partition subgroups;
++  **a finite carrier with decidable equality**
+   (`𝑭ₛ`{.AgdaBound}` : ``FiniteAlgebra`{.AgdaRecord}),
+   for finiteness of the power `Sᵐ`, decidable coset equality, and the membership
+   deciders of the partition subgroups;
 
-+  **a nontriviality witness** `s₀`{.AgdaBound} with `¬ (s₀ ≈ ε)`: for the
++  **a nontriviality witness** `s₀`{.AgdaBound} with `¬ (s₀ ≈ ε)`, for the
    order reflection and injectivity of `π ↦ K_π`, and for extracting
    invariance from closure in the expansion step (the indicator tuples);
 
 +  **Kurzweil surjectivity at every exponent**
-   (`KurzweilSurjectivityAt`{.AgdaFunction} `𝒮` `n`, Entry 4 of
+   (`KurzweilSurjectivityAt`{.AgdaFunction}` 𝒮 n`, Entry 4 of
    [FLRP.Assumptions][]): every subgroup in `[D , Sⁿ]` is a partition
    subgroup.
 
-*Nonabelianness and simplicity of `S` enter only through the third item* —
-they are what makes Entry 4 true classically — so no simplicity predicate is
-needed anywhere in the formal development.  Retiring Entry 4 (issue #522) and
-instantiating `𝒮` at a concrete finite nonabelian simple group such as `A₅`
-(issue #527) are tracked separately; on either completion this module's
-statements strengthen with no change to consumers.
+*Nonabelianness and simplicity of `S` enter only through the third item*;
+they are what makes Entry 4 true classically.  Thus no simplicity predicate is
+needed anywhere in the formal development.  Retiring Entry 4 and instantiating `𝒮`
+at a concrete finite nonabelian simple group such as `A₅` are tracked separately
+as follow-on work; on either completion this module's statements strengthen with
+no change to consumers.
 
 #### What the proof does not assume
 
-The manuscript reduces to unary operations by citing the unary-reduction
-theorem `Con 𝑨 = Con ⟨A , Pol₁ 𝑨⟩` (issue #501, not yet formalized).  The
-formal proof here does **not** take #501 as a hypothesis: the expansion lifts
-only the *basic translations* of `𝑨`{.AgdaBound}, and the translation
-criterion of [FLRP.KurzweilNetter.Translations][] — a self-contained
-Mal'cev-style walk — shows these already determine the congruences.  Issue
-#501 remains open as the full polynomial-clone statement; nothing here waits
-on it.
+The manuscript reduces to unary operations by citing the unary-reduction theorem
+`Con 𝑨 = Con ⟨A , Pol₁ 𝑨⟩` (not yet formalized).  The formal proof here does
+**not** take that result as a hypothesis: the expansion lifts only the
+*basic translations* of `𝑨`{.AgdaBound}, and the translation criterion of
+[FLRP.KurzweilNetter.Translations][], a self-contained Mal'cev-style walk, shows
+these already determine the congruences.[^1]
 
 #### Size
 
-The construction represents `dualLattice 𝑳` on the coset space `Sᵐ/D` of
-`|S|^{m-1}` elements — at least `60^{m-1}` once `𝒮` is instantiated at `A₅` —
-so the census's dual entries (issue #485) become assumption-free in
-*statement* while remaining computationally out of reach: no concrete
-certificate algebra is materialized by this theorem.
+The construction represents `dualLattice 𝑳` on the coset space `Sᵐ / D` of
+`|S|ᵐ⁻¹` elements, which is at least `60ᵐ⁻¹` once `𝒮` is instantiated at `A₅`, so
+the census's dual entries become assumption-free in *statement* while remaining
+computationally out of reach: no concrete certificate algebra is materialized by
+this theorem.
 
 <!--
 ```agda
@@ -92,83 +89,87 @@ open import Agda.Primitive using () renaming ( Set to Type )
 open import Data.Nat.Base    using ( ℕ )
 open import Data.Product     using ( _,_ ; proj₁ )
 open import Level            using ( 0ℓ )
+open import Function         using ( id ; _∘_ )
 open import Relation.Binary  using ( Setoid )
 open import Relation.Nullary using ( ¬_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Properties.Lattice          using  ( module Lattice-Order )
-open import Classical.Small.Structures.Lattice    using  ( Lattice )
-open import Classical.Structures.Group.Basic      using  ( Group ; module Group-Op )
-open import Classical.Structures.Lattice.Dual     using  ( dualLattice
-                                                         ; module LatticeDual )
-open import FLRP.Assumptions       using  ( KurzweilNetterDualityAt
-                                          ; KurzweilNetterDuality
-                                          ; KurzweilSurjectivityAt )
-open import FLRP.KurzweilNetter.Blocks        using  ( module KNBlocks )
-open import FLRP.KurzweilNetter.Expansion     using  ( module KNExpansion )
-open import FLRP.KurzweilNetter.Translations  using  ( module KNTranslations )
-open import FLRP.Representable     using  ( Representableᵈ ; ConIsoᵈ ; _⊆ᵈ_ ; _≑ᵈ_
-                                          ; module ConIsoᵈ-Consequences )
-open import Order.Iso              using  ( OrderIso ; OrderIso-trans )
-open import Overture               using  ( Signature )
-open import Setoid.Algebras.Basic  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Algebras.Finite             using  ( FiniteAlgebra )
-open import Setoid.Algebras.Finite.Irredundant using  ( IrredundantEnumeration
-                                                      ; irredundantEnumeration )
-open import Setoid.Congruences.Finite.Basic    using  ( DecCon )
-open import Setoid.Signatures.Finite           using  ( FiniteSignature )
+open import Classical.Properties.Lattice        using  ( module Lattice-Order )
+open import Classical.Small.Structures.Lattice  using  ( Lattice )
+open import Classical.Structures.Group.Basic    using  ( Group ; module Group-Op )
+open import Classical.Structures.Lattice.Dual   using  ( dualLattice
+                                                       ; module LatticeDual )
+open import FLRP.Assumptions                    using  ( KurzweilNetterDualityAt
+                                                       ; KurzweilNetterDuality
+                                                       ; KurzweilSurjectivityAt )
+open import FLRP.KurzweilNetter.Blocks          using  ( module KNBlocks )
+open import FLRP.KurzweilNetter.Expansion       using  ( module KNExpansion )
+open import FLRP.KurzweilNetter.Translations    using  ( module KNTranslations )
+open import FLRP.Representable                  using  ( Representableᵈ ; ConIsoᵈ
+                                                       ; _⊆ᵈ_ ; _≑ᵈ_
+                                                       ; module ConIsoᵈ-Consequences )
+open import Order.Iso                           using  ( OrderIso ; OrderIso-trans )
+open import Overture                            using  ( Signature )
+open import Setoid.Algebras.Basic               using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite              using  ( FiniteAlgebra )
+open import Setoid.Algebras.Finite.Irredundant  using  ( IrredundantEnumeration
+                                                       ; irredundantEnumeration )
+open import Setoid.Congruences.Finite.Basic     using  ( DecCon )
+open import Setoid.Signatures.Finite            using  ( FiniteSignature )
 ```
 -->
 
 #### The glue module
 
-`KNGlue`{.AgdaModule} assembles the composite over an *abstract* irredundant
-enumeration and an *abstract* surjectivity witness at its size, and glues the
+`KNGlue`{.AgdaModule} assembles the composite over an abstract irredundant
+enumeration and an abstract surjectivity witness at its size, and glues the
 stages with the generic composition `OrderIso-trans`{.AgdaFunction} of
 [Order.Iso][] rather than by hand.  Both choices are measured type-checking
-requirements, not style: with the concrete
-`irredundantEnumeration`{.AgdaFunction} value substituted throughout, or with
-the composite's round trips elaborated inline, the conversion checker
-re-normalizes the whole construction at each step — profiled at over three
-minutes for this one module — whereas over inert parameters, with the
-composition checked once against abstract relations, the same content checks
-in seconds.  The instantiation happens once, in
+requirements, not style: with the concrete `irredundantEnumeration`{.AgdaFunction}
+value substituted throughout, or with the composite's round trips elaborated
+inline, the conversion checker re-normalizes the whole construction at each step
+(profiled at over three minutes for this one module) whereas over inert
+parameters, with the composition checked once against abstract relations, the same
+content checks in seconds.  The instantiation happens once, in
 `KurzweilNetterProof`{.AgdaModule} at the bottom.
 
 ```agda
 module KNGlue
-  {𝑆 : Signature 0ℓ 0ℓ} {𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ}
-  (𝑺     : FiniteSignature 𝑆)
-  (𝑬ᵢ    : IrredundantEnumeration 𝑨)
-  (𝒮     : Group 0ℓ 0ℓ)
-  (𝑭ₛ    : FiniteAlgebra (proj₁ 𝒮))
-  (s₀    : 𝕌[ proj₁ 𝒮 ])
-  (s₀≉ε  : ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s₀ (Group-Op.ε 𝒮)))
-  (surjm : KurzweilSurjectivityAt 𝒮 (IrredundantEnumeration.icard 𝑬ᵢ))
-  (𝑳 : Lattice) (iso : ConIsoᵈ {𝑆 = 𝑆} 𝑨 𝑳)
+  {𝑆          : Signature 0ℓ 0ℓ}
+  {𝑨          : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ}
+  (𝑆fin       : FiniteSignature 𝑆)
+  (𝑬ᵢ         : IrredundantEnumeration 𝑨)
+  (𝒮@(𝑺 , _)  : Group 0ℓ 0ℓ)  (open Setoid 𝔻[ 𝑺 ] using (_≈_))
+                              (open Group-Op 𝒮 using (ε))
+  (𝑭ₛ         : FiniteAlgebra 𝑺)
+  (s₀         : 𝕌[ 𝑺 ])
+  (s₀≉ε       : ¬ s₀ ≈ ε)
+  (surjm      : KurzweilSurjectivityAt 𝒮 (IrredundantEnumeration.icard 𝑬ᵢ))
+  (𝓛@(𝑳 , _)  : Lattice)
+  (iso        : ConIsoᵈ 𝑨 𝓛)
   where
 ```
 
-The three stages are instantiated: the irredundant enumeration fixes the
-exponent `m`, the translation toolkit supplies the family the expansion lifts,
-and the expansion module builds the representing algebra `𝑬` on `Sᵐ/D`.
+**The three stages are instantiated**.  The irredundant enumeration fixes the
+exponent `m`, the translation toolkit supplies the family the expansion lifts, and
+the expansion module builds the representing algebra `𝑬` on `Sᵐ/D`.
 
 ```agda
   private
-    module KB  = KNBlocks 𝑨 𝑬ᵢ
-    module KT  = KNTranslations 𝑨 𝑺 𝑬ᵢ
-    module KE  = KNExpansion 𝒮 𝑭ₛ s₀ s₀≉ε
-                   (IrredundantEnumeration.icard 𝑬ᵢ) KT.trCount KT.trFamily surjm
+    module KB = KNBlocks 𝑨 𝑬ᵢ
+    module KT = KNTranslations 𝑨 𝑆fin 𝑬ᵢ
+    module KE = KNExpansion 𝒮 𝑭ₛ s₀ s₀≉ε  (IrredundantEnumeration.icard 𝑬ᵢ)
+                                          KT.trCount KT.trFamily surjm
 
-    module I₀     = OrderIso iso
-    module KEIso  = OrderIso KE.expansionIso
+    module I₀ = OrderIso iso
+    module KEIso = OrderIso KE.expansionIso
 
-    open ConIsoᵈ-Consequences {𝑆 = 𝑆} {𝑨 = 𝑨} {𝑳 = 𝑳} iso using ( to-cong≑ )
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆} {𝑨 = 𝑨} {𝑳 = 𝓛} iso using ( to-cong≑ )
 
-    open Setoid 𝔻[ proj₁ 𝑳 ] using () renaming ( trans to ≈ᴸ-trans )
+    open Setoid 𝔻[ 𝑳 ] using () renaming ( trans to ≈ᴸ-trans )
 ```
 
-The middle stage of the composite: the family-invariant partitions are the
+**The middle stage of the composite**.  The family-invariant partitions are the
 decidable congruences of `𝑨`{.AgdaBound}, by the translation toolkit — the
 congruence of an invariant partition one way, the invariant partition of a
 congruence the other.
@@ -183,11 +184,11 @@ congruence the other.
     midFrom d = KB.pvOf d , KT.pvOf-invariant-family d
 ```
 
-The middle stage as an order isomorphism in its own right: the round trips are
-the two dictionary round trips of [FLRP.KurzweilNetter.Blocks][], with the
+**The middle stage as an order isomorphism in its own right**.  The round trips
+are the two dictionary round trips of [FLRP.KurzweilNetter.Blocks][], with the
 relation of `midTo`{.AgdaFunction} definitionally the block relation of the
-partition, so both directions of each round trip are the prepared lemmas
-applied verbatim.
+partition, so both directions of each round trip are the prepared lemmas applied
+verbatim.
 
 ```agda
     infix 4 _⊇ᵈ_
@@ -200,48 +201,46 @@ applied verbatim.
     midIso = record
       { to         = midTo
       ; from       = midFrom
-      ; to-mono    = λ {P} {Q} ge → KB.blockRel-mono {pu = proj₁ Q} {pw = proj₁ P} ge
+      ; to-mono    = λ {(P , _)} {(Q , _)} ge → KB.blockRel-mono {pu = Q} {pw = P} ge
       ; from-mono  = λ {d} {e} sup → KB.pvOf-mono e d sup
       ; to∘from    = λ d → KB.blockRel-pvOf-out d , KB.blockRel-pvOf-in d
-      ; from∘to    = λ P → KB.pvOf-blockRel (midTo P) (proj₁ P) (λ p → p) (λ p → p)
+      ; from∘to    = λ P → KB.pvOf-blockRel (midTo P) (proj₁ P) id id
       }
 ```
 
-The lattice stage, dualized: the maps and round trips of the given
+**The lattice stage, dualized**: the maps and round trips of the given
 representation, with the monotonicity directions flipped through the two flip
 lemmas of [Classical.Structures.Lattice.Dual][].
 
 ```agda
     I₀-dual : OrderIso  (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) _⊇ᵈ_
-                        (Setoid._≈_ 𝔻[ proj₁ (dualLattice 𝑳) ])
-                        (Lattice-Order._≤_ (dualLattice 𝑳))
+                        (Setoid._≈_ 𝔻[ proj₁ (dualLattice 𝓛) ])
+                        (Lattice-Order._≤_ (dualLattice 𝓛))
     I₀-dual = record
-      { to         = I₀.to
-      ; from       = I₀.from
-      ; to-mono    = λ {d} {e} sup →
-          LatticeDual.≤ᵈ-unflip 𝑳 {x = I₀.to d} {y = I₀.to e} (I₀.to-mono {e} {d} sup)
-      ; from-mono  = λ {u} {v} le →
-          I₀.from-mono {v} {u} (LatticeDual.≤ᵈ-flip 𝑳 {x = u} {y = v} le)
-      ; to∘from    = I₀.to∘from
-      ; from∘to    = I₀.from∘to
+      { to = I₀.to
+      ; from = I₀.from
+      ; to-mono = λ sup → LatticeDual.≤ᵈ-unflip 𝓛 (I₀.to-mono sup)
+      ; from-mono = λ le → I₀.from-mono (LatticeDual.≤ᵈ-flip 𝓛 le)
+      ; to∘from = I₀.to∘from
+      ; from∘to = I₀.from∘to
       }
 ```
 
-The junction data for composing the three stages: transitivity of the mutual
+**The junction data for composing the three stages**: transitivity of the mutual
 containments, and the congruence of each map with respect to the middle
-equivalence it crosses — every one of them monotonicity applied twice.
+equivalence it crosses; every one of them is monotonicity applied twice.
 
 ```agda
     ≑ᴱ-trans : {a b c : DecCon KE.expandedAlgebra 0ℓ} → a ≑ᵈ b → b ≑ᵈ c → a ≑ᵈ c
-    ≑ᴱ-trans (p₁ , p₂) (q₁ , q₂) = (λ r → q₁ (p₁ r)) , (λ r → p₂ (q₂ r))
+    ≑ᴱ-trans (p₁ , p₂) (q₁ , q₂) = q₁ ∘ p₁ , p₂ ∘ q₂
 
     ≑ᴬ-trans : {a b c : DecCon 𝑨 0ℓ} → a ≑ᵈ b → b ≑ᵈ c → a ≑ᵈ c
-    ≑ᴬ-trans (p₁ , p₂) (q₁ , q₂) = (λ r → q₁ (p₁ r)) , (λ r → p₂ (q₂ r))
+    ≑ᴬ-trans (p₁ , p₂) (q₁ , q₂) = q₁ ∘ p₁ , p₂ ∘ q₂
 
     midTo-cong : {P Q : KE.InvPart} → P KE.≈ᵛ Q → midTo P ≑ᵈ midTo Q
-    midTo-cong {P} {Q} (uw , wu) =
-        KB.blockRel-mono {pu = proj₁ P} {pw = proj₁ Q} uw
-      , KB.blockRel-mono {pu = proj₁ Q} {pw = proj₁ P} wu
+    midTo-cong {(P , _)} {(Q , _)} (uw , wu) =
+        KB.blockRel-mono {pu = P} {pw = Q} uw
+      , KB.blockRel-mono {pu = Q} {pw = P} wu
 
     midFrom-cong : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → midFrom d KE.≈ᵛ midFrom e
     midFrom-cong {d} {e} (p , q) = KB.pvOf-mono d e p , KB.pvOf-mono e d q
@@ -256,8 +255,8 @@ equivalence it crosses — every one of them monotonicity applied twice.
       KEfrom-cong {midFrom d} {midFrom e} (midFrom-cong {d} {e} de)
 ```
 
-The composite isomorphism `DecCon 𝑬 ≅ dualLattice 𝑳`, by two applications of
-`OrderIso-trans`{.AgdaFunction} of [Order.Iso][].  Order reversal happens once,
+**The composite isomorphism `DecCon 𝑬 ≅ dualLattice 𝑳`**: by two applications of
+`OrderIso-trans`{.AgdaFunction} of [Order.Iso][]; order reversal happens once,
 inside the expansion isomorphism; the middle stages run against the reversed
 orders, and the boundary lands in the dual lattice's meet order.
 
@@ -271,7 +270,7 @@ orders, and the boundary lands in the dual lattice's meet order.
       (λ {a} {b} {c} → ≑ᴱ-trans {a} {b} {c})
       (λ {a} {b} {c} → ≑ᴬ-trans {a} {b} {c})
 
-    dualConIso : ConIsoᵈ {𝑆 = KE.Sig-Exp} KE.expandedAlgebra (dualLattice 𝑳)
+    dualConIso : ConIsoᵈ {𝑆 = KE.Sig-Exp} KE.expandedAlgebra (dualLattice 𝓛)
     dualConIso = OrderIso-trans stage₁ I₀-dual
       (λ {d} {e} → to-cong≑ {d} {e})
       (λ {d} {e} → stage₁-from-cong {d} {e})
@@ -279,12 +278,12 @@ orders, and the boundary lands in the dual lattice's meet order.
       (λ {x} {y} {z} → ≈ᴸ-trans {x} {y} {z})
 ```
 
-The representation of the dual: the expanded coset algebra, its finiteness and
-finite signature from the expansion module, and the composite isomorphism.
+**The representation of the dual**: the expanded coset algebra, its finiteness
+and finite signature from the expansion module, and the composite isomorphism.
 
 ```agda
   -- The dual of a decidably representable lattice is decidably representable.
-  dual-representation : Representableᵈ (dualLattice 𝑳)
+  dual-representation : Representableᵈ (dualLattice 𝓛)
   dual-representation = record
     { sigᵈ      = KE.Sig-Exp
     ; algᵈ      = KE.expandedAlgebra
@@ -302,18 +301,18 @@ canonical irredundant enumeration of each representation.
 
 One reading note, so the module cannot overstate itself: the definitions below
 inhabit `KurzweilNetterDuality`{.AgdaFunction} *inside* this parameterized
-module, so their closed types quantify over the package — the library holds no
-closed inhabitant of the statement, and Entry 4's family is a genuine
-hypothesis of the result.  Entry 2 of [FLRP.Assumptions][] is thereby *reduced
-to Entry 4*, not discharged; the registry entry records the same reading.
+module; the library holds no closed inhabitant of the statement, and Entry 4's
+family is a genuine hypothesis of the result.  Entry 2 of [FLRP.Assumptions][] is
+thereby *reduced to Entry 4*, not discharged; the registry entry records the same
+reading.
 
 ```agda
 module KurzweilNetterProof
-  (𝒮     : Group 0ℓ 0ℓ)
-  (𝑭ₛ    : FiniteAlgebra (proj₁ 𝒮))
-  (s₀    : 𝕌[ proj₁ 𝒮 ])
-  (s₀≉ε  : ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s₀ (Group-Op.ε 𝒮)))
-  (surj  : (n : ℕ) → KurzweilSurjectivityAt 𝒮 n)
+  (𝒮@(𝑺 , _)  : Group 0ℓ 0ℓ)
+  (𝑭ₛ         : FiniteAlgebra 𝑺)
+  (s₀         : 𝕌[ 𝑺 ])
+  (s₀≉ε       : ¬ (Setoid._≈_ 𝔻[ 𝑺 ] s₀ (Group-Op.ε 𝒮)))
+  (surj       : (n : ℕ) → KurzweilSurjectivityAt 𝒮 n)
   where
 
   -- Kurzweil–Netter duality at a lattice.
@@ -333,3 +332,6 @@ module KurzweilNetterProof
 ```
 
 --------------------------------------
+
+[^1]: Issue #501 remains open as the full polynomial-clone statement; nothing here
+      waits on it.

--- a/src/FLRP/KurzweilNetter/Duality.lagda.md
+++ b/src/FLRP/KurzweilNetter/Duality.lagda.md
@@ -1,0 +1,328 @@
+---
+layout: default
+file: "src/FLRP/KurzweilNetter/Duality.lagda.md"
+title: "FLRP.KurzweilNetter.Duality module (The Agda Universal Algebra Library)"
+date: "2026-07-28"
+author: "the agda-algebras development team"
+---
+
+### The Kurzweil–Netter duality theorem
+
+This is the [FLRP.KurzweilNetter.Duality][] module of the [Agda Universal Algebra Library][].
+
+**Theorem (Kurzweil 1985, Netter 1986).**  *If a finite lattice is decidably
+representable, then so is its dual.*
+
+This module assembles the formal proof from its three prepared stages,
+following the argument of `docs/papers/fin-lat-rep/SmallLatticeReps.tex`
+§ "Lattice duals: the theorem of Kurzweil and Netter" (after Pálfy's 2009
+lectures).  Given a representation `𝑳 ≅ DecCon 𝑨`:
+
+1. present the carrier of `𝑨`{.AgdaBound} by an irredundant enumeration
+   `Fin m` ([Setoid.Algebras.Finite.Irredundant][]), and its congruences as
+   the partitions of `Fin m`{.AgdaDatatype} invariant under the basic
+   translations ([FLRP.KurzweilNetter.Blocks][],
+   [FLRP.KurzweilNetter.Translations][] — the translation criterion);
+
+2. expand the coset algebra of the diagonal `D ≤ Sᵐ` by the lifted
+   translations; its decidable congruence poset is the *reversed* poset of
+   invariant partitions ([FLRP.KurzweilNetter.Expansion][], composing the
+   WP-3 bridge `DecCon (Sᵐ ↷ Sᵐ/D) ≅ [D , Sᵐ]` of [FLRP.Bridge][] with
+   Kurzweil's interval isomorphism `[D , Sᵐ] ≅ Eq(m)′` of
+   [FLRP.KurzweilInterval][]);
+
+3. compose the two, and the original representation, into
+   `DecCon 𝑬 ≅ dualLattice 𝑳` — the record
+   `dual-representation`{.AgdaFunction} below.
+
+#### What the proof assumes of the simple group
+
+Per the scoping decision of issue #502, the theorem is *parameterized* by the
+group `S` rather than instantiated at a concrete simple group, and the module
+parameters are the deliverable list of properties the argument actually uses:
+
++  **a finite carrier with decidable equality** (`𝑭ₛ`{.AgdaBound} `:`
+   `FiniteAlgebra`{.AgdaRecord}): for finiteness of the power `Sᵐ`, decidable
+   coset equality, and the membership deciders of the partition subgroups;
+
++  **a nontriviality witness** `s₀`{.AgdaBound} with `¬ (s₀ ≈ ε)`: for the
+   order reflection and injectivity of `π ↦ K_π`, and for extracting
+   invariance from closure in the expansion step (the indicator tuples);
+
++  **Kurzweil surjectivity at every exponent**
+   (`KurzweilSurjectivityAt`{.AgdaFunction} `𝒮` `n`, Entry 4 of
+   [FLRP.Assumptions][]): every subgroup in `[D , Sⁿ]` is a partition
+   subgroup.
+
+*Nonabelianness and simplicity of `S` enter only through the third item* —
+they are what makes Entry 4 true classically — so no simplicity predicate is
+needed anywhere in the formal development.  Retiring Entry 4 (issue #522) and
+instantiating `𝒮` at a concrete finite nonabelian simple group such as `A₅`
+(issue #527) are tracked separately; on either completion this module's
+statements strengthen with no change to consumers.
+
+#### What the proof does not assume
+
+The manuscript reduces to unary operations by citing the unary-reduction
+theorem `Con 𝑨 = Con ⟨A , Pol₁ 𝑨⟩` (issue #501, not yet formalized).  The
+formal proof here does **not** take #501 as a hypothesis: the expansion lifts
+only the *basic translations* of `𝑨`{.AgdaBound}, and the translation
+criterion of [FLRP.KurzweilNetter.Translations][] — a self-contained
+Mal'cev-style walk — shows these already determine the congruences.  Issue
+#501 remains open as the full polynomial-clone statement; nothing here waits
+on it.
+
+#### Size
+
+The construction represents `dualLattice 𝑳` on the coset space `Sᵐ/D` of
+`|S|^{m-1}` elements — at least `60^{m-1}` once `𝒮` is instantiated at `A₅` —
+so the census's dual entries (issue #485) become assumption-free in
+*statement* while remaining computationally out of reach: no concrete
+certificate algebra is materialized by this theorem.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.KurzweilNetter.Duality where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Nat.Base    using ( ℕ )
+open import Data.Product     using ( _,_ ; proj₁ )
+open import Level            using ( 0ℓ )
+open import Relation.Binary  using ( Setoid )
+open import Relation.Nullary using ( ¬_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Properties.Lattice          using  ( module Lattice-Order )
+open import Classical.Small.Structures.Lattice    using  ( Lattice )
+open import Classical.Structures.Group.Basic      using  ( Group ; module Group-Op )
+open import Classical.Structures.Lattice.Dual     using  ( dualLattice
+                                                         ; module LatticeDual )
+open import FLRP.Assumptions       using  ( KurzweilNetterDualityAt
+                                          ; KurzweilNetterDuality
+                                          ; KurzweilSurjectivityAt )
+open import FLRP.KurzweilNetter.Blocks        using  ( module KNBlocks )
+open import FLRP.KurzweilNetter.Expansion     using  ( module KNExpansion )
+open import FLRP.KurzweilNetter.Translations  using  ( module KNTranslations )
+open import FLRP.Representable     using  ( Representableᵈ ; ConIsoᵈ ; _⊆ᵈ_ ; _≑ᵈ_
+                                          ; module ConIsoᵈ-Consequences )
+open import Order.Iso              using  ( OrderIso ; OrderIso-trans )
+open import Overture               using  ( Signature )
+open import Setoid.Algebras.Basic  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite             using  ( FiniteAlgebra )
+open import Setoid.Algebras.Finite.Irredundant using  ( IrredundantEnumeration
+                                                      ; irredundantEnumeration )
+open import Setoid.Congruences.Finite.Basic    using  ( DecCon )
+open import Setoid.Signatures.Finite           using  ( FiniteSignature )
+```
+-->
+
+#### The glue module
+
+`KNGlue`{.AgdaModule} assembles the composite over an *abstract* irredundant
+enumeration and an *abstract* surjectivity witness at its size, and glues the
+stages with the generic composition `OrderIso-trans`{.AgdaFunction} of
+[Order.Iso][] rather than by hand.  Both choices are measured type-checking
+requirements, not style: with the concrete
+`irredundantEnumeration`{.AgdaFunction} value substituted throughout, or with
+the composite's round trips elaborated inline, the conversion checker
+re-normalizes the whole construction at each step — profiled at over three
+minutes for this one module — whereas over inert parameters, with the
+composition checked once against abstract relations, the same content checks
+in seconds.  The instantiation happens once, in
+`KurzweilNetterProof`{.AgdaModule} at the bottom.
+
+```agda
+module KNGlue
+  {𝑆 : Signature 0ℓ 0ℓ} {𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ}
+  (𝑺     : FiniteSignature 𝑆)
+  (𝑬ᵢ    : IrredundantEnumeration 𝑨)
+  (𝒮     : Group 0ℓ 0ℓ)
+  (𝑭ₛ    : FiniteAlgebra (proj₁ 𝒮))
+  (s₀    : 𝕌[ proj₁ 𝒮 ])
+  (s₀≉ε  : ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s₀ (Group-Op.ε 𝒮)))
+  (surjm : KurzweilSurjectivityAt 𝒮 (IrredundantEnumeration.icard 𝑬ᵢ))
+  (𝑳 : Lattice) (iso : ConIsoᵈ {𝑆 = 𝑆} 𝑨 𝑳)
+  where
+```
+
+The three stages are instantiated: the irredundant enumeration fixes the
+exponent `m`, the translation toolkit supplies the family the expansion lifts,
+and the expansion module builds the representing algebra `𝑬` on `Sᵐ/D`.
+
+```agda
+  private
+    module KB  = KNBlocks 𝑨 𝑬ᵢ
+    module KT  = KNTranslations 𝑨 𝑺 𝑬ᵢ
+    module KE  = KNExpansion 𝒮 𝑭ₛ s₀ s₀≉ε
+                   (IrredundantEnumeration.icard 𝑬ᵢ) KT.trCount KT.trFamily surjm
+
+    module I₀     = OrderIso iso
+    module KEIso  = OrderIso KE.expansionIso
+
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆} {𝑨 = 𝑨} {𝑳 = 𝑳} iso using ( to-cong≑ )
+
+    open Setoid 𝔻[ proj₁ 𝑳 ] using () renaming ( trans to ≈ᴸ-trans )
+```
+
+The middle stage of the composite: the family-invariant partitions are the
+decidable congruences of `𝑨`{.AgdaBound}, by the translation toolkit — the
+congruence of an invariant partition one way, the invariant partition of a
+congruence the other.
+
+```agda
+    -- an invariant partition presents a congruence of the represented algebra ...
+    midTo : KE.InvPart → DecCon 𝑨 0ℓ
+    midTo (pv , h) = KT.blockConᶠ pv h
+
+    -- ... and a congruence has an invariant partition.
+    midFrom : DecCon 𝑨 0ℓ → KE.InvPart
+    midFrom d = KB.pvOf d , KT.pvOf-invariant-family d
+```
+
+The middle stage as an order isomorphism in its own right: the round trips are
+the two dictionary round trips of [FLRP.KurzweilNetter.Blocks][], with the
+relation of `midTo`{.AgdaFunction} definitionally the block relation of the
+partition, so both directions of each round trip are the prepared lemmas
+applied verbatim.
+
+```agda
+    infix 4 _⊇ᵈ_
+
+    -- reversed congruence containment (the middle stages run dually)
+    _⊇ᵈ_ : DecCon 𝑨 0ℓ → DecCon 𝑨 0ℓ → Type _
+    d ⊇ᵈ e = e ⊆ᵈ d
+
+    midIso : OrderIso KE._≈ᵛ_ KE._≥ᵛ_ (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) _⊇ᵈ_
+    midIso = record
+      { to         = midTo
+      ; from       = midFrom
+      ; to-mono    = λ {P} {Q} ge → KB.blockRel-mono {pu = proj₁ Q} {pw = proj₁ P} ge
+      ; from-mono  = λ {d} {e} sup → KB.pvOf-mono e d sup
+      ; to∘from    = λ d → KB.blockRel-pvOf-out d , KB.blockRel-pvOf-in d
+      ; from∘to    = λ P → KB.pvOf-blockRel (midTo P) (proj₁ P) (λ p → p) (λ p → p)
+      }
+```
+
+The lattice stage, dualized: the maps and round trips of the given
+representation, with the monotonicity directions flipped through the two flip
+lemmas of [Classical.Structures.Lattice.Dual][].
+
+```agda
+    I₀-dual : OrderIso  (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) _⊇ᵈ_
+                        (Setoid._≈_ 𝔻[ proj₁ (dualLattice 𝑳) ])
+                        (Lattice-Order._≤_ (dualLattice 𝑳))
+    I₀-dual = record
+      { to         = I₀.to
+      ; from       = I₀.from
+      ; to-mono    = λ {d} {e} sup →
+          LatticeDual.≤ᵈ-unflip 𝑳 {x = I₀.to d} {y = I₀.to e} (I₀.to-mono {e} {d} sup)
+      ; from-mono  = λ {u} {v} le →
+          I₀.from-mono {v} {u} (LatticeDual.≤ᵈ-flip 𝑳 {x = u} {y = v} le)
+      ; to∘from    = I₀.to∘from
+      ; from∘to    = I₀.from∘to
+      }
+```
+
+The junction data for composing the three stages: transitivity of the mutual
+containments, and the congruence of each map with respect to the middle
+equivalence it crosses — every one of them monotonicity applied twice.
+
+```agda
+    ≑ᴱ-trans : {a b c : DecCon KE.expandedAlgebra 0ℓ} → a ≑ᵈ b → b ≑ᵈ c → a ≑ᵈ c
+    ≑ᴱ-trans (p₁ , p₂) (q₁ , q₂) = (λ r → q₁ (p₁ r)) , (λ r → p₂ (q₂ r))
+
+    ≑ᴬ-trans : {a b c : DecCon 𝑨 0ℓ} → a ≑ᵈ b → b ≑ᵈ c → a ≑ᵈ c
+    ≑ᴬ-trans (p₁ , p₂) (q₁ , q₂) = (λ r → q₁ (p₁ r)) , (λ r → p₂ (q₂ r))
+
+    midTo-cong : {P Q : KE.InvPart} → P KE.≈ᵛ Q → midTo P ≑ᵈ midTo Q
+    midTo-cong {P} {Q} (uw , wu) =
+        KB.blockRel-mono {pu = proj₁ P} {pw = proj₁ Q} uw
+      , KB.blockRel-mono {pu = proj₁ Q} {pw = proj₁ P} wu
+
+    midFrom-cong : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → midFrom d KE.≈ᵛ midFrom e
+    midFrom-cong {d} {e} (p , q) = KB.pvOf-mono d e p , KB.pvOf-mono e d q
+
+    KEfrom-cong : {P Q : KE.InvPart} → P KE.≈ᵛ Q → KEIso.from P ≑ᵈ KEIso.from Q
+    KEfrom-cong {P} {Q} (uw , wu) =
+      KEIso.from-mono {P} {Q} wu , KEIso.from-mono {Q} {P} uw
+
+    stage₁-from-cong : {d e : DecCon 𝑨 0ℓ}
+      → d ≑ᵈ e → KEIso.from (midFrom d) ≑ᵈ KEIso.from (midFrom e)
+    stage₁-from-cong {d} {e} de =
+      KEfrom-cong {midFrom d} {midFrom e} (midFrom-cong {d} {e} de)
+```
+
+The composite isomorphism `DecCon 𝑬 ≅ dualLattice 𝑳`, by two applications of
+`OrderIso-trans`{.AgdaFunction} of [Order.Iso][].  Order reversal happens once,
+inside the expansion isomorphism; the middle stages run against the reversed
+orders, and the boundary lands in the dual lattice's meet order.
+
+```agda
+    stage₁ : OrderIso  (_≑ᵈ_ {𝑨 = KE.expandedAlgebra} {ℓ = 0ℓ})
+                       (_⊆ᵈ_ {𝑨 = KE.expandedAlgebra} {ℓ = 0ℓ})
+                       (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) _⊇ᵈ_
+    stage₁ = OrderIso-trans KE.expansionIso midIso
+      (λ {P} {Q} → midTo-cong {P} {Q})
+      (λ {P} {Q} → KEfrom-cong {P} {Q})
+      (λ {a} {b} {c} → ≑ᴱ-trans {a} {b} {c})
+      (λ {a} {b} {c} → ≑ᴬ-trans {a} {b} {c})
+
+    dualConIso : ConIsoᵈ {𝑆 = KE.Sig-Exp} KE.expandedAlgebra (dualLattice 𝑳)
+    dualConIso = OrderIso-trans stage₁ I₀-dual
+      (λ {d} {e} → to-cong≑ {d} {e})
+      (λ {d} {e} → stage₁-from-cong {d} {e})
+      (λ {a} {b} {c} → ≑ᴱ-trans {a} {b} {c})
+      (λ {x} {y} {z} → ≈ᴸ-trans {x} {y} {z})
+```
+
+The representation of the dual: the expanded coset algebra, its finiteness and
+finite signature from the expansion module, and the composite isomorphism.
+
+```agda
+  -- The dual of a decidably representable lattice is decidably representable.
+  dual-representation : Representableᵈ (dualLattice 𝑳)
+  dual-representation = record
+    { sigᵈ      = KE.Sig-Exp
+    ; algᵈ      = KE.expandedAlgebra
+    ; finiteᵈ   = KE.expandedAlgebra-FiniteAlgebra
+    ; finsigᵈ   = KE.Sig-Exp-FiniteSignature
+    ; con-isoᵈ  = dualConIso
+    }
+```
+
+#### The theorem
+
+`KurzweilNetterProof`{.AgdaModule} fixes the base group with exactly the three
+property witnesses of the deliverable list, and instantiates the glue at the
+canonical irredundant enumeration of each representation.
+
+```agda
+module KurzweilNetterProof
+  (𝒮     : Group 0ℓ 0ℓ)
+  (𝑭ₛ    : FiniteAlgebra (proj₁ 𝒮))
+  (s₀    : 𝕌[ proj₁ 𝒮 ])
+  (s₀≉ε  : ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s₀ (Group-Op.ε 𝒮)))
+  (surj  : (n : ℕ) → KurzweilSurjectivityAt 𝒮 n)
+  where
+
+  -- Kurzweil–Netter duality at a lattice.
+  kurzweilNetterDualityAt : (𝑳 : Lattice) → KurzweilNetterDualityAt 𝑳
+  kurzweilNetterDualityAt 𝑳 r =
+    KNGlue.dual-representation {𝑆 = sigᵈ} {𝑨 = algᵈ} finsigᵈ 𝑬ᵢ
+      𝒮 𝑭ₛ s₀ s₀≉ε (surj (IrredundantEnumeration.icard 𝑬ᵢ)) 𝑳 con-isoᵈ
+    where
+    open Representableᵈ r  -- sigᵈ, algᵈ, finiteᵈ, finsigᵈ, con-isoᵈ
+
+    𝑬ᵢ : IrredundantEnumeration algᵈ
+    𝑬ᵢ = irredundantEnumeration finiteᵈ
+
+  -- The Kurzweil–Netter duality theorem.
+  kurzweilNetterDuality : KurzweilNetterDuality
+  kurzweilNetterDuality 𝑳 = kurzweilNetterDualityAt 𝑳
+```
+
+--------------------------------------

--- a/src/FLRP/KurzweilNetter/Expansion.lagda.md
+++ b/src/FLRP/KurzweilNetter/Expansion.lagda.md
@@ -130,7 +130,11 @@ module KNExpansion
   (surj  : KurzweilInterval.KurzweilSurjectivity 𝒮 m)
   where
 
-  open KurzweilInterval 𝒮 m  -- Sⁿ = Sᵐ, Diag, K, the interval, kurzweilIntervalIso
+  -- Sⁿ = Sᵐ, Diag, K, the interval, kurzweilIntervalIso; the power kit's
+  -- pointwise lemmas are renamed to match this module's ∙ₚ/εₚ/⁻¹ₚ convention.
+  open KurzweilInterval 𝒮 m
+    renaming ( ⊗-pointwise to ∙ₚ-pointwise ; e-pointwise to εₚ-pointwise
+             ; inv-pointwise to ⁻¹ₚ-pointwise )
 
   open Setoid 𝔻[ proj₁ 𝒮 ] using ()
     renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁

--- a/src/FLRP/KurzweilNetter/Expansion.lagda.md
+++ b/src/FLRP/KurzweilNetter/Expansion.lagda.md
@@ -1,0 +1,530 @@
+---
+layout: default
+file: "src/FLRP/KurzweilNetter/Expansion.lagda.md"
+title: "FLRP.KurzweilNetter.Expansion module (The Agda Universal Algebra Library)"
+date: "2026-07-28"
+author: "the agda-algebras development team"
+---
+
+### The expansion step: cutting the coset congruences down to the invariant partitions
+
+This is the [FLRP.KurzweilNetter.Expansion][] module of the [Agda Universal Algebra Library][].
+
+This is the heart of the Kurzweil–Netter construction (issue #502; the
+manuscript's Theorem `thm:duals-interv-subl`).  The transitive `Sᵐ`-set on
+`Sᵐ/D` has decidable congruence poset isomorphic to the interval `[D , Sᵐ]`
+([FLRP.Bridge][]), which is dually isomorphic to the partition lattice `Eq(m)`
+([FLRP.KurzweilInterval][]).  **Expanding** the coset algebra by the lifted
+maps `x ↦ x ∘ t`, one per member `t` of a given family of index maps, cuts the
+congruences down to the partitions *invariant* under the family
+([FLRP.KurzweilNetter.Invariance][]): the main result here is the order
+isomorphism
+
++  `expansionIso : DecCon 𝑬 ≅ (invariant partitions of Eq(m), order reversed)`,
+
+where `𝑬`{.AgdaBound} is the expanded coset algebra.  The family of index maps
+is an *abstract parameter* `tr : Fin T → Fin m → Fin m` — this module knows
+nothing about the algebra being represented; instantiating `tr` at the basic
+translations of [FLRP.KurzweilNetter.Translations][] is the business of
+[FLRP.KurzweilNetter.Duality][].
+
+Three design points, each forced by a constraint worth recording.
+
++  **The signature is an enumerated symbol type, not `Sig-Unary 𝕌[ Sᵐ ]`.**
+   The carrier of the power is a function type `Fin m → S`, and a
+   `FiniteSignature`{.AgdaRecord} requires its symbols to be enumerated up to
+   propositional equality — unprovable for a function type under `--safe`
+   (it is function extensionality).  So the expanded algebra's symbols are
+   `Fin N ⊎ Fin T`{.AgdaDatatype}: `inj₁ ν` acts by left translation by the
+   `ν`-th *enumerated* group element, `inj₂ τ` by composition with `tr τ`.
+   Compatibility with the enumerated actions still forces compatibility with
+   *every* group element, because congruences respect the coset equality and
+   the enumeration is surjective up to the pointwise equality of the power
+   (`forget`{.AgdaFunction} below) — so nothing is lost.
+
++  **The two halves of the invariance transfer have different prices.**  That
+   an invariant partition's subgroup `K_π` is closed under the lifts is one
+   line (`Inv→K-closed`{.AgdaFunction}).  The converse — a congruence of the
+   expanded algebra has an *invariant* partition — needs the indicator-tuple
+   argument of `K-reflects`{.AgdaFunction} of
+   [Classical.Structures.Group.PartitionSubgroup][], and with it the
+   *nontriviality witness* `s₀ ≉ ε` of the base group
+   (`K-closed→Inv`{.AgdaFunction}).  This is one of the few places the base
+   group's properties enter the proof at all.
+
++  **Kurzweil surjectivity enters as the registered hypothesis.**  The passage
+   from an arbitrary congruence to a partition routes through Entry 4 of
+   [FLRP.Assumptions][] (`KurzweilSurjectivity`{.AgdaFunction}, the classical
+   half of Kurzweil's lemma, true for `𝒮` finite nonabelian simple); this
+   module takes it as a module parameter, exactly as
+   `kurzweilIntervalIso`{.AgdaFunction} does.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.KurzweilNetter.Expansion where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Bool.Base      using ( if_then_else_ )
+open import Data.Empty          using ( ⊥-elim )
+open import Data.Fin.Base       using ( Fin ; splitAt ; join )
+open import Data.Fin.Properties using ( all? ; splitAt-join ) renaming ( _≟_ to _≟ᶠ_ )
+open import Data.Nat.Base       using ( ℕ ; _+_ )
+open import Data.Product        using ( Σ-syntax ; _,_ ; proj₁ ; proj₂ )
+open import Data.Sum.Base       using ( _⊎_ ; inj₁ ; inj₂ )
+open import Function            using ( _∘_ )
+open import Level               using ( 0ℓ )
+open import Relation.Binary     using ( Setoid ; IsEquivalence )
+open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl ; sym ; cong )
+open import Relation.Nullary    using ( ¬_ ; Dec ; yes ; no )
+open import Relation.Nullary.Decidable  using ( does ; dec-true ; dec-false
+                                              ; map′ ; _→-dec_ )
+open import Relation.Unary      using ( _∈_ ; _⊆_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Signatures.Finite          using  ( Sig-Unary-FiniteSignature )
+open import Classical.Signatures.Group           using  ( ∙-Op )
+open import Classical.Signatures.Unary           using  ( Sig-Unary )
+open import Classical.Structures.Group.Basic     using  ( Group ; module Group-Op )
+open import Classical.Structures.Group.Cosets    using  ( module Coset )
+open import Classical.Structures.Group.GSet      using  ( module CosetAction )
+open import Classical.Structures.Interpret       using  ( interp-cong )
+open import Classical.Structures.Lattice.Dual    using  ( module LatticeDual )
+open import Classical.Structures.Lattice.Partitions
+  using  ( SameBlock ; _⊑_ ; _≈ᵖ_ ; EqLattice ; ≤→⊑ )
+open import FLRP.Bridge                          using  ( module Bridge )
+open import FLRP.KurzweilInterval                using  ( module KurzweilInterval )
+open import FLRP.KurzweilNetter.Invariance       using  ( Inv )
+open import FLRP.Representable                   using  ( _⊆ᵈ_ ; _≑ᵈ_ )
+open import Order.Iso                            using  ( OrderIso )
+open import Overture                             using  ( Signature )
+open import Setoid.Algebras.Basic                using  ( Algebra ; 𝕌[_] ; 𝔻[_]
+                                                        ; mkAlgebra )
+open import Setoid.Algebras.Finite               using  ( FiniteAlgebra )
+open import Setoid.Algebras.Products.Finite      using  ( power-FiniteAlgebra )
+open import Setoid.Congruences.Basic             using  ( _∣≈_ ; mkcon ; reflexive
+                                                        ; is-equivalence ; is-compatible )
+open import Setoid.Congruences.Certificates.Schema  using  ( ParentVec ; parent )
+open import Setoid.Congruences.Finite.Basic      using  ( DecCon ; ConRel )
+open import Setoid.Signatures.Finite             using  ( FiniteSignature )
+```
+-->
+
+#### The expansion module
+
+`KNExpansion`{.AgdaModule} fixes the base group with its finiteness and
+nontriviality witnesses, the exponent `m`, the abstract family `tr` of index
+maps, and the Kurzweil surjectivity hypothesis at `m`.
+
+```agda
+module KNExpansion
+  (𝒮     : Group 0ℓ 0ℓ)
+  (𝑭ₛ    : FiniteAlgebra (proj₁ 𝒮))
+  (s₀    : 𝕌[ proj₁ 𝒮 ])
+  (s₀≉ε  : ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s₀ (Group-Op.ε 𝒮)))
+  (m T   : ℕ)
+  (tr    : Fin T → Fin m → Fin m)
+  (surj  : KurzweilInterval.KurzweilSurjectivity 𝒮 m)
+  where
+
+  open KurzweilInterval 𝒮 m  -- Sⁿ = Sᵐ, Diag, K, the interval, kurzweilIntervalIso
+
+  open Setoid 𝔻[ proj₁ 𝒮 ] using ()
+    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁
+             ; reflexive to reflexive₁ )
+  open Setoid 𝔻[ proj₁ Sⁿ ] using ()
+    renaming ( _≈_ to _≈ₚ_ ; refl to ≈ₚ-refl )
+  open Group-Op 𝒮  using () renaming ( ε to ε₁ ; _∙_ to _∙₁_ ; _⁻¹ to _⁻¹₁ )
+  open Group-Op Sⁿ using ( ∙-cong )
+    renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+
+  open Coset Sⁿ Diag Diag-isSubgroup        using ( _∼_ ; ≈⇒∼ ; ∼-congˡ ; ∼-dec
+                                                  ; cosetSetoid )
+  open CosetAction Sⁿ Diag Diag-isSubgroup  using ( cosetAlgebra )
+
+  private
+    G : Type 0ℓ
+    G = 𝕌[ proj₁ Sⁿ ]
+```
+
+#### Decidability of the diagonal and of the partition subgroups
+
+Membership in the diagonal and in a partition subgroup is a finite conjunction
+of decidable base-group equalities, so both are decidable — the Layer-D
+presentation data of the interval elements the construction manipulates.
+
+```agda
+  -- The diagonal has decidable membership.
+  Diag-dec : ∀ x → Dec (x ∈ Diag)
+  Diag-dec x = all? (λ i → all? (λ j → 𝑭ₛ ._≟_ (x i) (x j)))
+    where open FiniteAlgebra
+
+  -- Each partition subgroup has decidable membership.
+  K-dec : (pv : ParentVec m) → ∀ x → Dec (x ∈ K pv)
+  K-dec pv x =
+    map′ (λ f {i} {j} → f i j) (λ g i j → g)
+      (all? (λ i → all? (λ j → (parent pv i ≟ᶠ parent pv j) →-dec 𝑭ₛ ._≟_ (x i) (x j))))
+    where open FiniteAlgebra
+```
+
+#### Finiteness of the power
+
+The power `Sᵐ` is a finite algebra by [Setoid.Algebras.Products.Finite][]; its
+enumeration is the symbol set of the expanded signature's group half.
+
+```agda
+  -- The power Sᵐ is a finite algebra.
+  Sᵐ-FiniteAlgebra : FiniteAlgebra (proj₁ Sⁿ)
+  Sᵐ-FiniteAlgebra = power-FiniteAlgebra {n = m} 𝑭ₛ
+
+  private
+    N : ℕ
+    N = FiniteAlgebra.card Sᵐ-FiniteAlgebra
+
+    gEnum : Fin N → G
+    gEnum = FiniteAlgebra.enum Sᵐ-FiniteAlgebra
+
+    gEnum-sur : ∀ (x : G) → Σ[ ν ∈ Fin N ] gEnum ν ≈ₚ x
+    gEnum-sur = FiniteAlgebra.enum-sur Sᵐ-FiniteAlgebra
+```
+
+#### The expanded signature and algebra
+
+The expanded algebra lives on the *same* coset setoid as
+`cosetAlgebra`{.AgdaFunction}; its symbols are the enumerated group elements
+(acting by left translation) together with the family indices (acting by
+composition).  Left translation respects coset equality by
+`∼-congˡ`{.AgdaFunction}; composition respects it because
+`(x ∘ t)⁻¹ ∙ (y ∘ t)` agrees pointwise with `(x⁻¹ ∙ y) ∘ t`, and a tuple
+constant on all coordinates is constant on the coordinates `t` selects.
+
+```agda
+  -- The expanded signature: one unary symbol per enumerated group element and
+  -- per family member.
+  Sig-Exp : Signature 0ℓ 0ℓ
+  Sig-Exp = Sig-Unary (Fin N ⊎ Fin T)
+
+  -- The expanded signature is finite finitary.
+  Sig-Exp-FiniteSignature : FiniteSignature Sig-Exp
+  Sig-Exp-FiniteSignature =
+    Sig-Unary-FiniteSignature (N + T) (splitAt N) (λ s → join N T s , splitAt-join N T s)
+
+  private
+    -- (x ∘ t)⁻¹ ∙ (y ∘ t) agrees pointwise with (x⁻¹ ∙ y) ∘ t.
+    quot-comp : (x y : G) (t : Fin m → Fin m) (i : Fin m)
+      → ((x ∘ t) ⁻¹ₚ ∙ₚ (y ∘ t)) i ≈₁ ((x ⁻¹ₚ ∙ₚ y) ∘ t) i
+    quot-comp x y t i = trans₁ lhs (sym₁ rhs)
+      where
+      -- both sides normalize to this middle form
+      mid : 𝕌[ proj₁ 𝒮 ]
+      mid = (x (t i)) ⁻¹₁ ∙₁ y (t i)
+
+      lhs : ((x ∘ t) ⁻¹ₚ ∙ₚ (y ∘ t)) i ≈₁ mid
+      lhs = trans₁ (∙ₚ-pointwise ((x ∘ t) ⁻¹ₚ) (y ∘ t) i)
+              (interp-cong (proj₁ 𝒮) ∙-Op
+                (λ { Fin.zero → ⁻¹ₚ-pointwise (x ∘ t) i ; (Fin.suc Fin.zero) → refl₁ }))
+
+      rhs : ((x ⁻¹ₚ ∙ₚ y) ∘ t) i ≈₁ mid
+      rhs = trans₁ (∙ₚ-pointwise (x ⁻¹ₚ) y (t i))
+              (interp-cong (proj₁ 𝒮) ∙-Op
+                (λ { Fin.zero → ⁻¹ₚ-pointwise x (t i) ; (Fin.suc Fin.zero) → refl₁ }))
+
+    -- composition with an index map respects coset equality
+    lift-cong : (t : Fin m → Fin m) {x y : G} → x ∼ y → (x ∘ t) ∼ (y ∘ t)
+    lift-cong t {x} {y} x∼y =
+      Diag-respects (λ i → sym₁ (quot-comp x y t i)) (λ i j → x∼y (t i) (t j))
+
+  -- The expanded coset algebra.
+  expandedAlgebra : Algebra {𝑆 = Sig-Exp} 0ℓ 0ℓ
+  expandedAlgebra = mkAlgebra cosetSetoid op op-cong
+    where
+    op : (s : Fin N ⊎ Fin T) → (Fin 1 → G) → G
+    op (inj₁ ν) a = gEnum ν ∙ₚ a Fin.zero
+    op (inj₂ τ) a = a Fin.zero ∘ tr τ
+
+    op-cong : (s : Fin N ⊎ Fin T) {u v : Fin 1 → G}
+      → (∀ i → u i ∼ v i) → op s u ∼ op s v
+    op-cong (inj₁ ν) h = ∼-congˡ (gEnum ν) (h Fin.zero)
+    op-cong (inj₂ τ) h = lift-cong (tr τ) (h Fin.zero)
+
+  -- The expanded algebra is finite: same carrier, same coset equality.
+  expandedAlgebra-FiniteAlgebra : FiniteAlgebra expandedAlgebra
+  expandedAlgebra-FiniteAlgebra = record
+    { _≟_       = ∼-dec Diag-dec
+    ; card      = N
+    ; enum      = gEnum
+    ; enum-sur  = λ x → proj₁ (gEnum-sur x) , ≈⇒∼ (proj₂ (gEnum-sur x))
+    }
+```
+
+#### The invariance transfer
+
+Invariance of a partition and closure of its subgroup under composition are
+interchangeable.  The forward direction is immediate; the converse is the
+indicator-tuple argument, and consumes the nontriviality witness.
+
+```agda
+  -- An invariant partition's subgroup is closed under composition.
+  Inv→K-closed : (t : Fin m → Fin m) (pv : ParentVec m) → Inv t pv
+    → ∀ {z} → z ∈ K pv → (z ∘ t) ∈ K pv
+  Inv→K-closed t pv inv zk sb = zk (inv sb)
+
+  -- Closure of the subgroup under composition forces invariance.
+  K-closed→Inv : (t : Fin m → Fin m) (pv : ParentVec m)
+    → (∀ {z} → z ∈ K pv → (z ∘ t) ∈ K pv) → Inv t pv
+  K-closed→Inv t pv closed {i} {j} sb = decide (parent pv (t i) ≟ᶠ parent pv (t j))
+    where
+    -- the indicator of the pv-block of t i
+    ind : G
+    ind k = if does (parent pv k ≟ᶠ parent pv (t i)) then s₀ else ε₁
+
+    ind∈K : ind ∈ K pv
+    ind∈K sb' =
+      reflexive₁ (cong (λ z → if does (z ≟ᶠ parent pv (t i)) then s₀ else ε₁) sb')
+
+    decide : Dec (SameBlock pv (t i) (t j)) → SameBlock pv (t i) (t j)
+    decide (yes e)   = e
+    decide (no ¬e)   = ⊥-elim (s₀≉ε s₀≈ε)
+      where
+      ind-i : ind (t i) ≡ s₀
+      ind-i = cong (λ b → if b then s₀ else ε₁)
+                   (dec-true (parent pv (t i) ≟ᶠ parent pv (t i)) refl)
+
+      ind-j : ind (t j) ≡ ε₁
+      ind-j = cong (λ b → if b then s₀ else ε₁)
+                   (dec-false (parent pv (t j) ≟ᶠ parent pv (t i)) (λ e → ¬e (sym e)))
+
+      s₀≈ε : s₀ ≈₁ ε₁
+      s₀≈ε = trans₁ (reflexive₁ (sym ind-i))
+                    (trans₁ (closed ind∈K sb) (reflexive₁ ind-j))
+```
+
+#### Forgetting and extending
+
+A congruence of the expanded algebra is in particular a congruence of the coset
+algebra: compatibility with an *arbitrary* group element's action transfers
+from the enumerated actions through surjectivity of the enumeration, one coset
+rewriting on each side.  Conversely a coset congruence whose relation is closed
+under the lifts extends to the expanded algebra.  Both directions keep the
+relation and its decision procedure *definitionally* unchanged — only the
+compatibility proof is rebuilt — which is what lets the round trips below stay
+at the relation level.
+
+```agda
+  -- A congruence of the expanded algebra is a congruence of the coset algebra.
+  forget : DecCon expandedAlgebra 0ℓ → DecCon cosetAlgebra 0ℓ
+  forget ((θ , θcon) , θ?) = (θ , mkcon (reflexive θcon) (is-equivalence θcon) compat) , θ?
+    where
+    θ-refl : ∀ {x y} → x ∼ y → θ x y
+    θ-refl = reflexive θcon
+
+    θ-sym : ∀ {x y} → θ x y → θ y x
+    θ-sym = IsEquivalence.sym (is-equivalence θcon)
+
+    θ-trans : ∀ {x y z} → θ x y → θ y z → θ x z
+    θ-trans = IsEquivalence.trans (is-equivalence θcon)
+
+    compat : cosetAlgebra ∣≈ θ
+    compat g {u} {v} h =
+      θ-trans (θ-sym (step (u Fin.zero)))
+        (θ-trans (is-compatible θcon (inj₁ ν) {u} {v} h) (step (v Fin.zero)))
+      where
+      ν : Fin N
+      ν = proj₁ (gEnum-sur g)
+
+      -- the enumerated action agrees with g's action, coset-wise
+      step : (x : G) → θ (gEnum ν ∙ₚ x) (g ∙ₚ x)
+      step x = θ-refl (≈⇒∼ (∙-cong (proj₂ (gEnum-sur g)) ≈ₚ-refl))
+
+  -- A coset congruence closed under the lifts is a congruence of the expanded
+  -- algebra.
+  extend : (d : DecCon cosetAlgebra 0ℓ)
+    → ((τ : Fin T) → ∀ {x y} → ConRel d x y → ConRel d (x ∘ tr τ) (y ∘ tr τ))
+    → DecCon expandedAlgebra 0ℓ
+  extend ((θ , θcon) , θ?) compτ =
+    (θ , mkcon (reflexive θcon) (is-equivalence θcon) compat) , θ?
+    where
+    compat : expandedAlgebra ∣≈ θ
+    compat (inj₁ ν) {u} {v} h = is-compatible θcon (gEnum ν) {u} {v} h
+    compat (inj₂ τ) {u} {v} h = compτ τ (h Fin.zero)
+```
+
+#### From congruences to invariant partitions and back
+
+The forward passage composes the WP-3 bridge with the surjectivity hypothesis:
+the congruence's base-coset class is an interval element, the hypothesis hands
+over a partition, and closure of the class under the lifts (one compatibility
+instance at `ε`) makes that partition invariant through the indicator argument.
+
+```agda
+  private
+    module B = Bridge Sⁿ Diag Diag-isSubgroup
+
+  -- The interval element of an expanded congruence: its base-coset class.
+  intervalOf : DecCon expandedAlgebra 0ℓ → Interval≈
+  intervalOf θE = B.to (proj₁ (forget θE))
+
+  -- The partition the surjectivity hypothesis attaches to it.
+  partOf : DecCon expandedAlgebra 0ℓ → ParentVec m
+  partOf θE = proj₁ (surj (intervalOf θE))
+
+  private
+    partOf-in : (θE : DecCon expandedAlgebra 0ℓ) → set (intervalOf θE) ⊆ K (partOf θE)
+    partOf-in θE = proj₁ (proj₂ (surj (intervalOf θE)))
+
+    partOf-out : (θE : DecCon expandedAlgebra 0ℓ) → K (partOf θE) ⊆ set (intervalOf θE)
+    partOf-out θE = proj₂ (proj₂ (surj (intervalOf θE)))
+
+    -- the base-coset class is closed under the lifts
+    classClosed : (θE : DecCon expandedAlgebra 0ℓ) (τ : Fin T)
+      → ∀ {g} → g ∈ set (intervalOf θE) → (g ∘ tr τ) ∈ set (intervalOf θE)
+    classClosed ((θ , θcon) , θ?) τ {g} εθg =
+      θ-trans (θ-refl (≈⇒∼ ε∘t≈ε)) (is-compatible θcon (inj₂ τ) {λ _ → εₚ} {λ _ → g} (λ _ → εθg))
+      where
+      θ-refl : ∀ {x y} → x ∼ y → θ x y
+      θ-refl = reflexive θcon
+
+      θ-trans : ∀ {x y z} → θ x y → θ y z → θ x z
+      θ-trans = IsEquivalence.trans (is-equivalence θcon)
+
+      -- the identity tuple is fixed by the lift, up to pointwise equality
+      ε∘t≈ε : εₚ ≈ₚ (εₚ ∘ tr τ)
+      ε∘t≈ε i = trans₁ (εₚ-pointwise i) (sym₁ (εₚ-pointwise (tr τ i)))
+
+  -- The partition of an expanded congruence is invariant under the family.
+  partOf-invariant : (θE : DecCon expandedAlgebra 0ℓ) (τ : Fin T)
+    → Inv (tr τ) (partOf θE)
+  partOf-invariant θE τ = K-closed→Inv (tr τ) (partOf θE) closed
+    where
+    closed : ∀ {z} → z ∈ K (partOf θE) → (z ∘ tr τ) ∈ K (partOf θE)
+    closed zk = partOf-in θE (classClosed θE τ (partOf-out θE zk))
+```
+
+The backward passage is the bridge's inverse at the partition subgroup — whose
+membership is decidable (`K-dec`{.AgdaFunction}) — extended by the lifts, the
+lift-compatibility supplied by the easy half of the invariance transfer.
+
+```agda
+  private
+    -- the coset relation of an invariant partition is closed under the lifts
+    θK-comp : (pv : ParentVec m) → ((τ : Fin T) → Inv (tr τ) pv) → (τ : Fin T)
+      → ∀ {x y} → ConRel (B.fromᵈ (toInterval pv , K-dec pv)) x y
+      → ConRel (B.fromᵈ (toInterval pv , K-dec pv)) (x ∘ tr τ) (y ∘ tr τ)
+    θK-comp pv invτ τ {x} {y} mem =
+      K-respects pv (λ i → sym₁ (quot-comp x y (tr τ) i))
+        (Inv→K-closed (tr τ) pv (invτ τ) mem)
+```
+
+#### The invariant-partition poset and the expansion isomorphism
+
+The right-hand side of the expansion isomorphism: partitions invariant under
+the whole family, compared by the kernel equality and the *reversed*
+refinement of their underlying partitions — reversed because a larger
+congruence has a larger subgroup, hence a *finer* partition.
+
+```agda
+  -- A partition invariant under the whole family.
+  InvPart : Type 0ℓ
+  InvPart = Σ[ pv ∈ ParentVec m ] ((τ : Fin T) → Inv (tr τ) pv)
+
+  infix 4 _≈ᵛ_ _≥ᵛ_
+
+  -- Kernel equality of the underlying partitions.
+  _≈ᵛ_ : InvPart → InvPart → Type 0ℓ
+  P ≈ᵛ Q = proj₁ P ≈ᵖ proj₁ Q
+
+  -- The reversed refinement order.
+  _≥ᵛ_ : InvPart → InvPart → Type 0ℓ
+  P ≥ᵛ Q = proj₁ Q ⊑ proj₁ P
+```
+
+The two maps of the isomorphism.
+
+```agda
+  -- A congruence of the expanded algebra yields an invariant partition ...
+  toInvPart : DecCon expandedAlgebra 0ℓ → InvPart
+  toInvPart θE = partOf θE , partOf-invariant θE
+
+  -- ... and an invariant partition yields a congruence of the expanded algebra.
+  fromInvPart : InvPart → DecCon expandedAlgebra 0ℓ
+  fromInvPart (pv , invτ) = extend (B.fromᵈ (toInterval pv , K-dec pv)) (θK-comp pv invτ)
+```
+
+Monotonicity.  Forward: a containment of congruences passes through the bridge
+to an inclusion of interval elements, through the interval isomorphism of
+[FLRP.KurzweilInterval][] to the dual lattice order, and unflips to reversed
+refinement.  Backward: reversed refinement is an inclusion of partition
+subgroups (`K-antitone`{.AgdaFunction}), which the bridge's inverse forwards.
+
+```agda
+  private
+    KI = kurzweilIntervalIso s₀ s₀≉ε surj
+
+  toInvPart-mono : (θE φE : DecCon expandedAlgebra 0ℓ)
+    → (∀ {x y} → ConRel θE x y → ConRel φE x y) → toInvPart θE ≥ᵛ toInvPart φE
+  toInvPart-mono θE φE sub =
+    ≤→⊑ {pu = partOf φE} {pw = partOf θE}
+      (LatticeDual.≤ᵈ-flip (EqLattice m) {x = partOf θE} {y = partOf φE}
+        (OrderIso.to-mono KI {intervalOf θE} {intervalOf φE}
+          (B.to-mono {proj₁ (forget θE)} {proj₁ (forget φE)} sub)))
+
+  fromInvPart-mono : (P Q : InvPart) → P ≥ᵛ Q
+    → ∀ {x y} → ConRel (fromInvPart P) x y → ConRel (fromInvPart Q) x y
+  fromInvPart-mono (pu , _) (pw , _) w⊑u =
+    B.from-mono {toInterval pu} {toInterval pw} (K-antitone {pu = pw} {pw = pu} w⊑u)
+```
+
+The round trips.  On congruences: the relation of the back-and-forth is the
+coset relation of `K_{partOf θE}`, which the surjectivity certificates identify
+with the base-coset class, and the bridge's round trip identifies with the
+original relation.  On partitions: the interval element of the back-and-forth
+has the *same* base-coset class as the bridge's image of the partition
+subgroup (forgetting and extending leave the relation untouched), so the
+bridge's other round trip and injectivity of `K` close the loop.
+
+```agda
+  fromInvPart-toInvPart : (θE : DecCon expandedAlgebra 0ℓ)
+    → fromInvPart (toInvPart θE) ≑ᵈ θE
+  fromInvPart-toInvPart θE = fwd , bwd
+    where
+    conF = proj₁ (forget θE)
+
+    fwd : ∀ {x y} → ConRel (fromInvPart (toInvPart θE)) x y → ConRel θE x y
+    fwd p = B.from∘to conF .proj₁ (partOf-out θE p)
+
+    bwd : ∀ {x y} → ConRel θE x y → ConRel (fromInvPart (toInvPart θE)) x y
+    bwd p = partOf-in θE (B.from∘to conF .proj₂ p)
+
+  toInvPart-fromInvPart : (P : InvPart) → toInvPart (fromInvPart P) ≈ᵛ P
+  toInvPart-fromInvPart (pv , invτ) =
+    K-injective s₀ s₀≉ε {pu = partOf θP} {pw = pv} Kpv⊆KP KP⊆Kpv
+    where
+    θP = fromInvPart (pv , invτ)
+
+    -- the base-coset class of the round trip is the bridge image of K pv,
+    -- definitionally (extend and forget keep the relation)
+    KP⊆Kpv : K (partOf θP) ⊆ K pv
+    KP⊆Kpv q = B.to∘from (toInterval pv) .proj₁ (partOf-out θP q)
+
+    Kpv⊆KP : K pv ⊆ K (partOf θP)
+    Kpv⊆KP q = partOf-in θP (B.to∘from (toInterval pv) .proj₂ q)
+
+  -- The expansion isomorphism: congruences of the expanded coset algebra
+  -- correspond to the family-invariant partitions, order reversed.
+  expansionIso : OrderIso  (_≑ᵈ_ {𝑨 = expandedAlgebra} {ℓ = 0ℓ})
+                           (_⊆ᵈ_ {𝑨 = expandedAlgebra} {ℓ = 0ℓ})
+                           _≈ᵛ_ _≥ᵛ_
+  expansionIso = record
+    { to         = toInvPart
+    ; from       = fromInvPart
+    ; to-mono    = λ {θE} {φE} → toInvPart-mono θE φE
+    ; from-mono  = λ {P} {Q} → fromInvPart-mono P Q
+    ; to∘from    = toInvPart-fromInvPart
+    ; from∘to    = fromInvPart-toInvPart
+    }
+```
+
+--------------------------------------

--- a/src/FLRP/KurzweilNetter/Expansion.lagda.md
+++ b/src/FLRP/KurzweilNetter/Expansion.lagda.md
@@ -10,54 +10,57 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.KurzweilNetter.Expansion][] module of the [Agda Universal Algebra Library][].
 
-This is the heart of the Kurzweil–Netter construction (issue #502; the
-manuscript's Theorem `thm:duals-interv-subl`).  The transitive `Sᵐ`-set on
-`Sᵐ/D` has decidable congruence poset isomorphic to the interval `[D , Sᵐ]`
+This is the heart of the Kurzweil–Netter construction.  The transitive `Sᵐ`-set on
+`Sᵐ / D` has (decidable) congruence lattice isomorphic to the interval `[D , Sᵐ]`
 ([FLRP.Bridge][]), which is dually isomorphic to the partition lattice `Eq(m)`
-([FLRP.KurzweilInterval][]).  **Expanding** the coset algebra by the lifted
-maps `x ↦ x ∘ t`, one per member `t` of a given family of index maps, cuts the
-congruences down to the partitions *invariant* under the family
-([FLRP.KurzweilNetter.Invariance][]): the main result here is the order
-isomorphism
+([FLRP.KurzweilInterval][]).
 
-+  `expansionIso : DecCon 𝑬 ≅ (invariant partitions of Eq(m), order reversed)`,
+**Expanding** the coset algebra by the lifted maps `x ↦ x ∘ t`, one per member `t`
+of a given family of index maps, cuts the congruences down to the partitions
+*invariant* under the family ([FLRP.KurzweilNetter.Invariance][]): the main result
+here is the order isomorphism
 
-where `𝑬`{.AgdaBound} is the expanded coset algebra.  The family of index maps
-is an *abstract parameter* `tr : Fin T → Fin m → Fin m` — this module knows
-nothing about the algebra being represented; instantiating `tr` at the basic
-translations of [FLRP.KurzweilNetter.Translations][] is the business of
-[FLRP.KurzweilNetter.Duality][].
+`expansionIso : DecCon 𝑬 ≅ `(invariant partitions of `Eq(m)`, order reversed),
+
+where `𝑬`{.AgdaBound} is the expanded coset algebra.
+
+The family of index maps is an *abstract parameter* `tr : Fin T → Fin m → Fin m`;
+this module knows nothing about the algebra being represented; instantiating `tr`
+at the basic translations of [FLRP.KurzweilNetter.Translations][] is the business
+of [FLRP.KurzweilNetter.Duality][].
 
 Three design points, each forced by a constraint worth recording.
 
-+  **The signature is an enumerated symbol type, not `Sig-Unary 𝕌[ Sᵐ ]`.**
++  **The signature is an enumerated symbol type, not `Sig-Unary 𝕌[ Sᵐ ]`**.
    The carrier of the power is a function type `Fin m → S`, and a
    `FiniteSignature`{.AgdaRecord} requires its symbols to be enumerated up to
-   propositional equality — unprovable for a function type under `--safe`
+   propositional equality, unprovable for a function type under  `--safe`
    (it is function extensionality).  So the expanded algebra's symbols are
-   `Fin N ⊎ Fin T`{.AgdaDatatype}: `inj₁ ν` acts by left translation by the
-   `ν`-th *enumerated* group element, `inj₂ τ` by composition with `tr τ`.
-   Compatibility with the enumerated actions still forces compatibility with
-   *every* group element, because congruences respect the coset equality and
-   the enumeration is surjective up to the pointwise equality of the power
-   (`forget`{.AgdaFunction} below) — so nothing is lost.
+   `Fin N ⊎ Fin T`{.AgdaDatatype}: `inj₁ ν` acts by left translation by the `ν`-th
+   *enumerated* group element, `inj₂ τ` by composition with `tr τ`.  Compatibility
+   with the enumerated actions still forces compatibility with *every* group
+   element, because congruences respect the coset equality and the enumeration is
+   surjective up to the pointwise equality of the power (`forget`{.AgdaFunction}
+   below), so nothing is lost.
 
-+  **The two halves of the invariance transfer have different prices.**  That
-   an invariant partition's subgroup `K_π` is closed under the lifts is one
-   line (`Inv→K-closed`{.AgdaFunction}).  The converse — a congruence of the
-   expanded algebra has an *invariant* partition — needs the indicator-tuple
-   argument of `K-reflects`{.AgdaFunction} of
++  **The two halves of the invariance transfer have different prices**.
+
+   That an invariant partition's subgroup `K_π` is closed under the lifts is one
+   line (`Inv→K-closed`{.AgdaFunction}).  The converse asserts that a congruence
+   of the expanded algebra has an *invariant* partition; this needs the
+   indicator-tuple argument of `K-reflects`{.AgdaFunction} of
    [Classical.Structures.Group.PartitionSubgroup][], and with it the
    *nontriviality witness* `s₀ ≉ ε` of the base group
    (`K-closed→Inv`{.AgdaFunction}).  This is one of the few places the base
    group's properties enter the proof at all.
 
-+  **Kurzweil surjectivity enters as the registered hypothesis.**  The passage
-   from an arbitrary congruence to a partition routes through Entry 4 of
-   [FLRP.Assumptions][] (`KurzweilSurjectivity`{.AgdaFunction}, the classical
-   half of Kurzweil's lemma, true for `𝒮` finite nonabelian simple); this
-   module takes it as a module parameter, exactly as
-   `kurzweilIntervalIso`{.AgdaFunction} does.
++  **Kurzweil surjectivity enters as the registered hypothesis**.
+
+   The passage from an arbitrary congruence to a partition routes through Entry 4
+   of [FLRP.Assumptions][] (`KurzweilSurjectivity`{.AgdaFunction}, the classical
+   half of Kurzweil's lemma, true for `𝒮` finite nonabelian simple); this module
+   takes it as a module parameter, exactly as `kurzweilIntervalIso`{.AgdaFunction}
+   does.
 
 <!--
 ```agda
@@ -68,97 +71,97 @@ module FLRP.KurzweilNetter.Expansion where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
-open import Data.Bool.Base      using ( if_then_else_ )
-open import Data.Empty          using ( ⊥-elim )
-open import Data.Fin.Base       using ( Fin ; splitAt ; join )
-open import Data.Fin.Properties using ( all? ; splitAt-join ) renaming ( _≟_ to _≟ᶠ_ )
-open import Data.Nat.Base       using ( ℕ ; _+_ )
-open import Data.Product        using ( Σ-syntax ; _,_ ; proj₁ ; proj₂ )
-open import Data.Sum.Base       using ( _⊎_ ; inj₁ ; inj₂ )
-open import Function            using ( _∘_ )
-open import Level               using ( 0ℓ )
-open import Relation.Binary     using ( Setoid ; IsEquivalence )
-open import Relation.Binary.PropositionalEquality  using ( _≡_ ; refl ; sym ; cong )
-open import Relation.Nullary    using ( ¬_ ; Dec ; yes ; no )
-open import Relation.Nullary.Decidable  using ( does ; dec-true ; dec-false
-                                              ; map′ ; _→-dec_ )
-open import Relation.Unary      using ( _∈_ ; _⊆_ )
+open import Data.Bool.Base                         using  ( if_then_else_ )
+open import Data.Empty                             using  ( ⊥-elim )
+open import Data.Fin.Base                          using  ( Fin ; splitAt ; join )
+open import Data.Fin.Properties                    using  ( all? ; splitAt-join )
+                                                   renaming ( _≟_ to _≟ᶠ_ )
+open import Data.Nat.Base                          using  ( ℕ ; _+_ )
+open import Data.Product                           using  ( Σ-syntax ; _,_
+                                                          ; proj₁ ; proj₂ )
+open import Data.Sum.Base                          using  ( _⊎_ ; inj₁ ; inj₂ )
+open import Function                               using  ( _∘_ )
+open import Level                                  using  ( 0ℓ )
+open import Relation.Binary                        using  ( Setoid ; IsEquivalence )
+open import Relation.Binary.PropositionalEquality as ≡ using  ( _≡_ ; cong )
+open import Relation.Nullary                       using  ( ¬_ ; Dec ; yes ; no )
+open import Relation.Nullary.Decidable             using  ( does ; dec-true ; dec-false
+                                                          ; map′ ; _→-dec_ )
+open import Relation.Unary                         using  ( _∈_ ; _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Signatures.Finite          using  ( Sig-Unary-FiniteSignature )
-open import Classical.Signatures.Group           using  ( ∙-Op )
-open import Classical.Signatures.Unary           using  ( Sig-Unary )
-open import Classical.Structures.Group.Basic     using  ( Group ; module Group-Op )
-open import Classical.Structures.Group.Cosets    using  ( module Coset )
-open import Classical.Structures.Group.GSet      using  ( module CosetAction )
-open import Classical.Structures.Interpret       using  ( interp-cong )
-open import Classical.Structures.Lattice.Dual    using  ( module LatticeDual )
-open import Classical.Structures.Lattice.Partitions
-  using  ( SameBlock ; _⊑_ ; _≈ᵖ_ ; EqLattice ; ≤→⊑ )
-open import FLRP.Bridge                          using  ( module Bridge )
-open import FLRP.KurzweilInterval                using  ( module KurzweilInterval )
-open import FLRP.KurzweilNetter.Invariance       using  ( Inv )
-open import FLRP.Representable                   using  ( _⊆ᵈ_ ; _≑ᵈ_ )
-open import Order.Iso                            using  ( OrderIso )
-open import Overture                             using  ( Signature )
-open import Setoid.Algebras.Basic                using  ( Algebra ; 𝕌[_] ; 𝔻[_]
-                                                        ; mkAlgebra )
-open import Setoid.Algebras.Finite               using  ( FiniteAlgebra )
-open import Setoid.Algebras.Products.Finite      using  ( power-FiniteAlgebra )
-open import Setoid.Congruences.Basic             using  ( _∣≈_ ; mkcon ; reflexive
-                                                        ; is-equivalence ; is-compatible )
-open import Setoid.Congruences.Certificates.Schema  using  ( ParentVec ; parent )
-open import Setoid.Congruences.Finite.Basic      using  ( DecCon ; ConRel )
-open import Setoid.Signatures.Finite             using  ( FiniteSignature )
+open import Classical.Signatures.Finite              using  ( Sig-Unary-FiniteSignature )
+open import Classical.Signatures.Group               using  ( ∙-Op )
+open import Classical.Signatures.Unary               using  ( Sig-Unary )
+open import Classical.Structures.Group.Basic         using  ( Group ; module Group-Op )
+open import Classical.Structures.Group.Cosets        using  ( module Coset )
+open import Classical.Structures.Group.GSet          using  ( module CosetAction )
+open import Classical.Structures.Interpret           using  ( interp-cong )
+open import Classical.Structures.Lattice.Dual        using  ( module LatticeDual )
+open import Classical.Structures.Lattice.Partitions  using  ( SameBlock ; _⊑_ ; _≈ᵖ_
+                                                            ; EqLattice ; ≤→⊑ )
+open import FLRP.Bridge                              using  ( module Bridge )
+open import FLRP.KurzweilInterval                    using  ( module KurzweilInterval )
+open import FLRP.KurzweilNetter.Invariance           using  ( Inv )
+open import FLRP.Representable                       using  ( _⊆ᵈ_ ; _≑ᵈ_ )
+open import Order.Iso                                using  ( OrderIso )
+open import Overture                                 using  ( Signature )
+open import Setoid.Algebras.Basic                    using  ( Algebra ; 𝕌[_] ; 𝔻[_]
+                                                            ; mkAlgebra )
+open import Setoid.Algebras.Finite                   using  ( FiniteAlgebra )
+open import Setoid.Algebras.Products.Finite          using  ( power-FiniteAlgebra )
+open import Setoid.Congruences.Basic                 using  ( _∣≈_ ; is-equivalence
+                                                            ; mkcon ; is-compatible )
+                                                     renaming (reflexive to con-reflexive)
+open import Setoid.Congruences.Certificates.Schema   using  ( ParentVec ; parent )
+open import Setoid.Congruences.Finite.Basic          using  ( DecCon ; ConRel )
+open import Setoid.Signatures.Finite                 using  ( FiniteSignature )
 ```
 -->
 
 #### The expansion module
 
 `KNExpansion`{.AgdaModule} fixes the base group with its finiteness and
-nontriviality witnesses, the exponent `m`, the abstract family `tr` of index
-maps, and the Kurzweil surjectivity hypothesis at `m`.
+nontriviality witnesses, the exponent `m`, the abstract family `tr` of index maps,
+and the Kurzweil surjectivity hypothesis at `m`.
 
 ```agda
 module KNExpansion
-  (𝒮     : Group 0ℓ 0ℓ)
-  (𝑭ₛ    : FiniteAlgebra (proj₁ 𝒮))
-  (s₀    : 𝕌[ proj₁ 𝒮 ])
-  (s₀≉ε  : ¬ (Setoid._≈_ 𝔻[ proj₁ 𝒮 ] s₀ (Group-Op.ε 𝒮)))
-  (m T   : ℕ)
-  (tr    : Fin T → Fin m → Fin m)
-  (surj  : KurzweilInterval.KurzweilSurjectivity 𝒮 m)
+  (𝒮@(𝑺 , _)  : Group 0ℓ 0ℓ)  (open Setoid 𝔻[ 𝑺 ] using (_≈_))
+                               (open Group-Op 𝒮 using (ε))
+  (𝑭ₛ         : FiniteAlgebra 𝑺)
+  (s₀         : 𝕌[ 𝑺 ])
+  (s₀≉ε       : ¬ s₀ ≈ ε)
+  (m T        : ℕ)
+  (tr         : Fin T → Fin m → Fin m)
+  (surj       : KurzweilInterval.KurzweilSurjectivity 𝒮 m)
   where
 
   -- Sⁿ = Sᵐ, Diag, K, the interval, kurzweilIntervalIso; the power kit's
   -- pointwise lemmas are renamed to match this module's ∙ₚ/εₚ/⁻¹ₚ convention.
-  open KurzweilInterval 𝒮 m
-    renaming ( ⊗-pointwise to ∙ₚ-pointwise ; e-pointwise to εₚ-pointwise
-             ; inv-pointwise to ⁻¹ₚ-pointwise )
+  open KurzweilInterval 𝒮 m renaming  ( ⊗-pointwise    to ∙ₚ-pointwise
+                                       ; e-pointwise    to εₚ-pointwise
+                                       ; inv-pointwise  to ⁻¹ₚ-pointwise )
 
-  open Setoid 𝔻[ proj₁ 𝒮 ] using ()
-    renaming ( _≈_ to _≈₁_ ; refl to refl₁ ; sym to sym₁ ; trans to trans₁
-             ; reflexive to reflexive₁ )
-  open Setoid 𝔻[ proj₁ Sⁿ ] using ()
-    renaming ( _≈_ to _≈ₚ_ ; refl to ≈ₚ-refl )
-  open Group-Op 𝒮  using () renaming ( ε to ε₁ ; _∙_ to _∙₁_ ; _⁻¹ to _⁻¹₁ )
-  open Group-Op Sⁿ using ( ∙-cong )
-    renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+  open Setoid 𝔻[ 𝑺 ] using ( refl ; sym ; trans ; reflexive)
 
-  open Coset Sⁿ Diag Diag-isSubgroup        using ( _∼_ ; ≈⇒∼ ; ∼-congˡ ; ∼-dec
-                                                  ; cosetSetoid )
-  open CosetAction Sⁿ Diag Diag-isSubgroup  using ( cosetAlgebra )
+  open Setoid 𝔻[ Sⁿ ] using () renaming ( _≈_ to _≈ₚ_ ; refl to ≈ₚ-refl )
+  open Group-Op 𝒮  using ( _∙_ ; _⁻¹ )
+  open Group-Op 𝑺ⁿ using ( ∙-cong ) renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+
+  open Coset 𝑺ⁿ Diag Diag-isSubgroup using ( _∼_ ; ≈⇒∼ ; ∼-congˡ ; ∼-dec ; cosetSetoid )
+  open CosetAction 𝑺ⁿ Diag Diag-isSubgroup using ( cosetAlgebra )
 
   private
     G : Type 0ℓ
-    G = 𝕌[ proj₁ Sⁿ ]
+    G = 𝕌[ Sⁿ ]
 ```
 
 #### Decidability of the diagonal and of the partition subgroups
 
 Membership in the diagonal and in a partition subgroup is a finite conjunction
-of decidable base-group equalities, so both are decidable — the Layer-D
-presentation data of the interval elements the construction manipulates.
+of decidable base-group equalities, so both are decidable (the Layer-D
+presentation data of the interval elements the construction manipulates).
 
 ```agda
   -- The diagonal has decidable membership.
@@ -181,7 +184,7 @@ enumeration is the symbol set of the expanded signature's group half.
 
 ```agda
   -- The power Sᵐ is a finite algebra.
-  Sᵐ-FiniteAlgebra : FiniteAlgebra (proj₁ Sⁿ)
+  Sᵐ-FiniteAlgebra : FiniteAlgebra Sⁿ
   Sᵐ-FiniteAlgebra = power-FiniteAlgebra {n = m} 𝑭ₛ
 
   private
@@ -197,13 +200,13 @@ enumeration is the symbol set of the expanded signature's group half.
 
 #### The expanded signature and algebra
 
-The expanded algebra lives on the *same* coset setoid as
+The expanded algebra lives on the same coset setoid as
 `cosetAlgebra`{.AgdaFunction}; its symbols are the enumerated group elements
 (acting by left translation) together with the family indices (acting by
 composition).  Left translation respects coset equality by
-`∼-congˡ`{.AgdaFunction}; composition respects it because
-`(x ∘ t)⁻¹ ∙ (y ∘ t)` agrees pointwise with `(x⁻¹ ∙ y) ∘ t`, and a tuple
-constant on all coordinates is constant on the coordinates `t` selects.
+`∼-congˡ`{.AgdaFunction}; composition respects it because `(x ∘ t)⁻¹ ∙ (y ∘ t)`
+agrees pointwise with `(x⁻¹ ∙ y) ∘ t`, and a tuple constant on all coordinates is
+constant on the coordinates `t` selects.
 
 ```agda
   -- The expanded signature: one unary symbol per enumerated group element and
@@ -219,27 +222,27 @@ constant on all coordinates is constant on the coordinates `t` selects.
   private
     -- (x ∘ t)⁻¹ ∙ (y ∘ t) agrees pointwise with (x⁻¹ ∙ y) ∘ t.
     quot-comp : (x y : G) (t : Fin m → Fin m) (i : Fin m)
-      → ((x ∘ t) ⁻¹ₚ ∙ₚ (y ∘ t)) i ≈₁ ((x ⁻¹ₚ ∙ₚ y) ∘ t) i
-    quot-comp x y t i = trans₁ lhs (sym₁ rhs)
+      → ((x ∘ t ⁻¹ₚ) ∙ₚ (y ∘ t)) i ≈ ((x ⁻¹ₚ ∙ₚ y) ∘ t) i
+    quot-comp x y t i = trans lhs (sym rhs)
       where
       -- both sides normalize to this middle form
-      mid : 𝕌[ proj₁ 𝒮 ]
-      mid = (x (t i)) ⁻¹₁ ∙₁ y (t i)
+      mid : 𝕌[ 𝑺 ]
+      mid = (x (t i)) ⁻¹ ∙ y (t i)
 
-      lhs : ((x ∘ t) ⁻¹ₚ ∙ₚ (y ∘ t)) i ≈₁ mid
-      lhs = trans₁ (∙ₚ-pointwise ((x ∘ t) ⁻¹ₚ) (y ∘ t) i)
-              (interp-cong (proj₁ 𝒮) ∙-Op
-                (λ { Fin.zero → ⁻¹ₚ-pointwise (x ∘ t) i ; (Fin.suc Fin.zero) → refl₁ }))
+      lhs : ((x ∘ t) ⁻¹ₚ ∙ₚ (y ∘ t)) i ≈ mid
+      lhs = trans (∙ₚ-pointwise ((x ∘ t) ⁻¹ₚ) (y ∘ t) i)
+              (interp-cong 𝑺 ∙-Op
+                (λ { Fin.zero → ⁻¹ₚ-pointwise (x ∘ t) i ; (Fin.suc Fin.zero) → refl }))
 
-      rhs : ((x ⁻¹ₚ ∙ₚ y) ∘ t) i ≈₁ mid
-      rhs = trans₁ (∙ₚ-pointwise (x ⁻¹ₚ) y (t i))
-              (interp-cong (proj₁ 𝒮) ∙-Op
-                (λ { Fin.zero → ⁻¹ₚ-pointwise x (t i) ; (Fin.suc Fin.zero) → refl₁ }))
+      rhs : ((x ⁻¹ₚ ∙ₚ y) ∘ t) i ≈ mid
+      rhs = trans (∙ₚ-pointwise (x ⁻¹ₚ) y (t i))
+              (interp-cong 𝑺 ∙-Op
+                (λ { Fin.zero → ⁻¹ₚ-pointwise x (t i) ; (Fin.suc Fin.zero) → refl }))
 
     -- composition with an index map respects coset equality
     lift-cong : (t : Fin m → Fin m) {x y : G} → x ∼ y → (x ∘ t) ∼ (y ∘ t)
     lift-cong t {x} {y} x∼y =
-      Diag-respects (λ i → sym₁ (quot-comp x y t i)) (λ i j → x∼y (t i) (t j))
+      Diag-respects (λ i → sym (quot-comp x y t i)) (λ i j → x∼y (t i) (t j))
 
   -- The expanded coset algebra.
   expandedAlgebra : Algebra {𝑆 = Sig-Exp} 0ℓ 0ℓ
@@ -260,7 +263,7 @@ constant on all coordinates is constant on the coordinates `t` selects.
     { _≟_       = ∼-dec Diag-dec
     ; card      = N
     ; enum      = gEnum
-    ; enum-sur  = λ x → proj₁ (gEnum-sur x) , ≈⇒∼ (proj₂ (gEnum-sur x))
+    ; enum-sur  = λ x → proj₁ (gEnum-sur x) , ≈⇒∼ (gEnum-sur x .proj₂)
     }
 ```
 
@@ -283,47 +286,47 @@ indicator-tuple argument, and consumes the nontriviality witness.
     where
     -- the indicator of the pv-block of t i
     ind : G
-    ind k = if does (parent pv k ≟ᶠ parent pv (t i)) then s₀ else ε₁
+    ind k = if does (parent pv k ≟ᶠ parent pv (t i)) then s₀ else ε
 
     ind∈K : ind ∈ K pv
     ind∈K sb' =
-      reflexive₁ (cong (λ z → if does (z ≟ᶠ parent pv (t i)) then s₀ else ε₁) sb')
+      reflexive (≡.cong (λ z → if does (z ≟ᶠ parent pv (t i)) then s₀ else ε) sb')
 
     decide : Dec (SameBlock pv (t i) (t j)) → SameBlock pv (t i) (t j)
     decide (yes e)   = e
     decide (no ¬e)   = ⊥-elim (s₀≉ε s₀≈ε)
       where
       ind-i : ind (t i) ≡ s₀
-      ind-i = cong (λ b → if b then s₀ else ε₁)
-                   (dec-true (parent pv (t i) ≟ᶠ parent pv (t i)) refl)
+      ind-i = cong (λ b → if b then s₀ else ε)
+                   (dec-true (parent pv (t i) ≟ᶠ parent pv (t i)) ≡.refl)
 
-      ind-j : ind (t j) ≡ ε₁
-      ind-j = cong (λ b → if b then s₀ else ε₁)
-                   (dec-false (parent pv (t j) ≟ᶠ parent pv (t i)) (λ e → ¬e (sym e)))
+      ind-j : ind (t j) ≡ ε
+      ind-j = cong (λ b → if b then s₀ else ε)
+                   (dec-false (parent pv (t j) ≟ᶠ parent pv (t i)) (λ e → ¬e (≡.sym e)))
 
-      s₀≈ε : s₀ ≈₁ ε₁
-      s₀≈ε = trans₁ (reflexive₁ (sym ind-i))
-                    (trans₁ (closed ind∈K sb) (reflexive₁ ind-j))
+      s₀≈ε : s₀ ≈ ε
+      s₀≈ε = trans (reflexive (≡.sym ind-i))
+                    (trans (closed ind∈K sb) (reflexive ind-j))
 ```
 
 #### Forgetting and extending
 
 A congruence of the expanded algebra is in particular a congruence of the coset
-algebra: compatibility with an *arbitrary* group element's action transfers
-from the enumerated actions through surjectivity of the enumeration, one coset
+algebra.  Compatibility with an *arbitrary* group element's action transfers from
+the enumerated actions through surjectivity of the enumeration, one coset
 rewriting on each side.  Conversely a coset congruence whose relation is closed
 under the lifts extends to the expanded algebra.  Both directions keep the
-relation and its decision procedure *definitionally* unchanged — only the
-compatibility proof is rebuilt — which is what lets the round trips below stay
-at the relation level.
+relation and its decision procedure definitionally unchanged; only the
+compatibility proof is rebuilt, which is what lets the round trips below stay at
+the relation level.
 
 ```agda
   -- A congruence of the expanded algebra is a congruence of the coset algebra.
   forget : DecCon expandedAlgebra 0ℓ → DecCon cosetAlgebra 0ℓ
-  forget ((θ , θcon) , θ?) = (θ , mkcon (reflexive θcon) (is-equivalence θcon) compat) , θ?
+  forget ((θ , θcon) , θ?) = (θ , mkcon (con-reflexive θcon) (is-equivalence θcon) compat) , θ?
     where
     θ-refl : ∀ {x y} → x ∼ y → θ x y
-    θ-refl = reflexive θcon
+    θ-refl = con-reflexive θcon
 
     θ-sym : ∀ {x y} → θ x y → θ y x
     θ-sym = IsEquivalence.sym (is-equivalence θcon)
@@ -337,11 +340,11 @@ at the relation level.
         (θ-trans (is-compatible θcon (inj₁ ν) {u} {v} h) (step (v Fin.zero)))
       where
       ν : Fin N
-      ν = proj₁ (gEnum-sur g)
+      ν = gEnum-sur g .proj₁
 
       -- the enumerated action agrees with g's action, coset-wise
       step : (x : G) → θ (gEnum ν ∙ₚ x) (g ∙ₚ x)
-      step x = θ-refl (≈⇒∼ (∙-cong (proj₂ (gEnum-sur g)) ≈ₚ-refl))
+      step x = θ-refl (≈⇒∼ (∙-cong (gEnum-sur g .proj₂) ≈ₚ-refl))
 
   -- A coset congruence closed under the lifts is a congruence of the expanded
   -- algebra.
@@ -349,7 +352,7 @@ at the relation level.
     → ((τ : Fin T) → ∀ {x y} → ConRel d x y → ConRel d (x ∘ tr τ) (y ∘ tr τ))
     → DecCon expandedAlgebra 0ℓ
   extend ((θ , θcon) , θ?) compτ =
-    (θ , mkcon (reflexive θcon) (is-equivalence θcon) compat) , θ?
+    (θ , mkcon (con-reflexive θcon) (is-equivalence θcon) compat) , θ?
     where
     compat : expandedAlgebra ∣≈ θ
     compat (inj₁ ν) {u} {v} h = is-compatible θcon (gEnum ν) {u} {v} h
@@ -358,29 +361,29 @@ at the relation level.
 
 #### From congruences to invariant partitions and back
 
-The forward passage composes the WP-3 bridge with the surjectivity hypothesis:
-the congruence's base-coset class is an interval element, the hypothesis hands
+The forward passage composes the WP-3 bridge with the surjectivity hypothesis.
+The congruence's base-coset class is an interval element, the hypothesis hands
 over a partition, and closure of the class under the lifts (one compatibility
 instance at `ε`) makes that partition invariant through the indicator argument.
 
 ```agda
   private
-    module B = Bridge Sⁿ Diag Diag-isSubgroup
+    module B = Bridge 𝑺ⁿ Diag Diag-isSubgroup
 
   -- The interval element of an expanded congruence: its base-coset class.
   intervalOf : DecCon expandedAlgebra 0ℓ → Interval≈
-  intervalOf θE = B.to (proj₁ (forget θE))
+  intervalOf θE = B.to (forget θE .proj₁)
 
   -- The partition the surjectivity hypothesis attaches to it.
   partOf : DecCon expandedAlgebra 0ℓ → ParentVec m
-  partOf θE = proj₁ (surj (intervalOf θE))
+  partOf θE = surj (intervalOf θE) .proj₁
 
   private
     partOf-in : (θE : DecCon expandedAlgebra 0ℓ) → set (intervalOf θE) ⊆ K (partOf θE)
-    partOf-in θE = proj₁ (proj₂ (surj (intervalOf θE)))
+    partOf-in θE = surj (intervalOf θE) .proj₂ .proj₁
 
     partOf-out : (θE : DecCon expandedAlgebra 0ℓ) → K (partOf θE) ⊆ set (intervalOf θE)
-    partOf-out θE = proj₂ (proj₂ (surj (intervalOf θE)))
+    partOf-out θE = surj (intervalOf θE)  .proj₂ .proj₂
 
     -- the base-coset class is closed under the lifts
     classClosed : (θE : DecCon expandedAlgebra 0ℓ) (τ : Fin T)
@@ -389,14 +392,14 @@ instance at `ε`) makes that partition invariant through the indicator argument.
       θ-trans (θ-refl (≈⇒∼ ε∘t≈ε)) (is-compatible θcon (inj₂ τ) {λ _ → εₚ} {λ _ → g} (λ _ → εθg))
       where
       θ-refl : ∀ {x y} → x ∼ y → θ x y
-      θ-refl = reflexive θcon
+      θ-refl = con-reflexive θcon
 
       θ-trans : ∀ {x y z} → θ x y → θ y z → θ x z
       θ-trans = IsEquivalence.trans (is-equivalence θcon)
 
       -- the identity tuple is fixed by the lift, up to pointwise equality
       ε∘t≈ε : εₚ ≈ₚ (εₚ ∘ tr τ)
-      ε∘t≈ε i = trans₁ (εₚ-pointwise i) (sym₁ (εₚ-pointwise (tr τ i)))
+      ε∘t≈ε i = trans (εₚ-pointwise i) (sym (εₚ-pointwise (tr τ i)))
 
   -- The partition of an expanded congruence is invariant under the family.
   partOf-invariant : (θE : DecCon expandedAlgebra 0ℓ) (τ : Fin T)
@@ -407,8 +410,8 @@ instance at `ε`) makes that partition invariant through the indicator argument.
     closed zk = partOf-in θE (classClosed θE τ (partOf-out θE zk))
 ```
 
-The backward passage is the bridge's inverse at the partition subgroup — whose
-membership is decidable (`K-dec`{.AgdaFunction}) — extended by the lifts, the
+The backward passage is the bridge's inverse at the partition subgroup, whose
+membership is decidable (`K-dec`{.AgdaFunction}), extended by the lifts, the
 lift-compatibility supplied by the easy half of the invariance transfer.
 
 ```agda
@@ -418,16 +421,16 @@ lift-compatibility supplied by the easy half of the invariance transfer.
       → ∀ {x y} → ConRel (B.fromᵈ (toInterval pv , K-dec pv)) x y
       → ConRel (B.fromᵈ (toInterval pv , K-dec pv)) (x ∘ tr τ) (y ∘ tr τ)
     θK-comp pv invτ τ {x} {y} mem =
-      K-respects pv (λ i → sym₁ (quot-comp x y (tr τ) i))
+      K-respects pv (λ i → sym (quot-comp x y (tr τ) i))
         (Inv→K-closed (tr τ) pv (invτ τ) mem)
 ```
 
 #### The invariant-partition poset and the expansion isomorphism
 
-The right-hand side of the expansion isomorphism: partitions invariant under
-the whole family, compared by the kernel equality and the *reversed*
-refinement of their underlying partitions — reversed because a larger
-congruence has a larger subgroup, hence a *finer* partition.
+**The right-hand side of the expansion isomorphism**: partitions invariant under
+the whole family, compared by the kernel equality and the reversed refinement of
+their underlying partitions (reversed because a larger congruence has a larger
+subgroup, hence a *finer* partition).
 
 ```agda
   -- A partition invariant under the whole family.
@@ -438,11 +441,11 @@ congruence has a larger subgroup, hence a *finer* partition.
 
   -- Kernel equality of the underlying partitions.
   _≈ᵛ_ : InvPart → InvPart → Type 0ℓ
-  P ≈ᵛ Q = proj₁ P ≈ᵖ proj₁ Q
+  (P , _) ≈ᵛ (Q , _) = P ≈ᵖ Q
 
   -- The reversed refinement order.
   _≥ᵛ_ : InvPart → InvPart → Type 0ℓ
-  P ≥ᵛ Q = proj₁ Q ⊑ proj₁ P
+  (P , _) ≥ᵛ (Q , _) = Q ⊑ P
 ```
 
 The two maps of the isomorphism.
@@ -457,7 +460,7 @@ The two maps of the isomorphism.
   fromInvPart (pv , invτ) = extend (B.fromᵈ (toInterval pv , K-dec pv)) (θK-comp pv invτ)
 ```
 
-Monotonicity.  Forward: a containment of congruences passes through the bridge
+**Monotonicity**.  Forward: a containment of congruences passes through the bridge
 to an inclusion of interval elements, through the interval isomorphism of
 [FLRP.KurzweilInterval][] to the dual lattice order, and unflips to reversed
 refinement.  Backward: reversed refinement is an inclusion of partition
@@ -473,7 +476,7 @@ subgroups (`K-antitone`{.AgdaFunction}), which the bridge's inverse forwards.
     ≤→⊑ {pu = partOf φE} {pw = partOf θE}
       (LatticeDual.≤ᵈ-flip (EqLattice m) {x = partOf θE} {y = partOf φE}
         (OrderIso.to-mono KI {intervalOf θE} {intervalOf φE}
-          (B.to-mono {proj₁ (forget θE)} {proj₁ (forget φE)} sub)))
+          (B.to-mono {forget θE .proj₁} {forget φE .proj₁} sub)))
 
   fromInvPart-mono : (P Q : InvPart) → P ≥ᵛ Q
     → ∀ {x y} → ConRel (fromInvPart P) x y → ConRel (fromInvPart Q) x y
@@ -481,7 +484,7 @@ subgroups (`K-antitone`{.AgdaFunction}), which the bridge's inverse forwards.
     B.from-mono {toInterval pu} {toInterval pw} (K-antitone {pu = pw} {pw = pu} w⊑u)
 ```
 
-The round trips.  On congruences: the relation of the back-and-forth is the
+**The round trips**.  On congruences: the relation of the back-and-forth is the
 coset relation of `K_{partOf θE}`, which the surjectivity certificates identify
 with the base-coset class, and the bridge's round trip identifies with the
 original relation.  On partitions: the interval element of the back-and-forth
@@ -494,7 +497,7 @@ bridge's other round trip and injectivity of `K` close the loop.
     → fromInvPart (toInvPart θE) ≑ᵈ θE
   fromInvPart-toInvPart θE = fwd , bwd
     where
-    conF = proj₁ (forget θE)
+    conF = forget θE .proj₁
 
     fwd : ∀ {x y} → ConRel (fromInvPart (toInvPart θE)) x y → ConRel θE x y
     fwd p = B.from∘to conF .proj₁ (partOf-out θE p)

--- a/src/FLRP/KurzweilNetter/Invariance.lagda.md
+++ b/src/FLRP/KurzweilNetter/Invariance.lagda.md
@@ -13,14 +13,13 @@ This is the [FLRP.KurzweilNetter.Invariance][] module of the [Agda Universal Alg
 A partition `π` of `Fin n` is **invariant** under a map `t : Fin n → Fin n` when
 `t` carries blocks into blocks: indices in one block of `π` have their `t`-images
 in one block of `π`.  This is the pivotal notion of the Kurzweil–Netter expansion
-step (issue #502): on the algebra side, the congruences of a finite algebra `𝑨`
-indexed by `Fin n` correspond exactly to the partitions invariant under `𝑨`'s
-basic translations ([FLRP.KurzweilNetter.Translations][]); on the group side, the
+step: on the algebra side, the congruences of a finite algebra `𝑨` indexed by
+`Fin n` correspond exactly to the partitions invariant under `𝑨`'s basic
+translations ([FLRP.KurzweilNetter.Translations][]); on the group side, the
 congruences of the expanded coset algebra on `Sⁿ/D` correspond exactly to the
 partition subgroups `K_π` with `π` invariant under the lifted maps
-([FLRP.KurzweilNetter.Expansion][]).  The two sides meet in this definition,
-which is why it lives in its own small module, free of both the algebra and the
-group.
+([FLRP.KurzweilNetter.Expansion][]).  The two sides meet in this definition, which
+is why it lives in its own small module, free of both the algebra and the group.
 
 <!--
 ```agda
@@ -55,7 +54,7 @@ Inv t pv = ∀ {i j} → SameBlock pv i j → SameBlock pv (t i) (t j)
 ```
 
 Invariance is a property of the *kernel*, so it transports along partition
-equality (mutual refinement) — the lemma every round trip below needs when a
+equality (mutual refinement), the lemma every round trip below needs when a
 construction returns a merely `≈ᵖ`-equal presentation of a partition.
 
 ```agda

--- a/src/FLRP/KurzweilNetter/Invariance.lagda.md
+++ b/src/FLRP/KurzweilNetter/Invariance.lagda.md
@@ -1,0 +1,68 @@
+---
+layout: default
+file: "src/FLRP/KurzweilNetter/Invariance.lagda.md"
+title: "FLRP.KurzweilNetter.Invariance module (The Agda Universal Algebra Library)"
+date: "2026-07-28"
+author: "the agda-algebras development team"
+---
+
+### Invariant partitions
+
+This is the [FLRP.KurzweilNetter.Invariance][] module of the [Agda Universal Algebra Library][].
+
+A partition `π` of `Fin n` is **invariant** under a map `t : Fin n → Fin n` when
+`t` carries blocks into blocks: indices in one block of `π` have their `t`-images
+in one block of `π`.  This is the pivotal notion of the Kurzweil–Netter expansion
+step (issue #502): on the algebra side, the congruences of a finite algebra `𝑨`
+indexed by `Fin n` correspond exactly to the partitions invariant under `𝑨`'s
+basic translations ([FLRP.KurzweilNetter.Translations][]); on the group side, the
+congruences of the expanded coset algebra on `Sⁿ/D` correspond exactly to the
+partition subgroups `K_π` with `π` invariant under the lifted maps
+([FLRP.KurzweilNetter.Expansion][]).  The two sides meet in this definition,
+which is why it lives in its own small module, free of both the algebra and the
+group.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.KurzweilNetter.Invariance where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Fin.Base   using ( Fin )
+open import Data.Nat.Base   using ( ℕ )
+open import Data.Product    using ( _,_ )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Structures.Lattice.Partitions  using ( SameBlock ; _≈ᵖ_ )
+open import Setoid.Congruences.Certificates.Schema   using ( ParentVec )
+
+private variable n : ℕ
+```
+-->
+
+#### The invariance predicate
+
+`Inv t pv` says the kernel of `pv` is preserved by `t`: a block relation of the
+partition is carried to a block relation.
+
+```agda
+-- The partition pv is invariant under the index map t.
+Inv : (Fin n → Fin n) → ParentVec n → Type
+Inv t pv = ∀ {i j} → SameBlock pv i j → SameBlock pv (t i) (t j)
+```
+
+Invariance is a property of the *kernel*, so it transports along partition
+equality (mutual refinement) — the lemma every round trip below needs when a
+construction returns a merely `≈ᵖ`-equal presentation of a partition.
+
+```agda
+-- Invariance respects kernel equality of the partitions.
+Inv-resp-≈ᵖ : (t : Fin n → Fin n) {pu pw : ParentVec n}
+  → pu ≈ᵖ pw → Inv t pu → Inv t pw
+Inv-resp-≈ᵖ t (u⊑w , w⊑u) invᵤ sb = u⊑w (invᵤ (w⊑u sb))
+```
+
+--------------------------------------

--- a/src/FLRP/KurzweilNetter/Translations.lagda.md
+++ b/src/FLRP/KurzweilNetter/Translations.lagda.md
@@ -1,0 +1,418 @@
+---
+layout: default
+file: "src/FLRP/KurzweilNetter/Translations.lagda.md"
+title: "FLRP.KurzweilNetter.Translations module (The Agda Universal Algebra Library)"
+date: "2026-07-28"
+author: "the agda-algebras development team"
+---
+
+### Basic translations, and the invariant partitions of a finite algebra
+
+This is the [FLRP.KurzweilNetter.Translations][] module of the [Agda Universal Algebra Library][].
+
+The manuscript proof of Kurzweil–Netter duality
+(`docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals") opens by
+assuming the representing algebra has *unary* operations, citing the
+unary-reduction theorem `Con 𝑨 = Con ⟨A , Pol₁ 𝑨⟩` — which is issue #501 and is
+not yet formalized.  This module implements the deliberate scoping decision of
+issue #502: rather than importing #501 as a hypothesis, the construction lifts
+only the **basic translations** of `𝑨`{.AgdaBound} — the unary maps obtained
+from one basic operation by fixing all argument positions but one — and the
+classical Mal'cev-style observation that these already determine the
+congruences:
+
++  every congruence partition is invariant under every basic translation
+   (`pvOf-invariant`{.AgdaFunction} — one appeal to compatibility); and
+
++  conversely, a partition invariant under all basic translations induces a
+   relation compatible with *every* operation of any arity
+   (`blockRel-compatible`{.AgdaFunction}) — the **translation criterion**,
+   proved by walking the argument tuple one position at a time and using one
+   translation instance per step.
+
+This is strictly less than #501 (no polynomial clone is constructed, no
+composition of translations is needed), and it is exactly the interface the
+expansion step consumes: the operations lifted to the coset algebra in
+[FLRP.KurzweilNetter.Expansion][] are unary maps of the index set, and a family
+of unary index maps is precisely what this module produces.
+
+**Presentation of the translations.**  The carrier is presented by an
+irredundant enumeration `ienum : Fin m → 𝕌[ 𝑨 ]`
+([Setoid.Algebras.Finite.Irredundant][]), so a translation is presented as a
+map `Fin m → Fin m`: feed the moving index and the constants to the operation
+through `ienum`{.AgdaFunction}, and take the index of the result.  A
+translation datum `TrData`{.AgdaFunction} records an operation symbol (through
+the symbol enumeration of the `FiniteSignature`{.AgdaRecord}), a distinguished
+argument position, and the constant tuple *positionally encoded* as a single
+`Fin (m ^ k)`{.AgdaDatatype} via the standard library's
+`finToFun`{.AgdaFunction} — encoded rather than functional so that downstream
+the family can be *flatly indexed* by `Fin trCount`{.AgdaDatatype}
+(`trFamily`{.AgdaFunction} below), which is the shape the expanded algebra's
+finite signature needs.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module FLRP.KurzweilNetter.Translations where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Bool.Base      using ( if_then_else_ )
+open import Data.Empty          using ( ⊥-elim )
+open import Data.Fin.Base       using ( Fin ; toℕ ; fromℕ< ; finToFun ; funToFin )
+open import Data.Fin.Properties using ( toℕ<n ; toℕ-fromℕ< ; toℕ-injective
+                                      ; finToFun-funToFin )
+                                renaming ( _≟_ to _≟ᶠ_ )
+open import Data.List.Base      using ( List ; length ; lookup ; concatMap
+                                      ; cartesianProduct ; allFin )
+                                renaming ( map to lmap )
+open import Data.List.Membership.Propositional             using ( _∈_ )
+open import Data.List.Membership.Propositional.Properties  using ( ∈-allFin ; ∈-map⁺
+                                                                 ; ∈-cartesianProduct⁺
+                                                                 ; ∈-concat⁺′ )
+open import Data.List.Relation.Unary.Any             using ( index )
+open import Data.List.Relation.Unary.Any.Properties  using ( lookup-index )
+open import Data.Nat.Base        using ( ℕ ; zero ; suc ; _≤_ ; _<_ ; s≤s )
+                                 renaming ( _^_ to _^ᴺ_ )
+open import Data.Nat.Properties  using ( _<?_ ; ≤-refl ; ≤-trans ; n≤1+n
+                                       ; <-irrefl ; ≤∧≢⇒< )
+open import Data.Product         using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
+open import Function             using ( Func ; Inverse )
+open import Level                using ( 0ℓ )
+open import Relation.Binary      using ( Setoid ; IsEquivalence )
+open import Relation.Binary.PropositionalEquality
+                                 using ( _≡_ ; refl ; sym ; trans ; cong ; subst ; subst₂ )
+open import Relation.Nullary     using ( ¬_ ; Dec ; yes ; no )
+open import Relation.Nullary.Decidable  using ( does ; dec-true ; dec-false )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Structures.Lattice.Partitions  using ( SameBlock )
+open import FLRP.KurzweilNetter.Blocks                using ( module KNBlocks )
+open import FLRP.KurzweilNetter.Invariance            using ( Inv )
+open import Overture  using ( Signature ; OperationSymbolsOf ; ArityOf ; _|:_ )
+open import Setoid.Algebras.Basic                using ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_ )
+open import Setoid.Algebras.Finite.Irredundant   using ( IrredundantEnumeration )
+open import Setoid.Congruences.Basic             using ( _∣≈_ ; mkcon ; reflexive
+                                                       ; is-equivalence ; is-compatible )
+open import Setoid.Congruences.Certificates.Schema  using ( ParentVec )
+open import Setoid.Congruences.Finite.Basic      using ( DecCon ; ConRel )
+open import Setoid.Signatures.Finite             using ( FiniteSignature )
+
+open Algebra using ( Interp )
+```
+-->
+
+#### The translation toolkit
+
+`KNTranslations`{.AgdaModule} fixes the finite finitary algebra — through its
+signature-finiteness witness — and an irredundant enumeration of its carrier,
+and opens the relation-level dictionary of [FLRP.KurzweilNetter.Blocks][].
+
+```agda
+module KNTranslations {𝑆 : Signature 0ℓ 0ℓ} (𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ)
+                      (𝑺 : FiniteSignature 𝑆) (𝑬 : IrredundantEnumeration 𝑨) where
+
+  open KNBlocks 𝑨 𝑬
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
+    renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans ; reflexive to ≈reflexive )
+  open IrredundantEnumeration 𝑬 using ( ienum ) renaming ( icard to m )
+  open FiniteSignature 𝑺
+    using ( opCard ; opEnum ; opEnum-sur ; arCard ; arIdx ; arEnum ; arEnum-arIdx
+          ; finitary )
+
+  private
+    -- The other round trip of the arity bijection (the record exposes only
+    -- arEnum-arIdx; this direction is read off the underlying Inverse).
+    arIdx-arEnum : (f : OperationSymbolsOf 𝑆) (q : Fin (arCard f))
+      → arIdx f (arEnum f q) ≡ q
+    arIdx-arEnum f = Inverse.strictlyInverseˡ (proj₂ (finitary f))
+
+    -- Congruence of an operation application in its argument tuple.
+    fcong : (f : OperationSymbolsOf 𝑆) {u v : ArityOf 𝑆 f → 𝕌[ 𝑨 ]}
+      → (∀ a → u a ≈ v a) → (f ^ 𝑨) u ≈ (f ^ 𝑨) v
+    fcong f h = Func.cong (Interp 𝑨) (refl , h)
+```
+
+#### Translation data and the presented index maps
+
+A translation datum is an operation symbol (as an index into the symbol
+enumeration), a distinguished argument position, and a positional encoding of
+the constants at the remaining positions.  A nullary operation contributes no
+data (its position type is empty), matching the mathematics: constants impose
+no congruence constraint.
+
+```agda
+  -- One basic-translation instance, as pure data.
+  TrData : Type 0ℓ
+  TrData = Σ[ o ∈ Fin opCard ] (Fin (arCard (opEnum o)) × Fin (m ^ᴺ arCard (opEnum o)))
+
+  private
+    -- The index tuple fed to the operation: the moving index at the
+    -- distinguished position, the decoded constants elsewhere.
+    mixIx : {k : ℕ} → Fin k → Fin (m ^ᴺ k) → Fin m → Fin k → Fin m
+    mixIx p cc i q = if does (q ≟ᶠ p) then i else finToFun cc q
+
+  -- The unary index map presented by a translation datum.
+  trMapOf : TrData → Fin m → Fin m
+  trMapOf (o , p , cc) i =
+    eIdx ((opEnum o ^ 𝑨) (λ a → ienum (mixIx p cc i (arIdx (opEnum o) a))))
+```
+
+#### Soundness: congruence partitions are invariant
+
+The partition of a decidable congruence is invariant under every translation:
+the moving position carries the related pair, the constant positions carry
+reflexivity, and compatibility of the congruence does the rest.
+
+```agda
+  -- The partition of a decidable congruence is invariant under every translation.
+  pvOf-invariant : (d : DecCon 𝑨 0ℓ) (td : TrData) → Inv (trMapOf td) (pvOf d)
+  pvOf-invariant d (o , p , cc) {i} {j} sb = pvOf-complete d related
+    where
+    θ-refl≈  = reflexive (proj₂ (proj₁ d))
+    θ-sym    = IsEquivalence.sym (is-equivalence (proj₂ (proj₁ d)))
+    θ-trans  = IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+
+    f = opEnum o
+
+    -- the two argument tuples, and their pointwise relatedness
+    argsAt : Fin m → ArityOf 𝑆 f → 𝕌[ 𝑨 ]
+    argsAt i' a = ienum (mixIx p cc i' (arIdx f a))
+
+    mixRel : (q : Fin (arCard f)) (dq : Dec (q ≡ p))
+      → ConRel d  (ienum (if does dq then i else finToFun cc q))
+                  (ienum (if does dq then j else finToFun cc q))
+    mixRel q (yes _)  = pvOf-sound d sb
+    mixRel q (no _)   = θ-refl≈ ≈refl
+
+    relF : ConRel d ((f ^ 𝑨) (argsAt i)) ((f ^ 𝑨) (argsAt j))
+    relF = is-compatible (proj₂ (proj₁ d)) f
+             {argsAt i} {argsAt j} (λ a → mixRel (arIdx f a) (arIdx f a ≟ᶠ p))
+
+    related : ConRel d  (ienum (trMapOf (o , p , cc) i))
+                        (ienum (trMapOf (o , p , cc) j))
+    related = θ-trans (θ-refl≈ (eIdx-≈ ((f ^ 𝑨) (argsAt i))))
+                (θ-trans relF (θ-sym (θ-refl≈ (eIdx-≈ ((f ^ 𝑨) (argsAt j))))))
+```
+
+#### The translation criterion
+
+Conversely, a partition invariant under every translation induces a relation
+compatible with every operation.  The proof is the classical one-position walk:
+to relate `f u` and `f v` for pointwise-related tuples, pass through the
+hybrids `hyb l` that take `v`-values at positions below `l` and `u`-values at
+the rest; consecutive hybrids differ in one position, which is one invariance
+instance, with the constants of the instance encoding the current hybrid.
+
+```agda
+  -- The translation criterion: a partition invariant under every translation
+  -- induces a relation compatible with every operation of 𝑨.
+  blockRel-compatible : (pv : ParentVec m)
+    → ((td : TrData) → Inv (trMapOf td) pv) → 𝑨 ∣≈ blockRel pv
+  blockRel-compatible pv inv 𝑓 =
+    subst (λ g → (g ^ 𝑨) |: blockRel pv) (proj₂ (opEnum-sur 𝑓))
+          (compatAt (proj₁ (opEnum-sur 𝑓)))
+    where
+    compatAt : (o : Fin opCard) → (opEnum o ^ 𝑨) |: blockRel pv
+    compatAt o {u} {v} hyp = final
+      where
+      f = opEnum o
+      k = arCard f
+
+      -- the hybrid tuples: v-values strictly below the threshold, u-values above
+      hyb : ℕ → ArityOf 𝑆 f → 𝕌[ 𝑨 ]
+      hyb l a = if does (toℕ (arIdx f a) <? l) then v a else u a
+
+      -- boundary identifications
+      hyb0≈u : ∀ a → hyb 0 a ≈ u a
+      hyb0≈u a = ≈reflexive
+        (cong (λ b → if b then v a else u a) (dec-false (toℕ (arIdx f a) <? 0) λ ()))
+
+      hybk≈v : ∀ a → hyb k a ≈ v a
+      hybk≈v a = ≈reflexive
+        (cong (λ b → if b then v a else u a)
+              (dec-true (toℕ (arIdx f a) <? k) (toℕ<n (arIdx f a))))
+
+      -- one step of the walk: position l moves from its u-value to its v-value
+      step : (l : ℕ) (sl≤k : suc l ≤ k)
+        → blockRel pv ((f ^ 𝑨) (hyb l)) ((f ^ 𝑨) (hyb (suc l)))
+      step l sl≤k =
+        subst₂ (SameBlock pv) tI≡ tJ≡ (inv (o , pl , cc) (hyp p))
+        where
+        pl : Fin k
+        pl = fromℕ< sl≤k
+
+        p : ArityOf 𝑆 f
+        p = arEnum f pl
+
+        -- the constants encode the current hybrid
+        cc : Fin (m ^ᴺ k)
+        cc = funToFin (λ q → eIdx (hyb l (arEnum f q)))
+
+        toℕpl : toℕ pl ≡ l
+        toℕpl = toℕ-fromℕ< sl≤k
+
+        -- the distinguished position is not yet moved in hyb l ...
+        arIdx-p : arIdx f p ≡ pl
+        arIdx-p = arIdx-arEnum f pl
+
+        hybl-p : hyb l p ≡ u p
+        hybl-p = cong (λ b → if b then v p else u p)
+          (dec-false (toℕ (arIdx f p) <? l)
+            (λ lt → <-irrefl refl (subst (_< l) (trans (cong toℕ arIdx-p) toℕpl) lt)))
+
+        -- ... and is moved in hyb (suc l)
+        hybsl-p : hyb (suc l) p ≡ v p
+        hybsl-p = cong (λ b → if b then v p else u p)
+          (dec-true (toℕ (arIdx f p) <? suc l)
+            (subst (_< suc l) (sym (trans (cong toℕ arIdx-p) toℕpl)) ≤-refl))
+
+        -- away from the distinguished position the two hybrids agree
+        hyb-stable : (q : Fin k) → ¬ (q ≡ pl)
+          → hyb l (arEnum f q) ≡ hyb (suc l) (arEnum f q)
+        hyb-stable q ne =
+          stable (toℕ (arIdx f (arEnum f q)) <? l) (toℕ (arIdx f (arEnum f q)) <? suc l)
+          where
+          a' = arEnum f q
+
+          x≢l : ¬ (toℕ (arIdx f a') ≡ l)
+          x≢l xl = ne (toℕ-injective
+            (trans (trans (sym (cong toℕ (arIdx-arEnum f q))) xl) (sym toℕpl)))
+
+          stable : (d₁ : Dec (toℕ (arIdx f a') < l)) (d₂ : Dec (toℕ (arIdx f a') < suc l))
+            → (if does d₁ then v a' else u a') ≡ (if does d₂ then v a' else u a')
+          stable (yes _)   (yes _)   = refl
+          stable (no _)    (no _)    = refl
+          stable (yes lt)  (no nlt)  = ⊥-elim (nlt (≤-trans lt (n≤1+n l)))
+          stable (no nlt)  (yes lt)  = ⊥-elim (nlt (≤∧≢⇒< (pred≤ lt) x≢l))
+            where
+            pred≤ : suc (toℕ (arIdx f a')) ≤ suc l → toℕ (arIdx f a') ≤ l
+            pred≤ (s≤s le) = le
+
+        -- the translation at the moving u-index computes hyb l ...
+        keyU : (q : Fin k) (dq : Dec (q ≡ pl))
+          → ienum (if does dq then eIdx (u p) else finToFun cc q) ≈ hyb l (arEnum f q)
+        keyU q (yes e) = ≈trans (eIdx-≈ (u p))
+          (≈reflexive (sym (trans (cong (hyb l) (cong (arEnum f) e)) hybl-p)))
+        keyU q (no _)  = ≈trans
+          (≈reflexive (cong ienum (finToFun-funToFin (λ q' → eIdx (hyb l (arEnum f q'))) q)))
+          (eIdx-≈ (hyb l (arEnum f q)))
+
+        -- ... and at the moving v-index computes hyb (suc l)
+        keyV : (q : Fin k) (dq : Dec (q ≡ pl))
+          → ienum (if does dq then eIdx (v p) else finToFun cc q) ≈ hyb (suc l) (arEnum f q)
+        keyV q (yes e) = ≈trans (eIdx-≈ (v p))
+          (≈reflexive (sym (trans (cong (hyb (suc l)) (cong (arEnum f) e)) hybsl-p)))
+        keyV q (no ne) = ≈trans
+          (≈reflexive (cong ienum (finToFun-funToFin (λ q' → eIdx (hyb l (arEnum f q'))) q)))
+          (≈trans (eIdx-≈ (hyb l (arEnum f q))) (≈reflexive (hyb-stable q ne)))
+
+        argU : ∀ a → ienum (mixIx pl cc (eIdx (u p)) (arIdx f a)) ≈ hyb l a
+        argU a = ≈trans (keyU (arIdx f a) (arIdx f a ≟ᶠ pl))
+                        (≈reflexive (cong (hyb l) (arEnum-arIdx f a)))
+
+        argV : ∀ a → ienum (mixIx pl cc (eIdx (v p)) (arIdx f a)) ≈ hyb (suc l) a
+        argV a = ≈trans (keyV (arIdx f a) (arIdx f a ≟ᶠ pl))
+                        (≈reflexive (cong (hyb (suc l)) (arEnum-arIdx f a)))
+
+        tI≡ : trMapOf (o , pl , cc) (eIdx (u p)) ≡ eIdx ((f ^ 𝑨) (hyb l))
+        tI≡ = eIdx-cong (fcong f argU)
+
+        tJ≡ : trMapOf (o , pl , cc) (eIdx (v p)) ≡ eIdx ((f ^ 𝑨) (hyb (suc l)))
+        tJ≡ = eIdx-cong (fcong f argV)
+
+      -- the walk accumulates the steps from the all-u tuple ...
+      walk : (l : ℕ) → l ≤ k → blockRel pv ((f ^ 𝑨) u) ((f ^ 𝑨) (hyb l))
+      walk zero     _     = blockRel-refl≈ pv (fcong f (λ a → ≈sym (hyb0≈u a)))
+      walk (suc l)  sl≤k  = trans (walk l (≤-trans (n≤1+n l) sl≤k)) (step l sl≤k)
+
+      -- ... and lands on the all-v tuple
+      final : blockRel pv ((f ^ 𝑨) u) ((f ^ 𝑨) v)
+      final = trans (walk k ≤-refl) (blockRel-refl≈ pv (fcong f hybk≈v))
+```
+
+A partition invariant under every translation therefore presents a decidable
+congruence: the relation, its equivalence laws, its compatibility from the
+criterion, and its decision procedure by label comparison.
+
+```agda
+  -- The decidable congruence presented by an invariant partition.
+  blockCon : (pv : ParentVec m) → ((td : TrData) → Inv (trMapOf td) pv) → DecCon 𝑨 0ℓ
+  blockCon pv inv =
+    ( blockRel pv
+    , mkcon (blockRel-refl≈ pv) (blockRel-isEquivalence pv) (blockRel-compatible pv inv) )
+    , blockRel-dec pv
+```
+
+#### The flat family
+
+The expansion step ([FLRP.KurzweilNetter.Expansion][]) consumes the
+translations as a family indexed by a plain `Fin`{.AgdaDatatype} — the shape a
+finite signature's symbol type needs.  The family is obtained by listing all
+translation data (finitely many: symbols, positions, and constant codes are all
+enumerated) and reading the list back through positional lookup; completeness
+of the listing is what converts family-invariance back into invariance under
+every datum.
+
+```agda
+  private
+    blockOf : Fin opCard → List TrData
+    blockOf o = lmap (o ,_)
+      (cartesianProduct (allFin (arCard (opEnum o))) (allFin (m ^ᴺ arCard (opEnum o))))
+
+    trList : List TrData
+    trList = concatMap blockOf (allFin opCard)
+
+    trList-complete : (td : TrData) → td ∈ trList
+    trList-complete (o , p , cc) =
+      ∈-concat⁺′
+        (∈-map⁺ (o ,_) (∈-cartesianProduct⁺ (∈-allFin p) (∈-allFin cc)))
+        (∈-map⁺ blockOf (∈-allFin o))
+
+  -- The number of translation instances.
+  trCount : ℕ
+  trCount = length trList
+
+  -- The translation datum at a flat index.
+  trIdx : Fin trCount → TrData
+  trIdx = lookup trList
+
+  -- Every translation datum occurs at some flat index.
+  trIdx-complete : (td : TrData) → Σ[ τ ∈ Fin trCount ] trIdx τ ≡ td
+  trIdx-complete td = index mem , sym (lookup-index mem)
+    where
+    mem : td ∈ trList
+    mem = trList-complete td
+
+  -- The flatly indexed translation family.
+  trFamily : Fin trCount → Fin m → Fin m
+  trFamily τ = trMapOf (trIdx τ)
+```
+
+The two facing consequences, in the exact shapes the duality proof consumes:
+congruence partitions are invariant under the whole family, and
+family-invariance suffices for the criterion.
+
+```agda
+  -- Congruence partitions are invariant under the whole family.
+  pvOf-invariant-family : (d : DecCon 𝑨 0ℓ) (τ : Fin trCount)
+    → Inv (trFamily τ) (pvOf d)
+  pvOf-invariant-family d τ = pvOf-invariant d (trIdx τ)
+
+  -- Family invariance covers every translation datum.
+  family-invariant-all : (pv : ParentVec m)
+    → ((τ : Fin trCount) → Inv (trFamily τ) pv)
+    → (td : TrData) → Inv (trMapOf td) pv
+  family-invariant-all pv h td =
+    subst (λ z → Inv (trMapOf z) pv) (proj₂ (trIdx-complete td))
+          (h (proj₁ (trIdx-complete td)))
+
+  -- The decidable congruence presented by a family-invariant partition.
+  blockConᶠ : (pv : ParentVec m)
+    → ((τ : Fin trCount) → Inv (trFamily τ) pv) → DecCon 𝑨 0ℓ
+  blockConᶠ pv h = blockCon pv (family-invariant-all pv h)
+```
+
+--------------------------------------

--- a/src/FLRP/KurzweilNetter/Translations.lagda.md
+++ b/src/FLRP/KurzweilNetter/Translations.lagda.md
@@ -10,45 +10,40 @@ author: "the agda-algebras development team"
 
 This is the [FLRP.KurzweilNetter.Translations][] module of the [Agda Universal Algebra Library][].
 
-The manuscript proof of Kurzweil–Netter duality
-(`docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals") opens by
-assuming the representing algebra has *unary* operations, citing the
-unary-reduction theorem `Con 𝑨 = Con ⟨A , Pol₁ 𝑨⟩` — which is issue #501 and is
-not yet formalized.  This module implements the deliberate scoping decision of
-issue #502: rather than importing #501 as a hypothesis, the construction lifts
-only the **basic translations** of `𝑨`{.AgdaBound} — the unary maps obtained
-from one basic operation by fixing all argument positions but one — and the
-classical Mal'cev-style observation that these already determine the
-congruences:
+The manuscript proof of Kurzweil–Netter duality[^1] opens by assuming the
+representing algebra has *unary* operations, citing the unary-reduction theorem
+`Con 𝑨 = Con ⟨A , Pol₁ 𝑨⟩` which is not yet formalized in the library.  The
+construction in this module lifts only the **basic translations** of
+`𝑨`{.AgdaBound}, that is, the unary maps obtained from one basic operation by
+fixing all argument positions but one, and the classical Mal'cev-style observation
+that these already determine the congruences.
 
-+  every congruence partition is invariant under every basic translation
-   (`pvOf-invariant`{.AgdaFunction} — one appeal to compatibility); and
++  Every congruence partition is invariant under every basic translation
+   (`pvOf-invariant`{.AgdaFunction}, one appeal to compatibility); and, conversely,
 
-+  conversely, a partition invariant under all basic translations induces a
-   relation compatible with *every* operation of any arity
-   (`blockRel-compatible`{.AgdaFunction}) — the **translation criterion**,
++  a partition invariant under all basic translations induces a relation
+   compatible with every operation of every arity
+   (`blockRel-compatible`{.AgdaFunction}); this is the **translation criterion**,
    proved by walking the argument tuple one position at a time and using one
    translation instance per step.
 
-This is strictly less than #501 (no polynomial clone is constructed, no
-composition of translations is needed), and it is exactly the interface the
-expansion step consumes: the operations lifted to the coset algebra in
-[FLRP.KurzweilNetter.Expansion][] are unary maps of the index set, and a family
-of unary index maps is precisely what this module produces.
+This is exactly the interface the expansion step consumes: the operations lifted
+to the coset algebra in [FLRP.KurzweilNetter.Expansion][] are unary maps of the
+index set, and a family of unary index maps is precisely what this module
+produces.
 
-**Presentation of the translations.**  The carrier is presented by an
-irredundant enumeration `ienum : Fin m → 𝕌[ 𝑨 ]`
-([Setoid.Algebras.Finite.Irredundant][]), so a translation is presented as a
-map `Fin m → Fin m`: feed the moving index and the constants to the operation
-through `ienum`{.AgdaFunction}, and take the index of the result.  A
-translation datum `TrData`{.AgdaFunction} records an operation symbol (through
-the symbol enumeration of the `FiniteSignature`{.AgdaRecord}), a distinguished
-argument position, and the constant tuple *positionally encoded* as a single
-`Fin (m ^ k)`{.AgdaDatatype} via the standard library's
-`finToFun`{.AgdaFunction} — encoded rather than functional so that downstream
-the family can be *flatly indexed* by `Fin trCount`{.AgdaDatatype}
-(`trFamily`{.AgdaFunction} below), which is the shape the expanded algebra's
-finite signature needs.
+**Presentation of the translations**.  The carrier is presented by an
+irredundant enumeration `ienum[_] : Fin m → 𝕌[ 𝑨 ]`
+([Setoid.Algebras.Finite.Irredundant][]), so a translation is presented as a map
+`Fin m → Fin m`: feed the moving index and the constants to the operation through
+`ienum[_]`{.AgdaFunction}, and take the index of the result.  A translation datum
+`TrData`{.AgdaFunction} records an operation symbol (through the symbol
+enumeration of the `FiniteSignature`{.AgdaRecord}), a distinguished argument
+position, and the constant tuple *positionally encoded* as a single
+`Fin (m ^ k)`{.AgdaDatatype} via the standard library's `finToFun`{.AgdaFunction},
+encoded rather than functional so that downstream the family can be *flatly indexed*
+by `Fin trCount`{.AgdaDatatype} (`trFamily`{.AgdaFunction} below), which is the
+shape the expanded algebra's finite signature needs.
 
 <!--
 ```agda
@@ -59,46 +54,61 @@ module FLRP.KurzweilNetter.Translations where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
-open import Data.Bool.Base      using ( if_then_else_ )
-open import Data.Empty          using ( ⊥-elim )
-open import Data.Fin.Base       using ( Fin ; toℕ ; fromℕ< ; finToFun ; funToFin )
-open import Data.Fin.Properties using ( toℕ<n ; toℕ-fromℕ< ; toℕ-injective
-                                      ; finToFun-funToFin )
-                                renaming ( _≟_ to _≟ᶠ_ )
-open import Data.List.Base      using ( List ; length ; lookup ; concatMap
-                                      ; cartesianProduct ; allFin )
-                                renaming ( map to lmap )
-open import Data.List.Membership.Propositional             using ( _∈_ )
-open import Data.List.Membership.Propositional.Properties  using ( ∈-allFin ; ∈-map⁺
-                                                                 ; ∈-cartesianProduct⁺
-                                                                 ; ∈-concat⁺′ )
-open import Data.List.Relation.Unary.Any             using ( index )
-open import Data.List.Relation.Unary.Any.Properties  using ( lookup-index )
-open import Data.Nat.Base        using ( ℕ ; zero ; suc ; _≤_ ; _<_ ; s≤s )
-                                 renaming ( _^_ to _^ᴺ_ )
-open import Data.Nat.Properties  using ( _<?_ ; ≤-refl ; ≤-trans ; n≤1+n
-                                       ; <-irrefl ; ≤∧≢⇒< )
-open import Data.Product         using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
-open import Function             using ( Func ; Inverse )
-open import Level                using ( 0ℓ )
-open import Relation.Binary      using ( Setoid ; IsEquivalence )
-open import Relation.Binary.PropositionalEquality
-                                 using ( _≡_ ; refl ; sym ; trans ; cong ; subst ; subst₂ )
-open import Relation.Nullary     using ( ¬_ ; Dec ; yes ; no )
-open import Relation.Nullary.Decidable  using ( does ; dec-true ; dec-false )
+open import Data.Bool.Base                                 using  ( if_then_else_ )
+open import Data.Empty                                     using  ( ⊥-elim )
+open import Data.Fin.Base                                  using  ( Fin ; funToFin
+                                                                  ; fromℕ< ; toℕ
+                                                                  ; finToFun )
+open import Data.Fin.Properties                            using  ( toℕ<n ; toℕ-fromℕ<
+                                                                  ; toℕ-injective
+                                                                  ; finToFun-funToFin )
+                                                           renaming ( _≟_ to _≟ᶠ_ )
+open import Data.List.Base                                 using  ( List ; length
+                                                                  ; lookup ; concatMap
+                                                                  ; cartesianProduct
+                                                                  ; allFin )
+                                                           renaming ( map to lmap )
+open import Data.List.Membership.Propositional             using  ( _∈_ )
+open import Data.List.Membership.Propositional.Properties  using  ( ∈-allFin ; ∈-map⁺
+                                                                  ; ∈-cartesianProduct⁺
+                                                                  ; ∈-concat⁺′ )
+open import Data.List.Relation.Unary.Any                   using  ( index )
+open import Data.List.Relation.Unary.Any.Properties        using  ( lookup-index )
+open import Data.Nat.Base                                  using  ( ℕ ; zero ; suc
+                                                                  ; _≤_ ; _<_ ; s≤s )
+                                                           renaming ( _^_ to _^ᴺ_ )
+open import Data.Nat.Properties                            using  ( _<?_ ; ≤-refl
+                                                                  ; ≤-trans ; n≤1+n
+                                                                  ; <-irrefl ; ≤∧≢⇒< )
+open import Data.Product                                   using  ( Σ-syntax ; _×_
+                                                                  ; _,_ ; proj₁ ; proj₂ )
+open import Function                                       using  ( Func ; Inverse )
+open import Level                                          using  ( 0ℓ )
+open import Relation.Binary                                using  ( Setoid
+                                                                  ; IsEquivalence )
+open import Relation.Binary.PropositionalEquality          using  ( _≡_ ; refl ; sym
+                                                                  ; trans ; cong
+                                                                  ; subst ; subst₂ )
+open import Relation.Nullary                               using  ( ¬_ ; Dec ; yes ; no )
+open import Relation.Nullary.Decidable                     using  ( does ; dec-true
+                                                                  ; dec-false )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
-open import Classical.Structures.Lattice.Partitions  using ( SameBlock )
-open import FLRP.KurzweilNetter.Blocks                using ( module KNBlocks )
-open import FLRP.KurzweilNetter.Invariance            using ( Inv )
-open import Overture  using ( Signature ; OperationSymbolsOf ; ArityOf ; _|:_ )
-open import Setoid.Algebras.Basic                using ( Algebra ; 𝕌[_] ; 𝔻[_] ; _^_ )
-open import Setoid.Algebras.Finite.Irredundant   using ( IrredundantEnumeration )
-open import Setoid.Congruences.Basic             using ( _∣≈_ ; mkcon ; reflexive
-                                                       ; is-equivalence ; is-compatible )
-open import Setoid.Congruences.Certificates.Schema  using ( ParentVec )
-open import Setoid.Congruences.Finite.Basic      using ( DecCon ; ConRel )
-open import Setoid.Signatures.Finite             using ( FiniteSignature )
+open import Classical.Structures.Lattice.Partitions        using  ( SameBlock )
+open import FLRP.KurzweilNetter.Blocks                     using  ( module KNBlocks )
+open import FLRP.KurzweilNetter.Invariance                 using  ( Inv )
+open import Overture                                       using  ( Signature
+                                                                  ; OperationSymbolsOf
+                                                                  ; _|:_ ; ArityOf)
+open import Setoid.Algebras.Basic                          using  ( Algebra ; 𝕌[_]
+                                                                  ; 𝔻[_] ; _^_ )
+open import Setoid.Algebras.Finite.Irredundant             using  ( IrredundantEnumeration )
+open import Setoid.Congruences.Basic                       using  ( _∣≈_ ; mkcon ; reflexive
+                                                                  ; is-equivalence
+                                                                  ; is-compatible )
+open import Setoid.Congruences.Certificates.Schema         using  ( ParentVec )
+open import Setoid.Congruences.Finite.Basic                using  ( DecCon ; ConRel )
+open import Setoid.Signatures.Finite                       using  ( FiniteSignature )
 
 open Algebra using ( Interp )
 ```
@@ -106,28 +116,27 @@ open Algebra using ( Interp )
 
 #### The translation toolkit
 
-`KNTranslations`{.AgdaModule} fixes the finite finitary algebra — through its
-signature-finiteness witness — and an irredundant enumeration of its carrier,
+`KNTranslations`{.AgdaModule} fixes the finite finitary algebra, through its
+signature-finiteness witness, and an irredundant enumeration of its carrier,
 and opens the relation-level dictionary of [FLRP.KurzweilNetter.Blocks][].
 
 ```agda
-module KNTranslations {𝑆 : Signature 0ℓ 0ℓ} (𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ)
-                      (𝑺 : FiniteSignature 𝑆) (𝑬 : IrredundantEnumeration 𝑨) where
+module KNTranslations  {𝑆 : Signature 0ℓ 0ℓ} (𝑨 : Algebra {𝑆 = 𝑆} 0ℓ 0ℓ)
+                       (𝑺 : FiniteSignature 𝑆) (𝑬 : IrredundantEnumeration 𝑨) where
 
   open KNBlocks 𝑨 𝑬
-  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
-    renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans ; reflexive to ≈reflexive )
-  open IrredundantEnumeration 𝑬 using ( ienum ) renaming ( icard to m )
-  open FiniteSignature 𝑺
-    using ( opCard ; opEnum ; opEnum-sur ; arCard ; arIdx ; arEnum ; arEnum-arIdx
-          ; finitary )
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ) renaming  ( refl to ≈refl ; sym to ≈sym
+                                              ; trans to ≈trans ; reflexive to ≈reflexive )
+
+  open IrredundantEnumeration 𝑬 using ( ienum[_] ) renaming ( icard to m )
+  open FiniteSignature 𝑺 using  ( opCard ; opEnum ; opEnum-sur ; arCard ; arIdx
+                                ; arEnum ; arEnum-arIdx ; finitary )
 
   private
     -- The other round trip of the arity bijection (the record exposes only
     -- arEnum-arIdx; this direction is read off the underlying Inverse).
-    arIdx-arEnum : (f : OperationSymbolsOf 𝑆) (q : Fin (arCard f))
-      → arIdx f (arEnum f q) ≡ q
-    arIdx-arEnum f = Inverse.strictlyInverseˡ (proj₂ (finitary f))
+    arIdx-arEnum : (f : OperationSymbolsOf 𝑆) (q : Fin (arCard f)) → arIdx f (arEnum f q) ≡ q
+    arIdx-arEnum f = Inverse.strictlyInverseˡ (finitary f .proj₂)
 
     -- Congruence of an operation application in its argument tuple.
     fcong : (f : OperationSymbolsOf 𝑆) {u v : ArityOf 𝑆 f → 𝕌[ 𝑨 ]}
@@ -137,11 +146,10 @@ module KNTranslations {𝑆 : Signature 0ℓ 0ℓ} (𝑨 : Algebra {𝑆 = 𝑆}
 
 #### Translation data and the presented index maps
 
-A translation datum is an operation symbol (as an index into the symbol
-enumeration), a distinguished argument position, and a positional encoding of
-the constants at the remaining positions.  A nullary operation contributes no
-data (its position type is empty), matching the mathematics: constants impose
-no congruence constraint.
+A translation datum is an operation symbol (as an index into the symbol enumeration),
+a distinguished argument position, and a positional encoding of the constants at
+the remaining positions.  A nullary operation contributes no data (its position
+type is empty), matching the mathematics: constants impose no congruence constraint.
 
 ```agda
   -- One basic-translation instance, as pure data.
@@ -157,7 +165,7 @@ no congruence constraint.
   -- The unary index map presented by a translation datum.
   trMapOf : TrData → Fin m → Fin m
   trMapOf (o , p , cc) i =
-    eIdx ((opEnum o ^ 𝑨) (λ a → ienum (mixIx p cc i (arIdx (opEnum o) a))))
+    eIdx ((opEnum o ^ 𝑨) λ a → ienum[ mixIx p cc i (arIdx (opEnum o) a) ])
 ```
 
 #### Soundness: congruence partitions are invariant
@@ -169,30 +177,28 @@ reflexivity, and compatibility of the congruence does the rest.
 ```agda
   -- The partition of a decidable congruence is invariant under every translation.
   pvOf-invariant : (d : DecCon 𝑨 0ℓ) (td : TrData) → Inv (trMapOf td) (pvOf d)
-  pvOf-invariant d (o , p , cc) {i} {j} sb = pvOf-complete d related
+  pvOf-invariant d@((_θ_ , θcon) , _) (o , p , cc) {i} {j} sb = pvOf-complete d related
     where
-    θ-refl≈  = reflexive (proj₂ (proj₁ d))
-    θ-sym    = IsEquivalence.sym (is-equivalence (proj₂ (proj₁ d)))
-    θ-trans  = IsEquivalence.trans (is-equivalence (proj₂ (proj₁ d)))
+    θ-refl≈  = reflexive θcon
+    θ-sym    = IsEquivalence.sym (is-equivalence θcon)
+    θ-trans  = IsEquivalence.trans (is-equivalence θcon)
 
     f = opEnum o
 
     -- the two argument tuples, and their pointwise relatedness
     argsAt : Fin m → ArityOf 𝑆 f → 𝕌[ 𝑨 ]
-    argsAt i' a = ienum (mixIx p cc i' (arIdx f a))
+    argsAt i' a = ienum[ mixIx p cc i' (arIdx f a) ]
 
     mixRel : (q : Fin (arCard f)) (dq : Dec (q ≡ p))
-      → ConRel d  (ienum (if does dq then i else finToFun cc q))
-                  (ienum (if does dq then j else finToFun cc q))
+      → ienum[ if does dq then i else finToFun cc q ]
+        θ ienum[ if does dq then j else finToFun cc q ]
     mixRel q (yes _)  = pvOf-sound d sb
     mixRel q (no _)   = θ-refl≈ ≈refl
 
-    relF : ConRel d ((f ^ 𝑨) (argsAt i)) ((f ^ 𝑨) (argsAt j))
-    relF = is-compatible (proj₂ (proj₁ d)) f
-             {argsAt i} {argsAt j} (λ a → mixRel (arIdx f a) (arIdx f a ≟ᶠ p))
+    relF : (f ^ 𝑨)(argsAt i) θ (f ^ 𝑨)(argsAt j)
+    relF = is-compatible θcon f λ a → mixRel (arIdx f a) (arIdx f a ≟ᶠ p)
 
-    related : ConRel d  (ienum (trMapOf (o , p , cc) i))
-                        (ienum (trMapOf (o , p , cc) j))
+    related : ienum[ trMapOf (o , p , cc) i ] θ ienum[ trMapOf (o , p , cc) j ]
     related = θ-trans (θ-refl≈ (eIdx-≈ ((f ^ 𝑨) (argsAt i))))
                 (θ-trans relF (θ-sym (θ-refl≈ (eIdx-≈ ((f ^ 𝑨) (argsAt j))))))
 ```
@@ -212,8 +218,8 @@ instance, with the constants of the instance encoding the current hybrid.
   blockRel-compatible : (pv : ParentVec m)
     → ((td : TrData) → Inv (trMapOf td) pv) → 𝑨 ∣≈ blockRel pv
   blockRel-compatible pv inv 𝑓 =
-    subst (λ g → (g ^ 𝑨) |: blockRel pv) (proj₂ (opEnum-sur 𝑓))
-          (compatAt (proj₁ (opEnum-sur 𝑓)))
+    subst  (λ g → (g ^ 𝑨) |: blockRel pv) (opEnum-sur 𝑓 .proj₂)
+           (compatAt (opEnum-sur 𝑓 .proj₁))
     where
     compatAt : (o : Fin opCard) → (opEnum o ^ 𝑨) |: blockRel pv
     compatAt o {u} {v} hyp = final
@@ -231,13 +237,13 @@ instance, with the constants of the instance encoding the current hybrid.
         (cong (λ b → if b then v a else u a) (dec-false (toℕ (arIdx f a) <? 0) λ ()))
 
       hybk≈v : ∀ a → hyb k a ≈ v a
-      hybk≈v a = ≈reflexive
-        (cong (λ b → if b then v a else u a)
-              (dec-true (toℕ (arIdx f a) <? k) (toℕ<n (arIdx f a))))
+      hybk≈v a =
+        ≈reflexive (cong  (λ b → if b then v a else u a)
+                          (dec-true (toℕ (arIdx f a) <? k) (toℕ<n (arIdx f a))))
 
       -- one step of the walk: position l moves from its u-value to its v-value
       step : (l : ℕ) (sl≤k : suc l ≤ k)
-        → blockRel pv ((f ^ 𝑨) (hyb l)) ((f ^ 𝑨) (hyb (suc l)))
+        → blockRel pv ((f ^ 𝑨)(hyb l)) ((f ^ 𝑨)(hyb (suc l)))
       step l sl≤k =
         subst₂ (SameBlock pv) tI≡ tJ≡ (inv (o , pl , cc) (hyp p))
         where
@@ -293,27 +299,27 @@ instance, with the constants of the instance encoding the current hybrid.
 
         -- the translation at the moving u-index computes hyb l ...
         keyU : (q : Fin k) (dq : Dec (q ≡ pl))
-          → ienum (if does dq then eIdx (u p) else finToFun cc q) ≈ hyb l (arEnum f q)
+          → ienum[ if does dq then eIdx (u p) else finToFun cc q ] ≈ hyb l (arEnum f q)
         keyU q (yes e) = ≈trans (eIdx-≈ (u p))
           (≈reflexive (sym (trans (cong (hyb l) (cong (arEnum f) e)) hybl-p)))
         keyU q (no _)  = ≈trans
-          (≈reflexive (cong ienum (finToFun-funToFin (λ q' → eIdx (hyb l (arEnum f q'))) q)))
+          (≈reflexive (cong ienum[_] (finToFun-funToFin (λ q' → eIdx (hyb l (arEnum f q'))) q)))
           (eIdx-≈ (hyb l (arEnum f q)))
 
         -- ... and at the moving v-index computes hyb (suc l)
         keyV : (q : Fin k) (dq : Dec (q ≡ pl))
-          → ienum (if does dq then eIdx (v p) else finToFun cc q) ≈ hyb (suc l) (arEnum f q)
+          → ienum[ if does dq then eIdx (v p) else finToFun cc q ] ≈ hyb (suc l) (arEnum f q)
         keyV q (yes e) = ≈trans (eIdx-≈ (v p))
           (≈reflexive (sym (trans (cong (hyb (suc l)) (cong (arEnum f) e)) hybsl-p)))
         keyV q (no ne) = ≈trans
-          (≈reflexive (cong ienum (finToFun-funToFin (λ q' → eIdx (hyb l (arEnum f q'))) q)))
+          (≈reflexive (cong ienum[_] (finToFun-funToFin (λ q' → eIdx (hyb l (arEnum f q'))) q)))
           (≈trans (eIdx-≈ (hyb l (arEnum f q))) (≈reflexive (hyb-stable q ne)))
 
-        argU : ∀ a → ienum (mixIx pl cc (eIdx (u p)) (arIdx f a)) ≈ hyb l a
+        argU : ∀ a → ienum[ mixIx pl cc (eIdx (u p)) (arIdx f a) ] ≈ hyb l a
         argU a = ≈trans (keyU (arIdx f a) (arIdx f a ≟ᶠ pl))
                         (≈reflexive (cong (hyb l) (arEnum-arIdx f a)))
 
-        argV : ∀ a → ienum (mixIx pl cc (eIdx (v p)) (arIdx f a)) ≈ hyb (suc l) a
+        argV : ∀ a → ienum[ mixIx pl cc (eIdx (v p)) (arIdx f a) ] ≈ hyb (suc l) a
         argV a = ≈trans (keyV (arIdx f a) (arIdx f a ≟ᶠ pl))
                         (≈reflexive (cong (hyb (suc l)) (arEnum-arIdx f a)))
 
@@ -348,13 +354,12 @@ criterion, and its decision procedure by label comparison.
 
 #### The flat family
 
-The expansion step ([FLRP.KurzweilNetter.Expansion][]) consumes the
-translations as a family indexed by a plain `Fin`{.AgdaDatatype} — the shape a
-finite signature's symbol type needs.  The family is obtained by listing all
-translation data (finitely many: symbols, positions, and constant codes are all
-enumerated) and reading the list back through positional lookup; completeness
-of the listing is what converts family-invariance back into invariance under
-every datum.
+The expansion step ([FLRP.KurzweilNetter.Expansion][]) consumes the translations
+as a family indexed by a plain `Fin`{.AgdaDatatype}, which is the shape a finite
+signature's symbol type needs.  The family is obtained by listing all translation
+data (finitely many: symbols, positions, and constant codes are all enumerated)
+and reading the list back through positional lookup; completeness of the listing
+is what converts family-invariance back into invariance under every datum.
 
 ```agda
   private
@@ -406,8 +411,8 @@ family-invariance suffices for the criterion.
     → ((τ : Fin trCount) → Inv (trFamily τ) pv)
     → (td : TrData) → Inv (trMapOf td) pv
   family-invariant-all pv h td =
-    subst (λ z → Inv (trMapOf z) pv) (proj₂ (trIdx-complete td))
-          (h (proj₁ (trIdx-complete td)))
+    subst (λ z → Inv (trMapOf z) pv) (trIdx-complete td .proj₂)
+          (h (trIdx-complete td .proj₁))
 
   -- The decidable congruence presented by a family-invariant partition.
   blockConᶠ : (pv : ParentVec m)
@@ -416,3 +421,5 @@ family-invariance suffices for the criterion.
 ```
 
 --------------------------------------
+
+[^1]: See `docs/papers/fin-lat-rep/SmallLatticeReps.tex` § "Lattice duals".

--- a/src/Order/Iso.lagda.md
+++ b/src/Order/Iso.lagda.md
@@ -44,6 +44,7 @@ module Order.Iso where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
+open import Function         using ( _∘_ )
 open import Level            using ( Level ; _⊔_ )
 open import Relation.Binary  using () renaming ( Rel to BinaryRel )
 ```
@@ -65,3 +66,49 @@ record OrderIso
     to∘from    : ∀ u → to (from u) ≈₂ u
     from∘to    : ∀ x → from (to x) ≈₁ x
 ```
+
+#### Composition
+
+Order isomorphisms compose.  The round trips of the composite pass the inner
+round trip through the outer maps, which is sound only *up to the middle
+equivalence* — so composition asks for two congruence witnesses (the second
+map's `to` and the first map's `from` respect the middle equivalence) and for
+transitivity of the two end equivalences.  These are not derivable from the
+raw relations, but every instance has them: for setoid-valued orders they are
+the setoid laws, and for containment-style orders (congruences, intervals,
+partitions) they are monotonicity applied to the two directions of the
+equivalence.  Nothing is assumed of the middle relations beyond what the two
+isomorphisms already state.
+
+```agda
+module _
+  {a b c ℓ₁ ℓ₂ m₁ m₂ n₁ n₂ : Level}
+  {A : Type a} {B : Type b} {C : Type c}
+  {_≈₁_ : BinaryRel A ℓ₁} {_≤₁_ : BinaryRel A ℓ₂}
+  {_≈₂_ : BinaryRel B m₁} {_≤₂_ : BinaryRel B m₂}
+  {_≈₃_ : BinaryRel C n₁} {_≤₃_ : BinaryRel C n₂}
+  where
+
+  -- Composition of order isomorphisms, given the two congruence witnesses at
+  -- the middle equivalence and transitivity at the ends.
+  OrderIso-trans :
+      (F : OrderIso _≈₁_ _≤₁_ _≈₂_ _≤₂_) (G : OrderIso _≈₂_ _≤₂_ _≈₃_ _≤₃_)
+    → (∀ {x y} → x ≈₂ y → OrderIso.to G x ≈₃ OrderIso.to G y)
+    → (∀ {x y} → x ≈₂ y → OrderIso.from F x ≈₁ OrderIso.from F y)
+    → (∀ {x y z} → x ≈₁ y → y ≈₁ z → x ≈₁ z)
+    → (∀ {x y z} → x ≈₃ y → y ≈₃ z → x ≈₃ z)
+    → OrderIso _≈₁_ _≤₁_ _≈₃_ _≤₃_
+  OrderIso-trans F G G-to-cong F-from-cong ≈₁-trans ≈₃-trans = record
+    { to         = G.to ∘ F.to
+    ; from       = F.from ∘ G.from
+    ; to-mono    = G.to-mono ∘ F.to-mono
+    ; from-mono  = F.from-mono ∘ G.from-mono
+    ; to∘from    = λ u → ≈₃-trans (G-to-cong (F.to∘from (G.from u))) (G.to∘from u)
+    ; from∘to    = λ x → ≈₁-trans (F-from-cong (G.from∘to (F.to x))) (F.from∘to x)
+    }
+    where
+    module F = OrderIso F
+    module G = OrderIso G
+```
+
+--------------------------------------

--- a/src/Setoid/Algebras.lagda.md
+++ b/src/Setoid/Algebras.lagda.md
@@ -15,6 +15,8 @@ module Setoid.Algebras where
 
 open import Setoid.Algebras.Basic public
 open import Setoid.Algebras.Finite  public
+open import Setoid.Algebras.Finite.Irredundant public
 open import Setoid.Algebras.Products public
+open import Setoid.Algebras.Products.Finite public
 open import Setoid.Algebras.Reduct public
 ```

--- a/src/Setoid/Algebras.lagda.md
+++ b/src/Setoid/Algebras.lagda.md
@@ -31,8 +31,10 @@ representation.
 
 module Setoid.Algebras where
 
-open import Setoid.Algebras.Basic     public
-open import Setoid.Algebras.Finite    public
-open import Setoid.Algebras.Products  public
-open import Setoid.Algebras.Reduct    public
+open import Setoid.Algebras.Basic                public
+open import Setoid.Algebras.Finite               public
+open import Setoid.Algebras.Finite.Irredundant   public
+open import Setoid.Algebras.Products             public
+open import Setoid.Algebras.Products.Finite      public
+open import Setoid.Algebras.Reduct               public
 ```

--- a/src/Setoid/Algebras/Finite/Irredundant.lagda.md
+++ b/src/Setoid/Algebras/Finite/Irredundant.lagda.md
@@ -90,9 +90,9 @@ module _ {𝑆 : Signature 𝓞 𝓥} (𝑨 : Algebra {𝑆 = 𝑆} α ρ) where
   record IrredundantEnumeration : Type (α ⊔ ρ) where
     field
       icard      : ℕ
-      ienum      : Fin icard → 𝕌[ 𝑨 ]
-      ienum-sur  : ∀ x → ∃[ i ] ienum i ≈ x                 -- still hits everything
-      ienum-inj  : ∀ {i j} → ienum i ≈ ienum j → i ≡ j      -- but nothing twice
+      ienum[_]   : Fin icard → 𝕌[ 𝑨 ]
+      ienum-sur  : ∀ x → ∃[ i ] ienum[ i ] ≈ x                 -- still hits everything
+      ienum-inj  : ∀ {i j} → ienum[ i ] ≈ ienum[ j ] → i ≡ j      -- but nothing twice
 ```
 
 #### Two private list lemmas
@@ -170,7 +170,7 @@ trichotomy on the positions.
   irredundantEnumeration : IrredundantEnumeration 𝑨
   irredundantEnumeration = record
     { icard      = length dedup
-    ; ienum      = lookup dedup
+    ; ienum[_]   = lookup dedup
     ; ienum-sur  = sur
     ; ienum-inj  = λ {i} {j} → inj {i} {j}
     }

--- a/src/Setoid/Algebras/Finite/Irredundant.lagda.md
+++ b/src/Setoid/Algebras/Finite/Irredundant.lagda.md
@@ -1,0 +1,192 @@
+---
+layout: default
+file: "src/Setoid/Algebras/Finite/Irredundant.lagda.md"
+title: "Setoid.Algebras.Finite.Irredundant module (The Agda Universal Algebra Library)"
+date: "2026-07-28"
+author: "the agda-algebras development team"
+---
+
+### Irredundant enumerations of a finite carrier
+
+This is the [Setoid.Algebras.Finite.Irredundant][] module of the [Agda Universal Algebra Library][].
+
+The finiteness interface `FiniteAlgebra`{.AgdaRecord} of [Setoid.Algebras.Finite][]
+deliberately asks for a *surjective* enumeration only: `card`{.AgdaField} is an
+upper bound on the size of the carrier, and the same element may be hit many
+times.  That is the right interface for searching, but some constructions need
+the enumeration to be a *bijection up to `≈`* — one index per `≈`-class — so that
+the index set `Fin`{.AgdaDatatype}` m` is a faithful copy of the carrier.
+
+The first consumer is the Kurzweil–Netter duality proof ([FLRP.KurzweilNetter][],
+issue #502), which represents the dual of `Con 𝑨` on a power `S^m` *indexed by the
+carrier* of `𝑨`{.AgdaBound}: there the partitions of the index set must correspond
+exactly to the decidable equivalences on the carrier, which forces the enumeration
+to identify no two indices (a redundant index would admit partitions separating
+two copies of one element, and the correspondence would break).
+
+This module upgrades any `FiniteAlgebra`{.AgdaRecord} witness to an
+**irredundant enumeration**: a size `icard`{.AgdaField}, an enumeration
+`ienum`{.AgdaField} that is still surjective up to `≈`, and an injectivity
+proof `ienum-inj`{.AgdaField} stating that `≈`-equal values have equal indices.
+The construction is elementary and fully constructive: list the enumerated
+values, `deduplicate`{.AgdaFunction} the list using the decidable equality
+carried by the finiteness witness, and read the deduplicated list back as a
+function on its positions.  Surjectivity survives deduplication by the standard
+library's membership lemmas, and injectivity is exactly the pairwise
+distinctness (`Unique`{.AgdaFunction}) of the deduplicated list.
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Setoid.Algebras.Finite.Irredundant where
+
+open import Agda.Primitive using () renaming ( Set to Type )
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Empty          using ( ⊥-elim )
+open import Data.Fin.Base       using ( Fin ; zero ; suc ) renaming ( _<_ to _<ᶠ_ )
+open import Data.Fin.Properties using ( <-cmp )
+open import Data.List.Base      using ( List ; length ; lookup ; tabulate
+                                      ; deduplicate )
+open import Data.Nat.Base       using ( ℕ ; s≤s )
+open import Data.Product        using ( _,_ ; proj₁ ; proj₂ ; ∃-syntax )
+open import Level               using ( Level ; _⊔_ )
+open import Relation.Binary     using ( Setoid ; DecSetoid )
+open import Relation.Binary.Definitions           using ( tri< ; tri≈ ; tri> )
+open import Relation.Binary.PropositionalEquality using ( _≡_ )
+open import Relation.Nullary    using ( ¬_ )
+
+open import Data.List.Relation.Unary.All       using ( All ; [] ; _∷_ )
+open import Data.List.Relation.Unary.AllPairs  using ( AllPairs ; [] ; _∷_ )
+open import Data.List.Relation.Unary.Any       using ( Any ; index )
+open import Data.List.Relation.Unary.Any.Properties  using ( lookup-index )
+
+import Data.List.Membership.Setoid.Properties             as MembershipP
+import Data.List.Relation.Unary.Unique.DecSetoid.Properties as UniqueP
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Overture               using ( 𝓞 ; 𝓥 ; Signature )
+open import Setoid.Algebras.Basic  using ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite using ( FiniteAlgebra )
+
+private variable α ρ ℓ : Level
+```
+-->
+
+#### The interface
+
+An **irredundant enumeration** of the carrier of `𝑨`{.AgdaBound} is a surjective
+enumeration that hits each `≈`-class exactly once: `≈`-equal values have
+propositionally equal indices.  (Injectivity is stated in this converse-kernel
+form because it is the form consumers use: it makes the index map
+`x ↦ proj₁ (ienum-sur x)` a well-defined function on `≈`-classes.)
+
+```agda
+module _ {𝑆 : Signature 𝓞 𝓥} (𝑨 : Algebra {𝑆 = 𝑆} α ρ) where
+
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ )
+
+  record IrredundantEnumeration : Type (α ⊔ ρ) where
+    field
+      icard      : ℕ
+      ienum      : Fin icard → 𝕌[ 𝑨 ]
+      ienum-sur  : ∀ x → ∃[ i ] ienum i ≈ x                 -- still hits everything
+      ienum-inj  : ∀ {i j} → ienum i ≈ ienum j → i ≡ j      -- but nothing twice
+```
+
+#### Two private list lemmas
+
+Positions of a list of pairwise-distinct elements carry the distinctness: the
+values at two positions in `<`-order are related by the pairwise relation.  (The
+standard library states `AllPairs`{.AgdaDatatype} by structural induction; these
+two small lemmas read it back through positional `lookup`{.AgdaFunction}.)
+
+```agda
+module _ {A : Type α} where
+
+  private
+    -- The value at each position of an All-covered list satisfies the predicate.
+    lookup-All : {P : A → Type ℓ} {xs : List A}
+      → All P xs → (i : Fin (length xs)) → P (lookup xs i)
+    lookup-All []         ()
+    lookup-All (px ∷ pxs) zero     = px
+    lookup-All (px ∷ pxs) (suc i)  = lookup-All pxs i
+
+  -- Values at <-ordered positions of an AllPairs-covered list are related.
+  lookup-AllPairs : {R : A → A → Type ℓ} {xs : List A} → AllPairs R xs
+    → {i j : Fin (length xs)} → i <ᶠ j → R (lookup xs i) (lookup xs j)
+  lookup-AllPairs []         {i = ()}
+  lookup-AllPairs (px ∷ pxs) {i}      {zero}  ()
+  lookup-AllPairs (px ∷ pxs) {zero}   {suc j} _          = lookup-All px j
+  lookup-AllPairs (px ∷ pxs) {suc i}  {suc j} (s≤s i<j)  =
+    lookup-AllPairs pxs {i} {j} i<j
+```
+
+#### The construction
+
+Deduplicating the value list of the given enumeration yields the irredundant one.
+
+```agda
+module _ {𝑆 : Signature 𝓞 𝓥} {𝑨 : Algebra {𝑆 = 𝑆} α ρ} (𝑭 : FiniteAlgebra 𝑨) where
+
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ; sym ; trans )
+  open FiniteAlgebra 𝑭 using ( _≟_ ; enum ; enum-sur )
+
+  private
+    -- The carrier's decidable-setoid bundle, for the deduplication lemmas.
+    DS : DecSetoid α ρ
+    DS = record
+      { Carrier           = 𝕌[ 𝑨 ]
+      ; _≈_               = _≈_
+      ; isDecEquivalence  = record
+          { isEquivalence  = Setoid.isEquivalence 𝔻[ 𝑨 ]
+          ; _≟_            = _≟_
+          }
+      }
+
+    -- The enumerated values, as a list, deduplicated up to ≈.
+    values : List 𝕌[ 𝑨 ]
+    values = tabulate enum
+
+    dedup : List 𝕌[ 𝑨 ]
+    dedup = deduplicate _≟_ values
+
+    -- Membership in the value list survives deduplication (≈ respects itself).
+    ∈-dedup : {x : 𝕌[ 𝑨 ]} → Any (x ≈_) values → Any (x ≈_) dedup
+    ∈-dedup = MembershipP.∈-deduplicate⁺ 𝔻[ 𝑨 ] _≟_ (λ b≈a x≈a → trans x≈a (sym b≈a))
+
+    -- The deduplicated list is pairwise ≈-distinct.
+    dedup-distinct : AllPairs (λ x y → ¬ (x ≈ y)) dedup
+    dedup-distinct = UniqueP.deduplicate-! DS values
+```
+
+The three fields.  Surjectivity chases an element through its original
+enumeration index and the membership lemmas; injectivity turns an `≈`-collision
+of two distinct positions into a contradiction with pairwise distinctness, by
+trichotomy on the positions.
+
+```agda
+  irredundantEnumeration : IrredundantEnumeration 𝑨
+  irredundantEnumeration = record
+    { icard      = length dedup
+    ; ienum      = lookup dedup
+    ; ienum-sur  = sur
+    ; ienum-inj  = λ {i} {j} → inj {i} {j}
+    }
+    where
+    sur : ∀ x → ∃[ i ] lookup dedup i ≈ x
+    sur x = index mem , trans (sym (lookup-index mem)) (proj₂ (enum-sur x))
+      where
+      -- enum i₀ is in the value list, hence in the deduplicated list.
+      mem : Any (enum (proj₁ (enum-sur x)) ≈_) dedup
+      mem = ∈-dedup (MembershipP.∈-tabulate⁺ 𝔻[ 𝑨 ] (proj₁ (enum-sur x)))
+
+    inj : ∀ {i j} → lookup dedup i ≈ lookup dedup j → i ≡ j
+    inj {i} {j} e with <-cmp i j
+    ... | tri<  i<j _ _  = ⊥-elim (lookup-AllPairs dedup-distinct i<j e)
+    ... | tri≈  _ i≡j _  = i≡j
+    ... | tri>  _ _ j<i  = ⊥-elim (lookup-AllPairs dedup-distinct j<i (sym e))
+```
+
+--------------------------------------

--- a/src/Setoid/Algebras/Products/Finite.lagda.md
+++ b/src/Setoid/Algebras/Products/Finite.lagda.md
@@ -1,0 +1,96 @@
+---
+layout: default
+file: "src/Setoid/Algebras/Products/Finite.lagda.md"
+title: "Setoid.Algebras.Products.Finite module (The Agda Universal Algebra Library)"
+date: "2026-07-28"
+author: "the agda-algebras development team"
+---
+
+### Finiteness of finite powers
+
+This is the [Setoid.Algebras.Products.Finite][] module of the [Agda Universal Algebra Library][].
+
+A finite power of a finite algebra is finite.  This module discharges the
+`FiniteAlgebra`{.AgdaRecord} interface of [Setoid.Algebras.Finite][] for the
+constant-family product `⨅ (λ (_ : Fin n) → 𝑨)`{.AgdaFunction} of
+[Setoid.Algebras.Products][] — the *power* `𝑨ⁿ` — from a finiteness witness for
+the base algebra `𝑨`{.AgdaBound}:
+
++  **decidable equality** is decided coordinatewise, by a finite conjunction of
+   base-level decisions (`all?`{.AgdaFunction});
++  **the enumeration** of the `cardⁿ` tuples is the standard library's positional
+   base-`card` encoding `finToFun`{.AgdaFunction}, composed with the base
+   enumeration coordinatewise;
++  **surjectivity** holds *pointwise up to `≈`* — which is exactly the setoid
+   equality of the product — with no appeal to function extensionality: the
+   round-trip law `finToFun-funToFin`{.AgdaFunction} is itself pointwise.
+
+The first consumer is the Kurzweil–Netter duality proof (issue #502), which
+needs the power `Sᵐ` of a finite group to be a finite algebra so that the coset
+algebra on `Sᵐ/D` inherits finiteness through
+`cosetAlgebra-FiniteAlgebra`{.AgdaFunction} of
+[Classical.Structures.Group.GSet][].
+
+<!--
+```agda
+{-# OPTIONS --cubical-compatible --exact-split --safe #-}
+
+module Setoid.Algebras.Products.Finite where
+
+-- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Fin.Base        using ( Fin ; finToFun ; funToFin )
+open import Data.Fin.Properties  using ( all? ; finToFun-funToFin )
+open import Data.Nat.Base        using ( ℕ ; _^_ )
+open import Data.Product         using ( _,_ ; proj₁ ; proj₂ )
+open import Level                using ( Level )
+open import Relation.Binary      using ( Setoid )
+open import Relation.Binary.PropositionalEquality using ( cong )
+
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Overture                  using ( 𝓞 ; 𝓥 ; Signature )
+open import Setoid.Algebras.Basic     using ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Finite    using ( FiniteAlgebra )
+open import Setoid.Algebras.Products  using ( ⨅ )
+
+private variable α ρ : Level
+```
+-->
+
+#### The finiteness witness for a power
+
+```agda
+module _ {𝑆 : Signature 𝓞 𝓥} {𝑨 : Algebra {𝑆 = 𝑆} α ρ} {n : ℕ}
+         (𝑭 : FiniteAlgebra 𝑨) where
+
+  open Setoid 𝔻[ 𝑨 ] using ( _≈_ ; trans ) renaming ( reflexive to ≈-reflexive )
+  open FiniteAlgebra 𝑭 using ( _≟_ ; card ; enum ; enum-sur )
+
+  private
+    𝑷 : Algebra {𝑆 = 𝑆} α ρ
+    𝑷 = ⨅ {I = Fin n} (λ _ → 𝑨)
+
+    -- The tuple encoded by an index: base enumeration after digit extraction.
+    penum : Fin (card ^ n) → 𝕌[ 𝑷 ]
+    penum ν i = enum (finToFun ν i)
+
+    -- The index encoding a tuple: the digits are the base indices of its values.
+    pidx : 𝕌[ 𝑷 ] → Fin (card ^ n)
+    pidx x = funToFin (λ i → proj₁ (enum-sur (x i)))
+
+    -- The round trip hits the tuple coordinatewise, up to ≈.
+    penum-pidx : (x : 𝕌[ 𝑷 ]) (i : Fin n) → penum (pidx x) i ≈ x i
+    penum-pidx x i = trans
+      (≈-reflexive (cong enum (finToFun-funToFin (λ j → proj₁ (enum-sur (x j))) i)))
+      (proj₂ (enum-sur (x i)))
+
+  -- A finite power of a finite algebra is finite.
+  power-FiniteAlgebra : FiniteAlgebra 𝑷
+  power-FiniteAlgebra = record
+    { _≟_       = λ x y → all? (λ i → x i ≟ y i)
+    ; card      = card ^ n
+    ; enum      = penum
+    ; enum-sur  = λ x → pidx x , penum-pidx x
+    }
+```
+
+--------------------------------------


### PR DESCRIPTION
## Summary

Closes #502 (WP-5 stretch goal).  The **Kurzweil–Netter duality theorem**: if a finite lattice is decidably representable, then so is its dual. 

The theorem is proved *from a package of witnesses for the base group*: `kurzweilNetterDuality` of `FLRP.KurzweilNetter.Duality` inhabits Entry 2's statement `KurzweilNetterDuality` inside a module parameterized by exactly the properties the argument uses, so the closed result is conditional on that package, whose only classical ingredient is Entry 4.  `dual-Representableᵈ` of `FLRP.Closure` is rewired to it (taking the same package), and registry Entry 2 is **reduced to Entry 4** — retired as an independent assumption, its types kept as the theorem's canonical statement.

The argument follows `docs/papers/fin-lat-rep/SmallLatticeReps.tex` § *Lattice duals* (after Pálfy's 2009 lectures); since Netter's 1986 article may never have been published, this is plausibly the first complete write-up of the general proof in any medium, machine-checked or otherwise.

Stacked on #523 (the `Sⁿ`/`Diag`/`Eq(n)`/`K_π` prerequisites); only the five `[M6-16]` commits are new here.

## The two scoping decisions, as recorded in the module prose

+  **The simple group is a parameter, and the parameter list is the deliverable**.  `KurzweilNetterProof` takes a group `𝒮` with exactly the properties the argument uses: a `FiniteAlgebra` witness (finite carrier, decidable equality), a nontriviality witness `s₀` with `¬ (s₀ ≈ ε)` (consumed by the indicator-tuple arguments: order reflection and injectivity of `π ↦ K_π`, and the invariance extraction of the expansion step), and the Kurzweil-surjectivity family `(n : ℕ) → KurzweilSurjectivityAt 𝒮 n` (Entry 4).  Nonabelianness and simplicity enter *only* through Entry 4, so no simplicity predicate occurs anywhere in the development.  The `A₅` instantiation is tracked as [#527](https://github.com/ualib/agda-algebras/issues/527); Entry 4's retirement is [#522](https://github.com/ualib/agda-algebras/issues/522).

+  **No dependence on the unary-reduction theorem** ([#501](https://github.com/ualib/agda-algebras/issues/501)).  The manuscript says "we can assume `F` consists of unary operations"; instead of importing that as a hypothesis, the expansion lifts only the *basic translations* of the representing algebra, and `FLRP.KurzweilNetter.Translations` proves the Mal'cev-style **translation criterion** (a partition invariant under every basic translation induces a congruence of every arity) by the one-position-at-a-time walk.  This is strictly less than [#501](https://github.com/ualib/agda-algebras/issues/501) (no polynomial clone is constructed) and [#501](https://github.com/ualib/agda-algebras/issues/501) remains open, with nothing here waiting on it.

## The proof, by module

+  `Setoid.Algebras.Finite.Irredundant`: upgrades any `FiniteAlgebra` enumeration to one hitting each `≈`-class exactly once (deduplication by the carried decidable equality).  Irredundancy is a correctness condition: a redundant index would admit partitions separating two copies of one element and the correspondence would fail to biject.
+  `Setoid.Algebras.Products.Finite`: a finite power of a finite algebra is finite, via `finToFun`; surjectivity is pointwise up to `≈`, so no function extensionality.
+  `FLRP.KurzweilNetter.Invariance`: the invariance notion `Inv t pv` where the algebra side and the group side meet.
+  `FLRP.KurzweilNetter.Blocks`: the relation-level dictionary: decidable congruences of the carrier ↔ partitions of `Fin m` (`pvOf` by least-related-index search, `blockRel` by label comparison), monotone and mutually inverse.
+  `FLRP.KurzweilNetter.Translations`: translation data `(o , p , cc)` with positionally encoded constants, the flat family `trFamily : Fin trCount → Fin m → Fin m`, soundness (congruence partitions are invariant), and the translation criterion.
+  `FLRP.KurzweilNetter.Expansion`: the heart: the coset algebra on `Sᵐ/D`, expanded by an abstract family of lifted index maps over the enumerated symbol type `Fin N ⊎ Fin T`, has decidable congruence poset dually isomorphic to the family-invariant partitions (`expansionIso`), composing the WP-3 bridge `bridgeᵈ` of `FLRP.Bridge` with `kurzweilIntervalIso` of `FLRP.KurzweilInterval`.  The enumerated symbol type is forced: `FiniteSignature` needs `≡`-enumerated symbols, which a function-type carrier cannot have under `--safe`; compatibility with every group element is recovered from the enumerated actions through `≈`-surjectivity (`forget`).
+  `FLRP.KurzweilNetter.Duality`: the glue `KNGlue` (over an abstract enumeration and surjectivity witness) composes `expansionIso`, the block dictionary, and the given representation into `ConIsoᵈ 𝑬 (dualLattice 𝑳)`, and `KurzweilNetterProof` instantiates it.
+  `Order.Iso` gains `OrderIso-trans`: composition of order isomorphisms given the two middle-congruence witnesses and end transitivities: used to glue the stages.

## What this does and does not change

+  Entry 2 is reduced to Entry 4 (retired as an independent assumption); its types remain as the theorem's canonical statement, with no closed inhabitant claimed.  The residual classical content is exactly Entry 4 plus a concrete simple instantiation ([#522](https://github.com/ualib/agda-algebras/issues/522), [#527](https://github.com/ualib/agda-algebras/issues/527)).
+  The census's dual entries (`L18`/`L22`, [#485](https://github.com/ualib/agda-algebras/issues/485)) now rest on Entry 4 rather than the full duality theorem (assumption-free in *statement* modulo Entry 4) but remain computationally out of reach: the construction represents an `n`-element algebra's dual on `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹` elements, and no concrete certificate is materialized.

## Performance note

The first assembly of the composite took 190 s to type-check, 183 s of it `Typing.CheckRHS` pinned to a single round-trip definition by `--profile=definitions`: conversion re-normalized the instantiated construction while inverting implicit endpoints.  The landed shape (expensive inputs as inert module parameters of `KNGlue`, stages glued by the checked-once `OrderIso-trans`, congruence arguments eta-expanded) checks the same content in 5 s.  The measurement and the fix are recorded in the module prose.

## Gates

+  `make check` green (twice: before and after the import hygiene pass).
+  `make unused-imports` clean; `python3 scripts/python/test_unused_imports.py` 55/55.
+  `make gen-links` regenerated `docs/_links.md`; `make check-links` all resolve.

---

🤖 AI-assisted development: Claude Fable 5 (Anthropic)
