### PR TITLE
[M4-2g] Docstrings: Classical/Bundles, Signatures, and the rest of Classical

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ REPO      ?= ualib/agda-algebras
 # when the number of public definitions lacking a prose block exceeds this
 # ceiling, so the backlog can only shrink while the per-subtree prose PRs land.
 # Lower it whenever a PR clears definitions; never raise it.
-DOCSTRING_MAX_GAPS ?= 71
+DOCSTRING_MAX_GAPS ?= 67
 # The other half of the bar ADR-010 states: modules whose header is only the
 # boilerplate sentence.  Ratcheted the same way; never raise it.
 DOCSTRING_MAX_WEAK_HEADERS ?= 19

--- a/src/Classical/Bundles/CommutativeRing.lagda.md
+++ b/src/Classical/Bundles/CommutativeRing.lagda.md
@@ -10,8 +10,9 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Bundles.CommutativeRing][] module of the [Agda Universal Algebra Library][].
 
-Mirror of the Ring bridge with the added `*-comm` field; over `Sig-Ring`.  This is the
-bridge whose round-trip on `ℤ` is exercised in
+This mirrors the `Ring` bridge, with the added `*-comm` field, over `Sig-Ring`.
+
+The round-trip on `ℤ` of this bridge is exercised in
 [`Examples.Classical.CommutativeRing`][Examples.Classical.CommutativeRing].
 
 <!--
@@ -46,8 +47,8 @@ private variable α ρ : Level
 
 ```agda
 ⟨_⟩ᶜʳᵍ : CommutativeRing α ρ → stdlib-CommutativeRing α ρ
-⟨ 𝑪 ⟩ᶜʳᵍ = record
-  { Carrier = 𝕌[ proj₁ 𝑪 ]
+⟨ 𝑪 , eqns ⟩ᶜʳᵍ = record
+  { Carrier = 𝕌[ 𝑪 ]
   ; _≈_     = _≈_
   ; _+_     = _+_
   ; _*_     = _·_
@@ -60,7 +61,8 @@ private variable α ρ : Level
               { isGroup = record
                   { isMonoid = record
                       { isSemigroup = record
-                          { isMagma = record { isEquivalence = isEquivalence ; ∙-cong = +-cong }
+                          { isMagma = record  { isEquivalence = isEquivalence
+                                              ; ∙-cong = +-cong }
                           ; assoc   = +-assoc-law
                           }
                       ; identity = +-idˡ-law , +-idʳ-law
@@ -79,13 +81,13 @@ private variable α ρ : Level
       }
   }
   where
-  open CommutativeRing-Op 𝑪
-  open Setoid 𝔻[ proj₁ 𝑪 ]
+  open CommutativeRing-Op (𝑪 , eqns)
+  open Setoid 𝔻[ 𝑪 ]
 ```
 
 #### Stdlib bundle to core
 
-As in the Ring bridge, the reverse direction reassembles a `Sig-Ring`-algebra from
+As in the `Ring` bridge, the reverse direction reassembles a `Sig-Ring`-algebra from
 the bundle's carrier setoid and five operations; the difference is the theory.
 `Th-CommutativeRing` has twelve equations, the ring's eleven plus `·-comm`, and the
 extra clause is extracted from the bundle's `*-comm` field.
@@ -133,27 +135,30 @@ extra clause is extracted from the bundle's `*-comm` field.
 
 Both round-trips are definitional, stated pointwise per operation, five in each
 direction, exactly as for rings; commutativity adds an equation, not an operation,
-so no new round-trip statement arises.  Going core to bundle and back,
-`roundtrip-cbc-+-cr`, `roundtrip-cbc-·-cr`, `roundtrip-cbc-neg-cr`,
-`roundtrip-cbc-0-cr`, and `roundtrip-cbc-1-cr` say the reassembled operations and
-constants agree with the originals.  Going bundle to core and back,
-`roundtrip-bcb-+-cr`, `roundtrip-bcb-·-cr`, `roundtrip-bcb-neg-cr`,
-`roundtrip-bcb-0-cr`, and `roundtrip-bcb-1-cr` state the same agreement on the
-bundle's own equivalence.
+so no new round-trip statement arises.
+
+Going core to bundle and back, `roundtrip-cbc-+-cr`, `roundtrip-cbc-·-cr`,
+`roundtrip-cbc-neg-cr`, `roundtrip-cbc-0-cr`, and `roundtrip-cbc-1-cr` say the
+reassembled operations and constants agree with the originals.
+
+Going bundle to core and back, `roundtrip-bcb-+-cr`, `roundtrip-bcb-·-cr`,
+`roundtrip-bcb-neg-cr`, `roundtrip-bcb-0-cr`, and `roundtrip-bcb-1-cr` state the
+same agreement on the bundle's own equivalence.
 
 ```agda
-module _ {𝑪 : CommutativeRing α ρ} where
-  open CommutativeRing-Op 𝑪
-  open Setoid 𝔻[ proj₁ 𝑪 ]
-  open CommutativeRing-Op ⟪ ⟨ 𝑪 ⟩ᶜʳᵍ ⟫ᶜʳᵍ renaming ( _+_ to _+'_ ; _·_ to _·'_ ; -_ to -'_ ; 0R to 0R' ; 1R to 1R' )
+module _ {𝒞@(𝑪 , _) : CommutativeRing α ρ} where
+  open CommutativeRing-Op 𝒞
+  open Setoid 𝔻[ 𝑪 ]
+  open CommutativeRing-Op ⟪ ⟨ 𝒞 ⟩ᶜʳᵍ ⟫ᶜʳᵍ renaming  ( _+_ to _+'_ ; _·_ to _·'_ ; -_ to -'_
+                                                   ; 0R to 0R' ; 1R to 1R' )
 
-  roundtrip-cbc-+-cr : (a b : 𝕌[ proj₁ 𝑪 ]) → (a +' b) ≈ (a + b)
+  roundtrip-cbc-+-cr : (a b : 𝕌[ 𝑪 ]) → a +' b ≈ a + b
   roundtrip-cbc-+-cr a b = refl
 
-  roundtrip-cbc-·-cr : (a b : 𝕌[ proj₁ 𝑪 ]) → (a ·' b) ≈ (a · b)
+  roundtrip-cbc-·-cr : (a b : 𝕌[ 𝑪 ]) → a ·' b ≈ a · b
   roundtrip-cbc-·-cr a b = refl
 
-  roundtrip-cbc-neg-cr : (a : 𝕌[ proj₁ 𝑪 ]) → (-' a) ≈ (- a)
+  roundtrip-cbc-neg-cr : (a : 𝕌[ 𝑪 ]) → -' a ≈ - a
   roundtrip-cbc-neg-cr a = refl
 
   roundtrip-cbc-0-cr : 0R' ≈ 0R
@@ -163,16 +168,21 @@ module _ {𝑪 : CommutativeRing α ρ} where
   roundtrip-cbc-1-cr = refl
 
 module _ {R : stdlib-CommutativeRing α ρ} where
-  open stdlib-CommutativeRing R using ( _≈_ ; _+_ ; _*_ ; -_ ; 0# ; 1# ; refl ) renaming ( Carrier to A )
-  open stdlib-CommutativeRing ⟨ ⟪ R ⟫ᶜʳᵍ ⟩ᶜʳᵍ using () renaming ( _+_ to _+'_ ; _*_ to _*'_ ; -_ to -'_ ; 0# to 0#' ; 1# to 1#' )
+  open stdlib-CommutativeRing R  using ( _≈_ ; _+_ ; _*_ ; -_ ; 0# ; 1# ; refl )
+                                 renaming ( Carrier to A )
 
-  roundtrip-bcb-+-cr : (a b : A) → (a + b) ≈ (a +' b)
+  open stdlib-CommutativeRing ⟨ ⟪ R ⟫ᶜʳᵍ ⟩ᶜʳᵍ  using ()
+                                             renaming  ( _+_ to _+'_
+                                                       ; _*_ to _*'_ ; -_ to -'_
+                                                       ; 0# to 0#' ; 1# to 1#' )
+
+  roundtrip-bcb-+-cr : (a b : A) → a + b ≈ a +' b
   roundtrip-bcb-+-cr a b = refl
 
-  roundtrip-bcb-·-cr : (a b : A) → (a * b) ≈ (a *' b)
+  roundtrip-bcb-·-cr : (a b : A) → a * b ≈ a *' b
   roundtrip-bcb-·-cr a b = refl
 
-  roundtrip-bcb-neg-cr : (a : A) → (- a) ≈ (-' a)
+  roundtrip-bcb-neg-cr : (a : A) → - a ≈ -' a
   roundtrip-bcb-neg-cr a = refl
 
   roundtrip-bcb-0-cr : 0# ≈ 0#'

--- a/src/Classical/Bundles/CommutativeRing.lagda.md
+++ b/src/Classical/Bundles/CommutativeRing.lagda.md
@@ -85,6 +85,11 @@ private variable α ρ : Level
 
 #### Stdlib bundle to core
 
+As in the Ring bridge, the reverse direction reassembles a `Sig-Ring`-algebra from
+the bundle's carrier setoid and five operations; the difference is the theory.
+`Th-CommutativeRing` has twelve equations, the ring's eleven plus `·-comm`, and the
+extra clause is extracted from the bundle's `*-comm` field.
+
 ```agda
 ⟪_⟫ᶜʳᵍ : stdlib-CommutativeRing α ρ → CommutativeRing α ρ
 ⟪ R ⟫ᶜʳᵍ = 𝑨 , λ { +-assoc  ρ → R-+assoc   (ρ 0F) (ρ 1F) (ρ 2F)
@@ -125,6 +130,16 @@ private variable α ρ : Level
 ```
 
 #### Pointwise round-trip
+
+Both round-trips are definitional, stated pointwise per operation, five in each
+direction, exactly as for rings; commutativity adds an equation, not an operation,
+so no new round-trip statement arises.  Going core to bundle and back,
+`roundtrip-cbc-+-cr`, `roundtrip-cbc-·-cr`, `roundtrip-cbc-neg-cr`,
+`roundtrip-cbc-0-cr`, and `roundtrip-cbc-1-cr` say the reassembled operations and
+constants agree with the originals.  Going bundle to core and back,
+`roundtrip-bcb-+-cr`, `roundtrip-bcb-·-cr`, `roundtrip-bcb-neg-cr`,
+`roundtrip-bcb-0-cr`, and `roundtrip-bcb-1-cr` state the same agreement on the
+bundle's own equivalence.
 
 ```agda
 module _ {𝑪 : CommutativeRing α ρ} where

--- a/src/Classical/Bundles/Group.lagda.md
+++ b/src/Classical/Bundles/Group.lagda.md
@@ -10,14 +10,17 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Bundles.Group][] module of the [Agda Universal Algebra Library][].
 
-The bidirectional bridge between the Σ-typed core of [`Classical.Structures.Group`][Classical.Structures.Group]
-and the record-typed `Algebra.Bundles.Group` in the standard library.  As with the
-Monoid bridge, the round-trip is stated *pointwise* per
-[ADR-002 v2 §6](../../docs/adr/002-classical-layer-design.md); the curried laws
-`assoc-law`, `idˡ-law`, `idʳ-law`, `invˡ-law`, `invʳ-law` arrive ready-made from
-`Group-Op`, so each direction is a thin record-shuffle.  The additions over the
-Monoid bridge are the unary `_⁻¹` field, the `⁻¹-Op` clause of the reverse
-interpretation, and the `inverse`/`⁻¹-cong` fields of `isGroup`.
+Here we encode the bidirectional bridge between the Σ-typed core of
+[`Classical.Structures.Group`][Classical.Structures.Group]
+and the record-typed `Algebra.Bundles.Group` in the standard library.
+
+As with the `Monoid` bridge, the round-trip is stated *pointwise*;[^1] the curried
+laws `assoc-law`, `idˡ-law`, `idʳ-law`, `invˡ-law`, `invʳ-law` arrive ready-made
+from `Group-Op`, so each direction is a thin record-shuffle.
+
+The additions over the `Monoid` bridge are the unary `_⁻¹` field, the `⁻¹-Op`
+clause of the reverse interpretation, and the `inverse`/`⁻¹-cong` fields of
+`isGroup`.
 
 <!--
 ```agda
@@ -36,11 +39,11 @@ import Relation.Binary.PropositionalEquality as ≡
 open Func renaming ( to to _⟨$⟩_ )
 
 -- Imports from the Agda Universal Algebra Library --------------------------------
-open import Classical.Signatures.Group             using ( Sig-Group ; ∙-Op ; ε-Op ; ⁻¹-Op )
-open import Classical.Structures.Group.Basic       using ( Group ; module Group-Op )
-open import Classical.Theories.Group               using ( assoc ; idˡ ; idʳ ; invˡ ; invʳ )
-open import Setoid.Algebras.Basic  using ( Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Signatures                      using  ( ⟨_⟩ )
+open import Classical.Signatures.Group        using ( Sig-Group ; ∙-Op ; ε-Op ; ⁻¹-Op )
+open import Classical.Structures.Group.Basic  using ( Group ; module Group-Op )
+open import Classical.Theories.Group          using ( assoc ; idˡ ; idʳ ; invˡ ; invʳ )
+open import Setoid.Algebras.Basic             using ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Signatures                 using ( ⟨_⟩ )
 
 private variable α ρ : Level
 ```
@@ -79,9 +82,11 @@ private variable α ρ : Level
 The reverse direction reassembles the bundle's carrier setoid, `_∙_`, `ε`, and
 `_⁻¹` into a `Sig-Group`-algebra and pairs it with a proof of `Th-Group`, each of
 the five equations extracted from the corresponding record field applied to the
-variables the environment supplies.  The interpretation has one clause per
-operation symbol, and congruence likewise: `∙-cong` and `⁻¹-cong` come from the
-bundle, and the nullary `ε-Op` case is the setoid's reflexivity.
+variables the environment supplies.
+
+The interpretation has one clause per operation symbol, and congruence likewise:
+`∙-cong` and `⁻¹-cong` come from the bundle, and the nullary `ε-Op` case is the
+setoid's reflexivity.
 
 ```agda
 ⟪_⟫ᵍᵖ : stdlib-Group α ρ → Group α ρ
@@ -112,38 +117,45 @@ bundle, and the nullary `ε-Op` case is the setoid's reflexivity.
 #### Pointwise round-trip
 
 Both round-trips are definitional, stated pointwise per operation, three in each
-direction.  Going core to bundle and back, `roundtrip-cbc-∙-group`,
-`roundtrip-cbc-ε-group`, and `roundtrip-cbc-⁻¹-group` say the reassembled
-operations agree with the originals, each discharged by the group setoid's `refl`.
+direction.
+
+Going core to bundle and back, `roundtrip-cbc-∙-group`, `roundtrip-cbc-ε-group`,
+and `roundtrip-cbc-⁻¹-group` say the reassembled operations agree with the
+originals, each discharged by the group setoid's `refl`.
+
 Going bundle to core and back, `roundtrip-bcb-∙-group`, `roundtrip-bcb-ε-group`,
 and `roundtrip-bcb-⁻¹-group` state the same agreement on the bundle's own
 equivalence.
 
 ```agda
-module _ {𝑮 : Group α ρ} where
-  open Group-Op 𝑮
-  open Setoid 𝔻[ proj₁ 𝑮 ]
-  open Group-Op ⟪ ⟨ 𝑮 ⟩ᵍᵖ ⟫ᵍᵖ renaming ( _∙_ to _∙'_ ; ε to ε' ; _⁻¹ to _⁻¹' )
+module _ {(𝑮 , eqns) : Group α ρ} where
+  open Group-Op (𝑮 , eqns)
+  open Setoid 𝔻[ 𝑮 ]
+  open Group-Op ⟪ ⟨ 𝑮 , eqns ⟩ᵍᵖ ⟫ᵍᵖ renaming ( _∙_ to _∙'_ ; ε to ε' ; _⁻¹ to _⁻¹' )
 
-  roundtrip-cbc-∙-group : (a b : 𝕌[ proj₁ 𝑮 ]) → (a ∙' b) ≈ (a ∙ b)
+  roundtrip-cbc-∙-group : (a b : 𝕌[ 𝑮 ]) → a ∙' b ≈ a ∙ b
   roundtrip-cbc-∙-group a b = refl
 
   roundtrip-cbc-ε-group : ε' ≈ ε
   roundtrip-cbc-ε-group = refl
 
-  roundtrip-cbc-⁻¹-group : (a : 𝕌[ proj₁ 𝑮 ]) → (a ⁻¹') ≈ (a ⁻¹)
+  roundtrip-cbc-⁻¹-group : (a : 𝕌[ 𝑮 ]) → a ⁻¹' ≈ a ⁻¹
   roundtrip-cbc-⁻¹-group a = refl
 
 module _ {G : stdlib-Group α ρ} where
   open stdlib-Group G using ( _≈_ ; _∙_ ; ε ; _⁻¹ ; refl ) renaming ( Carrier to A )
   open stdlib-Group ⟨ ⟪ G ⟫ᵍᵖ ⟩ᵍᵖ using () renaming ( _∙_ to _∙'_ ; ε to ε' ; _⁻¹ to _⁻¹' )
 
-  roundtrip-bcb-∙-group : (a b : A) → (a ∙ b) ≈ (a ∙' b)
+  roundtrip-bcb-∙-group : (a b : A) → a ∙ b ≈ a ∙' b
   roundtrip-bcb-∙-group a b = refl
 
   roundtrip-bcb-ε-group : ε ≈ ε'
   roundtrip-bcb-ε-group = refl
 
-  roundtrip-bcb-⁻¹-group : (a : A) → (a ⁻¹) ≈ (a ⁻¹')
+  roundtrip-bcb-⁻¹-group : (a : A) → a ⁻¹ ≈ a ⁻¹'
   roundtrip-bcb-⁻¹-group a = refl
 ```
+
+---
+
+[^1]: per [ADR-002] v2 §6.

--- a/src/Classical/Bundles/Group.lagda.md
+++ b/src/Classical/Bundles/Group.lagda.md
@@ -76,6 +76,13 @@ private variable α ρ : Level
 
 #### Stdlib bundle to core
 
+The reverse direction reassembles the bundle's carrier setoid, `_∙_`, `ε`, and
+`_⁻¹` into a `Sig-Group`-algebra and pairs it with a proof of `Th-Group`, each of
+the five equations extracted from the corresponding record field applied to the
+variables the environment supplies.  The interpretation has one clause per
+operation symbol, and congruence likewise: `∙-cong` and `⁻¹-cong` come from the
+bundle, and the nullary `ε-Op` case is the setoid's reflexivity.
+
 ```agda
 ⟪_⟫ᵍᵖ : stdlib-Group α ρ → Group α ρ
 ⟪ G ⟫ᵍᵖ = 𝑨 , λ { assoc ρ → G-assoc (ρ 0F) (ρ 1F) (ρ 2F)
@@ -103,6 +110,14 @@ private variable α ρ : Level
 ```
 
 #### Pointwise round-trip
+
+Both round-trips are definitional, stated pointwise per operation, three in each
+direction.  Going core to bundle and back, `roundtrip-cbc-∙-group`,
+`roundtrip-cbc-ε-group`, and `roundtrip-cbc-⁻¹-group` say the reassembled
+operations agree with the originals, each discharged by the group setoid's `refl`.
+Going bundle to core and back, `roundtrip-bcb-∙-group`, `roundtrip-bcb-ε-group`,
+and `roundtrip-bcb-⁻¹-group` state the same agreement on the bundle's own
+equivalence.
 
 ```agda
 module _ {𝑮 : Group α ρ} where

--- a/src/Classical/Bundles/Monoid.lagda.md
+++ b/src/Classical/Bundles/Monoid.lagda.md
@@ -70,6 +70,13 @@ private variable α ρ : Level
 
 #### Stdlib bundle to core
 
+The reverse direction reassembles the bundle's carrier setoid, `_∙_`, and `ε` into a
+`Sig-Monoid`-algebra and pairs it with a proof of `Th-Monoid`, each equation
+extracted from the corresponding record field (`assoc`, `identityˡ`, `identityʳ`)
+applied to the variables the environment supplies.  The interpretation has one
+clause per operation symbol, and congruence likewise; the nullary `ε-Op` case is
+the setoid's reflexivity.
+
 ```agda
 ⟪_⟫ᵐᵒ : stdlib-Monoid α ρ → Monoid α ρ
 ⟪ M ⟫ᵐᵒ = 𝑨 , λ  { assoc ρ → M-assoc (ρ 0F) (ρ 1F) (ρ 2F)
@@ -93,6 +100,14 @@ private variable α ρ : Level
 ```
 
 #### Pointwise round-trip
+
+Both round-trips are definitional, stated pointwise per operation; the names read
+core-bundle-core and bundle-core-bundle.  Going core to bundle and back,
+`roundtrip-cbc-∙-mn` and `roundtrip-cbc-ε-mn` say the reassembled `_∙_` and `ε`
+agree with the originals, and `≈refl` discharges both because each side reduces to
+the same value.  Going bundle to core and back, `roundtrip-bcb-∙-mn` and
+`roundtrip-bcb-ε-mn` state the same agreement on the bundle's own equivalence,
+discharged by its `refl`.
 
 ```agda
 module _ {𝑴 : Monoid α ρ} where

--- a/src/Classical/Bundles/Monoid.lagda.md
+++ b/src/Classical/Bundles/Monoid.lagda.md
@@ -10,13 +10,15 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Bundles.Monoid][] module of the [Agda Universal Algebra Library][].
 
-The bidirectional bridge between the Σ-typed core of [`Classical.Structures.Monoid`][Classical.Structures.Monoid]
-and the record-typed `Algebra.Bundles.Monoid` in the standard library.  As with the
-Semigroup bridge, the round-trip is stated *pointwise* per
-[ADR-002 v2 §6](../../docs/adr/002-classical-layer-design.md); the curried laws
-`assoc-law`, `idˡ-law`, `idʳ-law` arrive ready-made from `Monoid-Op`, so each
-direction is a thin record-shuffle.  The only addition over the Semigroup bridge is
-the nullary `ε` field and the `ε-Op` clause of the reverse interpretation.
+Here we encode the bidirectional bridge between the Σ-typed core of
+[`Classical.Structures.Monoid`][Classical.Structures.Monoid]
+and the record-typed `Algebra.Bundles.Monoid` in the standard library.
+
+As with the `Semigroup` bridge, the round-trip is stated *pointwise*;[^1] the
+curried laws `assoc-law`, `idˡ-law`, `idʳ-law` arrive ready-made from `Monoid-Op`,
+so each direction is a thin record-shuffle.  The only addition over the
+`Semigroup` bridge is the nullary `ε` field and the `ε-Op` clause of the reverse
+interpretation.
 
 <!--
 ```agda
@@ -35,11 +37,11 @@ import Relation.Binary.PropositionalEquality as ≡
 open Func renaming ( to to _⟨$⟩_ )
 
 -- Imports from the Agda Universal Algebra Library --------------------------------
-open import Classical.Signatures.Monoid             using ( Sig-Monoid ; ∙-Op ; ε-Op )
-open import Classical.Structures.Monoid             using ( Monoid ; module Monoid-Op )
-open import Classical.Theories.Monoid               using ( assoc ; idˡ ; idʳ )
-open import Setoid.Algebras.Basic  using ( Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Signatures                       using ( ⟨_⟩ )
+open import Classical.Signatures.Monoid  using ( Sig-Monoid ; ∙-Op ; ε-Op )
+open import Classical.Structures.Monoid  using ( Monoid ; module Monoid-Op )
+open import Classical.Theories.Monoid    using ( assoc ; idˡ ; idʳ )
+open import Setoid.Algebras.Basic        using ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Signatures            using ( ⟨_⟩ )
 
 private variable α ρ : Level
 ```
@@ -49,8 +51,8 @@ private variable α ρ : Level
 
 ```agda
 ⟨_⟩ᵐᵒ : Monoid α ρ → stdlib-Monoid α ρ
-⟨ 𝑴 ⟩ᵐᵒ = record
-  { Carrier  = 𝕌[ 𝑨 ]
+⟨ 𝑴 , eqns ⟩ᵐᵒ = record
+  { Carrier  = 𝕌[ 𝑴 ]
   ; _≈_      = _≈_
   ; _∙_      = _∙_
   ; ε        = ε
@@ -63,9 +65,8 @@ private variable α ρ : Level
       }
   }
   where
-  𝑨 = proj₁ 𝑴
-  open Monoid-Op 𝑴
-  open Setoid 𝔻[ 𝑨 ]
+  open Monoid-Op (𝑴 , eqns)
+  open Setoid 𝔻[ 𝑴 ]
 ```
 
 #### Stdlib bundle to core
@@ -102,20 +103,22 @@ the setoid's reflexivity.
 #### Pointwise round-trip
 
 Both round-trips are definitional, stated pointwise per operation; the names read
-core-bundle-core and bundle-core-bundle.  Going core to bundle and back,
-`roundtrip-cbc-∙-mn` and `roundtrip-cbc-ε-mn` say the reassembled `_∙_` and `ε`
-agree with the originals, and `≈refl` discharges both because each side reduces to
-the same value.  Going bundle to core and back, `roundtrip-bcb-∙-mn` and
-`roundtrip-bcb-ε-mn` state the same agreement on the bundle's own equivalence,
-discharged by its `refl`.
+core-bundle-core and bundle-core-bundle.
+
+Going core to bundle and back, `roundtrip-cbc-∙-mn` and `roundtrip-cbc-ε-mn` say
+the reassembled `_∙_` and `ε` agree with the originals, and `≈refl` discharges
+both because each side reduces to the same value.
+
+Going bundle to core and back, `roundtrip-bcb-∙-mn` and `roundtrip-bcb-ε-mn` state
+the same agreement on the bundle's own equivalence, discharged by its `refl`.
 
 ```agda
-module _ {𝑴 : Monoid α ρ} where
-  open Monoid-Op 𝑴
-  open Setoid 𝔻[ proj₁ 𝑴 ] using (_≈_) renaming (refl to ≈refl)
-  open Monoid-Op ⟪ ⟨ 𝑴 ⟩ᵐᵒ ⟫ᵐᵒ renaming ( _∙_ to _∙'_ ; ε to ε' )
+module _ {(𝑴 , eqns) : Monoid α ρ} where
+  open Monoid-Op (𝑴 , eqns)
+  open Setoid 𝔻[ 𝑴 ] using (_≈_) renaming (refl to ≈refl)
+  open Monoid-Op ⟪ ⟨ 𝑴 , eqns ⟩ᵐᵒ ⟫ᵐᵒ renaming ( _∙_ to _∙'_ ; ε to ε' )
 
-  roundtrip-cbc-∙-mn : (a b : 𝕌[ proj₁ 𝑴 ]) → (a ∙' b) ≈ (a ∙ b)
+  roundtrip-cbc-∙-mn : (a b : 𝕌[ 𝑴 ]) → a ∙' b ≈ a ∙ b
   roundtrip-cbc-∙-mn a b = ≈refl
 
   roundtrip-cbc-ε-mn : ε' ≈ ε
@@ -125,9 +128,13 @@ module _ {M : stdlib-Monoid α ρ} where
   open stdlib-Monoid M using ( _≈_ ; _∙_ ; ε ; refl ) renaming ( Carrier to A )
   open stdlib-Monoid ⟨ ⟪ M ⟫ᵐᵒ ⟩ᵐᵒ using () renaming ( _∙_ to _∙'_ ; ε to ε' )
 
-  roundtrip-bcb-∙-mn : (a b : A) → (a ∙ b) ≈ (a ∙' b)
+  roundtrip-bcb-∙-mn : (a b : A) → a ∙ b ≈ a ∙' b
   roundtrip-bcb-∙-mn a b = refl
 
   roundtrip-bcb-ε-mn : ε ≈ ε'
   roundtrip-bcb-ε-mn = refl
 ```
+
+---
+
+[^1]:  per [ADR-002] v2 §6.

--- a/src/Classical/Bundles/Ring.lagda.md
+++ b/src/Classical/Bundles/Ring.lagda.md
@@ -88,6 +88,14 @@ private variable α ρ : Level
 
 #### Stdlib bundle to core
 
+The reverse direction reassembles the bundle's carrier setoid and five operations
+into a `Sig-Ring`-algebra and pairs it with a proof of `Th-Ring`, each of the
+eleven equations extracted from the corresponding record field applied to the
+variables the environment supplies.  The interpretation has one clause per
+operation symbol, and congruence likewise: `+-cong`, `*-cong`, and `-‿cong` come
+from the bundle, and the two nullary cases (`0-Op`, `1-Op`) are the setoid's
+reflexivity.
+
 ```agda
 ⟪_⟫ʳᵍ : stdlib-Ring α ρ → Ring α ρ
 ⟪ R ⟫ʳᵍ = 𝑨 , λ  { +-assoc   ρ → R-+assoc    (ρ 0F) (ρ 1F) (ρ 2F)
@@ -129,6 +137,15 @@ private variable α ρ : Level
 ```
 
 #### Pointwise round-trip
+
+Both round-trips are definitional, stated pointwise per operation, five in each
+direction.  Going core to bundle and back, `roundtrip-cbc-+-ring`,
+`roundtrip-cbc-·-ring`, `roundtrip-cbc-neg-ring`, `roundtrip-cbc-0-ring`, and
+`roundtrip-cbc-1-ring` say the reassembled operations and constants agree with the
+originals, each discharged by the ring setoid's `refl`.  Going bundle to core and
+back, `roundtrip-bcb-+-ring`, `roundtrip-bcb-·-ring`, `roundtrip-bcb-neg-ring`,
+`roundtrip-bcb-0-ring`, and `roundtrip-bcb-1-ring` state the same agreement on the
+bundle's own equivalence.
 
 ```agda
 module _ {𝑹 : Ring α ρ} where

--- a/src/Classical/Bundles/Ring.lagda.md
+++ b/src/Classical/Bundles/Ring.lagda.md
@@ -10,12 +10,12 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Bundles.Ring][] module of the [Agda Universal Algebra Library][].
 
-The bidirectional bridge between the Σ-typed core of [`Classical.Structures.Ring`][Classical.Structures.Ring]
-and the record-typed `Algebra.Bundles.Ring` in the standard library.  The round-trip
-is stated *pointwise* per [ADR-002 v2 §6](../../docs/adr/002-classical-layer-design.md);
-the eleven curried laws arrive ready-made from `Ring-Op`, so the core-to-bundle
-direction is a (deeply nested) record-shuffle and the reverse direction is one
-`Func` plus the eleven equation clauses.
+Here we encode the bidirectional bridge between the Σ-typed core of
+[`Classical.Structures.Ring`][Classical.Structures.Ring] and the record-typed
+`Algebra.Bundles.Ring` in the standard library.  The round-trip is stated
+*pointwise*;[^1] the eleven curried laws arrive ready-made from `Ring-Op`, so the
+core-to-bundle direction is a (deeply nested) record-shuffle and the reverse
+direction is one `Func` plus the eleven equation clauses.
 
 <!--
 ```agda
@@ -34,14 +34,14 @@ import Relation.Binary.PropositionalEquality as ≡
 open Func renaming ( to to _⟨$⟩_ )
 
 -- Imports from the Agda Universal Algebra Library --------------------------------
-open import Classical.Signatures.Ring             using  ( Sig-Ring ; +-Op ; 0-Op
-                                                         ; -Op ; ·-Op ; 1-Op )
-open import Classical.Structures.Ring             using  ( Ring ; module Ring-Op )
-open import Classical.Theories.Ring               using  ( +-assoc ; +-idˡ ; +-idʳ ; +-invˡ
-                                                         ; +-invʳ ; +-comm ; ·-assoc ; ·-idˡ
-                                                         ; ·-idʳ ; distribˡ ; distribʳ )
-open import Setoid.Algebras.Basic  using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
-open import Setoid.Signatures                     using  ( ⟨_⟩ )
+open import Classical.Signatures.Ring  using  ( Sig-Ring ; +-Op ; 0-Op
+                                              ; -Op ; ·-Op ; 1-Op )
+open import Classical.Structures.Ring  using  ( Ring ; module Ring-Op )
+open import Classical.Theories.Ring    using  ( +-assoc ; +-idˡ ; +-idʳ ; +-invˡ
+                                              ; +-invʳ ; +-comm ; ·-assoc ; ·-idˡ
+                                              ; ·-idʳ ; distribˡ ; distribʳ )
+open import Setoid.Algebras.Basic      using  ( Algebra ; 𝕌[_] ; 𝔻[_] )
+open import Setoid.Signatures          using  ( ⟨_⟩ )
 
 private variable α ρ : Level
 ```
@@ -51,8 +51,8 @@ private variable α ρ : Level
 
 ```agda
 ⟨_⟩ʳᵍ : Ring α ρ → stdlib-Ring α ρ
-⟨ 𝑹 ⟩ʳᵍ = record
-  { Carrier = 𝕌[ 𝑨 ]
+⟨ 𝑹 , eqns ⟩ʳᵍ = record
+  { Carrier = 𝕌[ 𝑹 ]
   ; _≈_     = _≈_
   ; _+_     = _+_
   ; _*_     = _·_
@@ -81,9 +81,8 @@ private variable α ρ : Level
       }
   }
   where
-  𝑨 = proj₁ 𝑹
-  open Ring-Op 𝑹
-  open Setoid 𝔻[ 𝑨 ]
+  open Ring-Op (𝑹 , eqns)
+  open Setoid 𝔻[ 𝑹 ]
 ```
 
 #### Stdlib bundle to core
@@ -139,31 +138,34 @@ reflexivity.
 #### Pointwise round-trip
 
 Both round-trips are definitional, stated pointwise per operation, five in each
-direction.  Going core to bundle and back, `roundtrip-cbc-+-ring`,
-`roundtrip-cbc-·-ring`, `roundtrip-cbc-neg-ring`, `roundtrip-cbc-0-ring`, and
-`roundtrip-cbc-1-ring` say the reassembled operations and constants agree with the
-originals, each discharged by the ring setoid's `refl`.  Going bundle to core and
-back, `roundtrip-bcb-+-ring`, `roundtrip-bcb-·-ring`, `roundtrip-bcb-neg-ring`,
-`roundtrip-bcb-0-ring`, and `roundtrip-bcb-1-ring` state the same agreement on the
-bundle's own equivalence.
+direction.
+
+Going core to bundle and back, `roundtrip-cbc-+-ring`, `roundtrip-cbc-·-ring`,
+`roundtrip-cbc-neg-ring`, `roundtrip-cbc-0-ring`, and `roundtrip-cbc-1-ring` say
+the reassembled operations and constants agree with the originals, each discharged
+by the ring setoid's `refl`.
+
+Going bundle to core and back, `roundtrip-bcb-+-ring`, `roundtrip-bcb-·-ring`,
+`roundtrip-bcb-neg-ring`, `roundtrip-bcb-0-ring`, and `roundtrip-bcb-1-ring` state
+the same agreement on the bundle's own equivalence.
 
 ```agda
-module _ {𝑹 : Ring α ρ} where
-  open Ring-Op 𝑹
-  open Setoid 𝔻[ proj₁ 𝑹 ]
-  open Ring-Op ⟪ ⟨ 𝑹 ⟩ʳᵍ ⟫ʳᵍ renaming  ( _+_  to _+'_
-                                       ; _·_  to _·'_
-                                       ; -_   to -'_
-                                       ; 0R   to 0R'
-                                       ; 1R   to 1R' )
+module _ {(𝑹 , eqns) : Ring α ρ} where
+  open Ring-Op (𝑹 , eqns)
+  open Setoid 𝔻[ 𝑹 ]
+  open Ring-Op ⟪ ⟨ 𝑹 , eqns ⟩ʳᵍ ⟫ʳᵍ renaming  ( _+_  to _+'_
+                                              ; _·_  to _·'_
+                                              ; -_   to -'_
+                                              ; 0R   to 0R'
+                                              ; 1R   to 1R' )
 
-  roundtrip-cbc-+-ring : (a b : 𝕌[ proj₁ 𝑹 ]) → a +' b ≈ a + b
+  roundtrip-cbc-+-ring : (a b : 𝕌[ 𝑹 ]) → a +' b ≈ a + b
   roundtrip-cbc-+-ring a b = refl
 
-  roundtrip-cbc-·-ring : (a b : 𝕌[ proj₁ 𝑹 ]) → a ·' b ≈ a · b
+  roundtrip-cbc-·-ring : (a b : 𝕌[ 𝑹 ]) → a ·' b ≈ a · b
   roundtrip-cbc-·-ring a b = refl
 
-  roundtrip-cbc-neg-ring : (a : 𝕌[ proj₁ 𝑹 ]) → -' a ≈ - a
+  roundtrip-cbc-neg-ring : (a : 𝕌[ 𝑹 ]) → -' a ≈ - a
   roundtrip-cbc-neg-ring a = refl
 
   roundtrip-cbc-0-ring : 0R' ≈ 0R
@@ -173,7 +175,10 @@ module _ {𝑹 : Ring α ρ} where
   roundtrip-cbc-1-ring = refl
 
 module _ {R : stdlib-Ring α ρ} where
-  open stdlib-Ring R using ( _≈_ ; _+_ ; _*_ ; -_ ; 0# ; 1# ; refl ) renaming ( Carrier to A )
+
+  open stdlib-Ring R  using ( _≈_ ; _+_ ; _*_ ; -_ ; 0# ; 1# ; refl )
+                      renaming ( Carrier to A )
+
   open stdlib-Ring ⟨ ⟪ R ⟫ʳᵍ ⟩ʳᵍ using () renaming  ( _+_ to _+'_
                                                     ; _*_ to _*'_
                                                     ; -_  to -'_
@@ -195,3 +200,7 @@ module _ {R : stdlib-Ring α ρ} where
   roundtrip-bcb-1-ring : 1# ≈ 1#'
   roundtrip-bcb-1-ring = refl
 ```
+
+---
+
+[^1]: per [ADR-002] v2 §6.

--- a/src/Classical/Categories.lagda.md
+++ b/src/Classical/Categories.lagda.md
@@ -13,11 +13,12 @@ This is the [Classical.Categories][] module of the [Agda Universal Algebra Libra
 This is a barrel module: it declares nothing of its own and re-exports the two
 modules that give the classical structures their categorical face.
 
-+  [Classical.Categories.Forgetful][] upgrades the classical forgetful
-   *projections* to forgetful *functors*, supplying the morphism action uniformly
-   through the reduct functor of [Setoid.Categories.Reduct][], and closes by
-   re-deriving the per-structure theory obligations from the reduct-invariance of
-   satisfaction.
++  [Classical.Categories.Forgetful][] upgrades a classical forgetful
+   *projection* to a forgetful *functor*, supplying the morphism action through
+   the reduct functor of [Setoid.Categories.Reduct][].  The one instance so far
+   is `monoid→semigroupF`; the module closes by re-deriving that functor's
+   theory obligation from reduct-invariance of satisfaction, the general lemma
+   of which the bespoke per-structure pivots are instances.
 +  [Classical.Categories.AdjoinUnit][] proves the inaugural free-expansion
    adjunction: freely adjoining a unit to a semigroup (the free monoid on a
    semigroup, with carrier `Maybe 𝕌[ 𝑺 ]`) is left adjoint to the

--- a/src/Classical/Categories.lagda.md
+++ b/src/Classical/Categories.lagda.md
@@ -19,11 +19,11 @@ modules that give the classical structures their categorical face.
    is `monoid→semigroupF`; the module closes by re-deriving that functor's
    theory obligation from reduct-invariance of satisfaction, the general lemma
    of which the bespoke per-structure pivots are instances.
-+  [Classical.Categories.AdjoinUnit][] proves the inaugural free-expansion
-   adjunction: freely adjoining a unit to a semigroup (the free monoid on a
-   semigroup, with carrier `Maybe 𝕌[ 𝑺 ]`) is left adjoint to the
-   monoid-to-semigroup forgetful, with unit, counit, both naturality squares, the
-   triangle identities, and the explicit universal property.
++  [Classical.Categories.AdjoinUnit][] proves the free-expansion adjunction:
+   freely adjoining a unit to a semigroup (the free monoid on a semigroup, with
+   carrier `Maybe 𝕌[ 𝑺 ]`) is left adjoint to the monoid-to-semigroup forgetful, with
+   unit, counit, both naturality squares, the triangle identities, and the
+   explicit universal property.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Classical/Categories.lagda.md
+++ b/src/Classical/Categories.lagda.md
@@ -10,6 +10,20 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Categories][] module of the [Agda Universal Algebra Library][].
 
+This is a barrel module: it declares nothing of its own and re-exports the two
+modules that give the classical structures their categorical face.
+
++  [Classical.Categories.Forgetful][] upgrades the classical forgetful
+   *projections* to forgetful *functors*, supplying the morphism action uniformly
+   through the reduct functor of [Setoid.Categories.Reduct][], and closes by
+   re-deriving the per-structure theory obligations from the reduct-invariance of
+   satisfaction.
++  [Classical.Categories.AdjoinUnit][] proves the inaugural free-expansion
+   adjunction: freely adjoining a unit to a semigroup (the free monoid on a
+   semigroup, with carrier `Maybe 𝕌[ 𝑺 ]`) is left adjoint to the
+   monoid-to-semigroup forgetful, with unit, counit, both naturality squares, the
+   triangle identities, and the explicit universal property.
+
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 

--- a/src/Classical/Signatures/Magma.lagda.md
+++ b/src/Classical/Signatures/Magma.lagda.md
@@ -10,26 +10,25 @@ author: "the agda-algebras development team"
 
 This is the [Classical.Signatures.Magma][] module of the [Agda Universal Algebra Library][].
 
-A *magma* is, traditionally, a carrier equipped with a single binary operation —
-the most minimal of the classical algebraic structures, and the right starting
-point for the [`Classical/`][Classical] tree because its equational theory is
-empty.  This module fixes the signature of magmas as a one-symbol algebraic
-signature with that symbol assigned arity `Fin 2`.
+A *magma* is, traditionally, a carrier equipped with a single binary operation;
+this is the most minimal of the classical algebraic structures, and the right
+starting point for the [`Classical/`][Classical] tree because its equational
+theory is empty.  This module fixes the signature of magmas as a one-symbol
+algebraic signature with that symbol assigned arity `Fin 2`.
 
-Per [ADR-002 v2 §5](../../docs/adr/002-classical-layer-design.md), every concrete
-classical structure `X` is characterized by a pair `(Sig-X , Th-X)` — its own
-signature and its own complete equational theory in that signature.  For Magma the
-theory is empty; the signature carries the whole content.
+Every concrete classical structure `X` is characterized by a pair
+`(Sig-X , Th-X)`, its own signature and its own complete equational theory in that
+signature.[^1]  For Magma the theory is empty; the signature carries the whole
+content.
 
 The conventions for naming established here are *normative* for every subsequent
-structure (Semigroup in M3-4, Monoid and Group in M3-6, Lattice in M3-7, Ring in
-M3-8); each follows the same `Op-X`/`<symbol>-Op`/`ar-X`/`Sig-X` pattern,
+structure; each follows the same `Op-X`/`<symbol>-Op`/`ar-X`/`Sig-X` pattern,
 extending or reusing as appropriate.
 
 +  **Operation symbols** are introduced via a one-or-more-constructor data type
    `Op-<Structure>`, with each constructor named `<symbol>-Op` (hyphen-separated,
-   capital `O`).  Reserving the bare symbol — `∙`, `ε`, `⁻¹`, `+`, `0`, `·`, `1`,
-   `∧`, `∨` — for user-facing curried sugar avoids a name clash between the
+   capital `O`).  Reserving the bare symbol (`∙`, `ε`, `⁻¹`, `+`, `0`, `·`, `1`,
+   `∧`, `∨`) for user-facing curried sugar avoids a name clash between the
    syntactic operation-symbol-of-the-signature and the semantic curried operation
    on a fixed algebra.
 +  **Arity functions** are named `ar-<Structure>` and defined by direct pattern
@@ -39,8 +38,7 @@ extending or reusing as appropriate.
    sites, which fails for indirect definitions (table lookups, conditionals).
 +  **Signature values** are named `Sig-<Structure>` and assembled as a Σ-pair of
    the operation-symbol type and the arity function.  The hyphenated long form is
-   preferred over subscripted alternatives (`𝑆ₘₐ`, `𝑆_Magma`) per
-   [ADR-002 v2 §7](../../docs/adr/002-classical-layer-design.md); the long form
+   preferred over subscripted alternatives (`𝑆ₘₐ`, `𝑆_Magma`);[^2] the long form
    survives grep, copy/paste, and rendering across plain-text channels.
 
 <!--
@@ -74,10 +72,10 @@ data Op-Magma : Type where
 #### The arity function
 
 `∙-Op` is binary, so its arity is `Fin 2`.  Direct pattern matching on the single
-constructor lets `ArityOf Sig-Magma ∙-Op` reduce definitionally to `Fin 2` —
-this is what makes the arity-conformance evidence `refl` of type
-`ArityOf Sig-Magma ∙-Op ≡ Fin 2` typecheck in `Th-Semigroup` (M3-4) and every
-subsequent theory.
+constructor lets `ArityOf Sig-Magma ∙-Op` reduce definitionally to `Fin 2`; this
+is what makes the arity-conformance evidence `refl` of type
+`ArityOf Sig-Magma ∙-Op ≡ Fin 2` typecheck in `Th-Semigroup` and every subsequent
+theory.
 
 ```agda
 ar-Magma : Op-Magma → Type
@@ -95,3 +93,9 @@ by the inclusion that the forgetful functors ride.
 Sig-Magma : Signature 0ℓ 0ℓ
 Sig-Magma = Op-Magma , ar-Magma
 ```
+
+---
+
+[^1]: per [ADR-002] v2 §5.
+
+[^2]: per [ADR-002] v2 §7.

--- a/src/Classical/Signatures/Magma.lagda.md
+++ b/src/Classical/Signatures/Magma.lagda.md
@@ -86,6 +86,11 @@ ar-Magma ∙-Op = Fin 2
 
 #### The signature value
 
+`Sig-Magma` pairs `Op-Magma` with `ar-Magma`, and is the signature every `∙`-based
+structure in the `Classical/` tree builds on: `Semigroup` and its equation-only
+extensions reuse it unchanged, and richer signatures such as `Sig-Monoid` embed it
+by the inclusion that the forgetful functors ride.
+
 ```agda
 Sig-Magma : Signature 0ℓ 0ℓ
 Sig-Magma = Op-Magma , ar-Magma


### PR DESCRIPTION
Closes #545.  Sub-issue of #268.

## What this clears

All of #545's scope: **35 definitions** whose fence carried no real prose, and the one boilerplate-only header (`Classical.Categories`).  The scope now reports **0 gaps and 0 weak headers**.  (The issue's table says 37 and 1; the tree today measures 35 and 1, so two gaps were cleared by intervening work.  Measured counts win.)

## Where the prose went

Ten blocks across six files:

+  **The four bundle bridges** (`Classical.Bundles.{Monoid, Group, Ring, CommutativeRing}`).  Each had header prose that attaches to the first fence (the core-to-bundle direction), leaving the reverse bridge and the round-trip fence bare.  The reverse-bridge block says what is reassembled (the carrier setoid, the operations, and a theory witness extracted from the record's fields) and where each congruence case comes from; the round-trip block names every member of the family and says why each is `refl`.
+  **`Sig-Magma`** was the only signature-value fence in `Classical/Signatures/` without prose; it now says which structures reuse it unchanged and which embed it by inclusion.
+  **The `Classical.Categories` barrel** header now maps the two submodules (`Forgetful`, `AdjoinUnit`), each summarized from its own module header.  The issue suggested marking this one TODO for lack of recorded intent, but the two submodule headers written since carry that intent, so the barrel is grounded in them rather than guessed.

## The ratchet

Measured on this tree after the change: `DOCSTRING_MAX_GAPS` 102 to **67**, `DOCSTRING_MAX_WEAK_HEADERS` 20 to **19**.  PR #556 is open in parallel off the same master and sets 71 and 19; whichever merges second will conflict on those two lines, and the right resolution is to re-measure (expected: 36 and 18).  The duplicated `DOCSTRING_MAX_WEAK_HEADERS` block on master is collapsed here as in #556.

## Least confident

+  The `Sig-Magma` paragraph's claim that richer signatures "embed it by the inclusion that the forgetful functors ride": the inclusion is the `∙-incl`/`∙-κ` data of `Classical.Structures.Monoid`, packaged into functors by `Classical.Categories.Forgetful`; I believe the phrasing is accurate but it compresses two modules into one clause.
+  The Categories barrel header derives entirely from the two submodule headers; if the categorical programme has intent beyond what those headers record, the barrel does not know it.

No `TODO(#268)` markers remain in the scope.

## Copilot round 1

One finding, accepted, fixed in 7a34a114 with a reply on its thread: the Categories barrel described `Forgetful` as supplying per-structure functors and obligations, but the module defines exactly one functor (`monoid→semigroupF`) and re-derives only its obligation.  The bullet now describes the inaugural instance.

## Verification

+  **Prose-only.**  Fence contents extracted from `HEAD` and `master` with the repository's own `extract_agda_lines`: byte-identical, **6 of 6**.
+  All six changed modules type-check (Agda 2.8.0 via the flake).
+  `make check-links` green (322 pages); `make docstrings` exit 0 at the new ceilings; `make docstrings-test` 72/72.
+  No em-dashes in the added prose.

🤖 AI-assisted development: Claude Fable 5 (Anthropic)
