### PR TITLE
[M4-2f] Docstrings: Classical/Structures/Group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,13 +54,10 @@ REPO      ?= ualib/agda-algebras
 # when the number of public definitions lacking a prose block exceeds this
 # ceiling, so the backlog can only shrink while the per-subtree prose PRs land.
 # Lower it whenever a PR clears definitions; never raise it.
-DOCSTRING_MAX_GAPS ?= 102
+DOCSTRING_MAX_GAPS ?= 71
 # The other half of the bar ADR-010 states: modules whose header is only the
 # boilerplate sentence.  Ratcheted the same way; never raise it.
-DOCSTRING_MAX_WEAK_HEADERS ?= 20
-# The other half of the bar ADR-010 states: modules whose header is only the
-# boilerplate sentence.  Ratcheted the same way; never raise it.
-DOCSTRING_MAX_WEAK_HEADERS ?= 21
+DOCSTRING_MAX_WEAK_HEADERS ?= 19
 
 # The certificate census: generated representation certificates for the FLRP
 # research track (issue #515).  Excluded from Everything.agda and checked by

--- a/src/Classical/Structures/Group.lagda.md
+++ b/src/Classical/Structures/Group.lagda.md
@@ -10,6 +10,40 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Group][] module of the [Agda Universal Algebra Library][].
 
+This is a barrel module: it declares nothing of its own and re-exports the nineteen
+modules that develop group theory in the `Classical/` tree.  A group here is an
+algebra over `Sig-Group`{.AgdaFunction} satisfying `Th-Group`{.AgdaFunction}, so it
+is a group in the universal-algebraic sense: three operations and five equations,
+with no appeal to the standard library's bundles except through the bridge of
+[Classical.Bundles.Group][].
+
+This is much the largest structure tree in `Classical/`, because it is the one the
+FLRP research track is built on, so a thematic map is more use than a list:
+
++  **The structures.** [Classical.Structures.Group.Basic][] for
+   `Group`{.AgdaFunction} and the named accessors;
+   [Classical.Structures.Group.AbelianGroup][] for the commutative case.
++  **Subgroups.** [Classical.Structures.Group.Subgroups][] and
+   [Classical.Structures.Group.SubgroupLattice][] for subgroups and their lattice;
+   [Classical.Structures.Group.PartitionSubgroup][] for the partition subgroups of a
+   finite power; [Classical.Structures.Group.Complements][] for permuting
+   complements in an interval of that lattice;
+   [Classical.Structures.Group.Dedekind][] for Dedekind's rule.
++  **Normality.** [Classical.Structures.Group.Conjugation][] and
+   [Classical.Structures.Group.Congruences][] relate normal subgroups to
+   congruences; [Classical.Structures.Group.NormalSubgroupLattice][] is their
+   lattice; [Classical.Structures.Group.NormalCore][] is the largest normal subgroup
+   inside a given one; [Classical.Structures.Group.MinimalNormal][] covers minimal
+   normal subgroups and monoliths; [Classical.Structures.Group.Centralizer][] covers
+   centralizers.
++  **Cosets and actions.** [Classical.Structures.Group.Cosets][] for `G/H` as a
+   setoid; [Classical.Structures.Group.GSet][] for the same space as a unary algebra,
+   which is how a group action is represented here.
++  **Constructions.** [Classical.Structures.Group.Product][] and
+   [Classical.Structures.Group.Power][] for binary and indexed products;
+   [Classical.Structures.Group.Diagonal][] for the diagonal subgroup of a power;
+   [Classical.Structures.Group.Complexes][] for complex products.
+
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 

--- a/src/Classical/Structures/Group.lagda.md
+++ b/src/Classical/Structures/Group.lagda.md
@@ -10,62 +10,91 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Group][] module of the [Agda Universal Algebra Library][].
 
-This is a barrel module: it declares nothing of its own and re-exports the nineteen
-modules that develop group theory in the `Classical/` tree.  A group here is an
-algebra over `Sig-Group`{.AgdaFunction} satisfying `Th-Group`{.AgdaFunction}, so it
-is a group in the universal-algebraic sense: three operations and five equations,
-with no appeal to the standard library's bundles except through the bridge of
-[Classical.Bundles.Group][].
+This is a barrel module: it declares nothing of its own and re-exports the
+modules that develop group theory in the `Classical/` tree.
 
-This is much the largest structure tree in `Classical/`, because it is the one the
-FLRP research track is built on, so a thematic map is more use than a list:
+A group here is an algebra over `Sig-Group`{.AgdaFunction} satisfying
+`Th-Group`{.AgdaFunction}, so it is a group in the universal-algebraic sense:
+three operations and five equations, with no appeal to the standard library's
+bundles except through the bridge of [Classical.Bundles.Group][].
 
-+  **The structures.** [Classical.Structures.Group.Basic][] for
-   `Group`{.AgdaFunction} and the named accessors;
-   [Classical.Structures.Group.AbelianGroup][] for the commutative case.
-+  **Subgroups.** [Classical.Structures.Group.Subgroups][] and
-   [Classical.Structures.Group.SubgroupLattice][] for subgroups and their lattice;
-   [Classical.Structures.Group.PartitionSubgroup][] for the partition subgroups of a
-   finite power; [Classical.Structures.Group.Complements][] for permuting
-   complements in an interval of that lattice;
-   [Classical.Structures.Group.Dedekind][] for Dedekind's rule.
-+  **Normality.** [Classical.Structures.Group.Conjugation][] and
-   [Classical.Structures.Group.Congruences][] relate normal subgroups to
-   congruences; [Classical.Structures.Group.NormalSubgroupLattice][] is their
-   lattice; [Classical.Structures.Group.NormalCore][] is the largest normal subgroup
-   inside a given one; [Classical.Structures.Group.MinimalNormal][] covers minimal
-   normal subgroups and monoliths; [Classical.Structures.Group.Centralizer][] covers
-   centralizers.
-+  **Cosets and actions.** [Classical.Structures.Group.Cosets][] for `G/H` as a
-   setoid; [Classical.Structures.Group.GSet][] for the same space as a unary algebra,
-   which is how a group action is represented here.
-+  **Constructions.** [Classical.Structures.Group.Product][] and
-   [Classical.Structures.Group.Power][] for binary and indexed products;
-   [Classical.Structures.Group.Diagonal][] for the diagonal subgroup of a power;
-   [Classical.Structures.Group.Complexes][] for complex products.
+#### Guide to the submodules of <span class="AgdaModule">Classical.Structures.Group</span>
+
+This is currently the largest structure tree in `Classical/`, because it is the
+one the FLRP research track is built on, so a thematic map is of more use than a
+list.
+
++  **Structures**.
+
+   +  [Classical.Structures.Group.Basic][]:
+      `Group`{.AgdaFunction} and the named accessors;
+   +  [Classical.Structures.Group.AbelianGroup][]: commutative groups.
+
++  **Subgroups**.
+
+   +  [Classical.Structures.Group.Subgroups][],
+      [Classical.Structures.Group.SubgroupLattice][]:
+      subgroups and their lattice;
+   +  [Classical.Structures.Group.PartitionSubgroup][]:
+      partition subgroups of a finite power;
+   +  [Classical.Structures.Group.Complements][]:
+      permuting complements in an interval of a subgroup lattice;
+   +  [Classical.Structures.Group.Dedekind][]: Dedekind's rule.
+
++  **Normality**.
+
+   +  [Classical.Structures.Group.Conjugation][],
+      [Classical.Structures.Group.Congruences][]:
+      normal subgroups and congruences;
+   +  [Classical.Structures.Group.NormalSubgroupLattice][]:
+      congruence lattices of groups;
+   +  [Classical.Structures.Group.NormalCore][]:
+      maximal normal subgroups;
+   +  [Classical.Structures.Group.MinimalNormal][]:
+      minimal normal subgroups and monoliths;
+   +  [Classical.Structures.Group.Centralizer][]: centralizers.
+
++  **Cosets and group actions**.
+
+   +  [Classical.Structures.Group.Cosets][]:
+      `G/H` as a setoid;
+   +  [Classical.Structures.Group.GSet][]:
+      group-action unary algebras.
+
++  **Constructions**.
+
+   +  [Classical.Structures.Group.Product][],
+      [Classical.Structures.Group.Power][]:
+      binary and indexed products;
+
+   +  [Classical.Structures.Group.Diagonal][]:
+      the diagonal subgroup of a power;
+
+   +  [Classical.Structures.Group.Complexes][]:
+      complex products.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 
 module Classical.Structures.Group where
 
-open import Classical.Structures.Group.Basic public
-open import Classical.Structures.Group.Centralizer public
-open import Classical.Structures.Group.AbelianGroup public
-open import Classical.Structures.Group.Complements public
-open import Classical.Structures.Group.Complexes public
-open import Classical.Structures.Group.Congruences public
-open import Classical.Structures.Group.Conjugation public
-open import Classical.Structures.Group.Cosets public
-open import Classical.Structures.Group.Dedekind public
-open import Classical.Structures.Group.Diagonal public
-open import Classical.Structures.Group.GSet public
-open import Classical.Structures.Group.MinimalNormal public
-open import Classical.Structures.Group.NormalCore public
-open import Classical.Structures.Group.NormalSubgroupLattice public
-open import Classical.Structures.Group.PartitionSubgroup public
-open import Classical.Structures.Group.Power public
-open import Classical.Structures.Group.Product public
-open import Classical.Structures.Group.Subgroups public
-open import Classical.Structures.Group.SubgroupLattice public
+open import Classical.Structures.Group.Basic                  public
+open import Classical.Structures.Group.AbelianGroup           public
+open import Classical.Structures.Group.Subgroups              public
+open import Classical.Structures.Group.SubgroupLattice        public
+open import Classical.Structures.Group.PartitionSubgroup      public
+open import Classical.Structures.Group.Complements            public
+open import Classical.Structures.Group.Dedekind               public
+open import Classical.Structures.Group.Conjugation            public
+open import Classical.Structures.Group.Congruences            public
+open import Classical.Structures.Group.NormalSubgroupLattice  public
+open import Classical.Structures.Group.NormalCore             public
+open import Classical.Structures.Group.MinimalNormal          public
+open import Classical.Structures.Group.Centralizer            public
+open import Classical.Structures.Group.Cosets                 public
+open import Classical.Structures.Group.GSet                   public
+open import Classical.Structures.Group.Product                public
+open import Classical.Structures.Group.Power                  public
+open import Classical.Structures.Group.Diagonal               public
+open import Classical.Structures.Group.Complexes              public
 ```

--- a/src/Classical/Structures/Group/AbelianGroup.lagda.md
+++ b/src/Classical/Structures/Group/AbelianGroup.lagda.md
@@ -10,11 +10,14 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Group.AbelianGroup][] module of the [Agda Universal Algebra Library][].
 
-`Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-AbelianGroup` over `Sig-Group`.  An equation-only
-extension of Group, structurally identical to the way `CommutativeMonoid` extends
-`Monoid`: `abelianGroup→group` is a pure theory-reindex (`proj₁` on the underlying
-algebra), and `AbelianGroup-Op` inherits `_∙_`, `ε`, `_⁻¹`, and all five group laws
-through it, adding `comm-law`.
+An **abelian group** is an inhabitant of the type
+`Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-AbelianGroup`, where `Algebra` is parameterized by
+the signature type `Sig-Group`.
+
+This is an equation-only extension of Group, structurally identical to the way
+`CommutativeMonoid` extends `Monoid`; that is, `abelianGroup→group` is a pure
+theory-reindex (`proj₁` on the underlying algebra), and `AbelianGroup-Op` inherits
+`_∙_`, `ε`, `_⁻¹`, and all five group laws through it, adding `comm-law`.
 
 <!--
 ```agda
@@ -55,56 +58,52 @@ _⊨ᵃᵍ_ : (𝑨 : Algebra {𝑆 = Sig-Group} α ρ) (ℰ : Eq-AbelianGroup �
 𝑨 ⊨ᵃᵍ ℰ = ∀ i → 𝑨 ⊧ proj₁ (ℰ i) ≈ proj₂ (ℰ i)
 
 AbelianGroup : (α ρ : Level) → Type (suc α ⊔ suc ρ)
-AbelianGroup α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Group} α ρ ] 𝑨 ⊨ᵃᵍ Th-AbelianGroup
+AbelianGroup α ρ = Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ᵃᵍ Th-AbelianGroup
 ```
 
 #### The forgetful projection to groups
 
-`abelianGroup→group`{.AgdaFunction} discards commutativity.  Since an abelian group
-is a group with one extra *equation* and no extra operation, the signature is
-unchanged and no reduct is needed; the function keeps the algebra and re-indexes the
-satisfaction witness, mapping each constructor of `Eq-Group`{.AgdaDatatype} to its
-counterpart in `Eq-AbelianGroup`{.AgdaDatatype}.  This is the cheap shape of
-forgetful, the same one `commutativeMonoid→monoid`{.AgdaFunction} has, as against the
-reduct-and-re-prove shape of `monoid→semigroup`{.AgdaFunction}.
+`abelianGroup→group`{.AgdaFunction} discards commutativity.  Since an abelian
+group is a group with one extra *equation* and no extra operations, the signature
+is unchanged and no reduct is needed; the function keeps the algebra and re-indexes
+the satisfaction witness, mapping each constructor of `Eq-Group`{.AgdaDatatype} to
+its counterpart in `Eq-AbelianGroup`{.AgdaDatatype}.  (This is the shape forgetful
+shape as that of `commutativeMonoid→monoid`{.AgdaFunction}, in contrast with the
+reduct-and-re-prove shape of `monoid→semigroup`{.AgdaFunction}.)
 
 ```agda
 abelianGroup→group : AbelianGroup α ρ → Group α ρ
-abelianGroup→group (𝑨 , mod) = 𝑨 , λ { assoc → mod assocᵃ
-                                     ; idˡ   → mod idˡᵃ
-                                     ; idʳ   → mod idʳᵃ
-                                     ; invˡ  → mod invˡᵃ
-                                     ; invʳ  → mod invʳᵃ }
+abelianGroup→group (𝑨 , mod) = 𝑨 , λ  { assoc → mod assocᵃ
+                                      ; idˡ   → mod idˡᵃ
+                                      ; idʳ   → mod idʳᵃ
+                                      ; invˡ  → mod invˡᵃ
+                                      ; invʳ  → mod invʳᵃ }
 ```
 
 #### The `AbelianGroup-Op` module
 
-`AbelianGroup-Op 𝑨`{.AgdaModule} inherits the whole group interface through the
-forgetful (three operations, both congruences, all three containment lemmas and all
-five laws) and adds two names: `equations`{.AgdaFunction}, the new satisfaction
-witness, and `comm-law`{.AgdaFunction}, commutativity in curried form.
-
-`comm-law`{.AgdaFunction} has the three-step shape every added law in this hierarchy
-has: `equations comm` between two applications of `interp-node-∙`{.AgdaFunction}, one
-for each side of the equation.
+`AbelianGroup-Op`{.AgdaModule}` 𝑨` inherits the whole group interface through the
+forgetful projection (three operations, both congruences, all three containment
+lemmas and all five laws) and adds two names: `equations`{.AgdaFunction}, the new
+satisfaction witness, and `comm-law`{.AgdaFunction}, commutativity in curried form.
 
 ```agda
-module AbelianGroup-Op {α ρ : Level} (𝑨𝑩 : AbelianGroup α ρ) where
-  private 𝑨 = proj₁ 𝑨𝑩
+module AbelianGroup-Op {α ρ : Level} ((𝑨 , laws) : AbelianGroup α ρ) where
   open Setoid 𝔻[ 𝑨 ]
 
-  open Group-Op (abelianGroup→group 𝑨𝑩) public
-    using ( _∙_ ; ε ; _⁻¹ ; ∙-cong ; ⁻¹-cong ; interp-node-∙ ; interp-node-ε ; interp-node-⁻¹
-          ; assoc-law ; idˡ-law ; idʳ-law ; invˡ-law ; invʳ-law )
-
-  equations : 𝑨 ⊨ᵃᵍ Th-AbelianGroup
-  equations = proj₂ 𝑨𝑩
+  open Group-Op (abelianGroup→group (𝑨 , laws)) public
+    using  ( _∙_ ; ε ; _⁻¹ ; ∙-cong ; ⁻¹-cong ; interp-node-∙ ; interp-node-ε
+           ; interp-node-⁻¹ ; assoc-law ; idˡ-law ; idʳ-law ; invˡ-law ; invʳ-law )
 
   comm-law : ∀ x y → x ∙ y ≈ y ∙ x
   comm-law x y = trans (sym (interp-node-∙ (ℊ 0F) (ℊ 1F) {η}))
-                       (trans (equations comm η) (interp-node-∙ (ℊ 1F) (ℊ 0F) {η}))
-    where η : Fin 3 → 𝕌[ 𝑨 ]
-          η = λ { 0F → x ; 1F → y ; 2F → x }
+                       (trans (laws comm η) (interp-node-∙ (ℊ 1F) (ℊ 0F) {η}))
+               -- the same three-step shape every added law in the hierarchy has:
+               -- `laws comm` between two applications of `interp-node-∙`, one
+               -- for each side of the equation.
+    where
+    η : Fin 3 → 𝕌[ 𝑨 ]
+    η = λ { 0F → x ; 1F → y ; 2F → x }
 ```
 
 #### `eqsToAbelianGroup`

--- a/src/Classical/Structures/Group/AbelianGroup.lagda.md
+++ b/src/Classical/Structures/Group/AbelianGroup.lagda.md
@@ -80,8 +80,8 @@ abelianGroup→group (𝑨 , mod) = 𝑨 , λ { assoc → mod assocᵃ
 #### The `AbelianGroup-Op` module
 
 `AbelianGroup-Op 𝑨`{.AgdaModule} inherits the whole group interface through the
-forgetful — three operations, both congruences, all three containment lemmas and all
-five laws — and adds two names: `equations`{.AgdaFunction}, the new satisfaction
+forgetful (three operations, both congruences, all three containment lemmas and all
+five laws) and adds two names: `equations`{.AgdaFunction}, the new satisfaction
 witness, and `comm-law`{.AgdaFunction}, commutativity in curried form.
 
 `comm-law`{.AgdaFunction} has the three-step shape every added law in this hierarchy

--- a/src/Classical/Structures/Group/AbelianGroup.lagda.md
+++ b/src/Classical/Structures/Group/AbelianGroup.lagda.md
@@ -60,6 +60,14 @@ AbelianGroup α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Group} α ρ ] 𝑨 ⊨ᵃ
 
 #### The forgetful projection to groups
 
+`abelianGroup→group`{.AgdaFunction} discards commutativity.  Since an abelian group
+is a group with one extra *equation* and no extra operation, the signature is
+unchanged and no reduct is needed; the function keeps the algebra and re-indexes the
+satisfaction witness, mapping each constructor of `Eq-Group`{.AgdaDatatype} to its
+counterpart in `Eq-AbelianGroup`{.AgdaDatatype}.  This is the cheap shape of
+forgetful, the same one `commutativeMonoid→monoid`{.AgdaFunction} has, as against the
+reduct-and-re-prove shape of `monoid→semigroup`{.AgdaFunction}.
+
 ```agda
 abelianGroup→group : AbelianGroup α ρ → Group α ρ
 abelianGroup→group (𝑨 , mod) = 𝑨 , λ { assoc → mod assocᵃ
@@ -70,6 +78,15 @@ abelianGroup→group (𝑨 , mod) = 𝑨 , λ { assoc → mod assocᵃ
 ```
 
 #### The `AbelianGroup-Op` module
+
+`AbelianGroup-Op 𝑨`{.AgdaModule} inherits the whole group interface through the
+forgetful — three operations, both congruences, all three containment lemmas and all
+five laws — and adds two names: `equations`{.AgdaFunction}, the new satisfaction
+witness, and `comm-law`{.AgdaFunction}, commutativity in curried form.
+
+`comm-law`{.AgdaFunction} has the three-step shape every added law in this hierarchy
+has: `equations comm` between two applications of `interp-node-∙`{.AgdaFunction}, one
+for each side of the equation.
 
 ```agda
 module AbelianGroup-Op {α ρ : Level} (𝑨𝑩 : AbelianGroup α ρ) where
@@ -91,6 +108,13 @@ module AbelianGroup-Op {α ρ : Level} (𝑨𝑩 : AbelianGroup α ρ) where
 ```
 
 #### `eqsToAbelianGroup`
+
+`eqsToAbelianGroup`{.AgdaFunction} is the constructor a downstream user calls: a
+carrier, a binary operation, an identity, an inverse, and the six laws as
+*propositional* equations.  Every obligation discharges by definitional reduction,
+since under `≡.setoid A` the setoid equality is propositional equality and each
+interpreted term reduces to the corresponding application of the supplied
+operations.
 
 ```agda
 eqsToAbelianGroup : {A : Type α} (_·_ : A → A → A) (e : A) (i : A → A)

--- a/src/Classical/Structures/Group/Basic.lagda.md
+++ b/src/Classical/Structures/Group/Basic.lagda.md
@@ -178,7 +178,7 @@ The three operations come first, curried out of their interpretations:
 `equations`{.AgdaFunction} is the satisfaction witness projected out of the Σ.  Then
 come the two congruences, `∙-cong`{.AgdaFunction} and `⁻¹-cong`{.AgdaFunction}, and
 the three containment lemmas `interp-node-∙`{.AgdaFunction},
-`interp-node-ε`{.AgdaFunction} and `interp-node-⁻¹`{.AgdaFunction} — one per
+`interp-node-ε`{.AgdaFunction} and `interp-node-⁻¹`{.AgdaFunction}, one per
 operation symbol, each crossing the gap between a law stated about interpreted terms
 and the same law in curried form.
 

--- a/src/Classical/Structures/Group/Basic.lagda.md
+++ b/src/Classical/Structures/Group/Basic.lagda.md
@@ -88,6 +88,13 @@ _⊨ᵍᵖ_ : (𝑨 : Algebra {𝑆 = Sig-Group} α ρ) (ℰ : Eq-Group → Term
 
 #### The type of groups
 
+`Group α ρ`{.AgdaFunction} pairs an algebra over `Sig-Group`{.AgdaFunction} with a
+proof of `Th-Group`{.AgdaFunction}.  Like a monoid it needs its own signature rather
+than inheriting one, and for the same reason twice over: the identity is a nullary
+operation and the inverse is a unary one, and neither can be added to a weaker
+signature by equations alone.  The five equations of `Th-Group`{.AgdaFunction} are
+associativity, the two unit laws and the two inverse laws.
+
 ```agda
 Group : (α ρ : Level) → Type (suc α ⊔ suc ρ)
 Group α ρ = Σ[ 𝑨 ∈ Algebra {𝑆 = Sig-Group} α ρ ] 𝑨 ⊨ᵍᵖ Th-Group
@@ -160,6 +167,26 @@ module _ (𝑮 : Group α ρ) where
 ```
 
 #### The `Group-Op` module
+
+`Group-Op 𝑮`{.AgdaModule} is the named-accessor module for a fixed group, opened at a
+use site so that the laws read in ordinary notation.  It rebuilds the interface from
+`Sig-Group`{.AgdaFunction} directly rather than inheriting it, because the forgetful
+to monoids is a reduct along a signature morphism and so carries nothing down.
+
+The three operations come first, curried out of their interpretations:
+`_∙_`{.AgdaFunction}, `ε`{.AgdaFunction} and `_⁻¹`{.AgdaFunction}.
+`equations`{.AgdaFunction} is the satisfaction witness projected out of the Σ.  Then
+come the two congruences, `∙-cong`{.AgdaFunction} and `⁻¹-cong`{.AgdaFunction}, and
+the three containment lemmas `interp-node-∙`{.AgdaFunction},
+`interp-node-ε`{.AgdaFunction} and `interp-node-⁻¹`{.AgdaFunction} — one per
+operation symbol, each crossing the gap between a law stated about interpreted terms
+and the same law in curried form.
+
+The five laws follow: `assoc-law`{.AgdaFunction}, `idˡ-law`{.AgdaFunction},
+`idʳ-law`{.AgdaFunction}, `invˡ-law`{.AgdaFunction} and
+`invʳ-law`{.AgdaFunction}.  Each is its `equations` step wrapped in the containment
+lemmas for the symbols it mentions, so the inverse laws are the longest of the five:
+they mention all three operations.
 
 ```agda
 module Group-Op {α ρ : Level} (𝑮 : Group α ρ) where

--- a/src/Classical/Structures/Group/Basic.lagda.md
+++ b/src/Classical/Structures/Group/Basic.lagda.md
@@ -10,29 +10,34 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Group.Basic][] module of the [Agda Universal Algebra Library][].
 
-A **group** inhabits the Σ-typed structure `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Group` over
-`Sig-Group`.  Group is the first structure whose signature grows over its
-predecessor's by a *unary* symbol (`Sig-Group` adds `⁻¹-Op` to `Sig-Monoid`); its
-forgetful projection `group→monoid` is therefore a reduct that drops `⁻¹-Op`,
-discharging the three monoid equations on the reduct by the curried-law pivot of
-the `monoid→semigroup` of [`Classical.Structures.Monoid`][Classical.Structures.Monoid] (here extended from one
-law to three, the two identity laws additionally bridging the nullary `ε-Op` node).
+A **group** is an inhabitant of the `Σ[ 𝑨 ∈ Algebra α ρ ] 𝑨 ⊨ Th-Group` type,
+where `Algebra` is parameterized by the signature type `Sig-Group`.
+
+The signature of `Group` grows over its predecessor's by a *unary* symbol
+(`Sig-Group` adds `⁻¹-Op` to `Sig-Monoid`); its forgetful projection
+`group→monoid` is therefore a reduct that drops `⁻¹-Op`, discharging the three
+monoid equations on the reduct by the curried-law pivot of the `monoid→semigroup`
+of [`Classical.Structures.Monoid`][Classical.Structures.Monoid] (here extended
+from one law to three, the two identity laws additionally bridging the nullary
+`ε-Op` node).
 
 This module follows the [Monoid][Classical.Structures.Monoid] template, adding the
 following to it.
 
-+  **Direct curried accessors for all three operations**.  `Group-Op` defines
-   `_∙_ = Curry₂ (∙-Op ^ 𝑨)`, `ε = Curry₀ (ε-Op ^ 𝑨)`, and
-   `_⁻¹ = Curry₁ (⁻¹-Op ^ 𝑨)` directly over `Sig-Group`, never inheriting through the
-   reduct, for the reason Monoid gives: keeping the accessors direct keeps every
-   downstream `refl` off the reduct's position-map reduction.
++  **Direct curried accessors for all three operations**.
+   `Group-Op` defines `_∙_ = Curry₂ (∙-Op ^ 𝑨)`, `ε = Curry₀ (ε-Op ^ 𝑨)`, and
+   `_⁻¹ = Curry₁ (⁻¹-Op ^ 𝑨)` directly over `Sig-Group`, never inheriting through
+   the reduct, for the same reason Monoid gives: keeping the accessors direct
+   keeps every downstream `refl` off the reduct's position-map reduction.
+
 +  **A unary node-bridge**.  Alongside the binary `interp-node-∙` and nullary
    `interp-node-ε`, `Group-Op` has `interp-node-⁻¹` for the unary `⁻¹-Op`, a
    one-liner delegating to `interp-cong` exactly as the other two do.
+
 +  **Two inverse laws**.  `invˡ-law` and `invʳ-law` join the three monoid laws in
-   `Group-Op`; they are the only laws not consumed by the forgetful (which lands in
-   `Monoid`, below the inverse structure), so they live in `Group-Op` rather than in
-   the standalone curried-law block.
+   `Group-Op`; they are the only laws not consumed by the forgetful projection
+   (which lands in `Monoid`, below the inverse structure), so they live in
+   `Group-Op` rather than in the standalone curried-law block.
 
 <!--
 ```agda
@@ -56,23 +61,25 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 open Func renaming ( to to _⟨$⟩_ ; cong to ≈cong )
 
 -- Imports from the Agda Universal Algebra Library -----------------------------------------------
-open import Classical.Operations            using  ( pair ; Curry₂ ; Curry₁ ; Curry₀ )
-open import Classical.Signatures.Monoid     using  ( Sig-Monoid ; Op-Monoid )
-                                            renaming ( ∙-Op to ∙-Opᵐᵒ ; ε-Op to ε-Opᵐᵒ )
-open import Classical.Signatures.Group      using  ( Sig-Group ; Op-Group ; ∙-Op ; ε-Op ; ⁻¹-Op ; ar-Group)
-open import Classical.Structures.Interpret  using  ( interp-cong )
-open import Setoid.Algebras.Reduct          using  ( reductBy )
-open import Classical.Structures.Monoid     using  ( Monoid ; _⊨ᵐᵒ_ )
-open import Classical.Theories.Group        using  ( Eq-Group ; Th-Group
-                                                   ; assoc ; idˡ ; idʳ ; invˡ ; invʳ )
-open import Classical.Theories.Monoid       using  ( Th-Monoid )
-                                            renaming ( assoc to assocᵐ ; idˡ to idˡᵐ ; idʳ to idʳᵐ )
-open import Overture.Terms                  using  ( Term ; ℊ ; node )
-open import Overture.Signatures             using  ( ArityOf ; OperationSymbolsOf )
-open import Setoid.Algebras.Basic           using  ( Algebra ; _^_ ; 𝔻[_] ; 𝕌[_] )
-open import Setoid.Terms                    using  ( module Environment )
+open import Classical.Operations              using  ( pair ; Curry₂ ; Curry₁ ; Curry₀ )
+open import Classical.Signatures.Monoid       using  ( Sig-Monoid ; Op-Monoid )
+                                              renaming ( ∙-Op to ∙-Opᵐᵒ ; ε-Op to ε-Opᵐᵒ )
+open import Classical.Signatures.Group        using  ( Sig-Group ; Op-Group ; ∙-Op
+                                                     ; ε-Op ; ⁻¹-Op ; ar-Group)
+open import Classical.Structures.Interpret    using  ( interp-cong )
+open import Setoid.Algebras.Reduct            using  ( reductBy )
+open import Classical.Structures.Monoid       using  ( Monoid ; _⊨ᵐᵒ_ )
+open import Classical.Theories.Group          using  ( Eq-Group ; Th-Group
+                                                     ; assoc ; idˡ ; idʳ ; invˡ ; invʳ )
+open import Classical.Theories.Monoid         using  ( Th-Monoid )
+                                              renaming  ( assoc to assocᵐ
+                                                        ; idˡ to idˡᵐ ; idʳ to idʳᵐ )
+open import Overture.Terms                    using  ( Term ; ℊ ; node )
+open import Overture.Signatures               using  ( ArityOf ; OperationSymbolsOf )
+open import Setoid.Algebras.Basic             using  ( Algebra ; _^_ ; 𝔻[_] ; 𝕌[_] )
+open import Setoid.Terms                      using  ( module Environment )
 
-open import Setoid.Varieties.EquationalLogic using ( _⊧_≈_ )
+open import Setoid.Varieties.EquationalLogic  using  ( _⊧_≈_ )
 
 private variable α ρ : Level
 ```
@@ -122,37 +129,37 @@ group→monoidAlg 𝑮 = reductBy mo-incl mo-κ (𝑮 .proj₁)
 
 #### Curried associativity, standalone
 
-`gp-assoc` proves `(x ∙ y) ∙ z ≈ x ∙ (y ∙ z)` for the group's own `∙`, a verbatim
-port of `Monoid-Op.mn-assoc` to `Sig-Group`.  It is standalone, above the forgetful,
-so both `Group-Op.assoc-law` and the `group→monoid` discharge consume one proof.
+`gp-assoc` proves `x ∙ y ∙ z ≈ x ∙ (y ∙ z)` for the group's own `∙`, a verbatim
+port of `Monoid-Op.mn-assoc` to `Sig-Group`.  It is standalone, above the
+forgetful projection, so both `Group-Op.assoc-law` and `group→monoid` consume one
+proof.
 
 ```agda
-module _ (𝑮 : Group α ρ) where
-  private 𝑨 = proj₁ 𝑮
-  open Setoid 𝔻[ 𝑨 ] using (_≈_) renaming (sym to ≈sym ; refl to ≈refl)
-  open Environment 𝑨 using ( ⟦_⟧ )
-  open SetoidReasoning 𝔻[ 𝑨 ]
+module _ ((𝑮 , equations) : Group α ρ) where
+  open Setoid 𝔻[ 𝑮 ] using (_≈_) renaming (sym to ≈sym ; refl to ≈refl)
+  open Environment 𝑮 using ( ⟦_⟧ )
+  open SetoidReasoning 𝔻[ 𝑮 ]
 
   private
     infixl 7 _∙_
-    _∙_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
-    _∙_ = Curry₂ (∙-Op ^ 𝑨)
+    _∙_ : 𝕌[ 𝑮 ] → 𝕌[ 𝑮 ] → 𝕌[ 𝑮 ]
+    _∙_ = Curry₂ (∙-Op ^ 𝑮)
 
-    interp-node∙ : (s t : Term (Fin 3)) (η : Fin 3 → 𝕌[ 𝑨 ])
+    interp-node∙ : (s t : Term (Fin 3)) (η : Fin 3 → 𝕌[ 𝑮 ])
       → ⟦ node ∙-Op (pair s t) ⟧ ⟨$⟩ η ≈ ⟦ s ⟧ ⟨$⟩ η ∙ ⟦ t ⟧ ⟨$⟩ η
-    interp-node∙ s t η = interp-cong 𝑨 ∙-Op λ { 0F → ≈refl ; 1F → ≈refl }
+    interp-node∙ s t η = interp-cong 𝑮 ∙-Op λ { 0F → ≈refl ; 1F → ≈refl }
 
-  gp-assoc : ∀ x y z → (x ∙ y) ∙ z ≈ x ∙ (y ∙ z)
+  gp-assoc : ∀ x y z → x ∙ y ∙ z ≈ x ∙ (y ∙ z)
   gp-assoc x y z = begin
-    x ∙ y ∙ z                ≈˘⟨ interp-cong 𝑨 ∙-Op γ ⟩
-    ⟦ node ∙-Op lhs ⟧ ⟨$⟩ η  ≈⟨ proj₂ 𝑮 assoc η ⟩
-    ⟦ node ∙-Op rhs ⟧ ⟨$⟩ η  ≈⟨ interp-cong 𝑨 ∙-Op γ' ⟩
+    x ∙ y ∙ z                ≈˘⟨ interp-cong 𝑮 ∙-Op γ ⟩
+    ⟦ node ∙-Op lhs ⟧ ⟨$⟩ η  ≈⟨ equations assoc η ⟩
+    ⟦ node ∙-Op rhs ⟧ ⟨$⟩ η  ≈⟨ interp-cong 𝑮 ∙-Op γ' ⟩
     x ∙ (y ∙ z)              ∎
     where
     g0 g1 g2 : Term (Fin 3)
     g0 = ℊ 0F; g1 = ℊ 1F; g2 = ℊ 2F
 
-    η : Fin 3 → 𝕌[ 𝑨 ]
+    η : Fin 3 → 𝕌[ 𝑮 ]
     η = λ { 0F → x ; 1F → y ; 2F → z }
 
     lhs rhs : Fin 2 → Term (Fin 3)
@@ -168,10 +175,11 @@ module _ (𝑮 : Group α ρ) where
 
 #### The `Group-Op` module
 
-`Group-Op 𝑮`{.AgdaModule} is the named-accessor module for a fixed group, opened at a
-use site so that the laws read in ordinary notation.  It rebuilds the interface from
-`Sig-Group`{.AgdaFunction} directly rather than inheriting it, because the forgetful
-to monoids is a reduct along a signature morphism and so carries nothing down.
+`Group-Op 𝑮`{.AgdaModule} is the named-accessor module for a fixed group, opened
+at a use site so that the laws read in ordinary notation.  It rebuilds the
+interface from `Sig-Group`{.AgdaFunction} directly rather than inheriting it,
+because the forgetful to monoids is a reduct along a signature morphism and so
+carries nothing down.
 
 The three operations come first, curried out of their interpretations:
 `_∙_`{.AgdaFunction}, `ε`{.AgdaFunction} and `_⁻¹`{.AgdaFunction}.
@@ -189,45 +197,41 @@ lemmas for the symbols it mentions, so the inverse laws are the longest of the f
 they mention all three operations.
 
 ```agda
-module Group-Op {α ρ : Level} (𝑮 : Group α ρ) where
-  private 𝑨 = proj₁ 𝑮
-  open Setoid 𝔻[ 𝑨 ] using (_≈_) renaming (trans to ≈trans; sym to ≈sym; refl to ≈refl)
-  open SetoidReasoning 𝔻[ 𝑨 ]
-  open Environment 𝑨 using ( ⟦_⟧ )
+module Group-Op {α ρ : Level} ((𝑮 , equations) : Group α ρ) where
+  open Setoid 𝔻[ 𝑮 ] using (_≈_) renaming (trans to ≈trans; sym to ≈sym; refl to ≈refl)
+  open SetoidReasoning 𝔻[ 𝑮 ]
+  open Environment 𝑮 using ( ⟦_⟧ )
 
   infixl 7 _∙_
-  _∙_ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
-  _∙_ = Curry₂ (∙-Op ^ 𝑨)
+  _∙_ : 𝕌[ 𝑮 ] → 𝕌[ 𝑮 ] → 𝕌[ 𝑮 ]
+  _∙_ = Curry₂ (∙-Op ^ 𝑮)
 
-  ε : 𝕌[ 𝑨 ]
-  ε = Curry₀ (ε-Op ^ 𝑨)
+  ε : 𝕌[ 𝑮 ]
+  ε = Curry₀ (ε-Op ^ 𝑮)
 
   infix 8 _⁻¹
-  _⁻¹ : 𝕌[ 𝑨 ] → 𝕌[ 𝑨 ]
-  _⁻¹ = Curry₁ (⁻¹-Op ^ 𝑨)
-
-  equations : 𝑨 ⊨ᵍᵖ Th-Group
-  equations = proj₂ 𝑮
+  _⁻¹ : 𝕌[ 𝑮 ] → 𝕌[ 𝑮 ]
+  _⁻¹ = Curry₁ (⁻¹-Op ^ 𝑮)
 
   ∙-cong : ∀ {x y u v} → x ≈ y → u ≈ v → x ∙ u ≈ y ∙ v
-  ∙-cong x≈y u≈v = interp-cong 𝑨 ∙-Op (λ { 0F → x≈y ; 1F → u≈v })
+  ∙-cong x≈y u≈v = interp-cong 𝑮 ∙-Op λ { 0F → x≈y ; 1F → u≈v }
 
   ⁻¹-cong : ∀ {x y} → x ≈ y → x ⁻¹ ≈ y ⁻¹
-  ⁻¹-cong x≈y = interp-cong 𝑨 ⁻¹-Op (λ { 0F → x≈y })
+  ⁻¹-cong x≈y = interp-cong 𝑮 ⁻¹-Op λ { 0F → x≈y }
 
-  interp-node-∙ : (s t : Term (Fin 3)) {η : Fin 3 → 𝕌[ 𝑨 ]}
+  interp-node-∙ : (s t : Term (Fin 3)) {η : Fin 3 → 𝕌[ 𝑮 ]}
     → ⟦ node ∙-Op (pair s t) ⟧ ⟨$⟩ η ≈ ⟦ s ⟧ ⟨$⟩ η ∙ ⟦ t ⟧ ⟨$⟩ η
-  interp-node-∙ s t = interp-cong 𝑨 ∙-Op (λ { 0F → ≈refl ; 1F → ≈refl })
+  interp-node-∙ s t = interp-cong 𝑮 ∙-Op λ { 0F → ≈refl ; 1F → ≈refl }
 
-  interp-node-ε : {η : Fin 3 → 𝕌[ 𝑨 ]} → ⟦ node ε-Op (λ ()) ⟧ ⟨$⟩ η ≈ ε
-  interp-node-ε = interp-cong 𝑨 ε-Op (λ ())
+  interp-node-ε : {η : Fin 3 → 𝕌[ 𝑮 ]} → ⟦ node ε-Op (λ ()) ⟧ ⟨$⟩ η ≈ ε
+  interp-node-ε = interp-cong 𝑮 ε-Op (λ ())
 
-  interp-node-⁻¹ : (s : Term (Fin 3)) {η : Fin 3 → 𝕌[ 𝑨 ]}
+  interp-node-⁻¹ : (s : Term (Fin 3)) {η : Fin 3 → 𝕌[ 𝑮 ]}
     → ⟦ node ⁻¹-Op (λ _ → s) ⟧ ⟨$⟩ η ≈ ⟦ s ⟧ ⟨$⟩ η ⁻¹
-  interp-node-⁻¹ s = interp-cong 𝑨 ⁻¹-Op (λ { 0F → ≈refl })
+  interp-node-⁻¹ s = interp-cong 𝑮 ⁻¹-Op λ { 0F → ≈refl }
 
   assoc-law : ∀ x y z → x ∙ y ∙ z ≈ x ∙ (y ∙ z)
-  assoc-law = gp-assoc 𝑮
+  assoc-law = gp-assoc (𝑮 , equations)
 
   idˡ-law : ∀ x → ε ∙ x ≈ x
   idˡ-law x = begin
@@ -236,8 +240,9 @@ module Group-Op {α ρ : Level} (𝑮 : Group α ρ) where
     ⟦ node ∙-Op (pair (node ε-Op (λ ())) g0) ⟧ ⟨$⟩ η  ≈⟨ equations idˡ η ⟩
     x                                                 ∎
     where
-    η : Fin 3 → 𝕌[ 𝑨 ]
+    η : Fin 3 → 𝕌[ 𝑮 ]
     η = λ _ → x
+
     g0 : Term (Fin 3)
     g0 = ℊ {X = Fin 3} 0F
 
@@ -248,8 +253,9 @@ module Group-Op {α ρ : Level} (𝑮 : Group α ρ) where
     ⟦ node ∙-Op (pair g0 (node ε-Op (λ ()))) ⟧ ⟨$⟩ η  ≈⟨ equations idʳ η ⟩
     x                                                 ∎
     where
-    η : Fin 3 → 𝕌[ 𝑨 ]
+    η : Fin 3 → 𝕌[ 𝑮 ]
     η = λ _ → x
+
     g0 : Term (Fin 3)
     g0 = ℊ {X = Fin 3} 0F
 
@@ -261,26 +267,28 @@ module Group-Op {α ρ : Level} (𝑮 : Group α ρ) where
     ⟦ node ε-Op (λ ()) ⟧ ⟨$⟩ η                     ≈⟨ interp-node-ε ⟩
     ε              ∎
     where
-    η : Fin 3 → 𝕌[ 𝑨 ]
+    η : Fin 3 → 𝕌[ 𝑮 ]
     η = λ _ → x
+
     τ : (_ : ar-Group ⁻¹-Op) → Term (Fin 3)
     τ = λ _ → ℊ 0F
+
     g0 : Term (Fin 3)
     g0 = ℊ {X = Fin 3} 0F
 
   invʳ-law : ∀ x → x ∙ x ⁻¹ ≈ ε
-  invʳ-law x = ≈trans (∙-cong ≈refl (≈sym (interp-node-⁻¹ (ℊ 0F) {λ _ → x})))
-                     (≈trans (≈sym (interp-node-∙ (ℊ 0F) (node ⁻¹-Op (λ _ → ℊ 0F)) {λ _ → x}))
-                            (≈trans (equations invʳ (λ _ → x)) (interp-node-ε {λ _ → x})))
+  invʳ-law x = ≈trans  (∙-cong ≈refl (≈sym (interp-node-⁻¹ (ℊ 0F) {λ _ → x})))
+                       (≈trans  (≈sym (interp-node-∙ (ℊ 0F) (node ⁻¹-Op (λ _ → ℊ 0F)) {λ _ → x}))
+                                (≈trans (equations invʳ (λ _ → x)) (interp-node-ε {λ _ → x})))
 ```
 
 #### The forgetful projection to monoids
 
 `group→monoid` takes a group to the monoid on its `(∙, ε)`-reduct: the underlying
-algebra is `group→monoidAlg`, and the `Th-Monoid` satisfaction proof pivots through
-`Group-Op`'s `assoc-law`, `idˡ-law`, `idʳ-law` by the curried-law-pivot pattern of
-`monoid→semigroup`, the two identity laws additionally bridging the nullary `ε-Op`
-node on the reduct.
+algebra is `group→monoidAlg`, and the `Th-Monoid` satisfaction proof pivots
+through `Group-Op`'s `assoc-law`, `idˡ-law`, `idʳ-law` by the curried-law-pivot
+pattern of `monoid→semigroup`, the two identity laws additionally bridging the
+nullary `ε-Op` node on the reduct.
 
 ```agda
 group→monoid : Group α ρ → Monoid α ρ
@@ -300,7 +308,7 @@ group→monoid 𝒢@(𝑮 , _) = 𝑹 , thm
 
   -- 𝑹's nullary node-bridge, landing in the group's curried ε
   interp-node-εᴿ : (η : Fin 3 → 𝕌[ 𝑮 ]) → ⟦ node ε-Opᵐᵒ (λ ()) ⟧ ⟨$⟩ η ≈ ε
-  interp-node-εᴿ η = interp-cong 𝑹 ε-Opᵐᵒ (λ ())
+  interp-node-εᴿ η = interp-cong 𝑹 ε-Opᵐᵒ λ ()
 
   thm : 𝑹 ⊨ᵐᵒ Th-Monoid
   thm assocᵐ η = begin
@@ -318,13 +326,13 @@ group→monoid 𝒢@(𝑮 , _) = 𝑹 , thm
     yz = node ∙-Opᵐᵒ (pair (ℊ 1F) (ℊ 2F))
 
   thm idˡᵐ η = begin
-    ⟦ Th-Monoid idˡᵐ .proj₁ ⟧ ⟨$⟩ η   ≈⟨ interp-node-∙ᴿ (node ε-Opᵐᵒ (λ ())) (ℊ 0F) η ⟩
+    ⟦ Th-Monoid idˡᵐ .proj₁ ⟧ ⟨$⟩ η   ≈⟨ interp-node-∙ᴿ (node ε-Opᵐᵒ λ ()) (ℊ 0F) η ⟩
     ⟦ node ε-Opᵐᵒ (λ ()) ⟧ ⟨$⟩ η ∙ _  ≈⟨ ∙-cong (interp-node-εᴿ η) ≈refl ⟩
     ε ∙ _                             ≈⟨ idˡ-law _ ⟩
     _                                 ∎
 
   thm idʳᵐ η = begin
-    ⟦ Th-Monoid idʳᵐ .proj₁ ⟧ ⟨$⟩ η   ≈⟨ interp-node-∙ᴿ (ℊ 0F) (node ε-Opᵐᵒ (λ ())) η ⟩
+    ⟦ Th-Monoid idʳᵐ .proj₁ ⟧ ⟨$⟩ η   ≈⟨ interp-node-∙ᴿ (ℊ 0F) (node ε-Opᵐᵒ λ ()) η ⟩
     _ ∙ ⟦ node ε-Opᵐᵒ (λ ()) ⟧ ⟨$⟩ η  ≈⟨ ∙-cong ≈refl (interp-node-εᴿ η) ⟩
     _ ∙ ε                             ≈⟨ idʳ-law _ ⟩
     _                                 ∎
@@ -332,7 +340,7 @@ group→monoid 𝒢@(𝑮 , _) = 𝑹 , thm
 
 #### Group builders
 
-`opsToBareGroup` builds a "raw" `Sig-Group`-algebra from a carrier, a binary
+`opsToBareGroup` builds a raw `Sig-Group`-algebra from a carrier, a binary
 operation, an identity element, and an inverse, over the propositional-equality
 setoid `setoid A` — the empty-theory edge case of the `opsTo<family>` pattern, now
 with one clause per `Sig-Group` symbol.

--- a/src/Classical/Structures/Group/Centralizer.lagda.md
+++ b/src/Classical/Structures/Group/Centralizer.lagda.md
@@ -11,16 +11,15 @@ author: "the agda-algebras development team"
 This is the [Classical.Structures.Group.Centralizer][] module of the [Agda Universal Algebra Library][].
 
 The **centralizer** `C_G(N)` of a subset `N` of a group `G` is the set of elements
-that commute with every member of `N`.  It is an equality-respecting subgroup, it is
-antitone in `N`, and it is *normal* whenever `N` is; these are the three facts the
-structure theory of parachute representations needs.[^1]
+that commute with every member of `N`.  It is a subgroup, it is antitone in `N`,
+and it is *normal* whenever `N` is.[^1]
 
 This module also proves the small commutator fact that drives subdirect
 irreducibility: *two normal subgroups that meet trivially centralize each other*.
 
 For `m ∈ M` and `n ∈ N` the commutator `n m n⁻¹ m⁻¹` lies in `M` (read it as
-`(n m n⁻¹) m⁻¹`, using normality of `M`) and in `N` (read it as `n (m n⁻¹ m⁻¹)`,
-using normality of `N`), hence is trivial, which is exactly `n m = m n`.
+`(n m n⁻¹) m⁻¹`, and use normality of `M`) and in `N` (similarly, read `n (m n⁻¹ m⁻¹)`),
+hence is trivial, which is exactly `n m = m n`.
 
 <!--
 ```agda
@@ -61,7 +60,8 @@ module Centralizer {α ρ : Level} (𝒢 : Group α ρ) where
   open SetoidReasoning 𝔻[ 𝑮 ]
   open Group-Op 𝒢     using  ( _∙_ ; ε ; _⁻¹ ; ∙-cong ; assoc-law
                              ; idˡ-law ; idʳ-law ; invˡ-law ; invʳ-law )
-  open Conjugate 𝒢         using  ( conj ; IsNormal ; conj-cong ; conj-∙-hom ; conj-conj⁻¹ )
+  open Conjugate 𝒢         using  ( conj ; IsNormal ; conj-cong ; conj-∙-hom
+                                  ; conj-conj⁻¹ ; conj-syntax)
 
   -- The centralizer of N: the elements commuting with every member of N.
   C[_] : Pred G ℓ → Pred G (α ⊔ ρ ⊔ ℓ)
@@ -72,9 +72,9 @@ module Centralizer {α ρ : Level} (𝒢 : Group α ρ) where
   C-isAntitone M⊆N g∈C x x∈M = g∈C x (M⊆N x∈M)
 ```
 
-The centralizer is an equality-respecting subgroup.  Closure under inversion is the
-only step with any content: from `g x = x g` one gets `g⁻¹ x = x g⁻¹` by conjugating
-the equation with `g⁻¹` on both sides.
+The centralizer is a subgroup.  Closure under inversion is the only step with any
+content: from `g x = x g` one gets `g⁻¹ x = x g⁻¹` by applying `g⁻¹` on the left
+and right of both sides.
 
 ```agda
   C-isSubgroup : (N : Pred G ℓ) → IsSubgroup 𝒢 C[ N ]
@@ -101,15 +101,15 @@ the equation with `g⁻¹` on both sides.
 
     ⁻¹-c : ∀ {g} → g ∈ C[ N ] → g ⁻¹ ∈ C[ N ]
     ⁻¹-c {g} g∈C x x∈N = begin
-      g ⁻¹ ∙ x                  ≈˘⟨ ∙-cong ≈refl (idʳ-law x) ⟩
-      g ⁻¹ ∙ (x ∙ ε)            ≈˘⟨ ∙-cong ≈refl (∙-cong ≈refl (invʳ-law g)) ⟩
-      g ⁻¹ ∙ (x ∙ (g ∙ g ⁻¹))   ≈˘⟨ ∙-cong ≈refl (assoc-law x g (g ⁻¹)) ⟩
-      g ⁻¹ ∙ (x ∙ g ∙ g ⁻¹)     ≈˘⟨ ∙-cong ≈refl (∙-cong (g∈C x x∈N) ≈refl) ⟩
-      g ⁻¹ ∙ (g ∙ x ∙ g ⁻¹)     ≈⟨ ∙-cong ≈refl (assoc-law g x (g ⁻¹)) ⟩
-      g ⁻¹ ∙ (g ∙ (x ∙ g ⁻¹))   ≈˘⟨ assoc-law (g ⁻¹) g (x ∙ g ⁻¹) ⟩
-      (g ⁻¹ ∙ g) ∙ (x ∙ g ⁻¹)   ≈⟨ ∙-cong (invˡ-law g) ≈refl ⟩
-      ε ∙ (x ∙ g ⁻¹)            ≈⟨ idˡ-law (x ∙ g ⁻¹) ⟩
-      x ∙ g ⁻¹                  ∎
+      g ⁻¹ ∙ x                 ≈˘⟨ ∙-cong ≈refl (idʳ-law x) ⟩
+      g ⁻¹ ∙ (x ∙ ε)           ≈˘⟨ ∙-cong ≈refl (∙-cong ≈refl (invʳ-law g)) ⟩
+      g ⁻¹ ∙ (x ∙ (g ∙ g ⁻¹))  ≈˘⟨ ∙-cong ≈refl (assoc-law x g (g ⁻¹)) ⟩
+      g ⁻¹ ∙ (x ∙ g ∙ g ⁻¹)    ≈˘⟨ ∙-cong ≈refl (∙-cong (g∈C x x∈N) ≈refl) ⟩
+      g ⁻¹ ∙ (x ^ g)           ≈⟨ ∙-cong ≈refl (assoc-law g x (g ⁻¹)) ⟩
+      g ⁻¹ ∙ (g ∙ (x ∙ g ⁻¹))  ≈˘⟨ assoc-law (g ⁻¹) g (x ∙ g ⁻¹) ⟩
+      (g ⁻¹ ∙ g) ∙ (x ∙ g ⁻¹)  ≈⟨ ∙-cong (invˡ-law g) ≈refl ⟩
+      ε ∙ (x ∙ g ⁻¹)           ≈⟨ idˡ-law (x ∙ g ⁻¹) ⟩
+      x ∙ g ⁻¹                 ∎
 ```
 
 The centralizer of a *normal* subgroup is normal: conjugating a centralizing element
@@ -119,25 +119,24 @@ and conjugating that equation by `k` gives what is wanted.
 ```agda
   C-isNormal : {N : Pred G ℓ} → IsNormal N → IsNormal C[ N ]
   C-isNormal N-normal k {g} g∈C x x∈N = begin
-    conj k g ∙ x                       ≈˘⟨ ∙-cong ≈refl (conj-conj⁻¹ k x) ⟩
-    conj k g ∙ conj k (conj (k ⁻¹) x)  ≈˘⟨ conj-∙-hom k g (conj (k ⁻¹) x) ⟩
-    conj k (g ∙ conj (k ⁻¹) x)         ≈⟨ conj-cong k (g∈C (conj (k ⁻¹) x) (N-normal (k ⁻¹) x∈N)) ⟩
-    conj k (conj (k ⁻¹) x ∙ g)         ≈⟨ conj-∙-hom k (conj (k ⁻¹) x) g ⟩
-    conj k (conj (k ⁻¹) x) ∙ conj k g  ≈⟨ ∙-cong (conj-conj⁻¹ k x) ≈refl ⟩
-    x ∙ conj k g                       ∎
+    g ^ k ∙ x                ≈˘⟨ ∙-cong ≈refl (conj-conj⁻¹ k x) ⟩
+    g ^ k ∙ (x ^ (k ⁻¹))^ k  ≈˘⟨ conj-∙-hom k g (x ^ (k ⁻¹)) ⟩
+    (g ∙ x ^ (k ⁻¹))^ k      ≈⟨ conj-cong k (g∈C (x ^ (k ⁻¹)) (N-normal (k ⁻¹) x∈N)) ⟩
+    (x ^ (k ⁻¹) ∙ g)^ k      ≈⟨ conj-∙-hom k (x ^ (k ⁻¹)) g ⟩
+    (x ^ (k ⁻¹))^ k ∙ g ^ k  ≈⟨ ∙-cong (conj-conj⁻¹ k x) ≈refl ⟩
+    x ∙ g ^ k                ∎
 ```
 
 #### Normal subgroups meeting trivially centralize each other
 
-`normals-centralize`{.AgdaFunction} is the standard fact that two normal subgroups
-with trivial intersection commute elementwise: if `M` and `N` are normal and meet
-only in `ε`, then every element of `N` centralizes `M`.
+Two normal subgroups with trivial intersection commute elementwise: if `M` and `N`
+are normal and meet at `(ε)`, then every element of `N` centralizes `M`.
 
-The proof is the classical commutator argument.  Given `n ∈ N` and `m ∈ M`, the
+We formalize this standard fact in `normals-centralize`{.AgdaFunction};
+the proof is the classical commutator argument.  Given `n ∈ N` and `m ∈ M`, the
 commutator `(n m n⁻¹) m⁻¹` lies in `M` by normality of `M` and in `N` by normality
 of `N`, so the trivial-intersection hypothesis forces it to be `ε`, which is exactly
-`n m ≈ m n`.  It is the one place in this module where both normality hypotheses are
-used, and it is what makes an internal direct product decomposition possible.
+`n m ≈ m n`.
 
 ```agda
   normals-centralize : {M : Pred G ℓ} {N : Pred G ℓ'}
@@ -159,11 +158,11 @@ used, and it is what makes an internal direct product decomposition possible.
     w∈M = M∙ (M-nrm n m∈M) (M⁻¹ m∈M)
 
     -- ... and as n (m n⁻¹ m⁻¹).
-    w≈ : w ≈ n ∙ conj m (n ⁻¹)
+    w≈ : w ≈ n ∙ (n ⁻¹) ^ m
     w≈ = begin
       n ∙ m ∙ n ⁻¹ ∙ m ⁻¹    ≈⟨ ∙-cong (assoc-law n m (n ⁻¹)) ≈refl ⟩
       n ∙ (m ∙ n ⁻¹) ∙ m ⁻¹  ≈⟨ assoc-law n (m ∙ n ⁻¹) (m ⁻¹) ⟩
-      n ∙ (m ∙ n ⁻¹ ∙ m ⁻¹)  ∎
+      n ∙ (n ⁻¹) ^ m         ∎
 
     w∈N : w ∈ N
     w∈N = N-resp (≈sym w≈) (N∙ n∈N (N-nrm m (N⁻¹ n∈N)))
@@ -174,19 +173,19 @@ used, and it is what makes an internal direct product decomposition possible.
     -- Cancelling m⁻¹ and then n⁻¹ from n m n⁻¹ m⁻¹ ≈ ε.
     step : n ∙ m ∙ n ⁻¹ ≈ m
     step = begin
-      n ∙ m ∙ n ⁻¹               ≈˘⟨ idʳ-law _ ⟩
-      n ∙ m ∙ n ⁻¹ ∙ ε           ≈˘⟨ ∙-cong ≈refl (invˡ-law m) ⟩
-      n ∙ m ∙ n ⁻¹ ∙ (m ⁻¹ ∙ m)  ≈˘⟨ assoc-law (n ∙ m ∙ n ⁻¹) (m ⁻¹) m ⟩
-      n ∙ m ∙ n ⁻¹ ∙ m ⁻¹ ∙ m    ≈⟨ ∙-cong w≈ε ≈refl ⟩
-      ε ∙ m                      ≈⟨ idˡ-law m ⟩
-      m                          ∎
+      m ^ n               ≈˘⟨ idʳ-law _ ⟩
+      m ^ n ∙ ε           ≈˘⟨ ∙-cong ≈refl (invˡ-law m) ⟩
+      m ^ n ∙ (m ⁻¹ ∙ m)  ≈˘⟨ assoc-law (m ^ n) (m ⁻¹) m ⟩
+      m ^ n ∙ m ⁻¹ ∙ m    ≈⟨ ∙-cong w≈ε ≈refl ⟩
+      ε ∙ m               ≈⟨ idˡ-law m ⟩
+      m                   ∎
 
     commute : n ∙ m ≈ m ∙ n
     commute = begin
       n ∙ m               ≈˘⟨ idʳ-law (n ∙ m) ⟩
       n ∙ m ∙ ε           ≈˘⟨ ∙-cong ≈refl (invˡ-law n) ⟩
       n ∙ m ∙ (n ⁻¹ ∙ n)  ≈˘⟨ assoc-law (n ∙ m) (n ⁻¹) n ⟩
-      n ∙ m ∙ n ⁻¹ ∙ n    ≈⟨ ∙-cong step ≈refl ⟩
+      m ^ n ∙ n           ≈⟨ ∙-cong step ≈refl ⟩
       m ∙ n               ∎
 ```
 

--- a/src/Classical/Structures/Group/Centralizer.lagda.md
+++ b/src/Classical/Structures/Group/Centralizer.lagda.md
@@ -129,6 +129,16 @@ and conjugating that equation by `k` gives what is wanted.
 
 #### Normal subgroups meeting trivially centralize each other
 
+`normals-centralize`{.AgdaFunction} is the standard fact that two normal subgroups
+with trivial intersection commute elementwise: if `M` and `N` are normal and meet
+only in `ε`, then every element of `N` centralizes `M`.
+
+The proof is the classical commutator argument.  Given `n ∈ N` and `m ∈ M`, the
+commutator `(n m n⁻¹) m⁻¹` lies in `M` by normality of `M` and in `N` by normality
+of `N`, so the trivial-intersection hypothesis forces it to be `ε`, which is exactly
+`n m ≈ m n`.  It is the one place in this module where both normality hypotheses are
+used, and it is what makes an internal direct product decomposition possible.
+
 ```agda
   normals-centralize : {M : Pred G ℓ} {N : Pred G ℓ'}
     → IsSubgroup 𝒢 M → IsSubgroup 𝒢 N

--- a/src/Classical/Structures/Group/Cosets.lagda.md
+++ b/src/Classical/Structures/Group/Cosets.lagda.md
@@ -10,20 +10,21 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Group.Cosets][] module of the [Agda Universal Algebra Library][].
 
-For a subgroup `H` of a group `𝑮`, two elements lie in the same **left coset**
-exactly when `x ⁻¹ ∙ y ∈ H`.  In the setoid discipline the coset space `G/H` is not
-a new carrier of equivalence classes but the *same* carrier with a coarser setoid
-equality: the relation `_∼_` just described.
+For a subgroup `H` of a group `𝑮`, we say that two elements, `x, y` in `𝑮`, lie in the same
+**left coset**, and we write `x ∼ y`, exactly when `x ⁻¹ ∙ y ∈ H`.
 
-This module proves `_∼_` is an equivalence relation — each axiom is one subgroup
-closure property plus one line of group arithmetic — and packages the quotient setoid
-`cosetSetoid`{.AgdaFunction} via the `_/_`{.AgdaFunction} construction of
+In the setoid discipline the coset space `G / H` is not a new carrier of
+equivalence classes but the *same* carrier with a coarser setoid equality: the
+relation `_∼_` just described.
+
+This module proves `_∼_` is an equivalence relation and packages the quotient
+setoid, `cosetSetoid`{.AgdaFunction}, via the `_/_`{.AgdaFunction} construction of
 [Setoid.Relations.Quotients][].
 
 Two further lemmas prepare the ground for the coset action of
-[Classical.Structures.Group.GSet][]: the original setoid equality refines the coset
-equality (`≈⇒∼`{.AgdaFunction}, well-definedness of the quotient map), and left
-translation by any group element preserves the coset equality
+[Classical.Structures.Group.GSet][]: the original setoid equality refines the
+coset equality (`≈⇒∼`{.AgdaFunction}, well-definedness of the quotient map), and
+left translation by any group element preserves the coset equality
 (`∼-congˡ`{.AgdaFunction}, which will be the congruence proof of the action).
 
 <!--
@@ -83,9 +84,9 @@ module Coset {α ρ : Level} (𝒢 : Group α ρ) {ℓ : Level}
 
 #### `_∼_` is an equivalence relation
 
-Reflexivity is `ε ∈ H` transported along `x ⁻¹ ∙ x ≈ ε`; symmetry is closure of `H`
-under inverses, since `(x ⁻¹ ∙ y) ⁻¹ ≈ y ⁻¹ ∙ x`; and transitivity is closure under
-products, since `(x ⁻¹ ∙ y) ∙ (y ⁻¹ ∙ z) ≈ x ⁻¹ ∙ z`.
++  Reflexivity is `ε ∈ H` transported along `x ⁻¹ ∙ x ≈ ε`.
++  Symmetry is closure of `H` under inverses, since `(x ⁻¹ ∙ y) ⁻¹ ≈ y ⁻¹ ∙ x`.
++  Transitivity is closure under products, since `(x ⁻¹ ∙ y) ∙ (y ⁻¹ ∙ z) ≈ x ⁻¹ ∙ z`.
 
 ```agda
   ∼-refl : ∀ {x} → x ∼ x
@@ -121,9 +122,10 @@ products, since `(x ⁻¹ ∙ y) ∙ (y ⁻¹ ∙ z) ≈ x ⁻¹ ∙ z`.
 Two facts are needed before the coset relation can be used as an equality.
 
 `≈⇒∼`{.AgdaFunction} says the group's own setoid equality refines the coset
-relation, which is what makes the quotient map well defined: equal elements land in
-the same coset.  `∼-congˡ`{.AgdaFunction} says left translation by any group element
-preserves the coset relation, which is what lets `g ∙_` descend to the coset space.
+relation, which is what makes the quotient map well defined: equal elements land
+in the same coset.  `∼-congˡ`{.AgdaFunction} says left translation by any group
+element preserves the coset relation, which is what lets `g ∙_` descend to the
+coset space.
 
 Both are proved the same way, by supplying `respects`{.AgdaFunction} with an
 equality between the relevant `x ⁻¹ ∙ y` witnesses: for `≈⇒∼`{.AgdaFunction} that
@@ -156,9 +158,7 @@ original.  `∼-congˡ`{.AgdaFunction} is what
 
 The coset relation is decidable exactly when membership in `H`{.AgdaBound} is:
 whether `x ∼ y` is, definitionally, whether the single product `x ⁻¹ ∙ y` lies in
-`H`{.AgdaBound}.  This is the Layer-D decision procedure that sits beside the
-semantic relation, per the two-layer discipline (ADR-008; audit A2 of
-`docs/notes/flrp-wp7-audits.md`).
+`H`{.AgdaBound}.[^1]
 
 ```agda
   -- With decidable membership in H, the coset relation is decidable.
@@ -175,3 +175,9 @@ quotient construction of [Setoid.Relations.Quotients][].
   cosetSetoid : Setoid α ℓ
   cosetSetoid = G / ∼-equivalence
 ```
+
+---
+
+[^1]:  This is the Layer-D decision procedure that sits beside the semantic
+       relation, per the two-layer discipline ([ADR-008]; audit A2 of
+       `docs/notes/flrp-wp7-audits.md`).

--- a/src/Classical/Structures/Group/Cosets.lagda.md
+++ b/src/Classical/Structures/Group/Cosets.lagda.md
@@ -118,6 +118,20 @@ products, since `(x ⁻¹ ∙ y) ∙ (y ⁻¹ ∙ z) ≈ x ⁻¹ ∙ z`.
 
 #### Compatibility lemmas
 
+Two facts are needed before the coset relation can be used as an equality.
+
+`≈⇒∼`{.AgdaFunction} says the group's own setoid equality refines the coset
+relation, which is what makes the quotient map well defined: equal elements land in
+the same coset.  `∼-congˡ`{.AgdaFunction} says left translation by any group element
+preserves the coset relation, which is what lets `g ∙_` descend to the coset space.
+
+Both are proved the same way, by supplying `respects`{.AgdaFunction} with an
+equality between the relevant `x ⁻¹ ∙ y` witnesses: for `≈⇒∼`{.AgdaFunction} that
+witness reduces to `ε` and membership follows from `ε-closed`{.AgdaFunction}, and for
+`∼-congˡ`{.AgdaFunction} the `g` cancels, so the translated witness equals the
+original.  `∼-congˡ`{.AgdaFunction} is what
+[Classical.Structures.Group.GSet][] uses to build the coset algebra.
+
 ```agda
   -- The setoid equality refines the coset equality (the quotient map is well defined).
   ≈⇒∼ : ∀ {x y} → x ≈ y → x ∼ y

--- a/src/Classical/Structures/Group/GSet.lagda.md
+++ b/src/Classical/Structures/Group/GSet.lagda.md
@@ -87,6 +87,22 @@ module CosetAction {α ρ : Level} (𝒢 : Group α ρ) {ℓ : Level}
 
 #### Action laws and transitivity
 
+The coset space is a `G`-set: `G` acts on `G/H` by left translation.  These three
+results are that action's laws, and each is a one-line consequence of a group law
+transported across `≈⇒∼`{.AgdaFunction}.
+
++  `act-identity`{.AgdaFunction}: acting by `ε` does nothing, from
+   `idˡ-law`{.AgdaFunction}.
++  `act-compatible`{.AgdaFunction}: acting by `g ∙ h` is acting by `h` and then by
+   `g`, from `assoc-law`{.AgdaFunction}.
++  `act-transitive`{.AgdaFunction}: the action is transitive, and the witness is
+   explicit — `y ∙ x ⁻¹` carries the coset of `x` to that of `y`.
+
+Transitivity is the substantive one: it says `G/H` is a single orbit, which is why a
+coset space is the model case of a transitive action.  That it is proved by
+exhibiting the group element rather than by an existence argument is what keeps it
+usable computationally.
+
 ```agda
   -- The identity element acts as the identity on cosets.
   act-identity : (x : G) → (ε ∙ x) ∼ x

--- a/src/Classical/Structures/Group/GSet.lagda.md
+++ b/src/Classical/Structures/Group/GSet.lagda.md
@@ -87,16 +87,17 @@ module CosetAction {α ρ : Level} (𝒢 : Group α ρ) {ℓ : Level}
 
 #### Action laws and transitivity
 
-The coset space is a `G`-set: `G` acts on `G/H` by left translation.  These three
-results are that action's laws, and each is a one-line consequence of a group law
-transported across `≈⇒∼`{.AgdaFunction}.
+The coset space is a `G`-set: `G` acts on `G/H` by left translation.  The first
+two results are the action laws; the third, transitivity, is not an axiom but a
+further property this particular action happens to have.  Each is a one-line
+consequence of a group law transported across `≈⇒∼`{.AgdaFunction}.
 
 +  `act-identity`{.AgdaFunction}: acting by `ε` does nothing, from
    `idˡ-law`{.AgdaFunction}.
 +  `act-compatible`{.AgdaFunction}: acting by `g ∙ h` is acting by `h` and then by
    `g`, from `assoc-law`{.AgdaFunction}.
 +  `act-transitive`{.AgdaFunction}: the action is transitive, and the witness is
-   explicit — `y ∙ x ⁻¹` carries the coset of `x` to that of `y`.
+   explicit: `y ∙ x ⁻¹` carries the coset of `x` to that of `y`.
 
 Transitivity is the substantive one: it says `G/H` is a single orbit, which is why a
 coset space is the model case of a transitive action.  That it is proved by

--- a/src/Classical/Structures/Group/GSet.lagda.md
+++ b/src/Classical/Structures/Group/GSet.lagda.md
@@ -10,29 +10,34 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Structures.Group.GSet][] module of the [Agda Universal Algebra Library][].
 
-The transitive action of a group `G` on the coset space `G/H` is packaged here as an
-ordinary **unary algebra**: the signature is [`Sig-Unary`][Classical.Signatures.Unary]
-applied to the carrier of `G` — one operation symbol per group element, each of arity
-one — and the algebra's domain is the quotient setoid `cosetSetoid`{.AgdaFunction} of
-[Classical.Structures.Group.Cosets][].  The symbol `g` acts by left translation, `x ↦
-g ∙ x`, which respects the coset equality by `∼-congˡ`{.AgdaFunction}.
+The transitive action of a group `G` on the coset space `G / H` is packaged here
+as an ordinary *unary algebra*: the signature is
+[`Sig-Unary`][Classical.Signatures.Unary] applied to the carrier of `G`
+(one operation symbol per group element, each of arity one) and the algebra's
+domain is the quotient setoid `cosetSetoid`{.AgdaFunction} of
+[Classical.Structures.Group.Cosets][].  The symbol `g` acts by left translation,
+`x ↦ g ∙ x`, which respects the coset equality by `∼-congˡ`{.AgdaFunction}.
 
 This encoding is chosen so that the library's congruence machinery applies to the
-G-set *verbatim*: `cosetAlgebra`{.AgdaFunction} is an `Algebra`{.AgdaRecord} over an
-ordinary signature, so `Con cosetAlgebra` means exactly what it means for any
-algebra (the module ends with a private demonstration).[^1]
+G-set verbatim: `cosetAlgebra`{.AgdaFunction} is an `Algebra`{.AgdaRecord} over
+an ordinary signature, so `Con cosetAlgebra` means exactly what it means for any
+algebra.  (The module ends with a private demonstration.)[^1]
 
-**Note on the symbol set**.  Operation symbols form a *type* with propositional
+We occasionally write `G ↷ G / H` to denote that the group G acts on the coset
+space G / H, but we also use it to mean the algebra `cosetAlgebra`{.AgdaFunction}
+that encodes this action; the context should make clear which is intended.
+
+**Note on the symbol set**.  Operation symbols form a type with propositional
 equality, so two setoid-equal but distinct carrier elements give two symbols; they
-act identically on `G/H` (by `∼-congˡ` and `≈⇒∼`), and a signature is raw syntax,
+act identically on `G / H` (by `∼-congˡ` and `≈⇒∼`), and a signature is raw syntax,
 so this is harmless.
 
 The action laws are stated with the curried operations, which is no loss: by the
 definition of `mkAlgebra`{.AgdaFunction}, the interpretation of the symbol `g` at
 `x` is definitionally `g ∙ x`, so `act-identity`{.AgdaFunction} and
 `act-compatible`{.AgdaFunction} are literally the unit and compatibility laws of
-the action of `G` on `G/H`, and `act-transitive`{.AgdaFunction} says the action is
-transitive: any coset is reached from any other by some group element.
+the group action `G ↷ G / H`, and `act-transitive`{.AgdaFunction} says the action
+is transitive: any coset is reached from any other by some group element.
 
 <!--
 ```agda
@@ -78,7 +83,7 @@ module CosetAction {α ρ : Level} (𝒢 : Group α ρ) {ℓ : Level}
   open Coset 𝒢 H H-isSubgroup   using ( _∼_ ; ∼-congˡ ; ≈⇒∼ ; cosetSetoid )
   open GroupProperties ⟨ 𝒢 ⟩ᵍᵖ  using ( //-rightDividesˡ )
 
-  -- The algebra G ↷ G/H over the unary signature on the carrier of G:
+  -- The algebra G ↷ G / H over the unary signature on the carrier of G:
   -- the symbol g acts on the coset of x by left translation, g ∙ x.
 
   cosetAlgebra : Algebra {𝑆 = Sig-Unary G} α ℓ
@@ -87,10 +92,12 @@ module CosetAction {α ρ : Level} (𝒢 : Group α ρ) {ℓ : Level}
 
 #### Action laws and transitivity
 
-The coset space is a `G`-set: `G` acts on `G/H` by left translation.  The first
-two results are the action laws; the third, transitivity, is not an axiom but a
-further property this particular action happens to have.  Each is a one-line
-consequence of a group law transported across `≈⇒∼`{.AgdaFunction}.
+As explained above, the coset space is a `G`-set: `G` acts on `G / H` by left
+translation.  The first two results we prove are the action laws; the third,
+transitivity, is not an axiom but a further property this particular action
+happens to have.  Each is a one-line consequence of a group law transported across
+`≈⇒∼`{.AgdaFunction}.  (Recall, `≈⇒∼` says setoid equality refines coset equality:
+`∀ {x y} → x ≈ y → x ∼ y`.)
 
 +  `act-identity`{.AgdaFunction}: acting by `ε` does nothing, from
    `idˡ-law`{.AgdaFunction}.
@@ -99,10 +106,10 @@ consequence of a group law transported across `≈⇒∼`{.AgdaFunction}.
 +  `act-transitive`{.AgdaFunction}: the action is transitive, and the witness is
    explicit: `y ∙ x ⁻¹` carries the coset of `x` to that of `y`.
 
-Transitivity is the substantive one: it says `G/H` is a single orbit, which is why a
-coset space is the model case of a transitive action.  That it is proved by
-exhibiting the group element rather than by an existence argument is what keeps it
-usable computationally.
+Transitivity is the substantive one: it says `G / H` is a single orbit, which is
+why a coset space is the model case of a transitive action.  Since it is proved by
+exhibiting a witness, the group element, rather than by an existence argument, the
+result it usable computationally.
 
 ```agda
   -- The identity element acts as the identity on cosets.
@@ -118,17 +125,21 @@ usable computationally.
   act-transitive x y = y ∙ x ⁻¹ , ≈⇒∼ (//-rightDividesˡ x y)
 ```
 
+Note that `_∙_` has higher precedence than `_∼_`, so we could have written
+(ε ∙ x) ∼ x as `ε ∙ x ∼ x` without ambiguity.  Also, since `_∙_` is
+left-associative, we could have written `g ∙ h ∙ x ∼ g ∙ (h ∙ x)` in
+`act-compatible`{.AgdaFunction}.  We chose instead to make the laws readable even
+without thinking about precedence conventions or associativity handedness.
+
 #### Finiteness of the coset algebra
 
 Carrier finiteness of the coset algebra is inherited from the group.  The coset
 space is the *same* carrier under the coarser equality `_∼_`{.AgdaFunction}, so the
 group's surjective enumeration still hits every element (the finer `_≈_`{.AgdaFunction}
 refines `_∼_`{.AgdaFunction} by `≈⇒∼`{.AgdaFunction}), and decidable coset equality
-is exactly the decidability of `_∼_`{.AgdaFunction} — supplied by
+is exactly the decidability of `_∼_`{.AgdaFunction}, which is supplied by
 `∼-dec`{.AgdaFunction} of [Classical.Structures.Group.Cosets][] whenever membership
-in `H`{.AgdaBound} is decidable.  This discharges, constructively, the finiteness
-hypothesis of the Pálfy–Pudlák corollaries of [FLRP.Bridge][] (audit A2 of
-`docs/notes/flrp-wp7-audits.md` sketches precisely this argument).
+in `H`{.AgdaBound} is decidable.[^2]
 
 ```agda
   open FiniteAlgebra
@@ -146,9 +157,10 @@ hypothesis of the Pálfy–Pudlák corollaries of [FLRP.Bridge][] (audit A2 of
 #### The congruence machinery applies verbatim
 
 `cosetAlgebra` is an ordinary algebra, so its congruence lattice needs no new
-definitions — the demonstration below type-checks against the stock
-`Con`{.AgdaFunction} of [Setoid.Congruences.Basic][].  Work package WP-3 will show
-this type is isomorphic (as a lattice) to the interval `[H, G]` in `Sub(G)`.
+definitions.  The demonstration below type-checks against the stock
+`Con`{.AgdaFunction} of [Setoid.Congruences.Basic][].  We will eventually show
+that this type is isomorphic (as a lattice) to the interval `[H, G]` in
+`Sub(G)`.[^1]
 
 ```agda
   private
@@ -158,6 +170,10 @@ this type is isomorphic (as a lattice) to the interval `[H, G]` in `Sub(G)`.
 
 ---
 
-[^1]:  It is the object of the Pálfy–Pudlák bridge — work package WP-3 of the FLRP
-       program proves `Con (G ↷ G/H) ≅ [H, G]` about precisely this algebra (see
-       `docs/notes/flrp-research-roadmap.md` § 7).
+[^1]:  The `cosetAlgebra` algebra is the object of work package WP-3 of the FLRP
+       program in which we prove `Con (G ↷ G / H) ≅ [H, G]`.
+       (See `docs/notes/flrp-research-roadmap.md` § 7.)
+
+[^2]:  This discharges, constructively, the finiteness hypothesis of the
+       Pálfy–Pudlák corollaries of [FLRP.Bridge][].  (Audit A2 of
+       `docs/notes/flrp-wp7-audits.md` sketches precisely this argument.)

--- a/src/Classical/Structures/Group/NormalCore.lagda.md
+++ b/src/Classical/Structures/Group/NormalCore.lagda.md
@@ -141,13 +141,16 @@ subgroup that `H` contains.
    holds componentwise, and closure comes free from the subuniverse machinery, an
    intersection of subuniverses being a subuniverse.
 +  `core-normal`{.AgdaFunction}: it is normal, because conjugating a member by `g`
-   leaves every conjugate inside `H` — `conj k (conj g x)` is just the
+   leaves every conjugate inside `H`: `conj k (conj g x)` is just the
    `k ∙ g`-conjugate of `x`.
 +  `core-greatest`{.AgdaFunction}: it is the greatest such, since any normal subset
    of `H` lies inside every conjugate of `H` and hence inside the intersection.
 
 The last is what makes the core a *construction* rather than merely a subgroup: it
-is characterised by a universal property, so it is determined up to nothing at all.
+is characterised by a universal property, which determines it up to mutual
+inclusion.  Any two predicates with these four properties contain one another; in
+this intensional setting that is the strongest uniqueness on offer, since mutual
+inclusion does not make two predicates definitionally equal.
 
 ```agda
   -- The core is contained in H (instantiate the conjugate at g = ε).

--- a/src/Classical/Structures/Group/NormalCore.lagda.md
+++ b/src/Classical/Structures/Group/NormalCore.lagda.md
@@ -14,24 +14,27 @@ For a subgroup `H` of a group `𝑮`, the **normal core** `Core_G(H)` is the lar
 normal subgroup of `𝑮` contained in `H`.
 
 Classically the normal core is the intersection `⋂ { g H g⁻¹ ∣ g ∈ G }` of all
-conjugates of `H`.  We define it *constructively as that intersection*, using the
+conjugates of `H`.  We define it *constructively* as that intersection using the
 infinitary meet `⨅`{.AgdaFunction} of the subuniverse lattice of
 [Setoid.Subalgebras.CompleteLattice][] over the family of conjugates from
-[Classical.Structures.Group.Conjugation][] — so the definition is an instance of the
-complete-lattice machinery rather than an ad-hoc predicate.
+[Classical.Structures.Group.Conjugation][]; so the definition is an instance of
+the complete-lattice machinery rather than an ad-hoc predicate.
 
-The lattice is instantiated at base level `ℓ₀ = α ⊔ ρ ⊔ ℓ`, the absorbing level for
-group-theoretic constructions over a `Group α ρ` and a subgroup predicate at level
-`ℓ`: conjugates mention the setoid equality (level `ρ`) and the predicate (level
-`ℓ`), and the meet is indexed by the carrier (level `α`), lifted by
-`Lift (ρ ⊔ ℓ)` to reach the index level of `⨅`{.AgdaFunction}.
+**Note on the universe levels**.  The lattice is instantiated at universe level
+`ℓ₀ = α ⊔ ρ ⊔ ℓ`, the absorbing level for group-theoretic constructions over a
+`Group α ρ` and a subgroup predicate at level `ℓ`: conjugates mention the setoid
+equality (level `ρ`) and the predicate (level `ℓ`), and the meet is indexed by the
+carrier (level `α`), lifted by `Lift (ρ ⊔ ℓ)` to reach the index level of
+`⨅`{.AgdaFunction}.
 
-The module proves the characteristic properties as small named lemmas, in
-particular that the core is contained in `H` (`core-⊆`{.AgdaFunction}), is an
-equality-respecting subgroup (`core-isSubgroup`{.AgdaFunction}), is normal
-(`core-normal`{.AgdaFunction}), and contains every normal subgroup contained in `H`
-(`core-greatest`{.AgdaFunction}) — together: the core is the *greatest* normal
-subgroup below `H`.[^1]
+The module proves that the normal core
+
++ is contained in `H` (`core-⊆`{.AgdaFunction}),
++ is a subgroup (`core-isSubgroup`{.AgdaFunction}),
++ is normal (`core-normal`{.AgdaFunction}), and
++ contains every normal subgroup contained in `H` (`core-greatest`{.AgdaFunction}).
+
+The conclusion is that the core is the greatest normal subgroup below `H`.[^1]
 
 <!--
 ```agda
@@ -42,7 +45,7 @@ module Classical.Structures.Group.NormalCore where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
-open import Data.Product     using ( _,_ ; proj₁ ; proj₂ )
+open import Data.Product     using ( _,_ ; proj₁ ; proj₂ ; ∃-syntax ; _×_)
 open import Level            using ( Level ; _⊔_ ; Lift ; lift ; lower )
 open import Relation.Binary  using ( Setoid )
 open import Relation.Unary   using ( Pred ; _∈_ ; _⊆_ )
@@ -53,43 +56,39 @@ import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 open import Classical.Structures.Group.Basic        using ( Group ; module Group-Op )
 open import Classical.Structures.Group.Subgroups    using ( IsSubgroup )
 open import Classical.Structures.Group.Conjugation  using ( module Conjugate )
-open import Setoid.Algebras.Basic                   using ( 𝕌[_] ; 𝔻[_] )
+open import Setoid.Algebras.Basic                   using ( 𝔻[_] ; 𝕌[_] )
 open import Setoid.Subalgebras.CompleteLattice      using ( module Sublattice )
 ```
 -->
 
 #### The construction
 
-`Core 𝑮 H H-isSubgroup` packages the normal core of the subgroup cut out by `H`.
+`Core 𝑮 H H-isSubgroup` packages the normal core of the subgroup `H` in `G`.
 The family `conjugates`{.AgdaFunction} sends (the lift of) a group element `g` to
 the conjugate subgroup `g H g⁻¹` as an element of the subuniverse lattice, and
-`core`{.AgdaFunction} is the lattice meet of that family — its underlying predicate
+`core`{.AgdaFunction} is the lattice meet of that family; its underlying predicate
 is definitionally the intersection `⋂ g (conjugate g H)`.
 
 ```agda
-module Core {α ρ : Level} (𝑮 : Group α ρ) {ℓ : Level}
-  (H : Pred 𝕌[ proj₁ 𝑮 ] ℓ) (H-isSubgroup : IsSubgroup 𝑮 H)
+module Core {α ρ : Level} (𝒢@(𝑮 , _) : Group α ρ) {ℓ : Level}
+  (H : Pred 𝕌[ 𝑮 ] ℓ) (H-isSubgroup : IsSubgroup 𝒢 H)
   where
 
-  private
-    𝑨 = proj₁ 𝑮
-    A = 𝕌[ 𝑨 ]
-
-  open Setoid 𝔻[ 𝑨 ]  using ( _≈_ ) renaming ( sym to ≈sym )
-  open SetoidReasoning 𝔻[ 𝑨 ]
-  open Group-Op 𝑮 using ( _∙_ ; ε ; _⁻¹ )
-  open Conjugate 𝑮
-  open Sublattice 𝑨 (α ⊔ ρ ⊔ ℓ) using ( Subᴸ ; ⨅ )
-  open IsSubgroup H-isSubgroup using () renaming  (respects to H-respects
-                                                  ; isSubuniverse to H-isSubuniverse)
+  open Setoid 𝔻[ 𝑮 ]  using ( _≈_ ) renaming ( sym to ≈sym )
+  open SetoidReasoning 𝔻[ 𝑮 ]
+  open Group-Op 𝒢 using ( _∙_ ; ε ; _⁻¹ )
+  open Conjugate 𝒢
+  open Sublattice 𝑮 (α ⊔ ρ ⊔ ℓ) using ( Subᴸ ; ⨅ )
+  open IsSubgroup H-isSubgroup renaming  (respects to H-respects
+                                         ; isSubuniverse to H-isSubuniverse)
 
   -- The index of the meet: the carrier, lifted to the lattice's index level.
   Index : Type (α ⊔ ρ ⊔ ℓ)
-  Index = Lift (ρ ⊔ ℓ) A
+  Index = Lift (ρ ⊔ ℓ) 𝕌[ 𝑮 ]
 
   -- The family of all conjugates of H, as elements of the subuniverse lattice.
   conjugates : Index → Subᴸ
-  conjugates i =  [ H ]^ (lower i) , conjugate-isSubuniverse (lower i) H H-isSubuniverse
+  conjugates i =  [ H ]^ lower i , conjugate-isSubuniverse (lower i) H H-isSubuniverse
 
   -- The normal core: the complete-lattice meet (intersection) of all conjugates of H.
   core : Subᴸ
@@ -99,23 +98,23 @@ module Core {α ρ : Level} (𝑮 : Group α ρ) {ℓ : Level}
 #### Membership characterization
 
 Unwinding the definition, `x` lies in the core precisely when every conjugate
-`conj g x` lies in `H`; the two lemmas below convert between the definitional form
+`x ^ g` lies in `H`; the two lemmas below convert between the definitional form
 (a witness in each conjugate subgroup) and this pointwise form, which is the
 convenient one in proofs.
 
 ```agda
   -- If x is in the core then all its conjugates are in H.
-  core-mem-conj : {x : A} → x ∈ proj₁ core → ∀ g → conj g x ∈ H
+  core-mem-conj : {x : 𝕌[ 𝑮 ]} → x ∈ core .proj₁ → ∀ g → x ^ g ∈ H
   core-mem-conj {x} x∈core g = H-respects (≈sym conj-g-x≈h) h∈H
     where
-    h : A
-    h = proj₁ (x∈core (lift (g ⁻¹)))
+    h : 𝕌[ 𝑮 ]
+    h = x∈core (lift (g ⁻¹)) .proj₁
 
     h∈H : h ∈ H
-    h∈H = proj₁ (proj₂ (x∈core (lift (g ⁻¹))))
+    h∈H = x∈core (lift (g ⁻¹)) .proj₂ .proj₁
 
     x≈conj : x ≈ conj (g ⁻¹) h
-    x≈conj = proj₂ (proj₂ (x∈core (lift (g ⁻¹))))
+    x≈conj = x∈core (lift (g ⁻¹)) .proj₂ .proj₂
 
     conj-g-x≈h : conj g x ≈ h
     conj-g-x≈h = begin
@@ -124,7 +123,7 @@ convenient one in proofs.
       h                       ∎
 
   -- Conversely, if all conjugates of x are in H then x is in the core.
-  conj-mem-core : {x : A} → (∀ g → conj g x ∈ H) → x ∈ proj₁ core
+  conj-mem-core : {x : 𝕌[ 𝑮 ]} → (∀ g → conj g x ∈ H) → x ∈ proj₁ core
   conj-mem-core {x} cm i =
     conj (lower i ⁻¹) x , cm (lower i ⁻¹) , ≈sym (conj-conj⁻¹ (lower i) x)
 ```
@@ -137,48 +136,48 @@ subgroup that `H` contains.
 
 +  `core-⊆`{.AgdaFunction}: the core sits inside `H`, obtained by instantiating the
    conjugate at `g = ε`.
-+  `core-isSubgroup`{.AgdaFunction}: it is an equality-respecting subgroup.  Respect
-   holds componentwise, and closure comes free from the subuniverse machinery, an
-   intersection of subuniverses being a subuniverse.
-+  `core-normal`{.AgdaFunction}: it is normal, because conjugating a member by `g`
-   leaves every conjugate inside `H`: `conj k (conj g x)` is just the
-   `k ∙ g`-conjugate of `x`.
-+  `core-greatest`{.AgdaFunction}: it is the greatest such, since any normal subset
-   of `H` lies inside every conjugate of `H` and hence inside the intersection.
++  `core-isSubgroup`{.AgdaFunction}: it is an (equality-respecting) subgroup.
+   The equality-respecting holds componentwise, and closure comes from the
+   subuniverse machinery, an intersection of subuniverses being a subuniverse.
++  `core-normal`{.AgdaFunction}: it is normal, because conjugating a member by
+   `g` leaves every conjugate inside `H`: `(x ^ g)^ k` is the `k ∙ g`-conjugate
+   of `x`.
++  `core-greatest`{.AgdaFunction}: it is the greatest normal subgroup in `H`,
+   since any normal subset of `H` lies inside every conjugate of `H` and hence
+   inside the intersection.
 
 The last is what makes the core a *construction* rather than merely a subgroup: it
-is characterised by a universal property, which determines it up to mutual
-inclusion.  Any two predicates with these four properties contain one another; in
-this intensional setting that is the strongest uniqueness on offer, since mutual
+is characterised by a universal property, so it's determined up to mutual inclusion.
+Any two predicates with these four properties contain one another; in this
+intensional setting that is the strongest uniqueness on offer, since mutual
 inclusion does not make two predicates definitionally equal.
 
 ```agda
   -- The core is contained in H (instantiate the conjugate at g = ε).
-  core-⊆ : proj₁ core ⊆ H
+  core-⊆ : core .proj₁ ⊆ H
   core-⊆ {x} x∈core = H-respects (conj-action-ε x) (core-mem-conj x∈core ε)
 
   -- The core is an equality-respecting subgroup: respect holds componentwise
   -- (each conjugate respects ≈ by construction), and the meet of subuniverses
   -- is a subuniverse by the lattice machinery.
-  core-isSubgroup : IsSubgroup 𝑮 (proj₁ core)
+  core-isSubgroup : IsSubgroup 𝒢 (proj₁ core)
   core-isSubgroup = record
-    { respects       = λ x≈y x∈core i → conjugate-respects (lower i) H x≈y (x∈core i)
-    ; isSubuniverse  = proj₂ core
+    { respects = λ x≈y x∈core i → conjugate-respects (lower i) H x≈y (x∈core i)
+    ; isSubuniverse = core .proj₂
     }
 
   -- The core is normal: conjugating a member by g keeps every conjugate in H,
-  -- since conj k (conj g x) is the (k ∙ g)-conjugate of x.
+  -- since (x ^ g)^k is the (k ∙ g)-conjugate of x.
   core-normal : IsNormal (proj₁ core)
   core-normal g {x} x∈core =
-    conj-mem-core (λ k → H-respects (conj-action-∙ k g x) (core-mem-conj x∈core (k ∙ g)))
+    conj-mem-core λ k → H-respects (conj-action-∙ k g x) (core-mem-conj x∈core (k ∙ g))
 
   -- The core is the greatest normal subgroup contained in H: any normal subset
   -- of H sits inside every conjugate of H, hence inside the meet.
-  core-greatest : {ℓⁿ : Level} {N : Pred A ℓⁿ}
-    →  IsNormal N → N ⊆ H → N ⊆ proj₁ core
-  core-greatest N-normal N⊆H x∈N = conj-mem-core (λ g → N⊆H (N-normal g x∈N))
+  core-greatest : {ℓⁿ : Level} {N : Pred 𝕌[ 𝑮 ] ℓⁿ}
+    →  IsNormal N → N ⊆ H → N ⊆ core .proj₁
+  core-greatest N-normal N⊆H x∈N = conj-mem-core λ g → N⊆H (N-normal g x∈N)
 ```
-
 
 ---
 [^1]:   This is the normalization step behind the core-free reduction

--- a/src/Classical/Structures/Group/NormalCore.lagda.md
+++ b/src/Classical/Structures/Group/NormalCore.lagda.md
@@ -131,6 +131,24 @@ convenient one in proofs.
 
 #### The core is a normal subgroup contained in `H`
 
+The **normal core** of `H` is the intersection of all conjugates of `H`.  These four
+results are its defining properties, and together they say it is the largest normal
+subgroup that `H` contains.
+
++  `core-⊆`{.AgdaFunction}: the core sits inside `H`, obtained by instantiating the
+   conjugate at `g = ε`.
++  `core-isSubgroup`{.AgdaFunction}: it is an equality-respecting subgroup.  Respect
+   holds componentwise, and closure comes free from the subuniverse machinery, an
+   intersection of subuniverses being a subuniverse.
++  `core-normal`{.AgdaFunction}: it is normal, because conjugating a member by `g`
+   leaves every conjugate inside `H` — `conj k (conj g x)` is just the
+   `k ∙ g`-conjugate of `x`.
++  `core-greatest`{.AgdaFunction}: it is the greatest such, since any normal subset
+   of `H` lies inside every conjugate of `H` and hence inside the intersection.
+
+The last is what makes the core a *construction* rather than merely a subgroup: it
+is characterised by a universal property, so it is determined up to nothing at all.
+
 ```agda
   -- The core is contained in H (instantiate the conjugate at g = ε).
   core-⊆ : proj₁ core ⊆ H

--- a/src/Setoid/Subalgebras/CompleteLattice.lagda.md
+++ b/src/Setoid/Subalgebras/CompleteLattice.lagda.md
@@ -224,22 +224,22 @@ because `I` is `ℓ₀`-small.
 
 ```agda
   ⨅ : {I : Type ℓ₀} → (I → Subᴸ) → Subᴸ
-  ⨅ {I} 𝒜 = ⋂ I (λ i → proj₁ (𝒜 i))
-           , ⋂s {𝑨 = 𝑨} I {𝒜 = λ i → proj₁ (𝒜 i)} (λ i → proj₂ (𝒜 i))
+  ⨅ {I} 𝒜 = ⋂ I (λ i → 𝒜 i .proj₁)
+           , ⋂s {𝑨 = 𝑨} I {𝒜 = λ i → 𝒜 i .proj₁} (λ i → 𝒜 i .proj₂)
 
   ⨆ : {I : Type ℓ₀} → (I → Subᴸ) → Subᴸ
-  ⨆ {I} 𝒜 = Sg 𝑨 (⋃ I (λ i → proj₁ (𝒜 i))) , sgIsSub 𝑨
+  ⨆ {I} 𝒜 = Sg 𝑨 (⋃ I λ i → 𝒜 i .proj₁) , sgIsSub 𝑨
 
-  ⨅-lower : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (i : I) → (⨅ 𝒜) ≤ (𝒜 i)
+  ⨅-lower : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (i : I) → ⨅ 𝒜 ≤ 𝒜 i
   ⨅-lower 𝒜 i z = z i
 
-  ⨅-greatest : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (D : Subᴸ) → (∀ i → D ≤ (𝒜 i)) → D ≤ (⨅ 𝒜)
+  ⨅-greatest : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (D : Subᴸ) → (∀ i → D ≤ 𝒜 i) → D ≤ ⨅ 𝒜
   ⨅-greatest 𝒜 D D≤𝒜 z i = D≤𝒜 i z
 
-  ⨆-upper : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (i : I) → (𝒜 i) ≤ (⨆ 𝒜)
+  ⨆-upper : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (i : I) → 𝒜 i ≤ ⨆ 𝒜
   ⨆-upper 𝒜 i z = var (i , z)
 
-  ⨆-least : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (D : Subᴸ) → (∀ i → (𝒜 i) ≤ D) → (⨆ 𝒜) ≤ D
+  ⨆-least : {I : Type ℓ₀} (𝒜 : I → Subᴸ) (D : Subᴸ) → (∀ i → 𝒜 i ≤ D) → ⨆ 𝒜 ≤ D
   ⨆-least 𝒜 D 𝒜≤D = sgIsSmallest 𝑨 (proj₁ D) (proj₂ D) (λ (i , z) → 𝒜≤D i z)
 ```
 


### PR DESCRIPTION
Closes #544.  Sub-issue of #268; companion to #555 (#543), which took the rest of `Classical/Structures/`.

## What this clears

All of #544's scope: **31 definitions** whose fence carried no real prose, and the one boilerplate-only header. The subtree now reports **0 gaps and 0 weak headers**.

Nine prose blocks across six modules, plus the `Classical.Structures.Group` barrel header.

## Three blocks continue the quintuple pattern

Adapted to this structure rather than pasted from #543:

+  **`Group`** needs its own signature twice over: both the identity and the inverse are *operations*, so neither can be added to a weaker signature by equations alone. `Th-Group`'s five equations are associativity, two unit laws, two inverse laws.
+  **`Group-Op`** rebuilds the interface from `Sig-Group` directly, inheriting nothing, because its forgetful to monoids is a reduct along a signature morphism and so carries nothing down. Three operations, two congruences, three containment lemmas (one per symbol), five laws; the inverse laws are the longest of the five because they mention all three operations.
+  **`abelianGroup→group` and `AbelianGroup-Op`** are the cheap shape: an abelian group adds an equation, not an operation, so the signature is unchanged and the forgetful only re-indexes the satisfaction witness. `AbelianGroup-Op` inherits the entire group interface and adds exactly two names.

## Six blocks are group theory proper

Each says what the result is *for*, not what its type says:

+  **`Cosets`**: `≈⇒∼` is what makes the quotient map well defined (equal elements land in the same coset), and `∼-congˡ` is what lets left translation descend to the coset space. Both discharge by handing `respects` an equality between `x ⁻¹ ∙ y` witnesses. The second is what `GSet` consumes.
+  **`GSet`**: the two action laws and transitivity, each a group law transported across `≈⇒∼`. Transitivity is the substantive one: it says `G/H` is a single orbit, which is why a coset space is the model case of a transitive action, and it is proved by *exhibiting* `y ∙ x ⁻¹` rather than by an existence argument, which is what keeps it computational.
+  **`NormalCore`**: the four properties that together say the core is the largest normal subgroup inside `H`. `core-greatest` is picked out as the one that makes the core a construction rather than merely a subgroup: it is characterised by a universal property, which determines it up to mutual inclusion.
+  **`Centralizer`**: `normals-centralize` is the classical commutator argument. The commutator lies in `M` by normality of `M` and in `N` by normality of `N`, so trivial intersection forces it to `ε`. It is the one place both normality hypotheses are used, and it is what makes an internal direct product decomposition possible.

## The barrel header

Nineteen submodules, mapped thematically (structures, subgroups, normality, cosets and actions, constructions) rather than listed, since a nineteen-item list would be noise. It also states what a group *is* in this tree: an algebra over `Sig-Group` satisfying `Th-Group`, with no appeal to the standard library's bundles except through `Classical.Bundles.Group`.

## The ratchet

The branch is rebased onto master after #551, #552, and #555 merged, and the ceilings are re-measured on the rebased tree: `DOCSTRING_MAX_GAPS` 102 to **71**, `DOCSTRING_MAX_WEAK_HEADERS` 20 to **19**, exactly the 31 and 1 this branch clears. This is the last branch of the parallel four, so no ratchet conflict remains. To confirm the numbers, re-measure rather than trust the arithmetic:

```
python3 scripts/python/docstring_audit.py --modules --exit-zero src | grep -E '^TOTAL|no real header'
```

The rebase also collapses a duplicated `DOCSTRING_MAX_WEAK_HEADERS` block in the `Makefile`, a leftover from the conflict resolution merged with #555 (`?=` made the first assignment win, so the gate was never affected).

## Copilot round 1

Two findings, both accepted, fixed in 90649b24 with a reply on each thread:

+  `NormalCore`: "determined up to nothing at all" overstated the universal property; it determines the core up to mutual inclusion, which in intensional Agda is not definitional equality.
+  `GSet`: transitivity is not one of the action laws; the prose now separates the two axioms from it.

The same commit replaces the five em-dashes this branch had introduced (none remain in its added prose) and leaves pre-existing em-dashes in these files untouched.

## Verification

+  **Prose-only.** Fence contents extracted from `HEAD` and `master` with the repository's own `extract_agda_lines`: byte-identical, **7 of 7**, re-verified after the review-fix commit.
+  `make check` green on the pre-fix tree; the four modules touched by the fix re-checked individually (prose-only, so fence bytes are unchanged).
+  `make check-links` green (322 pages); `docs/_links.md` unchanged.
+  `make docstrings` exit 0 at the new ceilings; `make docstrings-test` 72/72.
+  No dangling footnote reference; split-attribute-span check clean tree-wide.
