### PR TITLE
[M4-2] Exemplar: document Setoid.Algebras.Basic end to end (#268)

### DIFF
--- a/src/Setoid/Algebras/Basic.lagda.md
+++ b/src/Setoid/Algebras/Basic.lagda.md
@@ -9,9 +9,33 @@ author: "agda-algebras development team"
 
 This is the [Setoid.Algebras.Basic][] module of the [Agda Universal Algebra Library][].
 
-An **algebra over a signature** `𝑆`{.AgdaGeneralizable} is a setoid — a carrier type together with an equivalence relation on it — equipped with an interpretation of every operation symbol of `𝑆`{.AgdaGeneralizable} as a function on that carrier which *respects* the equivalence.  That last clause is the entire difference from the type-based development: on a setoid an operation is not a bare function but a `Func`{.AgdaRecord}, a function bundled with a proof that it sends related arguments to related results.  Carrying the proof inside the structure is what makes quotients cheap: a quotient algebra is the *same* carrier under a coarser equivalence, so forming one needs neither quotient types nor an axiom.  That matters here, because the library is `--safe --cubical-compatible`, where function extensionality is unavailable — see the discussion at `mkAlgebra`{.AgdaFunction} below for where the cost reappears.
+An **algebra over a signature** `𝑆`{.AgdaGeneralizable} is a setoid (i.e., a carrier
+type together with an equivalence relation on it) equipped with an interpretation
+of every operation symbol of `𝑆`{.AgdaGeneralizable} as a function on that carrier
+which *respects* the equivalence.
 
-This module is the canonical entry point for the `Setoid/` tree.  It defines the `Algebra`{.AgdaRecord} record, two smart constructors for building one from an ordinary interpretation function, the operation-interpretation operator `_^_`{.AgdaFunction}, and the universe-lifting operations that let algebras at different levels be compared.  For indexed products see [Setoid.Algebras.Products][]; for finite algebras, [Setoid.Algebras.Finite][]; for reducts to a smaller signature, [Setoid.Algebras.Reduct][].  Congruences and the quotients they generate are in [Setoid.Congruences.Basic][], and structure-preserving maps between algebras in [Setoid.Homomorphisms.Basic][].
+That last clause is the entire difference from the type-based development: on a
+setoid an operation is not a bare function but a `Func`{.AgdaRecord}, that is, a
+function bundled with a proof that it sends related arguments to related results.
+Carrying the proof inside the structure yields quotients: a quotient algebra is
+the *same* carrier under a coarser equivalence, so forming one needs neither
+quotient types nor an axiom.  That matters here, because the library is
+`--safe --cubical-compatible`, where function extensionality is unavailable; see
+the discussion at `mkAlgebra`{.AgdaFunction} below for where the cost reappears.
+
+This module is the canonical entry point for the `Setoid/` tree.  It defines the
+`Algebra`{.AgdaRecord} record, two smart constructors for building one from an
+ordinary interpretation function, the operation-interpretation operator
+`_^_`{.AgdaFunction}, and the universe-lifting operations that let algebras at
+different levels be compared and related.
+
+Modules most closely related to this one are the following:
+
++  [Setoid.Algebras.Products][]: indexed products;
++  [Setoid.Algebras.Finite][]: finite algebras;
++  [Setoid.Algebras.Reduct][]: reducts (to a smaller signature);
++  [Setoid.Congruences.Basic][]: congruences and the quotients they generate;
++  [Setoid.Homomorphisms.Basic][]: structure-preserving maps between algebras.
 
 <!--
 ```agda
@@ -37,45 +61,41 @@ private variable α ρ ι : Level
 ```
 -->
 
-`ov`{.AgdaFunction} names the level arithmetic that classes of algebras keep needing: `ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α`.  A membership condition on algebras is seldom a statement about one carrier; it quantifies over algebras themselves — `H`, `S` and `P` of [Setoid.Varieties.Closure][] each say "there is an algebra in `𝒦` such that …" — and `Algebra α ρ`{.AgdaRecord} is a type one universe above its carrier, which is precisely what `Level-of-Alg`{.AgdaFunction} below computes.  Such a condition therefore lands at `lsuc α`, and since it also mentions operation symbols and arities it joins `𝓞`{.AgdaGeneralizable} and `𝓥`{.AgdaGeneralizable}.  Abbreviating that join keeps the closure operators' level expressions readable: `Pred (Algebra α ρ) (ov α)` is the recurring shape of a class, and `class-product`{.AgdaFunction} of [Setoid.Algebras.Products][] builds an algebra at `ov (α ⊔ ρ)`.
-
-The same `lsuc` is what forces `Term`{.AgdaDatatype} to raise levels, `Term X : Type (ov χ)` for `X : Type χ`, and so what makes the term construction a *relative* monad rather than a monad; see [Setoid.Terms.Monad][].
+ov`{.AgdaFunction} abbreviates the recurring level join `ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α`;
+it combines the levels of operation symbols and arities with the successor of a
+caller-supplied level.  Abbreviating this join keeps many common level expressions
+readable.
 
 ```agda
 ov : {𝓞 𝓥 : Level}{𝑆 : Signature 𝓞 𝓥} → Level → Level
 ov {𝓞 = 𝓞}{𝓥 = 𝓥} α = 𝓞 ⊔ 𝓥 ⊔ lsuc α
 ```
 
+Other modules combine this shorthand with whatever carrier, equality, class, and
+index levels their definitions quantify over.  For example,
+[Setoid.Algebras.Products][] accepts `𝒦 : Pred (Algebra α ρ) (ov α)` and places
+the type of pairs `(𝑨 , 𝑨 ∈ 𝒦)` at `ov (α ⊔ ρ)`, which is also the carrier level
+of `class-product`{.AgdaFunction}; the signatures of `H`, `S`, and `P` in
+[Setoid.Varieties.Closure][] add the corresponding equality, class, and index
+levels explicitly.
+
+The `Term`{.AgdaDatatype} type over `X : Type χ` is defined at `Type (ov χ)`
+because the term construction needs the levels of the operation symbols and
+arities, plus one more level for the carrier of the term itself.[^1]
+
 
 #### Setoid Algebras
 
 Here we define algebras over a setoid, instead of a mere type with no equivalence on it.
 
-The operator `⟨_⟩`{.AgdaFunction} that translates an ordinary signature into a
-signature over a setoid domain — together with its companion `EqArgs`{.AgdaFunction}
-— is defined in the signature-generic module [Setoid.Signatures][] and imported
-here (see the import above).  Each takes its own signature argument rather than
-reading this module's `{𝑆}`, so housing them in a non-parameterized module means
-the unused `{𝑆 : Signature 𝓞 𝓥}` parameter of this module does not ride along as
-an unsolvable metavariable at use sites.  The `Interp`{.AgdaField} field of
-`Algebra`{.AgdaRecord} applies the imported `⟨ 𝑆 ⟩` to this module's signature `𝑆`.
-
-Because the carrier of `⟨ 𝑆 ⟩ Domain` is a `Σ`-type — an operation symbol paired with
-its argument tuple — an `Interp`{.AgdaField} clause matches it as `(o , args)`, which
-needs the pair constructor `_,_` in scope.  We therefore re-export `_,_` and
-`Σ-syntax`{.AgdaFunction} from this module (and hence from the `Setoid.Algebras` barrel),
-so that pattern-matching such a carrier needs no separate `Data.Product` import — and no
-longer trips the misleading "`∙-Op` is not a constructor of the datatype … `Σ`" error,
-which points at the operation symbol rather than at the missing `_,_`.
-
 ```agda
 open Func renaming ( to to _⟨$⟩_ ; cong to ≈cong )
 ```
 
-A setoid algebra is just like an algebra but we require that all basic operations
-of the algebra respect the underlying setoid equality. The `Func` record packs a
-function (`f`, aka apply, aka `_⟨$⟩_`) with a proof (cong) that the function respects
-equality.
+The `Algebra`{.AgdaRecord} defines a **setoid algebra**, which is just like an
+ordinary algebra but we require that all of its basic operations respect the
+underlying setoid equality.  The `Func` record packs a function (`f`, aka apply,
+aka `_⟨$⟩_`) with a proof (cong) that the function respects equality.
 
 ```agda
 record Algebra {𝑆 : Signature 𝓞 𝓥} α ρ : Type (𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)) where
@@ -94,14 +114,25 @@ record Algebra {𝑆 : Signature 𝓞 𝓥} α ρ : Type (𝓞 ⊔ 𝓥 ⊔ lsuc
 open Algebra
 ```
 
-`𝔻[_]`{.AgdaFunction} is the *domain* of an algebra: the setoid `⟨A, ≈⟩` underlying it, carrier and equivalence together.  It is the projection to reach for whenever the equality matters — stating that a map is a `Func`{.AgdaRecord} between two algebras, or opening a `Setoid`{.AgdaRecord} to name its `_≈_`.
+The operator `⟨_⟩`{.AgdaFunction} translates an ordinary signature into a
+signature over a setoid domain, together with its companion
+`EqArgs`{.AgdaFunction}; it is defined in the signature-generic module
+[Setoid.Signatures][].[^2]
+
+`𝔻[_]`{.AgdaFunction} is the **domain of an algebra**, which is the setoid
+underlying it.  In other words, the domain is the carrier and equivalence of the
+algebra, taken together.  It is the projection to reach for whenever the equality
+matters.
 
 ```agda
 𝔻[_] : Algebra {𝑆 = 𝑆} α ρ →  Setoid α ρ
 𝔻[ 𝑨 ] = Domain 𝑨
 ```
 
-`𝕌[_]`{.AgdaFunction} forgets one step further, to the bare carrier type.  Mathematically it is the underlying-set functor from algebras to sets, minus the equality: `𝕌[ 𝑨 ]` is what an element of `𝑨`{.AgdaGeneralizable} *is*, with no record of when two such elements count as equal.  Use it where a plain type is wanted — the codomain of an operation, as in `_^_`{.AgdaFunction} just below — and `𝔻[_]`{.AgdaFunction} everywhere the equality is needed.
+`𝕌[_]`{.AgdaFunction} forgets one step further, to the bare carrier type.
+Mathematically it is the underlying-set functor from algebras to sets, minus the
+equality: `𝕌[ 𝑨 ]` is inhabited by the elements of `𝑨`{.AgdaGeneralizable} and
+carries no notion of equality of its elements.
 
 ```agda
 -- Forgetful functor: returns the carrier of (the domain of) 𝑨, forgetting its structure.
@@ -110,7 +141,7 @@ open Algebra
 ```
 
 We use the ascii symbol `^` to define an infix function for operation-symbol
-interpretation in an algebra.[^1]
+interpretation in an algebra.[^3]
 
 ```agda
 -- Interpretation of an operation symbol in an algebra.
@@ -151,8 +182,8 @@ it removes only the `(refl , args≈)` boilerplate, never the mathematical conte
 `mkAlgebra`{.AgdaFunction} is the general builder.  Given a carrier setoid `𝐃`, an
 interpretation `f` of each operation symbol, and a proof `cong-f` that every `f o`
 respects pointwise setoid equality of its argument tuple, `mkAlgebra`{.AgdaFunction}
-assembles the `Algebra`{.AgdaRecord}, discharging the
-`{o , _} {.o , _} (refl , args≈)` match internally.
+assembles the `Algebra`{.AgdaRecord}, discharging the `{o , _} {.o , _} (refl , args≈)`
+match internally.
 
 ```agda
 module _ (𝐷 : Setoid α ρ) where
@@ -169,7 +200,7 @@ module _ (𝐷 : Setoid α ρ) where
 `mkAlgebraₚ`{.AgdaFunction} specialises `mkAlgebra`{.AgdaFunction} to a carrier whose
 equality is propositional `_≡_`.  It takes a bare type `A`, builds `Domain = ≡.setoid A`
 (a `Setoid α α`, so the result is `Algebra α α`), and asks for `cong-f` in pointwise `_≡_`
-form — e.g. `≡.cong₂` for a binary operation, as in the `ℕ∸`-magma of
+form; e.g., `≡.cong₂` for a binary operation, as in the `ℕ∸`-magma of
 `Examples.Setoid.FreeMagma`.
 
 ```agda
@@ -180,9 +211,14 @@ mkAlgebraₚ : (A : Type α)
 mkAlgebraₚ A f cong-f = mkAlgebra (≡.setoid A) f cong-f
 ```
 
-Sometimes a level has to be named that is only implicit in an algebra's type.  Because Agda's universes are non-cumulative, an algebra cannot be silently reused at a larger level; the two projections below recover the levels so that a caller can state the lifting it needs.
+Sometimes a level has to be named that is only implicit in an algebra's type.
+Because Agda's universes are non-cumulative, an algebra cannot be silently reused
+at a larger level; the two projections below recover the levels so that a caller
+can state the lifting it needs.
 
-`Level-of-Alg`{.AgdaFunction} returns the level of the *algebra type* itself, `𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)` — one universe above both the carrier and the equality, since `Algebra α ρ`{.AgdaRecord} is a record containing a `Setoid α ρ`{.AgdaRecord}.
+`Level-of-Alg`{.AgdaFunction} is the **level of the algebra type**,
+`𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)`, which is one universe above both the carrier and the
+equality, since `Algebra α ρ` is a record containing a `Setoid α ρ`.
 
 ```agda
 -- The universe level of an algebra
@@ -190,7 +226,7 @@ Level-of-Alg : {α ρ 𝓞 𝓥 : Level}{𝑆 : Signature 𝓞 𝓥} → Algebra
 Level-of-Alg {α = α}{ρ}{𝓞}{𝓥} _ = 𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)
 ```
 
-`Level-of-Carrier`{.AgdaFunction} returns just `α`, the level of the carrier — the argument to give `Lift-Alg`{.AgdaFunction} when only the elements, and not the equality, need to move up.
+`Level-of-Carrier`{.AgdaFunction} is the **universe level of the carrier of an algebra**.
 
 ```agda
 -- The universe level of the carrier of an algebra
@@ -201,11 +237,26 @@ Level-of-Carrier {α = α} _ = α
 
 #### Level lifting setoid algebra types
 
-Agda's universes are *non-cumulative*: an inhabitant of `Type α` is not thereby an inhabitant of `Type (α ⊔ ℓ)`, so two algebras built at different levels cannot simply be compared, and a theorem proved about `Algebra α ρ`{.AgdaRecord} does not automatically apply to `Algebra (α ⊔ ℓ) ρ`{.AgdaRecord}.  This bites constantly in universal algebra, where the closure operators of [Setoid.Varieties.Closure][] move between levels at every step.  The remedy is to *lift* an algebra explicitly, and the reason the remedy costs nothing mathematically is that a lifted algebra is isomorphic to the original: [Setoid.Homomorphisms.Isomorphisms][] proves `Lift-≅ : 𝑨 ≅ Lift-Alg 𝑨 ℓ ρ`, so isomorphism classes are closed under lifting and every isomorphism-invariant property survives it.
+Agda's universes are *non-cumulative*: an inhabitant of `Type α` is not an
+inhabitant of `Type (α ⊔ ℓ)`, so two algebras built at different levels cannot
+simply be compared, and a theorem proved about `Algebra α ρ` does not
+automatically apply to `Algebra (α ⊔ ℓ) ρ`.
 
-An algebra carries two independent levels — the carrier's `α` and the equality's `ρ` — so there are two liftings, and they are kept separate.
+This bites constantly in universal algebra, where the closure operators of
+[Setoid.Varieties.Closure][] move between levels at every step.  The remedy is to
+*lift* an algebra explicitly, and the reason the remedy costs nothing
+mathematically is that a lifted algebra is isomorphic to the original:
+[Setoid.Homomorphisms.Isomorphisms][] proves `Lift-≅ : 𝑨 ≅ Lift-Alg 𝑨 ℓ ρ`, so
+isomorphism classes are closed under lifting and every isomorphism-invariant
+property survives it.
 
-`Lift-Algˡ`{.AgdaFunction} raises the *carrier* level, from `α` to `α ⊔ ℓ`, leaving the equality where it is.  The carrier becomes `Lift ℓ ∣A∣` and two lifted elements are related exactly when the elements underneath them were, so the equivalence is transported unchanged.
+An algebra carries two independent levels: the carrier's `α` and the equality's
+`ρ`; so there are two liftings, and they are kept separate.
+
+`Lift-Algˡ`{.AgdaFunction} raises the *carrier* level, from `α` to `α ⊔ ℓ`,
+leaving the equality where it is.  The carrier becomes `Lift ℓ 𝕌[ 𝑨 ]` and two
+lifted elements are related exactly when the elements underneath them were, so the
+equivalence is transported unchanged.
 
 ```agda
 module _ {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = 𝑆} α ρ)(ℓ : Level) where
@@ -224,7 +275,10 @@ module _ {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = 𝑆} α ρ)(ℓ : 
   Lift-Algˡ .Interp .≈cong (refl , la=lb) = ≈cong (Interp 𝑨) (refl , la=lb)
 ```
 
-`Lift-Algʳ`{.AgdaFunction} is the mirror image: it raises the level of the *equality*, from `ρ` to `ρ ⊔ ℓ`, and leaves the carrier alone.  The relation becomes `Lift ℓ ∘₂ _≈₁_`, a proposition-level lift of the original, and the equivalence proofs are re-wrapped accordingly.
+`Lift-Algʳ`{.AgdaFunction} raises the level of the *equality*, from `ρ` to `ρ ⊔
+ℓ`, and leaves the carrier alone.  The relation becomes `Lift ℓ ∘₂ _≈₁_`, a
+proposition-level lift of the original, and the equivalence proofs are re-wrapped
+accordingly.
 
 ```agda
   Lift-Algʳ : Algebra {𝑆 = 𝑆} α (ρ ⊔ ℓ)
@@ -240,7 +294,12 @@ module _ {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = 𝑆} α ρ)(ℓ : 
   Lift-Algʳ .Interp .≈cong (refl , la≡lb) = lift $ ≈cong (Interp 𝑨) (≡.refl , (lower ∘ la≡lb))
 ```
 
-`Lift-Alg`{.AgdaFunction} composes the two, raising both levels at once, and is the form almost every caller wants: given target increments `ℓ₀` and `ℓ₁` it produces an algebra at `(α ⊔ ℓ₀, ρ ⊔ ℓ₁)`.  It is the operation the closure operators use to bring a class and a candidate algebra to a common level; `Lift-≅`{.AgdaFunction} of [Setoid.Homomorphisms.Isomorphisms][] is the isomorphism that makes the move harmless.
+`Lift-Alg`{.AgdaFunction} composes the two, raising both levels at once: given
+target increments `ℓ₀` and `ℓ₁` it produces an algebra at `(α ⊔ ℓ₀, ρ ⊔ ℓ₁)`.
+It is the operation the closure operators use to bring a class and a candidate
+algebra to a common level; `Lift-≅`{.AgdaFunction} of
+[Setoid.Homomorphisms.Isomorphisms][] is the isomorphism that makes the move
+harmless.
 
 ```agda
 Lift-Alg : (𝑨 : Algebra {𝑆 = 𝑆} α ρ)(ℓ₀ ℓ₁ : Level) → Algebra {𝑆 = 𝑆} (α ⊔ ℓ₀) (ρ ⊔ ℓ₁)
@@ -249,4 +308,18 @@ Lift-Alg 𝑨 ℓ₀ = Lift-Algʳ (Lift-Algˡ 𝑨 ℓ₀)
 
 --------------------------------
 
-[^1]: The `_^_` symbol is definitionally identical to `_̂_` and was introduced for grep-friendliness and to survive shell-pipeline tooling.  New `Classical/` code uses `_^_` exclusively; existing `Setoid/` code may continue to use `_̂_` until v3.1.  See ADR-002 §7 for the rationale and per-tree policy.
+[^1]: This is why the term construction is a *relative* monad rather than a monad;
+      see [Setoid.Terms.Monad][].
+
+[^2]: Because the carrier of `⟨ 𝑆 ⟩ Domain` is a `Σ`-type, an `Interp`{.AgdaField}
+      clause matches it as `(o , args)`, which needs the pair constructor `_,_` in scope.
+      We therefore re-export `_,_` and `Σ-syntax`{.AgdaFunction} from this module (and
+      hence from the `Setoid.Algebras` barrel), so that pattern-matching such a carrier
+      needs no separate `Data.Product` import, and no longer trips the misleading
+      "`∙-Op` is not a constructor of the datatype … `Σ`" error, which points at the
+      operation symbol rather than at the missing `_,_`.
+
+[^3]: The `_^_` symbol is definitionally identical to `_̂_` and was introduced for
+      grep-friendliness and to survive shell-pipeline tooling.  New `Classical/` code
+      uses `_^_` exclusively; existing `Setoid/` code may continue to use `_̂_` until
+      v3.1.  See ADR-002 §7 for the rationale and per-tree policy.

--- a/src/Setoid/Algebras/Basic.lagda.md
+++ b/src/Setoid/Algebras/Basic.lagda.md
@@ -9,6 +9,10 @@ author: "agda-algebras development team"
 
 This is the [Setoid.Algebras.Basic][] module of the [Agda Universal Algebra Library][].
 
+An **algebra over a signature** `𝑆`{.AgdaGeneralizable} is a setoid — a carrier type together with an equivalence relation on it — equipped with an interpretation of every operation symbol of `𝑆`{.AgdaGeneralizable} as a function on that carrier which *respects* the equivalence.  That last clause is the entire difference from the type-based development: on a setoid an operation is not a bare function but a `Func`{.AgdaRecord}, a function bundled with a proof that it sends related arguments to related results.  Carrying the proof inside the structure is what makes quotients cheap: a quotient algebra is the *same* carrier under a coarser equivalence, so forming one needs neither quotient types nor an axiom.  That matters here, because the library is `--safe --cubical-compatible`, where function extensionality is unavailable — see the discussion at `mkAlgebra`{.AgdaFunction} below for where the cost reappears.
+
+This module is the canonical entry point for the `Setoid/` tree.  It defines the `Algebra`{.AgdaRecord} record, two smart constructors for building one from an ordinary interpretation function, the operation-interpretation operator `_^_`{.AgdaFunction}, and the universe-lifting operations that let algebras at different levels be compared.  For indexed products see [Setoid.Algebras.Products][]; for finite algebras, [Setoid.Algebras.Finite][]; for reducts to a smaller signature, [Setoid.Algebras.Reduct][].  Congruences and the quotients they generate are in [Setoid.Congruences.Basic][], and structure-preserving maps between algebras in [Setoid.Homomorphisms.Basic][].
+
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
@@ -32,6 +36,10 @@ open import Setoid.Signatures    using ( ⟨_⟩ )
 private variable α ρ ι : Level
 ```
 -->
+
+`ov`{.AgdaFunction} names the level arithmetic that classes of algebras keep needing: `ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α`.  A membership condition on algebras is seldom a statement about one carrier; it quantifies over algebras themselves — `H`, `S` and `P` of [Setoid.Varieties.Closure][] each say "there is an algebra in `𝒦` such that …" — and `Algebra α ρ`{.AgdaRecord} is a type one universe above its carrier, which is precisely what `Level-of-Alg`{.AgdaFunction} below computes.  Such a condition therefore lands at `lsuc α`, and since it also mentions operation symbols and arities it joins `𝓞`{.AgdaGeneralizable} and `𝓥`{.AgdaGeneralizable}.  Abbreviating that join keeps the closure operators' level expressions readable: `Pred (Algebra α ρ) (ov α)` is the recurring shape of a class, and `class-product`{.AgdaFunction} of [Setoid.Algebras.Products][] builds an algebra at `ov (α ⊔ ρ)`.
+
+The same `lsuc` is what forces `Term`{.AgdaDatatype} to raise levels, `Term X : Type (ov χ)` for `X : Type χ`, and so what makes the term construction a *relative* monad rather than a monad; see [Setoid.Terms.Monad][].
 
 ```agda
 ov : {𝓞 𝓥 : Level}{𝑆 : Signature 𝓞 𝓥} → Level → Level
@@ -86,13 +94,16 @@ record Algebra {𝑆 : Signature 𝓞 𝓥} α ρ : Type (𝓞 ⊔ 𝓥 ⊔ lsuc
 open Algebra
 ```
 
-The next three definitions are merely syntactic sugar that we sometimes use to make
-the code more readable.
+`𝔻[_]`{.AgdaFunction} is the *domain* of an algebra: the setoid `⟨A, ≈⟩` underlying it, carrier and equivalence together.  It is the projection to reach for whenever the equality matters — stating that a map is a `Func`{.AgdaRecord} between two algebras, or opening a `Setoid`{.AgdaRecord} to name its `_≈_`.
 
 ```agda
 𝔻[_] : Algebra {𝑆 = 𝑆} α ρ →  Setoid α ρ
 𝔻[ 𝑨 ] = Domain 𝑨
+```
 
+`𝕌[_]`{.AgdaFunction} forgets one step further, to the bare carrier type.  Mathematically it is the underlying-set functor from algebras to sets, minus the equality: `𝕌[ 𝑨 ]` is what an element of `𝑨`{.AgdaGeneralizable} *is*, with no record of when two such elements count as equal.  Use it where a plain type is wanted — the codomain of an operation, as in `_^_`{.AgdaFunction} just below — and `𝔻[_]`{.AgdaFunction} everywhere the equality is needed.
+
+```agda
 -- Forgetful functor: returns the carrier of (the domain of) 𝑨, forgetting its structure.
 𝕌[_] : Algebra {𝑆 = 𝑆} α ρ →  Type α
 𝕌[ 𝑨 ] = Setoid.Carrier 𝔻[ 𝑨 ]
@@ -169,14 +180,19 @@ mkAlgebraₚ : (A : Type α)
 mkAlgebraₚ A f cong-f = mkAlgebra (≡.setoid A) f cong-f
 ```
 
-Sometimes we want to extract the universe level of a given algebra or its carrier.
-The following functions provide that information.
+Sometimes a level has to be named that is only implicit in an algebra's type.  Because Agda's universes are non-cumulative, an algebra cannot be silently reused at a larger level; the two projections below recover the levels so that a caller can state the lifting it needs.
+
+`Level-of-Alg`{.AgdaFunction} returns the level of the *algebra type* itself, `𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)` — one universe above both the carrier and the equality, since `Algebra α ρ`{.AgdaRecord} is a record containing a `Setoid α ρ`{.AgdaRecord}.
 
 ```agda
 -- The universe level of an algebra
 Level-of-Alg : {α ρ 𝓞 𝓥 : Level}{𝑆 : Signature 𝓞 𝓥} → Algebra {𝑆 = 𝑆} α ρ → Level
 Level-of-Alg {α = α}{ρ}{𝓞}{𝓥} _ = 𝓞 ⊔ 𝓥 ⊔ lsuc (α ⊔ ρ)
+```
 
+`Level-of-Carrier`{.AgdaFunction} returns just `α`, the level of the carrier — the argument to give `Lift-Alg`{.AgdaFunction} when only the elements, and not the equality, need to move up.
+
+```agda
 -- The universe level of the carrier of an algebra
 Level-of-Carrier : {α ρ 𝓞 𝓥  : Level}{𝑆 : Signature 𝓞 𝓥} → Algebra {𝑆 = 𝑆} α ρ → Level
 Level-of-Carrier {α = α} _ = α
@@ -184,6 +200,12 @@ Level-of-Carrier {α = α} _ = α
 
 
 #### Level lifting setoid algebra types
+
+Agda's universes are *non-cumulative*: an inhabitant of `Type α` is not thereby an inhabitant of `Type (α ⊔ ℓ)`, so two algebras built at different levels cannot simply be compared, and a theorem proved about `Algebra α ρ`{.AgdaRecord} does not automatically apply to `Algebra (α ⊔ ℓ) ρ`{.AgdaRecord}.  This bites constantly in universal algebra, where the closure operators of [Setoid.Varieties.Closure][] move between levels at every step.  The remedy is to *lift* an algebra explicitly, and the reason the remedy costs nothing mathematically is that a lifted algebra is isomorphic to the original: [Setoid.Homomorphisms.Isomorphisms][] proves `Lift-≅ : 𝑨 ≅ Lift-Alg 𝑨 ℓ ρ`, so isomorphism classes are closed under lifting and every isomorphism-invariant property survives it.
+
+An algebra carries two independent levels — the carrier's `α` and the equality's `ρ` — so there are two liftings, and they are kept separate.
+
+`Lift-Algˡ`{.AgdaFunction} raises the *carrier* level, from `α` to `α ⊔ ℓ`, leaving the equality where it is.  The carrier becomes `Lift ℓ ∣A∣` and two lifted elements are related exactly when the elements underneath them were, so the equivalence is transported unchanged.
 
 ```agda
 module _ {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = 𝑆} α ρ)(ℓ : Level) where
@@ -200,8 +222,11 @@ module _ {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = 𝑆} α ρ)(ℓ : 
             }
   Lift-Algˡ .Interp ⟨$⟩ (f , la) = lift $ (f ^ 𝑨) (lower ∘ la)
   Lift-Algˡ .Interp .≈cong (refl , la=lb) = ≈cong (Interp 𝑨) (refl , la=lb)
+```
 
+`Lift-Algʳ`{.AgdaFunction} is the mirror image: it raises the level of the *equality*, from `ρ` to `ρ ⊔ ℓ`, and leaves the carrier alone.  The relation becomes `Lift ℓ ∘₂ _≈₁_`, a proposition-level lift of the original, and the equivalence proofs are re-wrapped accordingly.
 
+```agda
   Lift-Algʳ : Algebra {𝑆 = 𝑆} α (ρ ⊔ ℓ)
   Lift-Algʳ .Domain =
     record  { Carrier = ∣A∣
@@ -213,7 +238,11 @@ module _ {𝑆 : Signature 𝓞 𝓥}(𝑨 : Algebra {𝑆 = 𝑆} α ρ)(ℓ : 
             }
   Lift-Algʳ .Interp ⟨$⟩ (f , la) = (f ^ 𝑨) la
   Lift-Algʳ .Interp .≈cong (refl , la≡lb) = lift $ ≈cong (Interp 𝑨) (≡.refl , (lower ∘ la≡lb))
+```
 
+`Lift-Alg`{.AgdaFunction} composes the two, raising both levels at once, and is the form almost every caller wants: given target increments `ℓ₀` and `ℓ₁` it produces an algebra at `(α ⊔ ℓ₀, ρ ⊔ ℓ₁)`.  It is the operation the closure operators use to bring a class and a candidate algebra to a common level; `Lift-≅`{.AgdaFunction} of [Setoid.Homomorphisms.Isomorphisms][] is the isomorphism that makes the move harmless.
+
+```agda
 Lift-Alg : (𝑨 : Algebra {𝑆 = 𝑆} α ρ)(ℓ₀ ℓ₁ : Level) → Algebra {𝑆 = 𝑆} (α ⊔ ℓ₀) (ρ ⊔ ℓ₁)
 Lift-Alg 𝑨 ℓ₀ = Lift-Algʳ (Lift-Algˡ 𝑨 ℓ₀)
 ```

--- a/src/Setoid/Algebras/Basic.lagda.md
+++ b/src/Setoid/Algebras/Basic.lagda.md
@@ -61,7 +61,7 @@ private variable α ρ ι : Level
 ```
 -->
 
-ov`{.AgdaFunction} abbreviates the recurring level join `ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α`;
+`ov`{.AgdaFunction} abbreviates the recurring level join `ov α = 𝓞 ⊔ 𝓥 ⊔ lsuc α`;
 it combines the levels of operation symbols and arities with the successor of a
 caller-supplied level.  Abbreviating this join keeps many common level expressions
 readable.


### PR DESCRIPTION
Part of [M4-2] #268.  Companion to #537 (the tool); independent, either order.

## tl;dr

+  One module taken to full coverage so the prose convention can be argued about on a real example.  **Please read the prose, not the diffstat.**
+  `Setoid.Algebras.Basic`: **7/13 → 13/13 documented, under the strict reading**.  33 lines added, 4 removed.
+  Chosen because `STYLE_GUIDE` § "Module headers have comment blocks" already drafts its header, so the mathematics is partly yours rather than mine.
+  **Prose-only, verified not asserted**: the Agda extracted from the fences is byte-identical to `master`; the module type-checks clean; CI green including the site build.
+  Two paragraphs flagged below as the ones to check hardest.

## Where each block comes from

I only wrote prose I could ground:

+  **Module header** — the `STYLE_GUIDE` draft, with one correction: it points at `Setoid.Algebras.Congruences`, which does not exist.  Congruences are in `Setoid.Congruences.Basic`.  Worth a separate fix to the guide; out of scope here.
+  **`ov`** — its definition, plus the level discussion in `Setoid.Terms.Monad` and the class-level usage in `Setoid.Algebras.Products`.
+  **`𝔻[_]` / `𝕌[_]`** — from the types; the existing "forgetful functor" comment is kept and promoted.
+  **`Level-of-Alg` / `Level-of-Carrier`** — from the types, tied to non-cumulativity.
+  **`Lift-Algˡ` / `Lift-Algʳ` / `Lift-Alg`** — the section opener takes its argument from `Examples.Demos.HSP` §§ "Universe levels of algebra types" and "Lift-Alg is an algebraic invariant", cross-referencing `Lift-≅` in `Setoid.Homomorphisms.Isomorphisms`.  The ˡ/ʳ split (carrier level vs equality level) is read off the two signatures.

## The two paragraphs to check hardest

Being explicit, since fluent-but-wrong is the failure mode worth guarding against:

1.  Module header: **"a quotient algebra is the *same* carrier under a coarser equivalence, so forming one needs neither quotient types nor an axiom."**  This is *my* framing of why the library is built on setoids, not a restatement of something the repo says.  If your reason differs, rewrite this sentence.
2.  `ov` block: **why a class predicate lands at `lsuc α`.**  My first draft claimed a predicate over `Algebra α ρ` "cannot live at `α`" — false, `Pred`'s level is a parameter.  Rewritten to the defensible claim: membership conditions here *quantify over algebras*, and `Algebra α ρ` is itself one universe above its carrier.  Please confirm that is why the closure operators land at `ov`.

Everything else is the style guide's text, the library's text, or a direct reading of a type signature.

## Two vague sentences removed

"The next three definitions are merely syntactic sugar" (there were two) and "sometimes we want to extract the universe level of a given algebra or its carrier", both replaced by per-definition prose.  Nothing else deleted.

## A convention point this raises

Giving `Lift-Algʳ` its own block meant closing and reopening the fence *inside* the `module _ … where` body.  That is legal and the corpus already does it.  This module therefore meets the one-definition-per-fence reading — which ADR-010 has since weighed and **rejected as the repository-wide rule**, precisely because it fragments indented module bodies.  Nothing here needs undoing: the adopted bar is per fence, and a module that goes further is fine.  What this PR is an exemplar *of* is the prose, not the fence granularity.

New prose is unwrapped, one paragraph per line, per `STYLE_GUIDE` § "Don't hard-wrap prose".  Pre-existing wrapped paragraphs are left alone; reflowing them would bury the new prose in noise.

## Checks

Extracted Agda byte-identical to `master` · `agda 2.8.0` clean (exit 0, no diagnostics, no holes) · `make check-links` green · all CI green including the 10m43s site build, which is what confirms the kramdown attribute spans and the five new reference links actually render.

Corpus-wide this moves the lenient count 201 → 197.

🤖 AI-assisted development: Claude Opus 5 (Anthropic)

