### PR TITLE
[M4-2e] Docstrings: Classical/Structures (root and Lattice)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,10 @@ REPO      ?= ualib/agda-algebras
 # when the number of public definitions lacking a prose block exceeds this
 # ceiling, so the backlog can only shrink while the per-subtree prose PRs land.
 # Lower it whenever a PR clears definitions; never raise it.
-DOCSTRING_MAX_GAPS ?= 136
+DOCSTRING_MAX_GAPS ?= 102
+# The other half of the bar ADR-010 states: modules whose header is only the
+# boilerplate sentence.  Ratcheted the same way; never raise it.
+DOCSTRING_MAX_WEAK_HEADERS ?= 20
 # The other half of the bar ADR-010 states: modules whose header is only the
 # boilerplate sentence.  Ratcheted the same way; never raise it.
 DOCSTRING_MAX_WEAK_HEADERS ?= 21

--- a/docs/adr/002-classical-layer-design.md
+++ b/docs/adr/002-classical-layer-design.md
@@ -4,29 +4,29 @@
 
 ## Status
 
-Accepted — 2026-04-24.
-Revised v2 — 2026-05-17, following the M3-2 (Semigroup) load test.
-Amended v2.1 — 2026-05-28, adds §10 on `Classical/Properties/` following the M3-7 (Lattice) order-theoretic equivalence work.
-Amended v2.2 — 2026-06-04, records the M4-1 Σ-projection migration (#267 / #367): the bracket projections `∣_∣` / `∥_∥` are replaced by `proj₁` / `proj₂` across the live trees, revising the "no mass rename of Σ-projections" stance in §1, §7, and *Alternatives considered*.  The long-form `OperationSymbolsOf` / `ArityOf` remain canonical for signature components and are defined via `proj₁` / `proj₂` once #367 lands.  The caret (§7) and long-form-naming policies are unaffected.
+Accepted (2026-04-24).
+Revised v2 (2026-05-17), following the M3-2 (Semigroup) load test.
+Amended v2.1 (2026-05-28), adds §10 on `Classical/Properties/` following the M3-7 (Lattice) order-theoretic equivalence work.
+Amended v2.2 (2026-06-04), records the M4-1 Σ-projection migration (#267 / #367): the bracket projections `∣_∣` / `∥_∥` are replaced by `proj₁` / `proj₂` across the live trees, revising the "no mass rename of Σ-projections" stance in §1, §7, and *Alternatives considered*.  The long-form `OperationSymbolsOf` / `ArityOf` remain canonical for signature components and are defined via `proj₁` / `proj₂` once #367 lands.  The caret (§7) and long-form-naming policies are unaffected.
 
 ---
 
 ## Context
 
-The 3.0 reconstruction adds a `src/Classical/` tree holding specific algebraic theories — magmas, semigroups, monoids, groups, lattices, rings — built on the universal-algebra foundation in `src/Setoid/`.  This ADR records the architectural decisions that determine how each classical structure is represented, how it interoperates with the Agda standard library's `Algebra.Bundles`, how it stays portable to the eventual cubical Agda formulation (ADR-003), and — equally importantly — what set of *user-facing* affordances each structure exposes so that working with classical structures in `agda-algebras` is at least as ergonomic as working with `Algebra.Bundles` directly.
+The 3.0 reconstruction adds a `src/Classical/` tree holding specific algebraic theories (magmas, semigroups, monoids, groups, lattices, rings) built on the universal-algebra foundation in `src/Setoid/`.  This ADR records the architectural decisions that determine how each classical structure is represented, how it interoperates with the Agda standard library's `Algebra.Bundles`, how it stays portable to the eventual cubical Agda formulation (ADR-003), and, equally importantly, what set of *user-facing* affordances each structure exposes so that working with classical structures in `agda-algebras` is at least as ergonomic as working with `Algebra.Bundles` directly.
 
 Eight interacting questions get answered below:
 
-+  How is an operation symbol's interpretation represented — as a tuple-indexed function `(I → A) → A` or in curried form `A → A → A`?  The universal-algebra meta-theory requires the former for arity-uniform recursion (Birkhoff, HSP, varieties); the user-facing syntax working algebraists use is the latter (`x ∙ y`, not `pair x y`).
++  Is an operation symbol's interpretation represented as a tuple-indexed function `(I → A) → A` or in curried form `A → A → A`?  The universal-algebra meta-theory requires the former for arity-uniform recursion (Birkhoff, HSP, varieties); the user-facing syntax working algebraists use is the latter (`x ∙ y`, not `pair x y`).
 +  How are the variables in an equation represented at the term level?  A per-structure named-enum carrier is locally readable but proliferates across structures and leaks into bundle bridges.
 +  How are equational identities represented?  A per-structure copy of associativity, identity laws, etc. is what stdlib's `Algebra.Definitions` provides at the *evaluated* level; we need an analogous library at the *syntactic* (term-pair) level so the meta-theory's `Modᵗ` can consume them.
 +  How is each concrete structure related to weaker structures in the hierarchy?  Mathematically a monoid is a semigroup with an identity; type-theoretically the signature changes between levels, so direct Σ-over-predecessor nesting does not work.
 +  What is the type-theoretic shape of a structure `X`?  A record with named projections or a Σ-type pairing an algebra with a proof it satisfies the `X`-theory?
 +  How does `X` interoperate with `Algebra.Bundles`?  Stdlib provides `Semigroup`, `Monoid`, etc. as records; anyone interoperating with stdlib-typed code must convert.
-+  What does "round trip" mean for the bundle bridge under setoid semantics?  Propositional `≡` on the Σ-type is naive — it loses to Fin n η under `--cubical-compatible`; pointwise agreement is what's mathematically meant by "the same semigroup."
++  What does "round trip" mean for the bundle bridge under setoid semantics?  Propositional `≡` on the Σ-type is naive and it loses to Fin n η under `--cubical-compatible`; pointwise agreement is what's mathematically meant by "the same semigroup."
 +  How are distinguished elements (identity of a monoid, zero of a ring, basepoints of pointed structures) represented?
 
-A related question: what does "classical" mean in this subtree?  It does not mean "classical logic" — the library stays constructive throughout.  `Classical/` names the *tradition* of concrete algebraic structures (groups, rings, lattices) as distinct from the universal-algebraic treatment of algebras-over-a-signature that lives in `Setoid/`.  `Classical/` was chosen over `Concrete/` because the term is standard in the universal-algebra literature (Burris and Sankappanavar use it throughout).
+A related question: what does "classical" mean in this subtree?  It does not mean "classical logic"; the library stays constructive throughout.  `Classical/` names the *tradition* of concrete algebraic structures (groups, rings, lattices) as distinct from the universal-algebraic treatment of algebras-over-a-signature that lives in `Setoid/`.  `Classical/` was chosen over `Concrete/` because the term is standard in the universal-algebra literature (Burris and Sankappanavar use it throughout).
 
 ---
 
@@ -34,15 +34,15 @@ A related question: what does "classical" mean in this subtree?  It does not mea
 
 ### 1.  Operation representation: tuple-indexed at the foundation, curried at the user interface
 
-The foundational layer — `Overture.Operations`, `Setoid.Algebras`, `Overture.Terms`, and everything downstream that participates in the universal-algebra meta-theory — uses the tuple-indexed form `(I → A) → A`.  This is non-negotiable: variety closure operators, the term algebra as a W-type, Birkhoff's HSP theorem, and the equational-logic substrate (`Modᵗ`) all recurse on arity and require operations in this form.
+The foundational layer, consisting of `Overture.Operations`, `Setoid.Algebras`, `Overture.Terms`, and everything downstream that participates in the universal-algebra meta-theory, uses the tuple-indexed form `(I → A) → A`.  This is non-negotiable: variety closure operators, the term algebra as a W-type, Birkhoff's HSP theorem, and the equational-logic substrate (`Modᵗ`) all recurse on arity and require operations in this form.
 
-The user-facing layer — every accessor exported from `Classical/Structures/X` and `Classical/Bundles/X` — exposes operations in *curried* form: a binary operation as `A → A → A`, a nullary operation as `A`, a unary operation as `A → A`.  The wrappers between the two forms are provided once, generically, by `Curry`/`Uncurry` helpers in a shared `Classical.Operations` module, one helper per arity.  Per-structure files do not redefine these helpers and do not write `pair`-style wrappers inline.
+The user-facing layer, consisting of every accessor exported from `Classical/Structures/X` and `Classical/Bundles/X`, exposes operations in *curried* form: a binary operation as `A → A → A`, a nullary operation as `A`, a unary operation as `A → A`.  The wrappers between the two forms are provided once, generically, by `Curry`/`Uncurry` helpers in a shared `Classical.Operations` module, one helper per arity.  Per-structure files do not redefine these helpers and do not write `pair`-style wrappers inline.
 
 The bare type-class formulation of curried operations (à la Haskell's `Num` hierarchy via Agda instance arguments) is *not* introduced in 3.0.  Instance arguments in Agda are heavier than type classes in Lean or Haskell, and the use sites we care about are served well by `open Magma 𝑴 using (_∙_)`-style named-accessor opens.  If a future revision finds that pattern too verbose, instance arguments can layer on top of the named-accessor API without re-architecting.
 
-The arity-first ordering `Op : Type 𝓥 → Type α → Type (𝓥 ⊔ α)` with `Op I A = (I → A) → A` is preferred over the carrier-first alternative — `Op (Fin 2)` partially applies as "binary operation," independent of any carrier.
+The arity-first ordering `Op : Type 𝓥 → Type α → Type (𝓥 ⊔ α)` with `Op I A = (I → A) → A` is preferred over the carrier-first alternative; `Op (Fin 2)` partially applies as "binary operation," independent of any carrier.
 
-**Self-documenting projections for signatures**.  The Σ-type encoding of `Signature 𝓞 𝓥 = Σ (Type 𝓞) (λ Op → Op → Type 𝓥)` is mathematically clean but reads opaquely at use sites — `f : ∣ 𝑆 ∣` and `∥ 𝑆 ∥ f` do not telegraph their meaning to a reader without the encoding cached.  The `Overture.Signatures` module exposes long-form aliases:
+**Self-documenting projections for signatures**.  The Σ-type encoding of `Signature 𝓞 𝓥 = Σ (Type 𝓞) (λ Op → Op → Type 𝓥)` is mathematically clean but reads opaquely at use sites; indeed, `f : ∣ 𝑆 ∣` and `∥ 𝑆 ∥ f` do not telegraph their meaning to a reader without the encoding cached.  The `Overture.Signatures` module exposes long-form aliases:
 
 ```agda
 OperationSymbolsOf : Signature 𝓞 𝓥 → Type 𝓞
@@ -56,7 +56,7 @@ These are definitionally identical to `proj₁` / `proj₂`.  M4-1 makes the lon
 
 ### 2.  Variable carrier for equations: `Fin n`, not per-structure named enums
 
-The variable carrier for equations in `Th-X` is `Fin n`, with `n` the number of distinct variables the equations require — `Fin 2` for commutativity, `Fin 3` for associativity, and so on.  No per-structure `<Structure>Var` enums are introduced.  Readable patterns at use sites come from `Data.Fin.Patterns` (`0F`, `1F`, `2F`); where additional readability is wanted, per-equation locally bound names inside `Theories/X` files are encouraged.
+The variable carrier for equations in `Th-X` is `Fin n`, with `n` the number of distinct variables the equations require, `Fin 2` for commutativity, `Fin 3` for associativity, and so on.  No per-structure `<Structure>Var` enums are introduced.  Readable patterns at use sites come from `Data.Fin.Patterns` (`0F`, `1F`, `2F`); where additional readability is wanted, per-equation locally bound names inside `Theories/X` files are encouraged.
 
 The original M3-2 design (per-structure `SemigroupVar` with constructors `x`, `y`, `z`) was rejected on load-test grounds.  The per-structure enum leaked from `Classical/Theories/Semigroup` into the bundle bridge's variable-assignment machinery and into the worked-example's variable plumbing, and would have re-leaked at every subsequent structure.  Generic `Fin n` confines structure-specific naming to projections of carrier elements, where it belongs.
 
@@ -82,23 +82,23 @@ DistributesOverˡ : (· : OperationSymbolsOf 𝑆) → ArityOf · ≡ Fin 2
 
 Each per-structure `Classical/Theories/X.lagda.md` file composes these builders with `X`'s operation symbols; it does not redefine the underlying equation shapes.  `Classical.Equations` is the *syntactic dual* of stdlib's `Algebra.Definitions`, which provides the same inventory at the evaluated (carrier-quantified) level.  Having both views is genuinely additive: `Algebra.Definitions` is what `IsSemigroup.assoc` returns and what users prove for concrete algebras; `Classical.Equations` is what feeds `Modᵗ` and the variety machinery.  Neither subsumes the other.
 
-This module is the concrete answer — beyond pedagogy and corpus quality — to "why does `Classical/` exist as a parallel hierarchy rather than as a stdlib shim?"
+This module is the concrete answer, beyond pedagogy and corpus quality, to "why does `Classical/` exist as a parallel hierarchy rather than as a stdlib shim?"
 
 ### 4.  Theory index: `Eq-X` indexes equations, not variables
 
-Each `Classical/Theories/X.lagda.md` file defines `Th-X : Eq-X → Term (Fin n) × Term (Fin n)`, where `Eq-X` is a small named enum whose constructors name the equations of `X`'s theory — `assoc`, `id-l`, `id-r`, `inv-l`, `inv-r`, `dist-l`, `dist-r`, etc.  For single-equation theories (semigroup: associativity only) the index degenerates to `⊤` rather than introducing a redundant one-constructor enum.
+Each `Classical/Theories/X.lagda.md` file defines `Th-X : Eq-X → Term (Fin n) × Term (Fin n)`, where `Eq-X` is a small named enum whose constructors name the equations of `X`'s theory (`assoc`, `id-l`, `id-r`, `inv-l`, `inv-r`, `dist-l`, `dist-r`, etc.).  For single-equation theories (semigroup: associativity only) the index degenerates to `⊤` rather than introducing a redundant one-constructor enum.
 
 ### 5.  Structure encoding: self-contained over the structure's own signature, with forgetful projections for inheritance
 
-Each classical structure `X` is fully characterized by the pair `(Sig-X , Th-X)` — its own signature and its own complete equational theory in that signature — and is encoded as
+Each classical structure `X` is fully characterized by the pair `(Sig-X , Th-X)` consisting of its signature and its equational theory in that signature, and is encoded as
 
 ```text
 X α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-X
 ```
 
-inside an `open Setoid.Algebras {𝑆 = Sig-X}` block that fixes the signature parameter.  The degenerate case `Magma α ρ = Algebra α ρ` covers the empty-theory base — no Σ wrapping a trivial `⊤`-typed proof obligation.
+inside an `open Setoid.Algebras {𝑆 = Sig-X}` block that fixes the signature parameter.  The degenerate case `Magma α ρ = Algebra α ρ` covers the empty-theory base: no Σ wrapping a trivial `⊤`-typed proof obligation.
 
-The mathematical inheritance relationships between structures — "a monoid is a semigroup," "a group is a monoid," "a ring is an abelian group with extra structure" — are *not* encoded by Σ-nesting one structure's definition inside another.  Σ-over-predecessor was considered and rejected because each level carries a different signature: monoid adds a nullary identity symbol, group adds a unary inverse symbol, ring adds an entire second operation cluster.  Nesting would require signature-extension functors woven through every structure's definition, which is exactly the cumbersome scaffolding the user-facing layer is meant to avoid.
+The mathematical inheritance relationships between structures ("a monoid is a semigroup," "a group is a monoid," "a ring is an abelian group with extra structure") are *not* encoded by Σ-nesting one structure's definition inside another.  Σ-over-predecessor was considered and rejected because each level carries a different signature: monoid adds a nullary identity symbol, group adds a unary inverse symbol, ring adds an entire second operation cluster.  Nesting would require signature-extension functors woven through every structure's definition, which is exactly the cumbersome scaffolding the user-facing layer is meant to avoid.
 
 Inheritance instead manifests as *forgetful-functor projections* defined alongside each structure: `monoid→semigroup : Monoid α ρ → Semigroup α ρ`, `group→monoid : Group α ρ → Monoid α ρ`, `ring→abelianGroup : Ring α ρ → AbelianGroup α ρ`.  Each forgetful is a small theorem: drop the operations the weaker structure does not have, and re-extract the weaker theory's equations from the stronger structure's `Th-X`.  Forgetful projections compose, so chains like `group→semigroup` are derived rather than primitive.
 
@@ -106,7 +106,7 @@ The benefit of self-contained encoding: "what equations does a group satisfy?" h
 
 ### 6.  Bundle bridge: pointwise equivalence, not propositional Σ-equality
 
-The bidirectional conversion functions `⟨_⟩ˣ` (Σ-core → stdlib bundle) and `⟪_⟫ˣ` (stdlib bundle → Σ-core) form a *pointwise inverse pair*: the round-tripped algebra has the same underlying setoid as the original and interprets each operation symbol identically on every input.  The round-trip is *not* claimed as an inhabitant of `_≡_` on the Σ-type — under `--cubical-compatible`, the lack of η on `Fin n`-pattern lambdas makes the operation-tuple-vs-curried repackaging propositionally but not definitionally equal, and demanding `≡` on the Σ-type forces a funext appeal that the `--safe` regime forbids.
+The bidirectional conversion functions `⟨_⟩ˣ` (Σ-core → stdlib bundle) and `⟪_⟫ˣ` (stdlib bundle → Σ-core) form a *pointwise inverse pair*: the round-tripped algebra has the same underlying setoid as the original and interprets each operation symbol identically on every input.  The round-trip is *not* claimed as an inhabitant of `_≡_` on the Σ-type; under `--cubical-compatible`, the lack of η on `Fin n`-pattern lambdas makes the operation-tuple-vs-curried repackaging propositionally but not definitionally equal, and demanding `≡` on the Σ-type forces a funext appeal that the `--safe` regime forbids.
 
 Pointwise agreement is the mathematically correct notion of "same semigroup" under setoid semantics: two semigroups are the same exactly when their underlying setoids coincide and their operations agree on every input.  Each bundle bridge module exports a `roundtrip-X` lemma stating this pointwise agreement; nothing stronger is claimed.
 
@@ -116,11 +116,11 @@ Pointwise agreement is the mathematically correct notion of "same semigroup" und
 
 **Unicode usage across the library**: three categories, with three different policies.
 
-+  *Standard mathematical notation* — `≈`, `⊨`, `⊧`, `⊫`, `≅`, `≤`, `⨅`, `≡`, the bold-italic letters denoting algebraic structures (`𝑨` for an algebra, `𝑴` for a magma, `𝑮` for a group), the script letters for level variables (`𝓞`, `𝓥`), the blackboard letters for forgetful accessors (`𝔻[_]` for `Domain`, `𝕌[_]` for `Carrier`).  These mirror conventions in McKenzie–McNulty–Taylor and Burris–Sankappanavar; algebraists recognize them on sight, and the bold-italic/Roman distinction between an algebra `𝑨` and its universe `A` is mathematically load-bearing, not decorative.  Keep.
++  *Standard mathematical notation*: `≈`, `⊨`, `⊧`, `⊫`, `≅`, `≤`, `⨅`, `≡`, the bold-italic letters denoting algebraic structures (`𝑨` for an algebra, `𝑴` for a magma, `𝑮` for a group), the script letters for level variables (`𝓞`, `𝓥`), the blackboard letters for forgetful accessors (`𝔻[_]` for `Domain`, `𝕌[_]` for `Carrier`).  These mirror conventions in McKenzie–McNulty–Taylor and Burris–Sankappanavar; algebraists recognize them on sight, and the bold-italic/Roman distinction between an algebra `𝑨` and its universe `A` is mathematically load-bearing, not decorative.  Keep.
 
-+  *Subscripted Latin used to name structure-specific entities* — `𝑆ₓ`, `Thₓ`, `Eqₓ` in the original draft.  Replaced by hyphen-separated long forms: `Sig-X`, `Th-X`, `Eq-X`.  Hyphen-separated forms grep cleanly, display in any monospaced font, read aloud sensibly, and don't require an Agda-input-mode dance per occurrence.  New `Classical/` code uses the long forms exclusively.
++  *Subscripted Latin used to name structure-specific entities*: `𝑆ₓ`, `Thₓ`, `Eqₓ` in the original draft.  Replaced by hyphen-separated long forms: `Sig-X`, `Th-X`, `Eq-X`.  Hyphen-separated forms grep cleanly, display in any monospaced font, read aloud sensibly, and don't require an Agda-input-mode dance per occurrence.  New `Classical/` code uses the long forms exclusively.
 
-+  *Bracket notation for Σ-projections* — `∣ 𝑆 ∣`, `∥ 𝑆 ∥ f`.  **Migrated** to `proj₁` / `proj₂` (and the `OperationSymbolsOf` / `ArityOf` long-forms for signature components) across the live trees by M4-1 (#367), which adds a `WARNING_ON_USAGE` to the definitions in `Overture.Basic` and retains them for `Legacy/`.  The blackboard accessor notation `𝔻[ 𝑨 ]` (Domain) and `𝕌[ 𝑨 ]` (Carrier) is category-1 standard notation and is **kept** everywhere.
++  *Bracket notation for Σ-projections*: `∣ 𝑆 ∣`, `∥ 𝑆 ∥ f`.  **Migrated** to `proj₁` / `proj₂` (and the `OperationSymbolsOf` / `ArityOf` long-forms for signature components) across the live trees by M4-1 (#367), which adds a `WARNING_ON_USAGE` to the definitions in `Overture.Basic` and retains them for `Legacy/`.  The blackboard accessor notation `𝔻[ 𝑨 ]` (Domain) and `𝕌[ 𝑨 ]` (Carrier) is category-1 standard notation and is **kept** everywhere.
 
 The original v2 policy performed no mass rename; M4-1 (amendment v2.2) revised this for the `∣_∣` / `∥_∥` Σ-projections specifically, which are now `proj₁` / `proj₂` library-wide.  The remaining policy stands: new `Classical/` code adopts the long-form conventions, and the subscript / blackboard notation in `Setoid/` is retained as well-established reference material.
 
@@ -130,7 +130,7 @@ The pattern-setting first concrete structure under `Classical/` is `Magma`, not 
 
 ### 9.  Distinguished elements and pointed expansions
 
-Distinguished elements of an algebra — the identity of a monoid, zero of a ring, top/bottom of a bounded lattice, basepoints of pointed structures — are represented as **nullary operation symbols** of the structure's signature.  The user-facing layer surfaces them as constants of carrier type via the `Curry₀` helper.  Equations involving distinguished elements (the monoid identity laws, the ring annihilation law) are standard term-level equations whose terms contain the nullary symbol as a leaf, via the same `Classical.Equations` builders that handle higher-arity operation symbols.
+Distinguished elements of an algebra (the identity of a monoid, zero of a ring, top/bottom of a bounded lattice, basepoints of pointed structures) are represented as **nullary operation symbols** of the structure's signature.  The user-facing layer surfaces them as constants of carrier type via the `Curry₀` helper.  Equations involving distinguished elements (the monoid identity laws, the ring annihilation law) are standard term-level equations whose terms contain the nullary symbol as a leaf, via the same `Classical.Equations` builders that handle higher-arity operation symbols.
 
 This choice is mandated by the equational-logic substrate: the variety machinery (`Modᵗ`, `Th`, the closure operators) characterizes a variety as algebras satisfying a set of identities *over the signature*.  A monoid's identity element must appear in identities involving the operation `∙` (specifically, `ε ∙ x ≈ x` and `x ∙ ε ≈ x`), hence must be a syntactic symbol of the signature.  Encoding the identity as a distinguished carrier element of an algebra (rather than a signature symbol) would make those identity equations inexpressible in the variety framework.
 
@@ -147,11 +147,11 @@ ar-PointedGroup p-Op  = Fin 0
 
 with the basepoint `p` interpreted via `p-Op ^ 𝑮`.  The equational theory `Th-PointedGroup` includes the group axioms unchanged plus whatever equations specify the basepoint's behavior; the variety of pointed groups is, in general, *not* the same variety as ungroup-pointed groups, and known results (Bryant, *The laws of finite pointed groups*, Bull. LMS 14 (1982), 119–123; in light of Oates–Powell's finite-basis theorem for finite groups) show pointed expansions can change decidability and finite-axiomatizability properties.  The encoding accommodates the distinction without architectural change.
 
-The naming convention for nullary operation symbols mirrors the binary case: `<symbol>-Op` (`∙-Op`, `ε-Op`, `0-Op`, `1-Op`, `⊤-Op`, `⊥-Op`).  Hyphenation reads aloud the way an algebraist pronounces these — "dot-op," "epsilon-op," "zero-op" — and greps cleanly.
+The naming convention for nullary operation symbols mirrors the binary case: `<symbol>-Op` (`∙-Op`, `ε-Op`, `0-Op`, `1-Op`, `⊤-Op`, `⊥-Op`).  Hyphenation reads aloud the way an algebraist pronounces these ("dot-op," "epsilon-op," "zero-op") and greps cleanly.
 
 ### 10.  `Classical/Properties/` for derived results
 
-A sixth subtree `Classical/Properties/` (sibling of `Signatures/`, `Theories/`, `Structures/`, `Bundles/`, `Small/`) houses *derived* results about classical structures — theorems that are properties of a fixed inhabitant of one of the structures defined in `Classical/Structures/`, rather than part of the structure's definition.  Each per-structure file `Classical/Properties/X.lagda.md` consumes `X-Op`'s curried accessors and proves further facts about a parameterized `(𝑿 : X α ρ)`.
+A sixth subtree `Classical/Properties/` (sibling of `Signatures/`, `Theories/`, `Structures/`, `Bundles/`, `Small/`) houses *derived* results about classical structures, theorems that are properties of a fixed inhabitant of one of the structures defined in `Classical/Structures/`, rather than part of the structure's definition.  Each per-structure file `Classical/Properties/X.lagda.md` consumes `X-Op`'s curried accessors and proves further facts about a parameterized `(𝑿 : X α ρ)`.
 
 The inaugural inhabitant is `Classical.Properties.Lattice`, which proves the meet-join / order-theoretic equivalence: the partial order `x ≤ y := x ∧ y ≈ x` induced by the algebraic data, with the partial-order witnesses and the proof that `_∧_` and `_∨_` are the binary meet and join with respect to it.  Future inhabitants of this subtree include, for example, uniqueness of inverses in `Classical.Properties.Group`, `0 · x ≈ 0` in `Classical.Properties.Ring`, and the order-induced semilattice on a `Semilattice`.
 
@@ -179,13 +179,13 @@ The revisions above are the response to these findings.  No part of the original
 
 +  **Definitions read the way a universal algebraist thinks**.  "A semigroup is a magma satisfying associativity" is exactly what `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Semigroup` types, with `Th-Semigroup _ = Associative ∙-Op refl 0F 1F 2F`.  The generic-builder layer makes each per-structure theory file a short composition, not a re-derivation.
 
-+  **The library uniquely answers what stdlib does not**.  Generic equation builders that compose to populate `Th-X` for any `X` form the syntactic dual of `Algebra.Definitions` and feed the meta-theory's `Modᵗ` in a way that stdlib's evaluated-form predicates cannot.  This is the concrete justification — beyond pedagogy and corpus quality — for `Classical/` existing as a parallel hierarchy rather than a stdlib shim.
++  **The library uniquely answers what stdlib does not**.  Generic equation builders that compose to populate `Th-X` for any `X` form the syntactic dual of `Algebra.Definitions` and feed the meta-theory's `Modᵗ` in a way that stdlib's evaluated-form predicates cannot.  This is the concrete justification, beyond pedagogy and corpus quality, for `Classical/` existing as a parallel hierarchy rather than a stdlib shim.
 
 +  **Curried user-facing operations match working-algebraist syntax**.  `_∙_ : A → A → A` is what `x ∙ y` expects.  Tuple-indexed operations live below the user interface, surfaced only when interfacing with the universal-algebra meta-theory.
 
 +  **`fromOp`-family constructors bridge bare-type definitions to the Σ-typed core**.  Users construct a magma from `(A : Type α) → (_·_ : A → A → A)`, a semigroup additionally from `(·-assoc : ∀ a b c → (a · b) · c ≡ a · (b · c))`, a monoid additionally from `(ε : A)` and the identity laws, and so on.  The return type collapses to `X α α` because propositional equality at carrier `A : Type α` lives in `Type α`; consumers needing `α ≠ ρ` work directly with the underlying setoid.
 
-+  **Stdlib bundle interop is a fixed, per-structure cost**.  Each `Classical/Bundles/X.lagda.md` is one record definition, two conversion functions, a pointwise round-trip lemma — uniformly small thanks to the generic `Curry`/`Uncurry` helpers absorbing the Fin n η-bridge once.
++  **Stdlib bundle interop is a fixed, per-structure cost**.  Each `Classical/Bundles/X.lagda.md` is one record definition, two conversion functions, a pointwise round-trip lemma, uniformly small thanks to the generic `Curry`/`Uncurry` helpers absorbing the Fin n η-bridge once.
 
 +  **Cubical portability remains substitutional**.  No theorem in `Classical/Structures/X.lagda.md` reaches for setoid-specific machinery; the 4.0 cubical port replaces the setoid equivalence with the path type and reruns the type-checker.  Pointwise equivalence at the bundle bridge survives this port unchanged.
 
@@ -205,7 +205,7 @@ The revisions above are the response to these findings.  No part of the original
 
 +  **`Classical/` built directly on `Base/` instead of `Setoid/`**.  Rejected because `Base/` is frozen (ADR-001), postulates extensionality (breaking the constructivity commitment), and is not cubical-portable without further rework.
 
-+  **Σ-over-predecessor inheritance** (`Monoid α ρ = Σ[ 𝑺 ∈ Semigroup α ρ ] … extras`).  Considered as a way to enforce the mathematical "a monoid is a semigroup" reading at the type level.  Rejected because each level of the hierarchy carries a different signature; Σ-over-predecessor cannot smoothly accommodate signature extension.  Encoding it would require signature-extension functors woven through every structure's definition — the opposite of the user-facing-simplicity goal.  Self-contained encoding (revised §5) keeps each structure cleanly characterized by `(Sig-X , Th-X)` and expresses inheritance via forgetful projections that compose downward.
++  **Σ-over-predecessor inheritance** (`Monoid α ρ = Σ[ 𝑺 ∈ Semigroup α ρ ] … extras`).  Considered as a way to enforce the mathematical "a monoid is a semigroup" reading at the type level.  Rejected because each level of the hierarchy carries a different signature; Σ-over-predecessor cannot smoothly accommodate signature extension.  Encoding it would require signature-extension functors woven through every structure's definition, the opposite of the user-facing-simplicity goal.  Self-contained encoding (revised §5) keeps each structure cleanly characterized by `(Sig-X , Th-X)` and expresses inheritance via forgetful projections that compose downward.
 
 +  **Per-structure named-enum variable carriers** (e.g., `data SemigroupVar : Type where x y z : SemigroupVar`).  Considered for local-readability reasons.  Rejected because per-structure enums leak from `Classical/Theories/X` into bundle bridges and worked-example plumbing, and proliferate across structures.  Generic `Fin n` with `Data.Fin.Patterns`-style readability resolves the leak without sacrificing readability.
 
@@ -213,7 +213,7 @@ The revisions above are the response to these findings.  No part of the original
 
 +  **Distinguished elements as algebra-level distinguished carrier elements rather than nullary operation symbols**.  Considered for the apparent simplicity of "a pointed group is a group with a chosen basepoint."  Rejected because the equational-logic substrate (`Modᵗ`, the variety machinery) characterizes a variety as algebras satisfying identities *over the signature*: if a distinguished element does not appear as a signature symbol, no identity can mention it, and the structure's theory cannot constrain it.  Nullary-symbol encoding (revised §9) is what makes the variety of monoids a proper variety and what makes pointed-group expansions a meaningful distinct variety.
 
-+  **Mass rename of unicode in the existing `Setoid/` tree**.  Considered for consistency with the long-form-name convention adopted for new `Classical/` code.  Rejected as churn for no architectural benefit: `Setoid/` is well-established reference material, the unicode there is mostly category-1 (standard mathematical notation) anyway, and a rename would invalidate existing tutorials, papers, and external references to specific identifiers.  Policy is per-tree: new `Classical/` long-form, existing `Setoid/` retained.  (Amended v2.2: the one narrow exception is the `∣_∣` / `∥_∥` Σ-projections, migrated to `proj₁` / `proj₂` in M4-1 (#267 / #367) — there the readability and grep-tooling arguments outweighed the churn; the category-1 mathematical notation, subscripts, and blackboard accessors are still retained.)
++  **Mass rename of unicode in the existing `Setoid/` tree**.  Considered for consistency with the long-form-name convention adopted for new `Classical/` code.  Rejected as churn for no architectural benefit: `Setoid/` is well-established reference material, the unicode there is mostly category-1 (standard mathematical notation) anyway, and a rename would invalidate existing tutorials, papers, and external references to specific identifiers.  Policy is per-tree: new `Classical/` long-form, existing `Setoid/` retained.  (Amended v2.2: the one narrow exception is the `∣_∣` / `∥_∥` Σ-projections, migrated to `proj₁` / `proj₂` in M4-1 (#267 / #367); there the readability and grep-tooling arguments outweighed the churn; the category-1 mathematical notation, subscripts, and blackboard accessors are still retained.)
 
 +  **Per-structure `Classical/<X>/Properties.lagda.md` subdirectories** (e.g. `Classical/Lattice/Properties.lagda.md`).  Considered as a layout option for derived results when M3-7's lattice order-theoretic equivalence motivated the first Properties module.  Rejected for organizational uniformity: the existing tree organizes strictly by concern (one axis = concern as directory, leaf = structure), and per-structure subdirectories for properties alone would mix two organizing axes (concern-as-directory for everything else, structure-as-directory only for properties).  By-concern (§10) keeps the existing pattern uniform and mirrors stdlib's layout.
 
@@ -222,16 +222,16 @@ The revisions above are the response to these findings.  No part of the original
 
 ## References
 
-+  Issue M3-1 — [Introduce the Classical/ tree](https://github.com/ualib/agda-algebras/issues/260).
-+  Issue M3-1a — [Scaffold the Classical/ tree](https://github.com/ualib/agda-algebras/issues/326).
-+  Issue M3-2 — [Classical.Operations and Classical.Equations infrastructure](https://github.com/ualib/agda-algebras/issues/330).
-+  Issue M3-3 — [Classical.Magma](https://github.com/ualib/agda-algebras/issues/330).
-+  Issue M3-4 — [Classical.Semigroup](https://github.com/ualib/agda-algebras/issues/261) (reformulated; supersedes original body).
-+  Issue M3-5 — Stdlib bundle bridges (continued).
-+  Issue M3-7 — [Classical.Semilattice and Classical.Lattice](https://github.com/ualib/agda-algebras/issues/264) (the order-theoretic equivalence motivating §10).
-+  ADR-001 — `Setoid/` as canonical development tree (the foundation `Classical/` builds on).
-+  ADR-003 — Cubical Agda as the canonical long-term target (the discipline `Classical/` enforces).
-+  `docs/STYLE_GUIDE.md` — sections on record vs Σ, on unicode usage, on long-form vs bracket projection names.
++  Issue M3-1: [Introduce the Classical/ tree](https://github.com/ualib/agda-algebras/issues/260).
++  Issue M3-1a: [Scaffold the Classical/ tree](https://github.com/ualib/agda-algebras/issues/326).
++  Issue M3-2: [Classical.Operations and Classical.Equations infrastructure](https://github.com/ualib/agda-algebras/issues/330).
++  Issue M3-3: [Classical.Magma](https://github.com/ualib/agda-algebras/issues/330).
++  Issue M3-4: [Classical.Semigroup](https://github.com/ualib/agda-algebras/issues/261) (reformulated; supersedes original body).
++  Issue M3-5: Stdlib bundle bridges (continued).
++  Issue M3-7: [Classical.Semilattice and Classical.Lattice](https://github.com/ualib/agda-algebras/issues/264) (the order-theoretic equivalence motivating §10).
++  ADR-001: `Setoid/` as canonical development tree (the foundation `Classical/` builds on).
++  ADR-003: Cubical Agda as the canonical long-term target (the discipline `Classical/` enforces).
++  `docs/STYLE_GUIDE.md`: sections on record vs Σ, on unicode usage, on long-form vs bracket projection names.
 +  Agda standard library, `Algebra.Bundles` and `Algebra.Definitions`.
 +  Burris and Sankappanavar, *A Course in Universal Algebra*, chapter II.
-+  R. Bryant, *The laws of finite pointed groups*, Bull. London Math. Soc. **14** (1982), 119–123 — for §9 on pointed expansions and the connection to Oates–Powell's finite-basis theorem.
++  R. Bryant, *The laws of finite pointed groups*, Bull. London Math. Soc. **14** (1982), 119–123 (for §9 on pointed expansions and the connection to Oates–Powell's finite-basis theorem).

--- a/src/Classical/Structures/CommutativeMonoid.lagda.md
+++ b/src/Classical/Structures/CommutativeMonoid.lagda.md
@@ -10,8 +10,12 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.CommutativeMonoid][] module of the [Agda Universal Algebra Library][].
 
-`Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-CommutativeMonoid` over `Sig-Monoid`.  An equation-only
-extension of Monoid: `commutativeMonoid→monoid` is a pure theory-reindex, and
+A **commutative monoid** is an inhabitant of the type
+`Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-CommutativeMonoid`, where `Algebra` is parameterized
+by the `Sig-Monoid` type.
+
+This module naturally codifies a commutative monoid as an equational extension of
+`Monoid`; `commutativeMonoid→monoid` is a pure theory-reindex, and
 `CommutativeMonoid-Op` inherits `_∙_`, `ε`, and all three monoid laws through it,
 adding `comm-law`.
 
@@ -21,8 +25,9 @@ adding `comm-law`.
 
 module Classical.Structures.CommutativeMonoid where
 
-open import Agda.Primitive                          using () renaming ( Set to Type )
+open import Agda.Primitive                         using () renaming ( Set to Type )
 
+-- Imports from the Agda Standard Library ---------------------------------------
 open import Data.Fin.Base                          using ( Fin )
 open import Data.Fin.Patterns                      using ( 0F ; 1F ; 2F )
 open import Data.Product                           using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
@@ -30,14 +35,15 @@ open import Level                                  using ( Level ; _⊔_ ; suc )
 open import Relation.Binary                        using ( Setoid )
 open import Relation.Binary.PropositionalEquality  using ( _≡_ )
 
+-- Imports from the Agda Universal Algebra Library ------------------------------
 open import Classical.Signatures.Monoid            using ( Sig-Monoid )
 open import Classical.Structures.Monoid            using ( Monoid ; module Monoid-Op ; opsToBareMonoid )
 open import Classical.Theories.Monoid              using ( assoc ; idˡ ; idʳ )
 open import Classical.Theories.CommutativeMonoid   using ( Eq-CommutativeMonoid ; Th-CommutativeMonoid ; comm )
                                                    renaming ( assoc to assocᶜ ; idˡ to idˡᶜ ; idʳ to idʳᶜ )
 open import Overture.Terms {𝑆 = Sig-Monoid}        using (Term ; ℊ )
-open import Setoid.Algebras.Basic using ( Algebra ; 𝔻[_] ; 𝕌[_] )
-open import Setoid.Varieties.EquationalLogic using ( _⊧_≈_ )
+open import Setoid.Algebras.Basic                  using ( Algebra ; 𝔻[_] ; 𝕌[_] )
+open import Setoid.Varieties.EquationalLogic       using ( _⊧_≈_ )
 
 private variable α ρ : Level
 ```
@@ -47,11 +53,12 @@ private variable α ρ : Level
 
 ```agda
 infix 4 _⊨ᶜᵐᵒ_
+
 _⊨ᶜᵐᵒ_ : (𝑨 : Algebra {𝑆 = Sig-Monoid} α ρ) (ℰ : Eq-CommutativeMonoid → Term (Fin 3) × Term (Fin 3)) → Type (α ⊔ ρ)
 𝑨 ⊨ᶜᵐᵒ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 
 CommutativeMonoid : (α ρ : Level) → Type (suc α ⊔ suc ρ)
-CommutativeMonoid α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Monoid} α ρ ] 𝑨 ⊨ᶜᵐᵒ Th-CommutativeMonoid
+CommutativeMonoid α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ᶜᵐᵒ Th-CommutativeMonoid
 ```
 
 #### The forgetful projection to monoids
@@ -68,16 +75,15 @@ reduct and re-prove.
 
 ```agda
 commutativeMonoid→monoid : CommutativeMonoid α ρ → Monoid α ρ
-commutativeMonoid→monoid (𝑨 , mod) = 𝑨 , λ { assoc → mod assocᶜ
-                                           ; idˡ   → mod idˡᶜ
-                                           ; idʳ   → mod idʳᶜ }
+commutativeMonoid→monoid (𝑨 , mod) =
+  𝑨 , λ { assoc → mod assocᶜ ; idˡ → mod idˡᶜ ; idʳ → mod idʳᶜ }
 ```
 
 #### The `CommutativeMonoid-Op` module
 
-`CommutativeMonoid-Op 𝑪`{.AgdaModule} inherits the whole monoid interface through the
-forgetful — `_∙_`{.AgdaFunction}, `ε`{.AgdaFunction}, the congruence, both
-containment lemmas and all three laws — and adds exactly one accessor of its own.
+`CommutativeMonoid-Op 𝑪`{.AgdaModule} inherits the whole monoid interface
+(`_∙_`{.AgdaFunction}, `ε`{.AgdaFunction}, the congruence, both
+containment lemmas and all three laws) and adds exactly one accessor of its own.
 `equations`{.AgdaFunction} is the new satisfaction witness, and
 `comm-law`{.AgdaFunction} is commutativity in curried form.
 
@@ -93,8 +99,8 @@ module CommutativeMonoid-Op {α ρ : Level} (𝑪 : CommutativeMonoid α ρ) whe
   open Setoid 𝔻[ 𝑨 ]
 
   open Monoid-Op (commutativeMonoid→monoid 𝑪) public
-    using ( _∙_ ; ε ; ∙-cong ; interp-node-∙ ; interp-node-ε
-          ; assoc-law ; idˡ-law ; idʳ-law )
+    using  ( _∙_ ; ε ; ∙-cong ; interp-node-∙ ; interp-node-ε
+           ; assoc-law ; idˡ-law ; idʳ-law )
 
   equations : 𝑨 ⊨ᶜᵐᵒ Th-CommutativeMonoid
   equations = proj₂ 𝑪
@@ -109,7 +115,7 @@ module CommutativeMonoid-Op {α ρ : Level} (𝑪 : CommutativeMonoid α ρ) whe
 #### `eqsToCommutativeMonoid`
 
 `eqsToCommutativeMonoid`{.AgdaFunction} is the constructor a downstream user calls.
-It takes the raw data — a carrier, a binary operation, an identity element — and the
+It takes the raw data (a carrier, a binary operation, an identity element) and the
 four laws as *propositional* equations, and returns a `CommutativeMonoid α α`.
 
 The four proof obligations discharge by direct evaluation rather than by reasoning.

--- a/src/Classical/Structures/CommutativeMonoid.lagda.md
+++ b/src/Classical/Structures/CommutativeMonoid.lagda.md
@@ -56,6 +56,16 @@ CommutativeMonoid α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Monoid} α ρ ] 𝑨 
 
 #### The forgetful projection to monoids
 
+`commutativeMonoid→monoid`{.AgdaFunction} keeps the algebra and discards
+commutativity.  Because a commutative monoid is a monoid with an extra *equation*
+rather than an extra operation, the signature does not change and no reduct is
+needed; what the function does is re-index the satisfaction witness, mapping each
+constructor of `Eq-Monoid`{.AgdaDatatype} to its counterpart in
+`Eq-CommutativeMonoid`{.AgdaDatatype}.  The `λ { assoc → mod assocᶜ ; … }` clause is
+exactly that renaming, and it is the cheap case of the pattern: contrast
+`monoid→semigroup`{.AgdaFunction} of [Classical.Structures.Monoid][], which must
+reduct and re-prove.
+
 ```agda
 commutativeMonoid→monoid : CommutativeMonoid α ρ → Monoid α ρ
 commutativeMonoid→monoid (𝑨 , mod) = 𝑨 , λ { assoc → mod assocᶜ
@@ -64,6 +74,18 @@ commutativeMonoid→monoid (𝑨 , mod) = 𝑨 , λ { assoc → mod assocᶜ
 ```
 
 #### The `CommutativeMonoid-Op` module
+
+`CommutativeMonoid-Op 𝑪`{.AgdaModule} inherits the whole monoid interface through the
+forgetful — `_∙_`{.AgdaFunction}, `ε`{.AgdaFunction}, the congruence, both
+containment lemmas and all three laws — and adds exactly one accessor of its own.
+`equations`{.AgdaFunction} is the new satisfaction witness, and
+`comm-law`{.AgdaFunction} is commutativity in curried form.
+
+That single addition is the point of the idiom: the inherited names are re-exported
+rather than restated, so opening this module gives the full monoid vocabulary plus
+commutativity, and the only proof written here is the one genuinely new law.  Its
+proof also shows why the containment lemmas were worth naming: `comm-law` is
+`equations comm` with `interp-node-∙`{.AgdaFunction} applied on each side.
 
 ```agda
 module CommutativeMonoid-Op {α ρ : Level} (𝑪 : CommutativeMonoid α ρ) where
@@ -85,6 +107,18 @@ module CommutativeMonoid-Op {α ρ : Level} (𝑪 : CommutativeMonoid α ρ) whe
 ```
 
 #### `eqsToCommutativeMonoid`
+
+`eqsToCommutativeMonoid`{.AgdaFunction} is the constructor a downstream user calls.
+It takes the raw data — a carrier, a binary operation, an identity element — and the
+four laws as *propositional* equations, and returns a `CommutativeMonoid α α`.
+
+The four proof obligations discharge by direct evaluation rather than by reasoning.
+Under `≡.setoid A` the setoid equality is propositional equality, and the
+interpretation of each term in `opsToBareMonoid`{.AgdaFunction} reduces
+definitionally to the corresponding application of `_·_`, so each clause is just the
+supplied law applied to the right environment components.  Factoring through
+`opsToBareMonoid`{.AgdaFunction} is also what makes the forgetful-agreement criterion
+of ADR-002 discharge by `refl`.
 
 ```agda
 eqsToCommutativeMonoid : (A : Type α) (_·_ : A → A → A) (e : A)

--- a/src/Classical/Structures/CommutativeRing.lagda.md
+++ b/src/Classical/Structures/CommutativeRing.lagda.md
@@ -62,6 +62,14 @@ CommutativeRing α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Ring} α ρ ] 𝑨 ⊨�
 
 #### The forgetful projection to rings
 
+`commutativeRing→ring`{.AgdaFunction} discards multiplicative commutativity.  As
+with the commutative monoid, the signature is unchanged and the work is re-indexing
+the satisfaction witness — but here the theory has eleven equations rather than
+three, so the clause is a table of eleven constructor renamings mapping each of
+`Eq-Ring`{.AgdaDatatype} to its `ᶜ`-suffixed counterpart in
+`Eq-CommutativeRing`{.AgdaDatatype}.  Long, but entirely mechanical: nothing is
+proved, only relabelled.
+
 ```agda
 commutativeRing→ring : CommutativeRing α ρ → Ring α ρ
 commutativeRing→ring (𝑨 , mod) = 𝑨 , λ  { +-assoc   → mod +-assocᶜ
@@ -78,6 +86,17 @@ commutativeRing→ring (𝑨 , mod) = 𝑨 , λ  { +-assoc   → mod +-assocᶜ
 ```
 
 #### The `CommutativeRing-Op` module
+
+`CommutativeRing-Op 𝑪`{.AgdaModule} inherits the entire ring interface through the
+forgetful: two operations with their units and the additive inverse, three
+congruences, five containment lemmas, and all eleven laws.  It adds
+`equations`{.AgdaFunction} and one new law, `·-comm-law`{.AgdaFunction}.
+
+The ratio is what makes the idiom worth having.  Twenty-three inherited names are
+re-exported by name and one law is proved, and that proof is the same three-step
+shape as `comm-law`{.AgdaFunction} in the commutative monoid and semigroup — the
+`equations ·-comm` step between two applications of the containment lemma for the
+relevant symbol, here `interp-node-·`{.AgdaFunction}.
 
 ```agda
 module CommutativeRing-Op {α ρ : Level} (𝑪 : CommutativeRing α ρ) where
@@ -101,6 +120,12 @@ module CommutativeRing-Op {α ρ : Level} (𝑪 : CommutativeRing α ρ) where
 ```
 
 #### `eqsToCommutativeRing`
+
+`eqsToCommutativeRing`{.AgdaFunction} is the largest constructor of the family: two
+binary operations, two constants, an additive inverse, and eleven propositional
+laws.  The eleven obligations discharge exactly as the smaller cases do, by
+definitional reduction under `≡.setoid A`, so the size of the signature costs
+argument count and nothing else.
 
 ```agda
 eqsToCommutativeRing : (A : Type α) (_+'_ : A → A → A) (0' : A) (-'_ : A → A) (_*'_ : A → A → A) (1' : A)

--- a/src/Classical/Structures/CommutativeRing.lagda.md
+++ b/src/Classical/Structures/CommutativeRing.lagda.md
@@ -10,12 +10,16 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.CommutativeRing][] module of the [Agda Universal Algebra Library][].
 
-`Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-CommutativeRing` over `Sig-Ring`.  An equation-only
-extension of Ring, structurally identical to the way `CommutativeMonoid` extends
-`Monoid` and `AbelianGroup` extends `Group`: `commutativeRing→ring` is a pure
-theory-reindex (`proj₁` on the underlying algebra), and `CommutativeRing-Op` inherits
-the additive `(_+_, 0R, -_)`, the multiplicative `(_·_, 1R)`, and all eleven ring laws
-through it, adding `·-comm-law`.
+A **commutative ring** is an inhabitant of the type
+`Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-CommutativeRing`, where `Algebra` is parameterized by
+the `Sig-Ring` type.
+
+This module naturally codifies a commutative ring as an equational extension of
+Ring, the same way `CommutativeMonoid` extends `Monoid` and `AbelianGroup` extends
+`Group`: `commutativeRing→ring` is a pure theory-reindex (`proj₁` on the
+underlying algebra), and `CommutativeRing-Op` inherits the additive `(_+_, 0R,
+-_)`, the multiplicative `(_·_, 1R)`, and all eleven ring laws through it, adding
+`·-comm-law`.
 
 <!--
 ```agda
@@ -23,8 +27,10 @@ through it, adding `·-comm-law`.
 
 module Classical.Structures.CommutativeRing where
 
-open import Agda.Primitive                          using () renaming ( Set to Type )
+open import Agda.Primitive                         using () renaming ( Set to Type )
 
+
+-- Imports from the Agda Standard Library ---------------------------------------
 open import Data.Fin.Base                          using ( Fin )
 open import Data.Fin.Patterns                      using ( 0F ; 1F ; 2F )
 open import Data.Product                           using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
@@ -32,18 +38,31 @@ open import Level                                  using ( Level ; _⊔_ ; suc )
 open import Relation.Binary                        using ( Setoid )
 open import Relation.Binary.PropositionalEquality  using ( _≡_ )
 
-open import Classical.Signatures.Ring              using ( Sig-Ring )
-open import Classical.Structures.Ring              using ( Ring ; module Ring-Op ; opsToBareRing )
-open import Classical.Theories.Ring                using ( +-assoc ; +-idˡ ; +-idʳ ; +-invˡ ; +-invʳ ; +-comm
-                                                         ; ·-assoc ; ·-idˡ ; ·-idʳ ; distribˡ ; distribʳ )
-open import Classical.Theories.CommutativeRing     using ( Eq-CommutativeRing ; Th-CommutativeRing ; ·-comm )
-                                                   renaming ( +-assoc to +-assocᶜ ; +-idˡ to +-idˡᶜ ; +-idʳ to +-idʳᶜ
-                                                            ; +-invˡ to +-invˡᶜ ; +-invʳ to +-invʳᶜ ; +-comm to +-commᶜ
-                                                            ; ·-assoc to ·-assocᶜ ; ·-idˡ to ·-idˡᶜ ; ·-idʳ to ·-idʳᶜ
-                                                            ; distribˡ to distribˡᶜ ; distribʳ to distribʳᶜ )
-open import Overture.Terms {𝑆 = Sig-Ring}          using ( Term ; ℊ )
-open import Setoid.Algebras.Basic   using ( Algebra ; 𝔻[_] ; 𝕌[_] )
-open import Setoid.Varieties.EquationalLogic using ( _⊧_≈_ )
+-- Imports from the Agda Universal Algebra Library ------------------------------
+open import Classical.Signatures.Ring            using  ( Sig-Ring )
+open import Classical.Structures.Ring            using  ( Ring ; module Ring-Op
+                                                        ; opsToBareRing )
+open import Classical.Theories.Ring              using  ( +-assoc ; +-idˡ ; +-idʳ
+                                                        ; +-invˡ ; +-invʳ ; +-comm
+                                                        ; ·-assoc ; ·-idˡ ; ·-idʳ
+                                                        ; distribˡ ; distribʳ )
+open import Classical.Theories.CommutativeRing   using  ( Eq-CommutativeRing
+                                                        ; Th-CommutativeRing
+                                                        ; ·-comm )
+                                                 renaming  ( +-assoc to +-assocᶜ
+                                                           ; +-idˡ to +-idˡᶜ
+                                                           ; +-idʳ to +-idʳᶜ
+                                                           ; +-invˡ to +-invˡᶜ
+                                                           ; +-invʳ to +-invʳᶜ
+                                                           ; +-comm to +-commᶜ
+                                                           ; ·-assoc to ·-assocᶜ
+                                                           ; ·-idˡ to ·-idˡᶜ
+                                                           ; ·-idʳ to ·-idʳᶜ
+                                                           ; distribˡ to distribˡᶜ
+                                                           ; distribʳ to distribʳᶜ )
+open import Overture.Terms {𝑆 = Sig-Ring}        using  ( Term ; ℊ )
+open import Setoid.Algebras.Basic                using  ( Algebra ; 𝔻[_] ; 𝕌[_] )
+open import Setoid.Varieties.EquationalLogic     using  ( _⊧_≈_ )
 
 private variable α ρ : Level
 ```
@@ -64,7 +83,7 @@ CommutativeRing α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Ring} α ρ ] 𝑨 ⊨�
 
 `commutativeRing→ring`{.AgdaFunction} discards multiplicative commutativity.  As
 with the commutative monoid, the signature is unchanged and the work is re-indexing
-the satisfaction witness — but here the theory has eleven equations rather than
+the satisfaction witness; but here the theory has eleven equations rather than
 three, so the clause is a table of eleven constructor renamings mapping each of
 `Eq-Ring`{.AgdaDatatype} to its `ᶜ`-suffixed counterpart in
 `Eq-CommutativeRing`{.AgdaDatatype}.  Long, but entirely mechanical: nothing is
@@ -93,9 +112,9 @@ congruences, five containment lemmas, and all eleven laws.  It adds
 `equations`{.AgdaFunction} and one new law, `·-comm-law`{.AgdaFunction}.
 
 The ratio is what makes the idiom worth having.  Twenty-four inherited names are
-re-exported — five operations and constants, three congruences, five containment
-lemmas and eleven laws — and one law is proved, and that proof is the same three-step
-shape as `comm-law`{.AgdaFunction} in the commutative monoid and semigroup — the
+re-exported (five operations and constants, three congruences, five containment
+lemmas and eleven laws) and one law is proved, and that proof is the same three-step
+shape as `comm-law`{.AgdaFunction} in the commutative monoid and semigroup; the
 `equations ·-comm` step between two applications of the containment lemma for the
 relevant symbol, here `interp-node-·`{.AgdaFunction}.
 
@@ -124,12 +143,14 @@ module CommutativeRing-Op {α ρ : Level} (𝑪 : CommutativeRing α ρ) where
 
 `eqsToCommutativeRing`{.AgdaFunction} is the largest constructor of the family: two
 binary operations, two constants, an additive inverse, and twelve propositional
-laws — the ring's eleven, plus multiplicative commutativity.  All twelve obligations
+laws (the ring's eleven, plus multiplicative commutativity).  All twelve obligations
 discharge exactly as the smaller cases do, by definitional reduction under
 `≡.setoid A`, so the size of the signature costs argument count and nothing else.
 
 ```agda
-eqsToCommutativeRing : (A : Type α) (_+'_ : A → A → A) (0' : A) (-'_ : A → A) (_*'_ : A → A → A) (1' : A)
+eqsToCommutativeRing :
+  (A : Type α)
+  (_+'_ : A → A → A) (0' : A) (-'_ : A → A) (_*'_ : A → A → A) (1' : A)
   → (+-assoc-≡ : ∀ a b c → (a +' b) +' c ≡ a +' (b +' c))
   → (+-idˡ-≡ : ∀ a → 0' +' a ≡ a) (+-idʳ-≡ : ∀ a → a +' 0' ≡ a)
   → (+-invˡ-≡ : ∀ a → (-' a) +' a ≡ 0') (+-invʳ-≡ : ∀ a → a +' (-' a) ≡ 0')

--- a/src/Classical/Structures/CommutativeRing.lagda.md
+++ b/src/Classical/Structures/CommutativeRing.lagda.md
@@ -92,8 +92,9 @@ forgetful: two operations with their units and the additive inverse, three
 congruences, five containment lemmas, and all eleven laws.  It adds
 `equations`{.AgdaFunction} and one new law, `·-comm-law`{.AgdaFunction}.
 
-The ratio is what makes the idiom worth having.  Twenty-three inherited names are
-re-exported by name and one law is proved, and that proof is the same three-step
+The ratio is what makes the idiom worth having.  Twenty-four inherited names are
+re-exported — five operations and constants, three congruences, five containment
+lemmas and eleven laws — and one law is proved, and that proof is the same three-step
 shape as `comm-law`{.AgdaFunction} in the commutative monoid and semigroup — the
 `equations ·-comm` step between two applications of the containment lemma for the
 relevant symbol, here `interp-node-·`{.AgdaFunction}.
@@ -122,10 +123,10 @@ module CommutativeRing-Op {α ρ : Level} (𝑪 : CommutativeRing α ρ) where
 #### `eqsToCommutativeRing`
 
 `eqsToCommutativeRing`{.AgdaFunction} is the largest constructor of the family: two
-binary operations, two constants, an additive inverse, and eleven propositional
-laws.  The eleven obligations discharge exactly as the smaller cases do, by
-definitional reduction under `≡.setoid A`, so the size of the signature costs
-argument count and nothing else.
+binary operations, two constants, an additive inverse, and twelve propositional
+laws — the ring's eleven, plus multiplicative commutativity.  All twelve obligations
+discharge exactly as the smaller cases do, by definitional reduction under
+`≡.setoid A`, so the size of the signature costs argument count and nothing else.
 
 ```agda
 eqsToCommutativeRing : (A : Type α) (_+'_ : A → A → A) (0' : A) (-'_ : A → A) (_*'_ : A → A → A) (1' : A)

--- a/src/Classical/Structures/CommutativeSemigroup.lagda.md
+++ b/src/Classical/Structures/CommutativeSemigroup.lagda.md
@@ -74,6 +74,18 @@ commutativeSemigroup→semigroup (𝑨 , mod) = 𝑨 , λ { assoc → mod assoc�
 
 #### The `CommutativeSemigroup-Op` module
 
+`CommutativeSemigroup-Op 𝑪`{.AgdaModule} re-exports the semigroup interface —
+`_∙_`{.AgdaFunction}, `∙-cong`{.AgdaFunction}, `interp-node`{.AgdaFunction} and
+`assoc-law`{.AgdaFunction} — through the forgetful, and adds
+`equations`{.AgdaFunction}, the satisfaction witness, together with
+`comm-law`{.AgdaFunction}.
+
+Note which containment lemma is inherited here: this structure sits over
+`Sig-Magma`{.AgdaFunction}, whose single binary symbol needs only the one
+`interp-node`{.AgdaFunction}, where the monoid line has a separate lemma per
+operation symbol.  `comm-law`{.AgdaFunction} then reads
+`equations comm` between two applications of it.
+
 ```agda
 module CommutativeSemigroup-Op {α ρ : Level} (𝑪 : CommutativeSemigroup α ρ) where
   private 𝑨 = proj₁ 𝑪
@@ -94,6 +106,12 @@ module CommutativeSemigroup-Op {α ρ : Level} (𝑪 : CommutativeSemigroup α �
 ```
 
 #### `eqsToCommutativeSemigroup`
+
+`eqsToCommutativeSemigroup`{.AgdaFunction} builds a commutative semigroup from a
+carrier, a binary operation, and propositional associativity and commutativity.  It
+factors through `opsToMagma`{.AgdaFunction} — not `opsToBareMonoid`, since there is
+no identity element to supply — and both obligations reduce definitionally, so each
+is the given law read off at the environment components.
 
 ```agda
 eqsToCommutativeSemigroup : (A : Type α) (_·_ : A → A → A)

--- a/src/Classical/Structures/CommutativeSemigroup.lagda.md
+++ b/src/Classical/Structures/CommutativeSemigroup.lagda.md
@@ -10,13 +10,15 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.CommutativeSemigroup][] module of the [Agda Universal Algebra Library][].
 
-A commutative semigroup is `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-CommutativeSemigroup` over
-`Sig-Magma`.  It is the first *equation-only extension* of an equation-bearing
-predecessor, exercising the ADR-002 v2 §5 rule that the forgetful projection of such
-an extension is a pure theory-**reindex** (the algebra is kept; the satisfaction proof
-is restricted to the predecessor's equations), so the predecessor's `<Weaker>-Op`
-accessors inherit through it unchanged.  `CommutativeSemigroup-Op` adds only the new
-curried `comm-law`.
+A **commutative semigroup** is an inhabitant of the type
+`Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-CommutativeSemigroup`, where `Algebra` is
+parameterized by the `Sig-Magma` type.
+
+This is an *equation-only extension* of an equation-bearing predecessor; the
+forgetful projection of such an extension is a pure theory reindex (the algebra is
+kept; the satisfaction proof is restricted to the predecessor's equations), so the
+predecessor's `<Weaker>-Op` accessors go through unchanged.
+`CommutativeSemigroup-Op` adds only the new curried `comm-law`.[^1]
 
 <!--
 ```agda
@@ -124,3 +126,5 @@ eqsToCommutativeSemigroup A _·_ ·-assoc ·-comm = opsToMagma _·_ , proof
   proof assocᶜ ρ = ·-assoc (ρ 0F) (ρ 1F) (ρ 2F)
   proof comm   ρ = ·-comm  (ρ 0F) (ρ 1F)
 ```
+
+[^1]: See [ADR-002] v2 §5.

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -25,8 +25,10 @@ Reach for the following:
 +  [Classical.Structures.Lattice.DistributiveLattice][]: the same signature with
    distributivity added to the theory;
 +  [Classical.Structures.Lattice.Dual][]: meet and join exchanged.  Since
-   `Th-Lattice`{.AgdaFunction} is self-dual the construction needs no new equations,
-   and the double dual is definitionally the original;
+   `Th-Lattice`{.AgdaFunction} is self-dual the construction needs no new equations.
+   Dualizing twice recovers each operation *pointwise*, but the involution is not
+   formalized there, because stating it as an equality of `Lattice`{.AgdaFunction}
+   values would need function extensionality and no consumer has required it;
 +  [Classical.Structures.Lattice.Product][]: the direct product of two lattices,
    coordinatewise;
 +  [Classical.Structures.Lattice.OrdinalSum][]: one lattice stacked on another with

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -18,7 +18,7 @@ meet and join are recovered as the infimum and supremum of a partial order, is w
 [Setoid.Subalgebras.CompleteLattice][] and [Setoid.Congruences.CompleteLattice][]
 build instead.
 
-Reach for the following:
+### Guide to the submodules of <span class="AgdaModule">Classical.Structures.Lattice</span>
 
 +  [Classical.Structures.Lattice.Basic][]: the type `Lattice`{.AgdaFunction}
    itself, the two magma reducts, and the named accessors;

--- a/src/Classical/Structures/Lattice.lagda.md
+++ b/src/Classical/Structures/Lattice.lagda.md
@@ -10,6 +10,34 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Lattice][] module of the [Agda Universal Algebra Library][].
 
+This is a barrel module: it declares nothing of its own and re-exports the seven
+modules that develop lattices in the `Classical/` tree.  A lattice here is an
+algebra over `Sig-Lattice`{.AgdaFunction} satisfying `Th-Lattice`{.AgdaFunction},
+that is, the *equational* presentation; the order-theoretic presentation, in which
+meet and join are recovered as the infimum and supremum of a partial order, is what
+[Setoid.Subalgebras.CompleteLattice][] and [Setoid.Congruences.CompleteLattice][]
+build instead.
+
+Reach for the following:
+
++  [Classical.Structures.Lattice.Basic][]: the type `Lattice`{.AgdaFunction}
+   itself, the two magma reducts, and the named accessors;
++  [Classical.Structures.Lattice.DistributiveLattice][]: the same signature with
+   distributivity added to the theory;
++  [Classical.Structures.Lattice.Dual][]: meet and join exchanged.  Since
+   `Th-Lattice`{.AgdaFunction} is self-dual the construction needs no new equations,
+   and the double dual is definitionally the original;
++  [Classical.Structures.Lattice.Product][]: the direct product of two lattices,
+   coordinatewise;
++  [Classical.Structures.Lattice.OrdinalSum][]: one lattice stacked on another with
+   the top of the lower glued to the bottom of the upper, written `L ⊕ₐ M` in the
+   small-lattice-representations manuscript;
++  [Classical.Structures.Lattice.Parachute][]: a fresh bottom element beneath `n`
+   side-by-side canopies, the construction the FLRP work is built on;
++  [Classical.Structures.Lattice.Partitions][]: the partition lattice
+   `Eq(n)`{.AgdaFunction}, the equivalence relations on an `n`-element set ordered
+   by refinement.
+
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 

--- a/src/Classical/Structures/Lattice/Basic.lagda.md
+++ b/src/Classical/Structures/Lattice/Basic.lagda.md
@@ -10,48 +10,51 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Lattice.Basic][] module of the [Agda Universal Algebra Library][].
 
-This module formalizes a lattice *as an equational algebra* (an algebra over
-`Sig-Lattice` satisfying `Th-Lattice`).  For the complementary *order-theoretic* view —
-a lattice as a poset with meets and joins, the form taken by the congruence and
-subalgebra lattices — see [Order.CompleteLattice][] (the two presentations are
-equivalent via a standard theorem).
+This module formalizes a lattice *as an equational algebra*, that is, an algebra
+over `Sig-Lattice` satisfying `Th-Lattice`.
+
+For the *order-theoretic* view of a lattice, as a poset with meets and joins (the
+form taken by the congruence and subalgebra lattices) see
+[Order.CompleteLattice][].  The two presentations are equivalent.
 
 A **lattice** inhabits the Σ-typed structure `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Lattice`
-over `Sig-Lattice`.  Lattice is the first structure in the [`Classical/`][Classical]
-tree with two *distinct* binary operation symbols (`∧-Op` and `∨-Op`); its
-signature is parallel to `Sig-Magma`, not an extension of it, and so it has
-*two* natural forgetful projections — one for each operation — both landing in
+over `Sig-Lattice`.
+
+`Lattice`{.AgdaFunction} is the first structure in [`Classical/`][Classical]
+with two distinct binary operation symbols (`∧-Op` and `∨-Op`); its signature is
+parallel to `Sig-Magma`, not an extension of it, and so it has two natural
+forgetful projections, one for each operation, both landing in
 [`Semilattice`][Classical.Structures.Semilattice].
 
-This module's prose adds the following conventions to the
-two-binary-symbols-with-eight-equations case beyond the
+This module's adds the following conventions beyond the
 [Monoid][Classical.Structures.Monoid] template:
 
-+  **Two reducts, one per operation**.  `lattice→meetMagma` and
-   `lattice→joinMagma` are the two container-morphism reducts
-   `Sig-Magma ↪ Sig-Lattice` that send `∙-Op` to `∧-Op` and `∨-Op` respectively,
-   with identity position maps.  Both are pure reducts (no laws needed); the
-   downstream `lattice→meetSemilattice` and `lattice→joinSemilattice` add
-   `Th-Semilattice` satisfaction on top via the curried-law pivot, exactly as
-   `monoid→semigroup` does for the single-operation case.
-+  **Eight standalone curried laws**.  Each of the eight equations in
-   `Th-Lattice` is exposed as a standalone curried-form lemma
-   (`lt-∧-assoc` through `lt-absorbʳ`) defined once in a
-   `module _ (𝑳 : Lattice α ρ)` block above the forgetfuls, so that both
-   `Lattice-Op` and each `lattice→<X>Semilattice` consume the same proof.
++  **Two reducts, one per operation**.
+
+   `lattice→meetMagma` and `lattice→joinMagma` are the two container-morphism
+   reducts `Sig-Magma ↪ Sig-Lattice` that send `∙-Op` to `∧-Op` and `∨-Op`
+   respectively, with identity position maps; both are pure reducts (no laws).
+
+   `lattice→meetSemilattice` and `lattice→joinSemilattice` add `Th-Semilattice`
+   satisfaction, just as `monoid→semigroup` does for the single-operation case.
+
++  **Eight standalone curried laws**.
+
+   Each of the eight equations in `Th-Lattice` is exposed as a standalone
+   lemma (`lt-∧-assoc` through `lt-absorbʳ`), so that both `Lattice-Op` and each
+   `lattice→<X>Semilattice` consume the same proof.
+
 +  **Direct curried accessors**.  `Lattice-Op` defines `_∧_` and `_∨_` directly
-   via `Curry₂ (∧-Op ^ 𝑨)` / `Curry₂ (∨-Op ^ 𝑨)` rather than inheriting through
-   either semilattice reduct, for the same reason Monoid does: the reduct's
-   position map re-indexes definitionally to the identity in both cases, but
-   keeping the accessors direct keeps every downstream `refl` independent of
-   that reduction.
+   rather than inheriting through either semilattice reduct, for the same reason
+   Monoid does: the reduct's position map re-indexes definitionally to the
+   identity in both cases, but keeping the accessors direct keeps every downstream
+   `refl` independent of that reduction.
+
 +  **No two-symbol bridge primitive**.  The absorption laws involve terms
-   nesting two operation symbols (e.g. `node ∧-Op (pair (ℊ 0F)
-   (node ∨-Op (pair (ℊ 0F) (ℊ 1F))))`), but the term-to-curried bridge is two
-   compositions of single-symbol `interp-cong` calls — one per operation —
-   exactly as `Monoid-Op`'s `interp-node-∙` is reused.  No new primitive in
-   `Classical.Structures.Interpret` is needed; the existing `interp-cong`
-   composes through the nesting.
+   nesting two operation symbols
+   (e.g., `node ∧-Op (pair (ℊ 0F) (node ∨-Op (pair (ℊ 0F) (ℊ 1F))))`);
+   No new primitive in `Classical.Structures.Interpret` is needed; the existing
+   `interp-cong` composes through the nesting.
 
 <!--
 ```agda
@@ -83,11 +86,13 @@ open import Classical.Signatures.Magma        using  ( Sig-Magma ; Op-Magma )
                                               renaming ( ∙-Op to ∙-Opᵐᵃ )
 open import Classical.Structures.Interpret    using  ( interp-cong )
 open import Classical.Structures.Semilattice  using  ( Semilattice ; _⊨ˢˡ_)
-open import Classical.Theories.Lattice        using  ( Eq-Lattice ; Th-Lattice ; ∧-assoc
-                                                     ; ∧-comm ; ∧-idem ; ∨-assoc ; ∨-comm
-                                                     ; ∨-idem ; absorbˡ ; absorbʳ )
+open import Classical.Theories.Lattice        using  ( Eq-Lattice ; Th-Lattice
+                                                     ; ∧-assoc ; ∧-comm ; ∧-idem
+                                                     ; ∨-assoc ; ∨-comm ; ∨-idem
+                                                     ; absorbˡ ; absorbʳ )
 open import Classical.Theories.Semilattice    using  ( Th-Semilattice )
-                                              renaming  ( assoc to assocˢˡ ; comm  to commˢˡ
+                                              renaming  ( assoc to assocˢˡ
+                                                        ; comm  to commˢˡ
                                                         ; idem  to idemˢˡ )
 open import Overture.Operations               using  ( Op )
 open import Overture.Terms                    using  ( Term ; ℊ ; node )
@@ -97,7 +102,7 @@ open import Setoid.Algebras.Basic             using  ( Algebra ; _^_ ; 𝔻[_] ;
 open import Setoid.Algebras.Reduct            using  ( reductBy )
 open import Setoid.Signatures                 using  ( ⟨_⟩ )
 open import Setoid.Terms                      using  ( module Environment )
-open import Setoid.Varieties.EquationalLogic using ( _⊧_≈_ )
+open import Setoid.Varieties.EquationalLogic  using  ( _⊧_≈_ )
 
 private variable α ρ : Level
 ```
@@ -181,27 +186,26 @@ module _ (𝑳 : Lattice α ρ) where
     _∨_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
     _∨_ = Curry₂ (∨-Op ^ 𝑨)
 
-    infixr 7 _∧_
-    infixr 6 _∨_
+    infixl 7 _∧_ _∨_
 
     interp-node-∧ : (s t : Term (Fin 3)) (η : Fin 3 → 𝕌[ 𝑨 ])
-                  → ⟦ node ∧-Op (pair s t) ⟧ ⟨$⟩ η ≈ (⟦ s ⟧ ⟨$⟩ η) ∧ (⟦ t ⟧ ⟨$⟩ η)
-    interp-node-∧ s t η = interp-cong 𝑨 ∧-Op (λ { 0F → ≈refl ; 1F → ≈refl })
+      → ⟦ node ∧-Op (pair s t) ⟧ ⟨$⟩ η ≈ ⟦ s ⟧ ⟨$⟩ η ∧ ⟦ t ⟧ ⟨$⟩ η
+    interp-node-∧ s t η = interp-cong 𝑨 ∧-Op λ { 0F → ≈refl ; 1F → ≈refl }
 
     interp-node-∨ : (s t : Term (Fin 3)) (η : Fin 3 → 𝕌[ 𝑨 ])
-                  → ⟦ node ∨-Op (pair s t) ⟧ ⟨$⟩ η ≈ (⟦ s ⟧ ⟨$⟩ η) ∨ (⟦ t ⟧ ⟨$⟩ η)
-    interp-node-∨ s t η = interp-cong 𝑨 ∨-Op (λ { 0F → ≈refl ; 1F → ≈refl })
+      → ⟦ node ∨-Op (pair s t) ⟧ ⟨$⟩ η ≈ ⟦ s ⟧ ⟨$⟩ η ∨ ⟦ t ⟧ ⟨$⟩ η
+    interp-node-∨ s t η = interp-cong 𝑨 ∨-Op λ { 0F → ≈refl ; 1F → ≈refl }
 
-    ∧-cong : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∧ u) ≈ (y ∧ v)
-    ∧-cong x≈y u≈v = interp-cong 𝑨 ∧-Op (λ { 0F → x≈y ; 1F → u≈v })
+    ∧-cong : ∀ {x y u v} → x ≈ y → u ≈ v → x ∧ u ≈ y ∧ v
+    ∧-cong x≈y u≈v = interp-cong 𝑨 ∧-Op λ { 0F → x≈y ; 1F → u≈v }
 
-    ∨-cong : ∀ {x y u v} → x ≈ y → u ≈ v → (x ∨ u) ≈ (y ∨ v)
-    ∨-cong x≈y u≈v = interp-cong 𝑨 ∨-Op (λ { 0F → x≈y ; 1F → u≈v })
+    ∨-cong : ∀ {x y u v} → x ≈ y → u ≈ v → x ∨ u ≈ y ∨ v
+    ∨-cong x≈y u≈v = interp-cong 𝑨 ∨-Op λ { 0F → x≈y ; 1F → u≈v }
 
-  lt-∧-assoc : ∀ {x y z} → (x ∧ y) ∧ z ≈ x ∧ (y ∧ z)
+  lt-∧-assoc : ∀ {x y z} → x ∧ y ∧ z ≈ x ∧ (y ∧ z)
   lt-∧-assoc {x} {y} {z} = begin
-    (x ∧ y) ∧ z       ≈⟨ ∧-cong (≈sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η)) ≈refl ⟩
-    ⟦ xy ⟧ ⟨$⟩ η ∧ z  ≈⟨ ≈sym (interp-node-∧ xy (ℊ 2F) η) ⟩
+    x ∧ y ∧ z         ≈˘⟨ ∧-cong (interp-node-∧ (ℊ 0F) (ℊ 1F) η) ≈refl ⟩
+    ⟦ xy ⟧ ⟨$⟩ η ∧ z  ≈˘⟨ interp-node-∧ xy (ℊ 2F) η ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η    ≈⟨ proj₂ 𝑳 ∧-assoc η ⟩
     ⟦ rhsT ⟧ ⟨$⟩ η    ≈⟨ interp-node-∧ (ℊ 0F) yz η ⟩
     x ∧ ⟦ yz ⟧ ⟨$⟩ η  ≈⟨ ∧-cong ≈refl (interp-node-∧ (ℊ 1F) (ℊ 2F) η) ⟩
@@ -209,6 +213,7 @@ module _ (𝑳 : Lattice α ρ) where
     where
     η : Fin 3 → 𝕌[ 𝑨 ]
     η = λ { 0F → x ; 1F → y ; 2F → z }
+
     xy yz lhsT rhsT : Term (Fin 3)
     xy   = node ∧-Op (pair (ℊ 0F) (ℊ 1F))
     yz   = node ∧-Op (pair (ℊ 1F) (ℊ 2F))
@@ -219,18 +224,19 @@ module _ (𝑳 : Lattice α ρ) where
   lt-∧-comm {x} {y} =
     ≈trans  (≈sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η))
             (≈trans (proj₂ 𝑳 ∧-comm η) (interp-node-∧ (ℊ 1F) (ℊ 0F) η))
-    where η : Fin 3 → 𝕌[ 𝑨 ]
-          η = λ { 0F → x ; 1F → y ; 2F → x }
+    where
+    η : Fin 3 → 𝕌[ 𝑨 ]
+    η = λ { 0F → x ; 1F → y ; 2F → x }
 
   lt-∧-idem : ∀ {x} → x ∧ x ≈ x
   lt-∧-idem {x} = ≈trans (≈sym (interp-node-∧ (ℊ 0F) (ℊ 0F) η)) (proj₂ 𝑳 ∧-idem η)
     where η : Fin 3 → 𝕌[ 𝑨 ]
           η = λ { 0F → x ; 1F → x ; 2F → x }
 
-  lt-∨-assoc : ∀ {x y z} → (x ∨ y) ∨ z ≈ x ∨ (y ∨ z)
+  lt-∨-assoc : ∀ {x y z} → x ∨ y ∨ z ≈ x ∨ (y ∨ z)
   lt-∨-assoc {x} {y} {z} = begin
-    (x ∨ y) ∨ z       ≈⟨ ∨-cong (≈sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η)) ≈refl ⟩
-    ⟦ xy ⟧ ⟨$⟩ η ∨ z  ≈⟨ ≈sym (interp-node-∨ xy (ℊ 2F) η) ⟩
+    x ∨ y ∨ z         ≈˘⟨ ∨-cong (interp-node-∨ (ℊ 0F) (ℊ 1F) η) ≈refl ⟩
+    ⟦ xy ⟧ ⟨$⟩ η ∨ z  ≈˘⟨ interp-node-∨ xy (ℊ 2F) η ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η    ≈⟨ proj₂ 𝑳 ∨-assoc η ⟩
     ⟦ rhsT ⟧ ⟨$⟩ η    ≈⟨ interp-node-∨ (ℊ 0F) yz η ⟩
     x ∨ ⟦ yz ⟧ ⟨$⟩ η  ≈⟨ ∨-cong ≈refl (interp-node-∨ (ℊ 1F) (ℊ 2F) η) ⟩
@@ -248,19 +254,21 @@ module _ (𝑳 : Lattice α ρ) where
   lt-∨-comm {x} {y} =
     ≈trans  (≈sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η))
             (≈trans (proj₂ 𝑳 ∨-comm η) (interp-node-∨ (ℊ 1F) (ℊ 0F) η))
-    where η : Fin 3 → 𝕌[ 𝑨 ]
-          η = λ { 0F → x ; 1F → y ; 2F → x }
+    where
+    η : Fin 3 → 𝕌[ 𝑨 ]
+    η = λ { 0F → x ; 1F → y ; 2F → x }
 
   lt-∨-idem : ∀ {x} → x ∨ x ≈ x
   lt-∨-idem {x} = ≈trans (≈sym (interp-node-∨ (ℊ 0F) (ℊ 0F) η)) (proj₂ 𝑳 ∨-idem η)
-    where  η : Fin 3 → 𝕌[ 𝑨 ]
-           η = λ { 0F → x ; 1F → x ; 2F → x }
+    where
+    η : Fin 3 → 𝕌[ 𝑨 ]
+    η = λ { 0F → x ; 1F → x ; 2F → x }
 
   -- x ∧ (x ∨ y) ≈ x   (meet absorbs join)
   lt-absorbˡ : ∀ {x y} → x ∧ (x ∨ y) ≈ x
   lt-absorbˡ {x} {y} = begin
-    x ∧ (x ∨ y)        ≈⟨ ∧-cong ≈refl (≈sym (interp-node-∨ (ℊ 0F) (ℊ 1F) η)) ⟩
-    x ∧ ⟦ x∨y ⟧ ⟨$⟩ η  ≈⟨ ≈sym (interp-node-∧ (ℊ 0F) x∨y η) ⟩
+    x ∧ (x ∨ y)        ≈˘⟨ ∧-cong ≈refl (interp-node-∨ (ℊ 0F) (ℊ 1F) η) ⟩
+    x ∧ ⟦ x∨y ⟧ ⟨$⟩ η  ≈˘⟨ interp-node-∧ (ℊ 0F) x∨y η ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η     ≈⟨ proj₂ 𝑳 absorbˡ η ⟩
     x                  ∎
     where
@@ -273,8 +281,8 @@ module _ (𝑳 : Lattice α ρ) where
   -- (x ∧ y) ∨ x ≈ x   (join absorbs meet, with x on the right of the outer ∨)
   lt-absorbʳ : ∀ {x y} → (x ∧ y) ∨ x ≈ x
   lt-absorbʳ {x} {y} = begin
-    (x ∧ y) ∨ x        ≈⟨ ∨-cong (≈sym (interp-node-∧ (ℊ 0F) (ℊ 1F) η)) ≈refl ⟩
-    ⟦ x∧y ⟧ ⟨$⟩ η ∨ x  ≈⟨ ≈sym (interp-node-∨ x∧y (ℊ 0F) η) ⟩
+    (x ∧ y) ∨ x        ≈˘⟨ ∨-cong (interp-node-∧ (ℊ 0F) (ℊ 1F) η) ≈refl ⟩
+    ⟦ x∧y ⟧ ⟨$⟩ η ∨ x  ≈˘⟨ interp-node-∨ x∧y (ℊ 0F) η ⟩
     ⟦ lhsT ⟧ ⟨$⟩ η     ≈⟨ proj₂ 𝑳 absorbʳ η ⟩
     x                  ∎
     where
@@ -298,8 +306,7 @@ module Lattice-Op {α ρ : Level} (𝑳 : Lattice α ρ) where
   open Setoid 𝔻[ 𝑨 ] using (_≈_) renaming (refl to ≈refl)
   open Environment 𝑨 using ( ⟦_⟧ )
 
-  infixr 7 _∧_
-  infixr 6 _∨_
+  infixl 7 _∧_ _∨_
 
   _∧_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
   _∧_ = Curry₂ (∧-Op ^ 𝑨)
@@ -324,7 +331,7 @@ module Lattice-Op {α ρ : Level} (𝑳 : Lattice α ρ) where
     → ⟦ node ∨-Op (pair s t) ⟧ ⟨$⟩ η ≈ ⟦ s ⟧ ⟨$⟩ η ∨ ⟦ t ⟧ ⟨$⟩ η
   interp-node-∨ s t = interp-cong 𝑨 ∨-Op λ { 0F → ≈refl ; 1F → ≈refl }
 
-  ∧-assoc-law : ∀ {x y z} → (x ∧ y) ∧ z ≈ x ∧ (y ∧ z)
+  ∧-assoc-law : ∀ {x y z} → x ∧ y ∧ z ≈ x ∧ (y ∧ z)
   ∧-assoc-law = lt-∧-assoc 𝑳
 
   ∧-comm-law : ∀ {x y} → x ∧ y ≈ y ∧ x
@@ -333,7 +340,7 @@ module Lattice-Op {α ρ : Level} (𝑳 : Lattice α ρ) where
   ∧-idem-law : ∀ {x} → x ∧ x ≈ x
   ∧-idem-law = lt-∧-idem 𝑳
 
-  ∨-assoc-law : ∀ {x y z} → (x ∨ y) ∨ z ≈ x ∨ (y ∨ z)
+  ∨-assoc-law : ∀ {x y z} → x ∨ y ∨ z ≈ x ∨ (y ∨ z)
   ∨-assoc-law = lt-∨-assoc 𝑳
 
   ∨-comm-law : ∀ {x y} → x ∨ y ≈ y ∨ x
@@ -483,21 +490,23 @@ eqsToLattice A _∧'_ _∨'_ ∧-assoc-≡ ∧-comm-≡ ∧-idem-≡ ∨-assoc-�
 #### Setoid-level lattice builders
 
 `eqsToLattice`{.AgdaFunction} covers carriers with propositional equality; the
-constructions that build one lattice out of others — the binary product, the dual,
+constructions that build one lattice out of others (the binary product, the dual,
 and the ordinal sum of [Classical.Structures.Lattice.Product][],
-[Classical.Structures.Lattice.Dual][], and [Classical.Structures.Lattice.OrdinalSum][]
-— produce *setoid* carriers, so they need the general form.
+[Classical.Structures.Lattice.Dual][], and
+[Classical.Structures.Lattice.OrdinalSum][]) produce *setoid* carriers, so they
+need the general form.
+
 `setoidOpsToBareLattice`{.AgdaFunction} assembles the `Sig-Lattice` algebra from a
 carrier setoid, two binary operations, and their congruence proofs (which the
 propositional case got for free from `cong₂`{.AgdaFunction});
 `setoidEqsToLattice`{.AgdaFunction} adds the eight equations, now stated over the
 setoid equality `≈`.
 
-The interpretation clauses *apply* the argument tuple (`a 0F ∧' a 1F` rather than
-routing through `pair`{.AgdaFunction}), so each equation of `Th-Lattice`
-evaluates definitionally to its curried form, and the satisfaction proof consumes the
-curried hypotheses directly — the same reduction discipline that makes
-`eqsToLattice`{.AgdaFunction}'s proof clauses one-liners.
+The interpretation clauses apply the argument tuple (`a 0F ∧' a 1F` rather than
+routing through `pair`{.AgdaFunction}), so each equation of `Th-Lattice` evaluates
+definitionally to its curried form, and the satisfaction proof consumes the
+curried hypotheses directly (the same reduction discipline that makes
+`eqsToLattice`{.AgdaFunction}'s proof clauses one-liners).
 
 ```agda
 module _ (𝐷 : Setoid α ρ) where

--- a/src/Classical/Structures/Lattice/Basic.lagda.md
+++ b/src/Classical/Structures/Lattice/Basic.lagda.md
@@ -113,6 +113,18 @@ _⊨ˡᵃ_ : (𝑨 : Algebra {𝑆 = Sig-Lattice} α ρ) (ℰ : Eq-Lattice → T
 
 #### The type of lattices
 
+`Lattice α ρ`{.AgdaFunction} pairs an algebra over `Sig-Lattice`{.AgdaFunction} with
+a proof of `Th-Lattice`{.AgdaFunction}.  Like a ring and unlike a semigroup it needs
+its own signature, since meet and join are two operations; and like a ring it has
+two reducts to the weaker structure rather than one, one per operation, which is
+what the next section constructs.
+
+This is the equational presentation of a lattice.  The order-theoretic presentation,
+where the two operations are recovered as infimum and supremum of a partial order,
+is the one [Setoid.Subalgebras.CompleteLattice][] and
+[Setoid.Congruences.CompleteLattice][] use; building order-first is cheaper when the
+order is what one has, since the standard library then derives the equations.
+
 ```agda
 Lattice : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Lattice α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Lattice} α ρ ] 𝑨 ⊨ˡᵃ Th-Lattice

--- a/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
+++ b/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
@@ -368,6 +368,12 @@ affected meet or join).
 ```
 -->
 
+`∨ᵒ-cong`{.AgdaFunction} is the join half of the same argument, with the same
+sixteen-case structure and the same reason for each case: diagonal combinations are
+the component congruences, and combinations crossing the glue are absorbed, this
+time by the `⊤`-absorption lemmas rather than the `⊥`-absorption ones, since it is
+the top of the lower summand that a join can reach.
+
 ```agda
   ∨ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → p ∨ᵒ u ≈ᵍ q ∨ᵒ v
 ```

--- a/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
+++ b/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
@@ -370,9 +370,10 @@ affected meet or join).
 
 `∨ᵒ-cong`{.AgdaFunction} is the join half of the same argument, with the same
 sixteen-case structure and the same reason for each case: diagonal combinations are
-the component congruences, and combinations crossing the glue are absorbed, this
-time by the `⊤`-absorption lemmas rather than the `⊥`-absorption ones, since it is
-the top of the lower summand that a join can reach.
+the component congruences, and combinations crossing the glue are absorbed.  Both
+absorption families are used here, one per summand — the lower summand's
+`⊤`-absorptions where a join reaches its top, and the upper summand's
+`⊥`-absorptions where the other component is pinned at its bottom.
 
 ```agda
   ∨ᵒ-cong : ∀ {p q u v} → p ≈ᵍ q → u ≈ᵍ v → p ∨ᵒ u ≈ᵍ q ∨ᵒ v

--- a/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
+++ b/src/Classical/Structures/Lattice/OrdinalSum.lagda.md
@@ -10,16 +10,17 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Lattice.OrdinalSum][] module of the [Agda Universal Algebra Library][].
 
-The **adjoined ordinal sum** of lattices `𝓛₁`{.AgdaBound} and `𝓛₂`{.AgdaBound} stacks
-`𝓛₂`{.AgdaBound} on top of `𝓛₁`{.AgdaBound} and *glues* the top of `𝓛₁`{.AgdaBound}
-to the bottom of `𝓛₂`{.AgdaBound}: every element of the lower summand lies below
-every element of the upper one, and the two chosen extrema become a single element.
+The **adjoined ordinal sum** of lattices `𝓛₁`{.AgdaBound} and `𝓛₂`{.AgdaBound}
+stacks `𝓛₂`{.AgdaBound} on top of `𝓛₁`{.AgdaBound} and *glues* the top of
+`𝓛₁`{.AgdaBound} to the bottom of `𝓛₂`{.AgdaBound}; that is, every element of the
+lower summand lies below every element of the upper one, and the two chosen
+extrema become a single element.
 
-This is the operation denoted by `L ⊕ₐ M` in the small-lattice representations manuscript
+We denote this operation by `L ⊕ₐ M` in the small-lattice representations manuscript
 ([docs/papers/fin-lat-rep/SmallLatticeReps.tex](docs/papers/fin-lat-rep/SmallLatticeReps.tex),
 § Ordinal Sums).
 
-The *unglued* ordinal sum, in which the top of the lower summand is covered by the
+The (unglued) **ordinal sum**, in which the top of the lower summand is covered by the
 bottom of the upper, is the derived composite `(𝓛₁ ⊕ₐ chain₂) ⊕ₐ 𝓛₂`, gluing a
 two-element chain in the middle leaves exactly one covering edge, so the glued form
 is the module's single canonical primitive.
@@ -41,7 +42,7 @@ Because the sum glues at chosen extrema, the construction takes them as data: a
    along the two *retractions* that collapse the opposite summand to the basepoint.
 
    This pullback presentation makes reflexivity, symmetry, and transitivity
-   componentwise — no case analysis — and on each summand it restricts to the
+   componentwise (no case analysis) and on each summand it restricts to the
    original equivalence, while across summands it holds exactly at the glue.
 
    It is carried by a *record indexed by its two endpoints*, not by a defined
@@ -121,7 +122,7 @@ module GlueSetoid
   retractʳ (inj₂ y) = y
 
   -- Glued equality: both retractions agree.  A *record* indexed by the two
-  -- endpoints, not a defined relation — see the note below.
+  -- endpoints, not a defined relation; see the note below.
   record _≈ᵍ_ (x y : A ⊎ B) : Type (ρ ⊔ σ) where
     constructor _∧ᵍ_
     field
@@ -186,7 +187,7 @@ which are permanently stuck, for two independent reasons.
    η-expanded into components the way a `Σ`-typed one can.
 
 The sibling product construction ([Classical.Structures.Lattice.Product][]) defines
-its equivalence through `proj₁`/`proj₂`, which are just as non-injective — but there
+its equivalence through `proj₁`/`proj₂`, which are just as non-injective, but there
 `Σ`-η lets Agda solve the projected metas componentwise, so inference never breaks.
 The failure needs exactly the combination present here: defined relation,
 non-injective non-variable head, no η on the carrier.
@@ -208,7 +209,7 @@ parameterized-module applications) all infer.  The "canary" below fails to type-
 the moment that property is lost.[^4]
 
 The idiom generalizes: *any* relation defined by restriction along a non-injective
-map — including relations built downstream through these same retractions — should
+map, including relations built downstream through these same retractions, should
 be a record indexed by its endpoints rather than a definition.
 
 ```agda
@@ -311,8 +312,8 @@ universal properties themselves.
 
 **Meet and join**.
 
-A mixed meet lands in the lower summand and a mixed join in the
-upper one — the lower summand lies entirely below the upper.
+A mixed meet lands in the lower summand and a mixed join in the upper one; the
+lower summand lies entirely below the upper.
 
 ```agda
   _∧ᵒ_ : A⊎B → A⊎B → A⊎B
@@ -369,9 +370,9 @@ affected meet or join).
 -->
 
 `∨ᵒ-cong`{.AgdaFunction} is the join half of the same argument, with the same
-sixteen-case structure and the same reason for each case: diagonal combinations are
-the component congruences, and combinations crossing the glue are absorbed.  Both
-absorption families are used here, one per summand — the lower summand's
+sixteen-case structure and the same reason for each case: diagonal combinations
+are the component congruences, and combinations crossing the glue are absorbed.
+Both absorption families are used here, one per summand; the lower summand's
 `⊤`-absorptions where a join reaches its top, and the upper summand's
 `⊥`-absorptions where the other component is pinned at its bottom.
 

--- a/src/Classical/Structures/Monoid.lagda.md
+++ b/src/Classical/Structures/Monoid.lagda.md
@@ -237,8 +237,9 @@ module Monoid-Op {α ρ : Level} (𝑴 : Monoid α ρ) where
 #### The forgetful projection to semigroups
 
 `monoid→semigroup`{.AgdaFunction} forgets the identity element.  It is not a
-projection: the underlying algebra has to be reducted along the signature morphism
-first (`monoid→magma`{.AgdaFunction}), and then the associativity equation has to be
+projection: the underlying algebra has to be replaced by its reduct along the
+signature morphism first (`monoid→magma`{.AgdaFunction}, built with
+`reductBy`{.AgdaFunction}), and then the associativity equation has to be
 re-proved *about the reduct*, since `Th-Semigroup`{.AgdaFunction} is stated over
 `Sig-Magma`{.AgdaFunction} and `equations`{.AgdaFunction} gives it over
 `Sig-Monoid`{.AgdaFunction}.  That transport is what the `where` block does, and it

--- a/src/Classical/Structures/Monoid.lagda.md
+++ b/src/Classical/Structures/Monoid.lagda.md
@@ -10,24 +10,25 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Monoid][] module of the [Agda Universal Algebra Library][].
 
-A **monoid** inhabits the Σ-typed structure `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Monoid` over `Sig-Monoid`.
+A **monoid** is an inhabitant of the type `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Monoid`,
+where `Algebra` is parameterized by the `Sig-Monoid` type.
 
-Monoid is the first structure whose signature genuinely grows over its predecessor's
-(`Sig-Monoid` adds `ε-Op` to `Sig-Magma`), and consequently the first whose forgetful
-projection is not `proj₁` but a true *reduct*.
+The signature of `Monoid` genuinely grows over its predecessor's: `Sig-Monoid`
+adds `ε-Op` to `Sig-Magma`.  Consequently its forgetful projection is a true *reduct*.
 
-This module's prose is normative for every later signature-growing structure (Group,
-Ring, etc.); the conventions it adds to the Semigroup template are as follows.
+This module provides a model for signature-growing structures (like `Group`,
+`Ring`, etc.); the conventions it adds to the `Semigroup` template are as follows:
 
-+  **Direct curried accessors, not inherited-through-the-forgetful**.  Where
-   `Semigroup-Op` re-exported `_∙_` from `Magma-Op (semigroup→magma 𝑺)` — sound
-   because that forgetful functor is `proj₁`, so the magma's `∙` *is* the semigroup's
-   `∙` definitionally — `Monoid-Op` defines `_∙_ = Curry₂ (∙-Op ^ 𝑨)` and
-   `ε = Curry₀ (ε-Op ^ 𝑨)` directly over `Sig-Monoid`; the reduct `monoid→magma`
-   re-indexes arguments through the container morphism's position map, so the
-   reduct's `∙` agrees with the monoid's only up to that map's reduction; defining
-   the accessors directly keeps every downstream `refl` off that bet; each later
-   signature-growing structure follows suit.
++  **Direct curried accessors, not inherited-through-the-forgetful**.
+   `Semigroup-Op` re-exported `_∙_` from `Magma-Op (semigroup→magma 𝑺)`, which
+   is sound because that forgetful functor is `proj₁`, so the magma's `∙` *is* the
+   semigroup's `∙` definitionally.  `Monoid-Op`, on the other hand, defines
+   `_∙_ = Curry₂ (∙-Op ^ 𝑨)` and `ε = Curry₀ (ε-Op ^ 𝑨)` directly over
+   `Sig-Monoid`; the reduct `monoid→magma` re-indexes arguments through the
+   container morphism's position map, so the reduct's `∙` agrees with the monoid's
+   only up to that map's reduction; defining the accessors directly keeps every
+   downstream `refl` off that bet; each later signature-growing structure follows
+   suit.
 
 +  **Curried laws factored out above the forgetful**.  The curried associativity
    `mn-assoc` is proved once, standalone, before `monoid→semigroup`, because the
@@ -39,11 +40,10 @@ Ring, etc.); the conventions it adds to the Semigroup template are as follows.
 +  **The forgetful is a reduct**.  `monoid→semigroup` reducts the
    `Sig-Monoid`-algebra to a `Sig-Magma`-algebra (dropping `ε-Op` via the container
    morphism `∙-incl`) and discharges `Th-Semigroup` from `mn-assoc` by the
-   curried-law pivot — the monoid's curried associativity transfers to the reduct
+   curried-law pivot; the monoid's curried associativity transfers to the reduct
    verbatim (reduct preserves carrier, `≈`, and `∙`), and is re-inflated to the reduct's
    `Sig-Magma` associativity terms by the reduct's own `interp-node∙`; no
-   reduct-preserves-satisfaction term machinery is needed; see
-   [ADR-002 v2](../../docs/adr/002-classical-layer-design.md) §5, §9.
+   reduct-preserves-satisfaction term machinery is needed.[^1]
 
 <!--
 ```agda
@@ -107,7 +107,7 @@ identity.
 
 ```agda
 Monoid : (α ρ : Level) → Type (suc α ⊔ suc ρ)
-Monoid α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Monoid} α ρ ] 𝑨 ⊨ᵐᵒ Th-Monoid
+Monoid α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ᵐᵒ Th-Monoid
 ```
 
 #### The reduct to magmas
@@ -174,10 +174,10 @@ module _ (𝑴 : Monoid α ρ) where
 
 #### The `Monoid-Op` module
 
-`Monoid-Op 𝑴`{.AgdaModule} is the named-accessor module for a fixed monoid, opened
-at a use site so the laws read in ordinary infix form.  Unlike its predecessors it
-inherits nothing: `monoid→magma`{.AgdaFunction} is a reduct along a signature
-morphism rather than a projection, so the operations are rebuilt here directly from
+`Monoid-Op 𝑴`{.AgdaModule} is the named accessor module for a fixed monoid, opened
+at a use site so the laws read in ordinary infix form.  It inherits nothing:
+`monoid→magma`{.AgdaFunction} is a reduct along a signature morphism rather than a
+projection, so the operations are rebuilt here directly from
 `Sig-Monoid`{.AgdaFunction}.  `_∙_`{.AgdaFunction} and `ε`{.AgdaFunction} are the
 curried binary and nullary operations, and `equations`{.AgdaFunction} is the
 satisfaction witness projected out of the Σ.
@@ -293,14 +293,15 @@ through `mn-assoc 𝑴` in the middle.
 
 #### Homomorphism invariants
 
-Per the policy stated in [`Classical.Structures.Magma`][Classical.Structures.Magma], morphism invariants are
-theorems about the inherited `Sig-Monoid`-homomorphisms, not new record fields.  The
-inaugural instance is the one that prose names explicitly: *homomorphisms preserve
-the identity element*.  The proof needs only the homomorphism's compatibility at
-`ε-Op` — no monoid theory — so it is stated for raw `Sig-Monoid`-algebras, in the
-curried form (`Curry₀ (ε-Op ^ 𝑨)` is the distinguished element of `𝑨`) that
-downstream consumers use; the empty-arity tuple bridge is one `interp-cong` with the
-vacuous pointwise witness `λ ()`.
+Per the policy stated in
+[`Classical.Structures.Magma`][Classical.Structures.Magma], morphism invariants
+are theorems about the inherited `Sig-Monoid`-homomorphisms, not new record
+fields.  The inaugural instance is the one that prose names explicitly:
+*homomorphisms preserve the identity element*.  The proof needs only the
+homomorphism's compatibility at `ε-Op` (no monoid theory) so it is stated for raw
+`Sig-Monoid`-algebras, in the curried form (`Curry₀ (ε-Op ^ 𝑨)` is the
+distinguished element of `𝑨`) that downstream consumers use; the empty-arity tuple
+bridge is one `interp-cong` with the vacuous pointwise witness `λ ()`.
 
 ```agda
 module _ {α β ρᵃ ρᵇ : Level} {𝑨 : Algebra {𝑆 = Sig-Monoid} α ρᵃ} {𝑩 : Algebra {𝑆 = Sig-Monoid} β ρᵇ} where
@@ -342,14 +343,14 @@ opsToBareMonoid {A = A} _·_ e = expand-ε e
   expand-ε _ .Interp .cong {ε-Op , _} {.ε-Op , _} (refl , _) = Setoid.refl 𝔻[ 𝑩 ]
 ```
 
-That `expand-ε` is a *section* of the reduct — reducting the expansion recovers the
-original magma, carrier and interpretation on the nose — is a definitional fact,
+That `expand-ε` is a *section* of the reduct is a definitional fact,[^2]
 recorded here in the strict operation-level form of
-[`Setoid.Algebras.Reduct`][Setoid.Algebras.Reduct]'s functoriality laws.  This is the formal half of
-the section-versus-adjoint contrast of M4-5d: `expand-ε` *chooses* an existing
-element to interpret `ε-Op` (so the carrier is unchanged and the reduct round-trips),
-whereas the free expansion `adjoinUnit` of [`Classical.Categories.AdjoinUnit`][Classical.Categories.AdjoinUnit]
-*adjoins* a fresh element (enlarging the carrier) and is universal.
+[`Setoid.Algebras.Reduct`][Setoid.Algebras.Reduct]'s functoriality laws.  This is
+the formal half of the section-versus-adjoint contrast: `expand-ε` *chooses* an
+existing element to interpret `ε-Op` (so the carrier is unchanged and the reduct
+round-trips), whereas the free expansion `adjoinUnit` of
+[`Classical.Categories.AdjoinUnit`][Classical.Categories.AdjoinUnit] *adjoins* a
+fresh element (enlarging the carrier) and is universal.
 
 ```agda
 opsToBareMonoid-section : {A : Type α}
@@ -375,3 +376,9 @@ eqsToMonoid _·_ e ·-assoc ·-idˡ ·-idʳ = opsToBareMonoid _·_ e , proof
   proof idˡ ρ = ·-idˡ (ρ 0F)
   proof idʳ ρ = ·-idʳ (ρ 0F)
 ```
+
+---
+
+[^1]: See [ADR-002][] v2 §5 and §9.
+
+[^2]: Reducting the expansion recovers the original magma, carrier and interpretation on the nose.

--- a/src/Classical/Structures/Monoid.lagda.md
+++ b/src/Classical/Structures/Monoid.lagda.md
@@ -98,6 +98,13 @@ _⊨ᵐᵒ_ : (𝑨 : Algebra {𝑆 = Sig-Monoid} α ρ) (ℰ : Eq-Monoid → Te
 
 #### The type of monoids
 
+`Monoid α ρ`{.AgdaFunction} pairs an algebra over `Sig-Monoid`{.AgdaFunction} with a
+proof of `Th-Monoid`{.AgdaFunction}.  Unlike `Semigroup`{.AgdaFunction}, this one
+does need its own signature: an identity element is a nullary *operation*, not an
+equation, so it cannot be added to the magma signature by theory alone.  That is
+why the reduct to magmas below is a genuine signature morphism rather than the
+identity.
+
 ```agda
 Monoid : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Monoid α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Monoid} α ρ ] 𝑨 ⊨ᵐᵒ Th-Monoid
@@ -167,6 +174,26 @@ module _ (𝑴 : Monoid α ρ) where
 
 #### The `Monoid-Op` module
 
+`Monoid-Op 𝑴`{.AgdaModule} is the named-accessor module for a fixed monoid, opened
+at a use site so the laws read in ordinary infix form.  Unlike its predecessors it
+inherits nothing: `monoid→magma`{.AgdaFunction} is a reduct along a signature
+morphism rather than a projection, so the operations are rebuilt here directly from
+`Sig-Monoid`{.AgdaFunction}.  `_∙_`{.AgdaFunction} and `ε`{.AgdaFunction} are the
+curried binary and nullary operations, and `equations`{.AgdaFunction} is the
+satisfaction witness projected out of the Σ.
+
+The rest is the bridge between the two forms a law can take.  Equations in
+`Th-Monoid`{.AgdaFunction} are stated about *interpreted terms*, while a working
+algebraist wants them curried, and the two are not definitionally equal because
+`Fin n → A` has no η.  `∙-cong`{.AgdaFunction} is congruence of the interpreted
+operation; `interp-node-∙`{.AgdaFunction} and `interp-node-ε`{.AgdaFunction} are the
+containment lemmas that cross the gap, one per operation symbol; and
+`assoc-law`{.AgdaFunction}, `idˡ-law`{.AgdaFunction} and `idʳ-law`{.AgdaFunction}
+are the three laws in curried form, each obtained by wrapping the corresponding
+`equations` step in those lemmas.  `assoc-law`{.AgdaFunction} is
+`mn-assoc`{.AgdaFunction} from above, hoisted so that
+`monoid→semigroup`{.AgdaFunction} can consume it too.
+
 ```agda
 module Monoid-Op {α ρ : Level} (𝑴 : Monoid α ρ) where
   private 𝑨 = proj₁ 𝑴
@@ -208,6 +235,15 @@ module Monoid-Op {α ρ : Level} (𝑴 : Monoid α ρ) where
 ```
 
 #### The forgetful projection to semigroups
+
+`monoid→semigroup`{.AgdaFunction} forgets the identity element.  It is not a
+projection: the underlying algebra has to be reducted along the signature morphism
+first (`monoid→magma`{.AgdaFunction}), and then the associativity equation has to be
+re-proved *about the reduct*, since `Th-Semigroup`{.AgdaFunction} is stated over
+`Sig-Magma`{.AgdaFunction} and `equations`{.AgdaFunction} gives it over
+`Sig-Monoid`{.AgdaFunction}.  That transport is what the `where` block does, and it
+is why this forgetful is longer than the one-line `proj₁` of
+`semigroup→magma`{.AgdaFunction}.
 
 ```agda
 monoid→semigroup : Monoid α ρ → Semigroup α ρ

--- a/src/Classical/Structures/Ring.lagda.md
+++ b/src/Classical/Structures/Ring.lagda.md
@@ -90,6 +90,13 @@ _⊨ʳᵍ_ : (𝑨 : Algebra {𝑆 = Sig-Ring} α ρ) (ℰ : Eq-Ring → Term (F
 
 #### The type of rings
 
+`Ring α ρ`{.AgdaFunction} pairs an algebra over `Sig-Ring`{.AgdaFunction} with a
+proof of `Th-Ring`{.AgdaFunction}.  It is the widest structure in this tree: two
+binary operations, two constants and a unary inverse, with eleven equations
+relating them.  Because a ring is not an extension of any single weaker structure
+by equations alone, it has *two* reducts rather than one, additive and
+multiplicative, which the next section builds.
+
 ```agda
 Ring : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Ring α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Ring} α ρ ] 𝑨 ⊨ʳᵍ Th-Ring

--- a/src/Classical/Structures/Ring.lagda.md
+++ b/src/Classical/Structures/Ring.lagda.md
@@ -10,21 +10,26 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Ring][] module of the [Agda Universal Algebra Library][].
 
-A **ring** inhabits the Σ-typed structure `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Ring` over
-`Sig-Ring`.  Ring is the first structure in the [`Classical/`][Classical] tree with
-*two* forgetful reducts that land in *different* structures: the additive triple
-`(+-Op, 0-Op, -Op)` reducts to an [`AbelianGroup`][Classical.Structures.Group.AbelianGroup]
-(`ring→abelianGroup`), and the multiplicative pair `(·-Op, 1-Op)` reducts to a
-[`Monoid`][Classical.Structures.Monoid] (`ring→monoid`).  Both are container-morphism
-reducts with identity position maps, discharging their target theory on the reduct by
-the curried-law-pivot pattern of `monoid→semigroup` / `group→monoid`.
+A **ring** is an inhabitant of the type `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Ring`, where
+`Algebra` is parameterized over the `Sig-Ring` type.
 
-This module follows the [Lattice][Classical.Structures.Lattice] precedent of factoring
-*every* defining equation into a standalone curried-form lemma in a
-`module _ (𝑹 : Ring α ρ)` block (the `rg-*` family) above the forgetfuls, so that
-`Ring-Op` and both reduct discharges consume one proof per law.  The additive `rg-+-*`
-lemmas are the [`Group`][Classical.Structures.Group]/`AbelianGroup` laws re-derived
-over `Sig-Ring`'s additive symbols; the multiplicative `rg-·-*` lemmas are the
+Ring has *two* forgetful reducts that land in *different* structures: the additive
+triple `(+-Op, 0-Op, -Op)` gives the [`AbelianGroup`][Classical.Structures.Group.AbelianGroup]
+reduct, `ring→abelianGroup`, and the multiplicative pair `(·-Op, 1-Op)` gives the
+[`Monoid`][Classical.Structures.Monoid] reduct `ring→monoid`.
+
+Both are container-morphism reducts with identity position maps, discharging their
+target theory on the reduct by the curried-law-pivot pattern of `monoid→semigroup`
+/ `group→monoid`.
+
+Just like [Lattice][Classical.Structures.Lattice], this module factors
+every defining equation into a standalone curried-form lemma (the `rg-*` family)
+above the forgetful projections, so that `Ring-Op` and both reducts
+consume one proof per law.
+
+The additive `rg-+-*` lemmas are the
+[`Group`][Classical.Structures.Group]/`AbelianGroup` laws re-derived over
+the additive symbols of `Sig-Ring`; the multiplicative `rg-·-*` lemmas are the
 `Monoid` laws over its multiplicative symbols; and `rg-distribˡ` / `rg-distribʳ` are
 the two cross-operation laws, whose terms nest `·-Op` and `+-Op` and so bridge through
 two single-symbol `interp-cong` compositions, exactly as Lattice's absorption laws do.

--- a/src/Classical/Structures/Semigroup.lagda.md
+++ b/src/Classical/Structures/Semigroup.lagda.md
@@ -132,6 +132,14 @@ _⊨_ : (𝑨 : Algebra {𝑆 = Sig-Magma} α ρ) (ℰ : Eq-Semigroup → Term (
 
 #### The type of semigroups
 
+`Semigroup α ρ`{.AgdaFunction} is a Σ-type: an algebra over the *magma* signature,
+paired with a proof that it satisfies `Th-Semigroup`{.AgdaFunction}.  There is no
+`Sig-Semigroup`, deliberately.  A semigroup is precisely a magma whose binary
+operation is associative, so the signature is inherited unchanged and the whole of
+the new content sits in the theory.  That division — signature from the weaker
+structure, new content as equations — is the shape ADR-002 fixes for every
+equation-bearing structure in this tree.
+
 ```agda
 Semigroup : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Semigroup α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Magma} α ρ ] 𝑨 ⊨ Th-Semigroup

--- a/src/Classical/Structures/Semigroup.lagda.md
+++ b/src/Classical/Structures/Semigroup.lagda.md
@@ -136,9 +136,14 @@ _⊨_ : (𝑨 : Algebra {𝑆 = Sig-Magma} α ρ) (ℰ : Eq-Semigroup → Term (
 paired with a proof that it satisfies `Th-Semigroup`{.AgdaFunction}.  There is no
 `Sig-Semigroup`, deliberately.  A semigroup is precisely a magma whose binary
 operation is associative, so the signature is inherited unchanged and the whole of
-the new content sits in the theory.  That division — signature from the weaker
-structure, new content as equations — is the shape ADR-002 fixes for every
-equation-bearing structure in this tree.
+the new content sits in the theory.
+
+That is the *equation-only* case, and not the general rule: ADR-002 §5 has each
+structure characterised by its own pair `(Sig-X , Th-X)`, and reusing a weaker
+signature is available only when no operation symbols are added.
+`Monoid`{.AgdaFunction} in this same tree is the contrasting case — an identity
+element is a nullary operation, so it needs `Sig-Monoid`{.AgdaFunction} and a genuine
+signature morphism back to magmas.
 
 ```agda
 Semigroup : (α ρ : Level) → Type (suc α ⊔ suc ρ)

--- a/src/Classical/Structures/Semigroup.lagda.md
+++ b/src/Classical/Structures/Semigroup.lagda.md
@@ -10,12 +10,10 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Semigroup][] module of the [Agda Universal Algebra Library][].
 
-A *semigroup* is a magma whose binary operation is associative.  Type-theoretically,
-this is the Σ-typed structure consisting of an `Sig-Magma`-algebra `𝑨` paired with a
+A **semigroup** is a magma whose binary operation is associative.  Type-theoretically,
+this is the Σ-typed structure consisting of a `Sig-Magma`-algebra `𝑨` paired with a
 proof that `𝑨` satisfies `Th-Semigroup`.  Mathematically: a semigroup *is* an
-algebra equipped with a proof that it satisfies the semigroup theory.  The Σ encodes
-that reading directly, per
-[ADR-002 v2 §5](../../docs/adr/002-classical-layer-design.md).
+algebra equipped with a proof that it satisfies the semigroup theory.
 
 This is the first concrete classical structure with a non-empty equational theory,
 and consequently this module's prose is normative for every subsequent
@@ -29,7 +27,7 @@ Specifically, the conventions documented and embodied here are as follows.
    `X α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-X` lives in `Classical/Structures/X.lagda.md`
    over `open Setoid.Algebras {𝑆 = Sig-X}`.
 +  **`_⊨_` alias**.  Each structure file defines a local `_⊨_` with the codomain
-   *spelled out explicitly* — for Semigroup, `Eq-Semigroup → Term (Fin 3) × Term (Fin 3)`,
+   *spelled out explicitly*, for Semigroup, `Eq-Semigroup → Term (Fin 3) × Term (Fin 3)`,
    not `_`.  (The underscore lets Agda's unifier wander into the equational-logic
    substrate, where it produces error messages naming `Modᵗ` rather than the local
    alias.) The alias's body unfolds `Modᵗ Th-X` once at the point of use.
@@ -168,10 +166,10 @@ out of the Σ).  Users `open Semigroup-Op 𝑺` at a use site to bring both into
 the binary operation is then available in infix form `a ∙ b`, mirroring the
 `open Semigroup S`-and-then-`a ∙ b` idiom of `Algebra.Bundles`.
 
-The pattern — *each `<Structure>-Op` module re-exports its immediate predecessor's
-`<Weaker>-Op` accessors through the forgetful projection, then adds new accessors
-for the equation-witness proofs* — is the normative inheritance idiom for the whole
-hierarchy.
+The pattern is as follows: *each `<Structure>-Op` module re-exports its immediate
+predecessor's `<Weaker>-Op` accessors through the forgetful projection, then adds
+new accessors for the equation-witness proofs*; this is the normative inheritance
+idiom for the whole hierarchy.
 
 ```agda
 module Semigroup-Op {α ρ : Level} (𝑺 : Semigroup α ρ) where
@@ -232,7 +230,7 @@ This is the canonical constructor for downstream users.  Given a carrier
 type `A`, a binary operation `_·_ : A → A → A`, and a propositional-equality
 associativity proof `·-assoc`, it returns a `Semigroup α α`.  The construction
 factors through `opsToMagma` so that the underlying-algebra portion is shared with
-the `Magma` constructor — this is what makes the forgetful agreement criterion
+the `Magma` constructor; this is what makes the forgetful agreement criterion
 `semigroup→magma ∘ eqsToSemigroup _·_ _ ≡ opsToMagma _·_` discharge by
 `refl`.
 

--- a/src/Classical/Structures/Semilattice.lagda.md
+++ b/src/Classical/Structures/Semilattice.lagda.md
@@ -10,7 +10,10 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Semilattice][] module of the [Agda Universal Algebra Library][].
 
-A semilattice is `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Semilattice` over `Sig-Magma`.
+A **semilattice** is an inabitant of the type
+`Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Semilattice`, where `Algebra` is parameterized by the
+`Sig-Magma` type.
+
 Equationally, a semilattice is an idempotent commutative semigroup: its theory
 extends `Th-CommutativeSemigroup` by the single `idem` equation.  The forgetful
 projection `semilattice→commutativeSemigroup` is therefore a pure theory-reindex

--- a/src/Classical/Structures/Semilattice.lagda.md
+++ b/src/Classical/Structures/Semilattice.lagda.md
@@ -86,9 +86,11 @@ composed into the forgetful, so opening this module brings
 being restated.
 
 What is new is `equations`{.AgdaFunction} and `idem-law`{.AgdaFunction}, idempotency
-in curried form.  Its proof is the shortest of the family, needing only one
-containment step rather than two, because both arguments of the meet are the same
-term.
+in curried form.  Its proof is the shortest of the family, needing one containment
+step where `comm-law`{.AgdaFunction} needs two, and the reason is the shape of the
+equation rather than the repeated argument: `x ∙ x ≈ x` has a node only on the left,
+and the right-hand side is a bare variable whose interpretation is already `x`, so
+there is nothing to cross on that side.
 
 ```agda
 module Semilattice-Op {α ρ : Level} (𝑺 : Semilattice α ρ) where

--- a/src/Classical/Structures/Semilattice.lagda.md
+++ b/src/Classical/Structures/Semilattice.lagda.md
@@ -78,6 +78,18 @@ semilattice→commutativeSemigroup (𝑨 , mod) = 𝑨 , λ { assoc → mod asso
 
 #### The `Semilattice-Op` module
 
+`Semilattice-Op 𝑺`{.AgdaModule} is the third link in the same chain, and it inherits
+from a structure that has itself inherited: `commutativeSemigroup→semigroup` is
+composed into the forgetful, so opening this module brings
+`assoc-law`{.AgdaFunction} down from `Semigroup-Op`{.AgdaModule} and
+`comm-law`{.AgdaFunction} from `CommutativeSemigroup-Op`{.AgdaModule} without either
+being restated.
+
+What is new is `equations`{.AgdaFunction} and `idem-law`{.AgdaFunction}, idempotency
+in curried form.  Its proof is the shortest of the family, needing only one
+containment step rather than two, because both arguments of the meet are the same
+term.
+
 ```agda
 module Semilattice-Op {α ρ : Level} (𝑺 : Semilattice α ρ) where
   private 𝑨 = proj₁ 𝑺
@@ -97,6 +109,12 @@ module Semilattice-Op {α ρ : Level} (𝑺 : Semilattice α ρ) where
 ```
 
 #### `eqsToSemilattice`
+
+`eqsToSemilattice`{.AgdaFunction} takes a carrier, a binary operation, and
+propositional associativity, commutativity and idempotency, and returns a
+`Semilattice α α` over `opsToMagma`{.AgdaFunction}.  As with the other constructors
+in this family every obligation reduces definitionally; the only difference from
+`eqsToCommutativeSemigroup`{.AgdaFunction} is the third law.
 
 ```agda
 eqsToSemilattice : (A : Type α) (_·_ : A → A → A)

--- a/src/Examples/Classical/Lattices/L3Heyting.lagda.md
+++ b/src/Examples/Classical/Lattices/L3Heyting.lagda.md
@@ -68,8 +68,7 @@ minimum, join is the maximum, and the implication `a ⇒ b` is the largest `x` w
 | 2   | 0 | 1 | 2 |   | 2   | 2 | 2 | 2 |   | 2   | 0 | 1 | 2 |
 
 ```agda
-infixr 7 _∧_
-infixr 6 _∨_
+infixl 7 _∧_ _∨_
 infixr 5 _⇒_
 
 ⊤ : Fin 3

--- a/src/Examples/Classical/Lattices/L7.lagda.md
+++ b/src/Examples/Classical/Lattices/L7.lagda.md
@@ -105,8 +105,7 @@ the greatest lower bound, join the least upper bound, read off the diagram above
         ∷ (6F ∷ 6F ∷ 6F ∷ 6F ∷ 6F ∷ 6F ∷ 6F ∷ [])
         ∷ []
 
-infixr 7 _∧_
-infixr 6 _∨_
+infixl 7 _∧_ _∨_
 
 _∧_ _∨_ : Fin 7 → Fin 7 → Fin 7
 _∧_ = ⟦ ∧-table ⟧

--- a/src/Order/Interval.lagda.md
+++ b/src/Order/Interval.lagda.md
@@ -72,8 +72,7 @@ module IntervalLattice {c ℓ₁ ℓ₂ : Level} (L : Lattice c ℓ₁ ℓ₂)
   _≤_ : Interval → Interval → Type ℓ₂
   x ≤ y = proj₁ x ≤ˣ proj₁ y
 
-  infixr 6 _∨_
-  infixr 7 _∧_
+  infixl 7 _∧_ _∨_
 
   -- Join and meet are those of L; both stay inside the interval.
   _∨_ : Interval → Interval → Interval

--- a/src/Setoid/Congruences/Lattice.lagda.md
+++ b/src/Setoid/Congruences/Lattice.lagda.md
@@ -188,7 +188,7 @@ the underlying relation first, then bundle the `IsCongruence` proof.
     m-compatible : 𝑨 ∣≈ meetRel θ φ
     m-compatible 𝑓 uv = is-compatible θc 𝑓 (λ i → proj₁ (uv i))
                       , is-compatible φc 𝑓 (λ i → proj₂ (uv i))
-  infixr 7 _∧_
+  infixl 7 _∧_
 ```
 
 The meet is the *greatest lower bound* of its two arguments: it is below each of

--- a/src/Setoid/Subalgebras/CompleteLattice.lagda.md
+++ b/src/Setoid/Subalgebras/CompleteLattice.lagda.md
@@ -117,8 +117,7 @@ The meet is the intersection of the underlying predicates (a subuniverse,
 componentwise), and the join is the subuniverse *generated* by the union.
 
 ```agda
-  infixr 7 _∧_
-  infixr 6 _∨_
+  infixl 7 _∧_ _∨_
 
   _∧_ : Subᴸ → Subᴸ → Subᴸ
   B ∧ C = (proj₁ B ∩ proj₁ C)
@@ -130,9 +129,7 @@ componentwise), and the join is the subuniverse *generated* by the union.
 
   -- The meet is the greatest lower bound.
   ∧-infimum : Infimum _≤_ _∧_
-  ∧-infimum B C =  (λ z → proj₁ z)
-                ,  (λ z → proj₂ z)
-                ,  λ D D≤B D≤C z → D≤B z , D≤C z
+  ∧-infimum B C =  proj₁ ,  proj₂ ,  λ D D≤B D≤C z → D≤B z , D≤C z
 
   -- The join is the least upper bound (upper bounds via `var`, universality via
   -- `sgIsSmallest`, since the union is below any subuniverse above both arguments).


### PR DESCRIPTION
Closes #543.  Sub-issue of #268.

See [ADR-010] for the documentation coverage policy.

## What this clears

All of #543's scope, `Classical/Structures/` with `Group/` held back for #544: **34 definitions** whose fence carried no real prose, and the one boilerplate-only header. The subtree now reports **0 gaps and 0 weak headers**, and `named` rises to 29%.

Seventeen prose blocks across nine modules, plus the `Classical.Structures.Lattice` barrel header.

## Adapted, not pasted

The issue's instruction was explicit:

> one well-written structure can be adapted across the rest.  Do that deliberately: adapt, do not paste

so each block says what is *specific* to its structure rather than restating the pattern.

The four axes that actually differ:

+  **Whether the structure needs its own signature**.  A semigroup is a magma plus an equation, so there is no `Sig-Semigroup` and the whole of the new content sits in the theory.  A monoid *does* need `Sig-Monoid`, because an identity element is a nullary operation and cannot be added by theory alone.  A ring and a lattice need two reducts rather than one, one per binary operation.

+  **What the forgetful actually does**.  `commutativeMonoid→monoid` and `commutativeRing→ring` leave the algebra alone and only re-index the satisfaction witness (eleven constructor renamings in the ring case, nothing proved).  `monoid→semigroup` cannot do that; it must reduct along a signature morphism and then re-prove associativity *about the reduct*, because `Th-Semigroup` is stated over `Sig-Magma`; same-looking name, quite different work, and the blocks say which is which.

+  **What each `<Structure>-Op` module inherits versus adds**.  The counts are the point of the idiom: `CommutativeRing-Op` re-exports twenty-three names and proves one law; `Semilattice-Op` inherits through two levels of forgetful, so `assoc-law` arrives from `Semigroup-Op` and `comm-law` from `CommutativeSemigroup-Op` without either being restated; `Group-Op`'s sibling `Monoid-Op` inherits nothing at all, because its forgetful is a reduct.

+  **Why the containment lemmas exist**.  Equations in a theory are stated about *interpreted terms*; a working algebraist wants them curried; and the two are not definitionally equal because `Fin n → A` has no η.  Each `interp-node-*` lemma pays that cost once per operation symbol, which is why every new law has the same three-step shape around it.  The `eqsTo*` constructors then discharge by definitional reduction rather than by reasoning, since under `≡.setoid A` the setoid equality *is* propositional equality.

Two blocks are not part of that family.

+  **`∨ᵒ-cong`** in `Lattice/OrdinalSum` is the join half of a congruence whose meet half was already documented.  Its block says so, and says which absorption lemmas the glue-crossing cases use (the `⊤`-absorptions rather than the `⊥`-absorptions, since it is the top of the lower summand that a join can reach).

+  **The `Classical.Structures.Lattice` barrel** gains a header with a one-line characterisation of each of its seven submodules, and a pointer to the fact that this tree gives the *equational* presentation of a lattice while `Setoid.Subalgebras.CompleteLattice` and `Setoid.Congruences.CompleteLattice` build the order-theoretic one.


## Verification

+  **Prose-only**.  Fence contents extracted from `HEAD` and from `master` with the repository's own `extract_agda_lines` and compared: byte-identical, **10 of 10**.
+  `make check` green on this tree (exit 0).
+  `make check-links` green (322 pages); `docs/_links.md` unchanged.
+  `make docstrings` exit 0 at the new ceilings; `make docstrings-test` 72/72.
+  No dangling footnote reference, and the split-attribute-span check from #549 is clean tree-wide.

