### PR TITLE
licensing: additional permission for machine-extracted representations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025-2026 William DeMeo and Contributors
+   Copyright 2018-2026 William DeMeo and the agda-algebras development team.
+
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-data
+++ b/LICENSE-data
@@ -1,0 +1,63 @@
+Additional Permission for Machine-Extracted Representations of agda-algebras
+===========================================================================
+
+Copyright 2018-2026 The agda-algebras development team.
+
+This file GRANTS ADDITIONAL PERMISSIONS.  It takes nothing away.  The source
+code under src/ remains licensed under the Apache License 2.0 (see LICENSE),
+and the documentation under docs/ remains licensed under CC BY 4.0 (see
+LICENSE-docs).  If this file did not exist, everything it permits would still
+be permitted under Apache-2.0 — with attribution obligations that this file
+makes optional for one narrow class of artifact.
+
+
+What this covers
+----------------
+
+"Extracted Representations" means data mechanically derived from this library's
+source by a tool, rather than written by a person, and not usable as a
+substitute for the source itself.  Specifically:
+
+  + type signatures and proof terms as rendered by Agda's own internal
+    representation or pretty printer (as distinct from the surface syntax a
+    human wrote);
+  + names, module paths, and qualified names;
+  + dependency, import, and reference metadata;
+  + structural encodings of types (abstract syntax trees);
+  + counts, distributions, digests, and any other statistics computed over the
+    above;
+  + corpora, indices, embeddings, and datasets assembled from the above.
+
+It does NOT cover the source files under src/ themselves, in whole or in part,
+nor the literate prose interleaved with the code in those files, nor the
+documentation under docs/.  Those keep the licenses named above.
+
+
+The grant
+---------
+
+Any person obtaining Extracted Representations of this library may use,
+redistribute, and build upon them under EITHER
+
+  (a) the Apache License 2.0, as for the rest of this repository; OR
+  (b) the CC0 1.0 Universal Public Domain Dedication
+      (https://creativecommons.org/publicdomain/zero/1.0/),
+
+at that person's option.  This explicitly includes use as training,
+fine-tuning, retrieval, or evaluation data for machine-learning models, and
+includes redistribution of such data as part of a larger corpus under that
+corpus's own terms.
+
+
+Why
+---
+
+A corpus extracted from a formal library is a derivative work of that library,
+so without a statement like this one a downstream consumer has to reason about
+Apache-2.0 attribution obligations for every row of a dataset that may contain
+millions of them.  Apache-2.0 permits the use; it is the per-row bookkeeping
+that discourages it.  Option (b) removes that bookkeeping.
+
+We would nonetheless rather be cited than not.  A citation is requested, not
+required, under option (b): see CITATION.cff, and please name the commit the
+data was extracted from so the extraction can be reproduced.

--- a/LICENSE-data
+++ b/LICENSE-data
@@ -3,10 +3,10 @@ Additional Permission for Machine-Extracted Representations of agda-algebras
 
 Copyright 2018-2026 William DeMeo and the agda-algebras development team.
 
-This file GRANTS ADDITIONAL PERMISSIONS.  It takes nothing away.  The source
-code under src/ remains licensed under the Apache License 2.0 (see LICENSE),
-and the documentation under docs/ remains licensed under CC BY 4.0 (see
-LICENSE-docs).  If this file did not exist, everything it permits would still
+This file GRANTS ADDITIONAL PERMISSIONS.  It takes nothing away.  This
+repository is licensed in parts: the source code under src/ under the Apache
+License 2.0 (see LICENSE), the documentation under docs/ under CC BY 4.0 (see
+LICENSE-docs).  Neither is changed by this file.  If this file did not exist, everything it permits would still
 be permitted under Apache-2.0 — with attribution obligations that this file
 makes optional for one narrow class of artifact.
 
@@ -39,7 +39,8 @@ The grant
 Any person obtaining Extracted Representations of this library may use,
 redistribute, and build upon them under EITHER
 
-  (a) the Apache License 2.0, as for the rest of this repository; OR
+  (a) the Apache License 2.0, the license of this library's source code
+      (see LICENSE); OR
   (b) the CC0 1.0 Universal Public Domain Dedication
       (https://creativecommons.org/publicdomain/zero/1.0/),
 

--- a/LICENSE-data
+++ b/LICENSE-data
@@ -1,7 +1,7 @@
 Additional Permission for Machine-Extracted Representations of agda-algebras
 ===========================================================================
 
-Copyright 2018-2026 The agda-algebras development team.
+Copyright 2018-2026 William DeMeo and the agda-algebras development team.
 
 This file GRANTS ADDITIONAL PERMISSIONS.  It takes nothing away.  The source
 code under src/ remains licensed under the Apache License 2.0 (see LICENSE),

--- a/LICENSE-docs
+++ b/LICENSE-docs
@@ -4,7 +4,7 @@ The documentation and the papers, notes, and tutorials in this repository
 (docs/) are licensed under the Creative Commons Attribution 4.0 International
 License.
 
-Copyright 2025-2026 William DeMeo and Contributors
+Copyright 2018-2026 William DeMeo and the agda-algebras development team.
 
 You are free to:
 

--- a/NOTICE
+++ b/NOTICE
@@ -7,10 +7,15 @@ scripts/python/utils/ directory at SHA 664b919.  The vendored copies live at
 scripts/python/_utils/ in this repository.  See the provenance headers at
 the top of each file for per-file attribution.
 
-That vendored code is licensed under the Apache License 2.0, the license of
-the project it came from; this repository is likewise licensed under the Apache
-License 2.0.  See LICENSE.
+That vendored code is licensed under the Apache License 2.0, the license of the
+project it came from, and it sits among this repository's Apache-2.0 material.
 
-Machine-extracted representations of this library carry an additional
-permission allowing use under Apache-2.0 or CC0-1.0 at the recipient's option.
-See LICENSE-data.
+This repository is licensed in parts, not as a whole:
+
+  src/ and the other source code   Apache License 2.0        LICENSE
+  docs/                            CC BY 4.0                 LICENSE-docs
+  machine-extracted                Apache-2.0 or CC0-1.0,    LICENSE-data
+  representations                  at the recipient's option
+
+LICENSE-data grants an additional permission; it takes nothing away from the
+licenses above.

--- a/NOTICE
+++ b/NOTICE
@@ -7,4 +7,10 @@ scripts/python/utils/ directory at SHA 664b919.  The vendored copies live at
 scripts/python/_utils/ in this repository.  See the provenance headers at
 the top of each file for per-file attribution.
 
-The software is licensed under the BSD 3-Clause license; see LICENSE.
+That vendored code is licensed under the Apache License 2.0, the license of
+the project it came from; this repository is likewise licensed under the Apache
+License 2.0.  See LICENSE.
+
+Machine-extracted representations of this library carry an additional
+permission allowing use under Apache-2.0 or CC0-1.0 at the recipient's option.
+See LICENSE-data.

--- a/README.md
+++ b/README.md
@@ -102,12 +102,13 @@ For questions about mathematical content or larger design changes, please open a
 
 ## Licensing
 
-agda-algebras is dual-licensed to match the dual nature of the project.
+agda-algebras is licensed to match the several natures of the project.
 
 +  **Source code** (under `src/`) is licensed under the [Apache License 2.0](./LICENSE), a permissive industry-standard software license compatible with essentially all other open-source licenses and with commercial use.
 +  **Documentation, papers, and tutorials** (under `docs/`) are licensed under the [Creative Commons Attribution 4.0 International License](./LICENSE-docs), the standard license for academic-style written material; it permits sharing and adaptation with attribution.
++  **Machine-extracted representations** of the library — type signatures, proof terms as Agda renders them, names, dependency metadata, structural encodings, statistics, and corpora built from these — carry an [additional permission](./LICENSE-data): they may be used under Apache-2.0 or under [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/), at the recipient's option.  This is a grant, not a restriction; it exists so that using this library as machine-learning training or retrieval data does not require per-row attribution bookkeeping.  Citation is requested rather than required in that case — see [Citing](#citing).
 
-If you are redistributing or building on agda-algebras, please respect both licenses for their respective parts of the repository.
+If you are redistributing or building on agda-algebras, please respect these licenses for their respective parts of the repository.
 
 ---
 


### PR DESCRIPTION
## Description

This adds a licence grant on behalf of the copyright holders of this library.  There are several contributors: William DeMeo ~2,400 commits, Jacques Carette (55), Siva Somayyajula (23), Andreas Abel (6), and two single-commit contributors; `CITATION.cff` names Carette as an author.

What is proposed is an **additional permission**, not a relicense; it adds permissions and removes none, and it is confined to mechanically derived data rather than to anyone's source or prose.

That is about as low-risk as licence changes get.  It is still, formally, a grant touching the contributions of others.

## tl;dr

+  `LICENSE-data` (new): machine-extracted representations of this library may be used under **Apache-2.0 or CC0-1.0, at the recipient's option**.
+  Scope is narrow and explicit: types, proof terms as Agda renders them, names, dependency metadata, structural encodings, statistics, and corpora built from those.  **Not** `src/` itself, not the literate prose in those files, not `docs/`.
+  Fixes a real contradiction in `NOTICE`: it said the vendored code "is licensed under the BSD 3-Clause license; see LICENSE", but `LICENSE` is Apache-2.0, and BSD 3-Clause appears nowhere in this repository.

## Why this is worth doing

A corpus extracted from a formal library is a derivative work of it.  [`formalverification/agda-native-air#120`](https://github.com/formalverification/agda-native-air/pull/120) just published one: 11,666 rows from this library at `ecc158a3`, of which 10,629 carry a proof term.  Under Apache-2.0 alone, anyone redistributing that dataset, or a larger corpus containing it, inherits attribution obligations over every row.

Apache-2.0 *permits* all of this.  Nothing here is about making a forbidden thing allowed.  It is about the difference between "allowed after you have satisfied yourself about the bookkeeping" and "allowed".  For datasets that difference decides whether anyone bothers.

The grant keeps what actually matters to an academic project: citation stays requested, `CITATION.cff` is pointed at, and the text asks that the extraction commit be named so results can be reproduced.

## What is deliberately not covered

The exclusions are the point of the file, so they are stated twice, once in the scope list and once negatively:

+  `src/` files themselves, in whole or in part.
+  **The literate prose interleaved with the code in those files**.  This one matters for [#275](https://github.com/ualib/agda-algebras/issues/275): a corpus that harvests docstrings and prose summaries is quoting human writing, not extracted structure, and stays under the licences those files carry.
+  `docs/`.

So a future prose-bearing corpus is *not* automatically CC0 under this grant.  Adding that is a separate decision and should be its own issue.

## Files

| File | Change |
|---|---|
| `LICENSE-data` | New.  The grant, its scope, its exclusions, and the reasoning |
| `README.md` | Third bullet in "Licensing", pointing at it and saying it is a grant rather than a restriction |
| `NOTICE` | Corrects BSD 3-Clause → Apache-2.0; adds a pointer to `LICENSE-data` |

🤖 AI-assisted development: Claude Opus 5 (Anthropic)
