### PR TITLE
[M4-2d] Docstrings: Setoid/Functions, Setoid/Relations, and the Setoid barrels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ REPO      ?= ualib/agda-algebras
 # when the number of public definitions lacking a prose block exceeds this
 # ceiling, so the backlog can only shrink while the per-subtree prose PRs land.
 # Lower it whenever a PR clears definitions; never raise it.
-DOCSTRING_MAX_GAPS ?= 142
+DOCSTRING_MAX_GAPS ?= 136
 # The other half of the bar ADR-010 states: modules whose header is only the
 # boilerplate sentence.  Ratcheted the same way; never raise it.
-DOCSTRING_MAX_WEAK_HEADERS ?= 26
+DOCSTRING_MAX_WEAK_HEADERS ?= 21
 
 # The certificate census: generated representation certificates for the FLRP
 # research track (issue #515).  Excluded from Everything.agda and checked by

--- a/src/Setoid/Functions.lagda.md
+++ b/src/Setoid/Functions.lagda.md
@@ -9,6 +9,29 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Functions][] module of the [Agda Universal Algebra Library][].
 
+This is a barrel module: it declares nothing of its own and re-exports the five
+modules that develop functions between setoids.  A setoid function is a map
+bundled with a proof that it respects the two equalities, and that packaging is
+what lets the library do without function extensionality: a construction that
+would otherwise have to prove two functions equal instead reasons with the
+congruence proof each function already carries.
+
+Reach for the following:
+
++  [Setoid.Functions.Basic][]: the identity, composition, and universe lifting of
+   a setoid;
++  [Setoid.Functions.Injective][]: `IsInjective`{.AgdaFunction} and its
+   composition law;
++  [Setoid.Functions.Surjective][]: `IsSurjective`{.AgdaFunction}, its
+   composition law `⊙-IsSurjective`{.AgdaFunction}, the right inverse
+   `SurjInv`{.AgdaFunction} of a surjection, and the decidable-index projections
+   `proj`{.AgdaFunction} and `projIsOnto`{.AgdaFunction};
++  [Setoid.Functions.Inverses][]: images and ranges, `Image_∋_`{.AgdaDatatype}
+   and `IsInRange`{.AgdaFunction};
++  [Setoid.Functions.Bijective][]: `IsBijective`{.AgdaFunction} as
+   injective-and-surjective, with the inverse `BijInv`{.AgdaFunction}.
+
+
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Setoid/Functions.lagda.md
+++ b/src/Setoid/Functions.lagda.md
@@ -19,7 +19,7 @@ functions.  See `function-equality`{.AgdaFunction} of
 [Setoid.Relations.Discrete][] and, for homomorphisms, `_≋_`{.AgdaFunction} of
 [Setoid.Categories.Algebra][].
 
-Reach for the following:
+### Guide to the submodules of <span class="AgdaModule">Setoid.Functions</span>
 
 +  [Setoid.Functions.Basic][]: the identity, composition, and universe lifting of
    a setoid;
@@ -36,8 +36,6 @@ Reach for the following:
    and `IsInRange`{.AgdaFunction};
 +  [Setoid.Functions.Bijective][]: `IsBijective`{.AgdaFunction} as
    injective-and-surjective, with the inverse `BijInv`{.AgdaFunction}.
-
-
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Setoid/Functions.lagda.md
+++ b/src/Setoid/Functions.lagda.md
@@ -11,10 +11,13 @@ This is the [Setoid.Functions][] module of the [Agda Universal Algebra Library][
 
 This is a barrel module: it declares nothing of its own and re-exports the five
 modules that develop functions between setoids.  A setoid function is a map
-bundled with a proof that it respects the two equalities, and that packaging is
-what lets the library do without function extensionality: a construction that
-would otherwise have to prove two functions equal instead reasons with the
-congruence proof each function already carries.
+bundled with a proof that it respects the two equalities.  That proof is about a
+single map, so it is only half of how the library does without function
+extensionality; the other half is that wherever two functions must be compared,
+an explicitly pointwise relation is used rather than propositional equality of
+functions.  See `function-equality`{.AgdaFunction} of
+[Setoid.Relations.Discrete][] and, for homomorphisms, `_≋_`{.AgdaFunction} of
+[Setoid.Categories.Algebra][].
 
 Reach for the following:
 
@@ -24,8 +27,11 @@ Reach for the following:
    composition law;
 +  [Setoid.Functions.Surjective][]: `IsSurjective`{.AgdaFunction}, its
    composition law `⊙-IsSurjective`{.AgdaFunction}, the right inverse
-   `SurjInv`{.AgdaFunction} of a surjection, and the decidable-index projections
-   `proj`{.AgdaFunction} and `projIsOnto`{.AgdaFunction};
+   `SurjInv`{.AgdaFunction} of a surjection, and `epic-factor`{.AgdaFunction}.
+   The decidable-index projections `proj`{.AgdaFunction} and
+   `projIsOnto`{.AgdaFunction} that `ProjAlgIsOnto`{.AgdaFunction} of
+   [Setoid.Algebras.Products][] consumes are *not* here; they are bare-types
+   results in [Overture.Functions][];
 +  [Setoid.Functions.Inverses][]: images and ranges, `Image_∋_`{.AgdaDatatype}
    and `IsInRange`{.AgdaFunction};
 +  [Setoid.Functions.Bijective][]: `IsBijective`{.AgdaFunction} as

--- a/src/Setoid/Functions/Basic.lagda.md
+++ b/src/Setoid/Functions/Basic.lagda.md
@@ -12,8 +12,14 @@ This is the [Setoid.Functions.Basic][] module of the [Agda Universal Algebra Lib
 A **setoid function** `A ⟶ B` is the standard library's `Func`{.AgdaRecord}: a map
 on carriers together with a proof that it respects the equalities of `A` and `B`.
 Carrying the proof inside the function is the move the whole `Setoid/` tree rests
-on, since it means no construction ever has to prove two *functions* equal, and so
-none of them needs function extensionality.
+on, but it is worth being precise about what it does.  `cong`{.AgdaField} says
+that *one* map sends related arguments to related results; it says nothing about
+when two maps are the same.  Where two functions do have to be compared, the
+library never asks for propositional equality of functions — which is what would
+require extensionality — but uses an explicitly pointwise relation instead:
+`function-equality`{.AgdaFunction} of [Setoid.Relations.Discrete][], and
+`_≋_`{.AgdaFunction} of [Setoid.Categories.Algebra][] for homomorphisms.  The two
+devices together are what keep the development extensionality-free.
 
 This module holds the primitives everything else is built from, and nothing
 deeper: the identity setoid function, composition, and the universe lifting of a

--- a/src/Setoid/Functions/Basic.lagda.md
+++ b/src/Setoid/Functions/Basic.lagda.md
@@ -9,6 +9,16 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Functions.Basic][] module of the [Agda Universal Algebra Library][].
 
+A **setoid function** `A ⟶ B` is the standard library's `Func`{.AgdaRecord}: a map
+on carriers together with a proof that it respects the equalities of `A` and `B`.
+Carrying the proof inside the function is the move the whole `Setoid/` tree rests
+on, since it means no construction ever has to prove two *functions* equal, and so
+none of them needs function extensionality.
+
+This module holds the primitives everything else is built from, and nothing
+deeper: the identity setoid function, composition, and the universe lifting of a
+setoid.  They are gathered here so that the lifting lemmas in particular exist in
+one place, rather than being re-derived wherever a level has to change.
 
 <!--
 ```agda
@@ -24,6 +34,25 @@ open import Relation.Binary  using ( Setoid )
 private variable α ρᵃ β ρᵇ γ ρᶜ : Level
 ```
 -->
+
+Because a setoid function carries its own congruence proof, identity and
+composition need no side conditions: each simply does to the proofs what it does
+to the maps.
+
++  `𝑖𝑑`{.AgdaFunction} is the identity, whose congruence proof is itself the
+   identity.
++  `_⊙_`{.AgdaFunction} is composition, taking the composite of the two maps and
+   the composite of the two congruence proofs.  It is written right to left, so
+   `f ⊙ g` applies `g` first.
+
+The rest of the fence lifts a setoid to a higher universe level, which Agda's
+non-cumulative universes make necessary.  `𝑙𝑖𝑓𝑡 ℓ`{.AgdaFunction} raises the level
+of the carrier and leaves the equality alone, relating two lifted elements exactly
+when the elements underneath them were related.  `liftFunc`{.AgdaFunction} is the
+setoid function into the lift, and `lift∼lower`{.AgdaFunction} and
+`lower∼lift`{.AgdaFunction} say that lifting and lowering are mutually inverse.
+Both are proved by reflexivity alone, which is the point: the lifted equality *is*
+the original equality read through `lower`, so there is nothing to transport.
 
 ```agda
 𝑖𝑑 : {A : Setoid α ρᵃ} → A ⟶ A

--- a/src/Setoid/Functions/Basic.lagda.md
+++ b/src/Setoid/Functions/Basic.lagda.md
@@ -10,16 +10,17 @@ author: "the agda-algebras development team"
 This is the [Setoid.Functions.Basic][] module of the [Agda Universal Algebra Library][].
 
 A **setoid function** `A ⟶ B` is the standard library's `Func`{.AgdaRecord}: a map
-on carriers together with a proof that it respects the equalities of `A` and `B`.
-Carrying the proof inside the function is the move the whole `Setoid/` tree rests
-on, but it is worth being precise about what it does.  `cong`{.AgdaField} says
-that *one* map sends related arguments to related results; it says nothing about
-when two maps are the same.  Where two functions do have to be compared, the
-library never asks for propositional equality of functions — which is what would
-require extensionality — but uses an explicitly pointwise relation instead:
-`function-equality`{.AgdaFunction} of [Setoid.Relations.Discrete][], and
-`_≋_`{.AgdaFunction} of [Setoid.Categories.Algebra][] for homomorphisms.  The two
-devices together are what keep the development extensionality-free.
+on carriers together with a proof that the map respects the equalities of `A` and
+`B`.  Carrying that proof along with the function is what the whole `Setoid/` tree
+rests on, but it is worth being precise about what it does.
+
+`cong`{.AgdaField} says that *one* map sends related arguments to related results;
+it says nothing about when two maps are the same.  Where two functions do have to
+be compared, the library never asks for propositional equality of functions, but
+instead uses an explicitly pointwise relation: `function-equality`{.AgdaFunction}
+of [Setoid.Relations.Discrete][], and `_≋_`{.AgdaFunction} of
+[Setoid.Categories.Algebra][] for homomorphisms.  The two devices together are
+what keep the development extensionality-free.
 
 This module holds the primitives everything else is built from, and nothing
 deeper: the identity setoid function, composition, and the universe lifting of a
@@ -51,14 +52,17 @@ to the maps.
    the composite of the two congruence proofs.  It is written right to left, so
    `f ⊙ g` applies `g` first.
 
-The rest of the fence lifts a setoid to a higher universe level, which Agda's
-non-cumulative universes make necessary.  `𝑙𝑖𝑓𝑡 ℓ`{.AgdaFunction} raises the level
-of the carrier and leaves the equality alone, relating two lifted elements exactly
-when the elements underneath them were related.  `liftFunc`{.AgdaFunction} is the
-setoid function into the lift, and `lift∼lower`{.AgdaFunction} and
-`lower∼lift`{.AgdaFunction} say that lifting and lowering are mutually inverse.
-Both are proved by reflexivity alone, which is the point: the lifted equality *is*
-the original equality read through `lower`, so there is nothing to transport.
+The remaining items lift a setoid to a higher universe level, which Agda's
+universe non-cumulativity makes necessary.
+
++  `𝑙𝑖𝑓𝑡 ℓ`{.AgdaFunction} raises the level of the carrier and leaves the equality
+   alone, relating two lifted elements exactly when the elements underneath them
+   were related;
++  `liftFunc`{.AgdaFunction} is the setoid function into the lift;
++  `lift∼lower`{.AgdaFunction} and `lower∼lift`{.AgdaFunction} say that lifting
+   and lowering are mutually inverse; both are proved by reflexivity alone, which
+   is the point: the lifted equality *is* the original equality read through
+   `lower`, so there is nothing to transport.
 
 ```agda
 𝑖𝑑 : {A : Setoid α ρᵃ} → A ⟶ A

--- a/src/Setoid/Relations.lagda.md
+++ b/src/Setoid/Relations.lagda.md
@@ -17,7 +17,7 @@ carriers and "respects the equality" is stated separately as needed.  A congruen
 for instance, is required to contain the setoid equality exactly so that
 quotienting by it is well defined.
 
-Reach for the following:
+### Guide to the submodules of <span class="AgdaModule">Setoid.Relations</span>
 
 +  [Setoid.Relations.Discrete][]: binary relations, pointwise equality of setoid
    functions, image containment, and the kernel of a setoid function;
@@ -31,7 +31,6 @@ Reach for the following:
    `Reflexive`{.AgdaFunction}, `Symmetric`{.AgdaFunction},
    `Transitive`{.AgdaFunction} and their companions are in scope for anything
    that opens the barrel.
-
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Setoid/Relations.lagda.md
+++ b/src/Setoid/Relations.lagda.md
@@ -26,7 +26,11 @@ Reach for the following:
 +  [Setoid.Relations.Continuous][]: relations of arbitrary arity, where the arity
    is an arbitrary type rather than a natural number, so that finite, countable
    and uncountable arities are handled uniformly;
-+  [Setoid.Relations.Properties][]: the remaining lemmas.
++  [Setoid.Relations.Properties][]: no results of its own, but a public
+   re-export of the standard library's `Relation.Binary.Definitions`, so that
+   `Reflexive`{.AgdaFunction}, `Symmetric`{.AgdaFunction},
+   `Transitive`{.AgdaFunction} and their companions are in scope for anything
+   that opens the barrel.
 
 
 ```agda

--- a/src/Setoid/Relations.lagda.md
+++ b/src/Setoid/Relations.lagda.md
@@ -9,6 +9,26 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Relations][] module of the [Agda Universal Algebra Library][].
 
+This is a barrel module: it declares nothing of its own and re-exports the four
+modules on relations over setoids.  The distinction this tree turns on is between
+a relation on a setoid's *carrier* and one that respects the setoid's equality.
+Both are wanted, and neither subsumes the other, so the relation types take bare
+carriers and "respects the equality" is stated separately as needed.  A congruence,
+for instance, is required to contain the setoid equality exactly so that
+quotienting by it is well defined.
+
+Reach for the following:
+
++  [Setoid.Relations.Discrete][]: binary relations, pointwise equality of setoid
+   functions, image containment, and the kernel of a setoid function;
++  [Setoid.Relations.Quotients][]: equivalence classes, the quotient setoid
+   `_/_`{.AgdaFunction}, and that a kernel is an equivalence relation;
++  [Setoid.Relations.Continuous][]: relations of arbitrary arity, where the arity
+   is an arbitrary type rather than a natural number, so that finite, countable
+   and uncountable arities are handled uniformly;
++  [Setoid.Relations.Properties][]: the remaining lemmas.
+
+
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 

--- a/src/Setoid/Relations/Discrete.lagda.md
+++ b/src/Setoid/Relations/Discrete.lagda.md
@@ -9,6 +9,22 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Relations.Discrete][] module of the [Agda Universal Algebra Library][].
 
+"Discrete" here means *binary*, as opposed to the arbitrary-arity relations of
+[Setoid.Relations.Continuous][].
+
+The centre of the module is the **kernel** of a setoid function: the relation on
+the domain holding of two elements just when the function sends them to elements
+that are equal in the codomain.  It appears in three shapes, because three are
+wanted downstream: `fker`{.AgdaFunction} as a binary relation,
+`fkerPred`{.AgdaFunction} as a predicate on pairs, and `fkerlift`{.AgdaFunction}
+with its level raised.  Also here are `function-equality`{.AgdaFunction}, pointwise
+equality of setoid functions, and `Im_⊆_`{.AgdaFunction}, the assertion that a
+function's image lands inside a given subset.
+
+Kernels of *homomorphisms*, which are these kernels together with compatibility
+with the operations, are in [Setoid.Homomorphisms.Kernels][].
+
+
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Setoid/Relations/Quotients.lagda.md
+++ b/src/Setoid/Relations/Quotients.lagda.md
@@ -9,6 +9,21 @@ author: "the agda-algebras development team"
 
 This is the [Setoid.Relations.Quotients][] module of the [Agda Universal Algebra Library][].
 
+Quotienting is where the setoid formulation pays for itself.  A quotient of a
+setoid by an equivalence relation keeps the same carrier and changes only the
+equality, so it needs neither a quotient type nor any axiom: `_/_`{.AgdaFunction}
+takes a type together with an `Equivalence`{.AgdaRecord} bundle and returns the
+setoid whose equality *is* that relation, and `Quotient`{.AgdaFunction} is the type
+of its classes.
+
+The module also supplies what makes quotients reachable in practice:
+`ker-IsEquivalence`{.AgdaFunction}, that the kernel of a setoid function is an
+equivalence relation, so that every kernel may be quotiented by; and the
+machinery of equivalence classes and blocks.  The algebraic counterpart, where the
+quotient must respect the operations as well, is `_╱_`{.AgdaFunction} of
+[Setoid.Congruences.Basic][].
+
+
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Setoid/Relations/Quotients.lagda.md
+++ b/src/Setoid/Relations/Quotients.lagda.md
@@ -23,7 +23,6 @@ machinery of equivalence classes and blocks.  The algebraic counterpart, where t
 quotient must respect the operations as well, is `_╱_`{.AgdaFunction} of
 [Setoid.Congruences.Basic][].
 
-
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Setoid/Relations/Quotients.lagda.md
+++ b/src/Setoid/Relations/Quotients.lagda.md
@@ -12,7 +12,7 @@ This is the [Setoid.Relations.Quotients][] module of the [Agda Universal Algebra
 Quotienting is where the setoid formulation pays for itself.  A quotient of a
 setoid by an equivalence relation keeps the same carrier and changes only the
 equality, so it needs neither a quotient type nor any axiom: `_/_`{.AgdaFunction}
-takes a type together with an `Equivalence`{.AgdaRecord} bundle and returns the
+takes a type together with an `Equivalence`{.AgdaFunction} bundle and returns the
 setoid whose equality *is* that relation, and `Quotient`{.AgdaFunction} is the type
 of its classes.
 


### PR DESCRIPTION
Closes #542.  Sub-issue of #268; the bar is ADR-010's and wrapping follows #549.

## What this clears

All of #542's scope: **6 definitions** whose fence carried no real prose, and **5 module headers** that were the boilerplate sentence and nothing more. The subtree now reports **0 gaps and 0 weak headers**, and the advisory `named` column rises 19% to 28%.

As #542 predicted, this one is mostly header work: all six gaps sit on a single fence.

## The one prose block

`Setoid/Functions/Basic` holds the primitives the rest of the tree is built from, and its one undocumented fence carries all six. The block covers them in two groups, because that is what they are:

+  `𝑖𝑑` and `_⊙_`. The thing worth saying is *why* they are unremarkable: a setoid function carries its own congruence proof, so identity and composition need no side conditions and simply do to the proofs what they do to the maps. `_⊙_` is also noted to compose right to left, so `f ⊙ g` applies `g` first — worth stating because `⊙-hom` in `Setoid.Homomorphisms.Properties` takes its arguments the *other* way, in diagrammatic order.
+  `𝑙𝑖𝑓𝑡`, `liftFunc`, `lift∼lower`, `lower∼lift`, the universe lifting of a setoid. `𝑙𝑖𝑓𝑡` raises the carrier level and leaves the equality alone, and the two round-trip lemmas hold *by reflexivity alone* — which is the point, since the lifted equality **is** the original equality read through `lower`, so there is nothing to transport.

## The five headers

The `Setoid.Functions` and `Setoid.Relations` barrels, plus `Functions/Basic`, `Relations/Discrete` and `Relations/Quotients`. Both barrels get a "reach for the following" index derived from their `open import … public` lists.

Two of these headers say something a reader would otherwise have to reconstruct:

+  **`Setoid.Relations`** explains the split the tree actually turns on. The relation types take *bare carrier* types and "respects the setoid equality" is stated separately, rather than baking the setoid in. `Setoid.Relations.Continuous`'s own header gives the reasons (call-site migration, consistency with `Quotients`, and level inference, since `Carrier` is not injective in the equality level), and the barrel header now points at that split so the reader is not surprised by it.
+  **`Relations/Quotients`** says why quotienting is cheap here: the carrier does not change, only the equality does, so `_/_` needs neither a quotient type nor an axiom. It also names the algebraic counterpart, `_╱_` of `Setoid.Congruences.Basic`, where the quotient must respect the operations too.

## Where the prose comes from

The definitions themselves, in every case — this subtree has no HSP-paper analogue to mine. Every cross-reference and every module attribution was grepped before being written, which mattered four times:

+  `SurjInv` is in `Setoid.Functions.Surjective`, not in `Inverses` as the name suggests; the barrel entry says so.
+  `Inverses` holds `Image_∋_` and `IsInRange`, so it is described as images and ranges rather than as inverses.
+  `Setoid.Relations.Continuous`'s "arbitrary arity" really is an arbitrary *type*, not a natural number, and its own header says so explicitly.
+  ~~`proj` / `projIsOnto` are exported from `Surjective`~~ — **this was wrong**, and Copilot caught it. They are bare-types results in `Overture.Functions` (`:184`, `:205`), which is where `Setoid.Algebras.Products` imports them from; `Setoid.Functions.Surjective` neither defines nor re-exports them. The barrel entry named an API the listed module does not provide, and now says where they actually live. A reminder that "I grepped it" is only worth as much as the grep: I had confirmed `SurjInv` and `⊙-IsSurjective` in `Surjective` and carried the projections along with them without checking separately.

## What I am least sure of

Every added paragraph is mine. Two framing sentences rather than facts:

1.  **`Setoid.Functions` barrel, first paragraph.** "That packaging is what lets the library do without function extensionality: a construction that would otherwise have to prove two functions equal instead reasons with the congruence proof each function already carries." This is the standard reason for the setoid formulation and it matches what `Setoid.Algebras.Basic`'s header says about quotients, but it is an account of the design rather than anything the module proves.
2.  **`Relations/Quotients`, first sentence.** "Quotienting is where the setoid formulation pays for itself." Editorial; the substance after it (carrier unchanged, only the equality changes) is read straight off `_/_`.

**No `TODO(#268)` markers were needed.**

## Rebased onto master

#550 has merged, so this branch is rebased onto the new master. The Makefile ceilings were the only conflict, and neither side was correct: master now carries 153 / 35, this branch had set 170 / 35 against the older master, and the rebased tree measures **147 / 30**, which is 153 − 6 and 35 − 5.

**#551 is still parallel to this one**, rebased onto the same master and setting 142 / 26. Whichever merges second will conflict on those lines again; after both, the correct values are **136 and 21**.

## Copilot round 1

Five findings, all correct, all mine. Every thread has a reply.

The substantive one, made twice (on `Functions/Basic` and again on the barrel): I attributed the library's freedom from function extensionality to `Func`'s congruence proof. That proof says one map sends related arguments to related results and says nothing about when two maps are the same, so it cannot be the mechanism. What is: wherever two functions must be compared the library uses an explicitly pointwise relation rather than propositional equality of functions — `function-equality` of `Setoid.Relations.Discrete`, `_≋_` of `Setoid.Categories.Algebra` for homomorphisms. Both passages now say both halves, and the absolute "no construction ever" phrasing is gone.

Three misattributions in the barrel indexes, all now corrected: `proj`/`projIsOnto` are in `Overture.Functions`, not `Functions.Surjective` (see above); `Setoid.Relations.Properties` has no lemmas of its own but publicly re-exports the standard library's `Relation.Binary.Definitions`; and `Equivalence` is a Σ-bundle alias, so `.AgdaFunction` rather than `.AgdaRecord`.

That last one is worth a note beyond this PR: **nothing in the repository validates attribute-span classes.** `check_links` checks reference-style links; no gate checks that `` `x`{.AgdaRecord} `` agrees with Agda's own idea of what `x` is. I check mine against existing corpus usage, which is why this is the only instance across the three PRs, but a real check would need the highlighter's output. Probably worth its own issue.

## The ratchet, superseded above

~~`DOCSTRING_MAX_GAPS` 176 to **170**, `DOCSTRING_MAX_WEAK_HEADERS` 40 to **35**~~ — superseded by the rebase; see above. The counts this branch clears are unchanged at 6 and 5.

**This is now a three-way conflict on those two lines.** #550, #551 and this branch are all off the same master:

| PR | issue | clears | sets |
|---|---|---|---|
| #550 | #540 | 23 gaps, 5 headers | 153 / 35 |
| #551 | #541 | 11 gaps, 9 headers | 165 / 31 |
| #552 | #542 | 6 gaps, 5 headers | 170 / 35 |

After all three merge the correct values are **136 and 21** (176 − 23 − 11 − 6 and 40 − 5 − 9 − 5). Worth re-measuring on master rather than trusting the arithmetic:

```
python3 scripts/python/docstring_audit.py --modules --exit-zero src | grep -E '^TOTAL|no real header'
```

Nothing else overlaps — the three branches touch disjoint subtrees, so the `Makefile` is the only conflict in each case.

## Verification

+  **Prose-only, proved not asserted.** Fence contents extracted from `HEAD` and from `master` with the repository's own `extract_agda_lines` and compared: byte-identical, **5 of 5**.
+  **Type-checking.** All five modified modules check individually; `make check` is green on this tree.
+  `make check-links` green (322 pages); `docs/_links.md` unchanged.
+  `make docstrings` exit 0 at the new ceilings; `make docstrings-test` 72/72.
+  No dangling footnote reference introduced.

