### PR TITLE
[M4-2h] Docstrings: Examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ REPO      ?= ualib/agda-algebras
 DOCSTRING_MAX_GAPS ?= 67
 # The other half of the bar ADR-010 states: modules whose header is only the
 # boilerplate sentence.  Ratcheted the same way; never raise it.
-DOCSTRING_MAX_WEAK_HEADERS ?= 19
+DOCSTRING_MAX_WEAK_HEADERS ?= 12
 
 # The certificate census: generated representation certificates for the FLRP
 # research track (issue #515).  Excluded from Everything.agda and checked by

--- a/src/Examples.lagda.md
+++ b/src/Examples.lagda.md
@@ -9,6 +9,22 @@ author: "the agda-algebras development team"
 
 This is the [Examples][] module of the [Agda Universal Algebra Library][].
 
+This is the aggregator for the example tree: importing it type-checks every worked
+example in the library.  The submodules group the examples by flavour, as follows:
+
++  [Examples.Classical][] pairs one worked instance with each classical structure:
+   canonical first examples, finite groups from Cayley tables, the two-element
+   lattices, and deliberate failure modes such as a magma that is not a semigroup.
++  [Examples.Demos][] collects self-contained demonstrations, among them the
+   frozen literate artifact of the TYPES 2021 paper.
++  [Examples.FunctionTypeBijections][] and [Examples.PolynomialFunctors][] are
+   illustrative studies relocated out of the Legacy tree: n-ary function encodings
+   and their η-obstructions, and polynomial functors with W-types.
++  [Examples.Setoid][] exercises the generic `Setoid/` machinery directly: free
+   algebras, presentations, quotients, and Birkhoff's HSP theorem specialized to a
+   concrete algebra.
++  [Examples.Structures][] instantiates the general operations-and-relations
+   structures of the frozen Legacy tree.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Examples.lagda.md
+++ b/src/Examples.lagda.md
@@ -9,12 +9,13 @@ author: "the agda-algebras development team"
 
 This is the [Examples][] module of the [Agda Universal Algebra Library][].
 
-This is the aggregator for the example tree: importing it type-checks every worked
-example in the library.  The submodules group the examples by flavour, as follows:
+This is the aggregator for the example tree.  The submodules group the examples by
+flavour, as follows:
 
-+  [Examples.Classical][] pairs one worked instance with each classical structure:
-   canonical first examples, finite groups from Cayley tables, the two-element
-   lattices, and deliberate failure modes such as a magma that is not a semigroup.
++  [Examples.Classical][] collects the worked instances of the classical
+   structures: canonical first examples, finite groups from Cayley tables, the
+   small lattices, and deliberate failure modes such as a magma that is not a
+   semigroup.
 +  [Examples.Demos][] collects self-contained demonstrations, among them the
    frozen literate artifact of the TYPES 2021 paper.
 +  [Examples.FunctionTypeBijections][] and [Examples.PolynomialFunctors][] are

--- a/src/Examples/Classical.lagda.md
+++ b/src/Examples/Classical.lagda.md
@@ -26,6 +26,7 @@ module Examples.Classical where
 
 open import Examples.Classical.CommutativeIdempotentMagma public
 open import Examples.Classical.CommutativeMonoid public
+open import Examples.Classical.CommutativeRing public
 open import Examples.Classical.CommutativeSemigroup public
 open import Examples.Classical.Groups public
 open import Examples.Classical.Lattices public

--- a/src/Examples/Classical/CommutativeIdempotentMagma.lagda.md
+++ b/src/Examples/Classical/CommutativeIdempotentMagma.lagda.md
@@ -73,6 +73,11 @@ _·_ = ⟦ cim-table ⟧
 
 #### The magma `(Fin 4, _·_)`
 
+`cim-magma` packages the carrier and the tabulated operation as a small `Magma`
+through `opsToMagma`; a magma owes no equations, so the two arguments are the whole
+construction.  The `open` line names the accessor's curried operation `_∙_` for the
+acceptance checks below.
+
 ```agda
 cim-magma : Magma
 cim-magma = opsToMagma (Fin 4) _·_

--- a/src/Examples/Classical/CommutativeMonoid.lagda.md
+++ b/src/Examples/Classical/CommutativeMonoid.lagda.md
@@ -10,6 +10,12 @@ author: "the agda-algebras development team"
 
 This is the [Examples.Classical.CommutativeMonoid][] module of the [Agda Universal Algebra Library][].
 
+The natural numbers under addition and zero form the canonical commutative monoid;
+the contrast case is the deliberately non-commutative
+[`Examples.Classical.Monoid`][Examples.Classical.Monoid] on lists.  The construction
+is one line because `eqsToCommutativeMonoid` asks for exactly the four stdlib
+lemmas named below.
+
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Examples/Classical/CommutativeSemigroup.lagda.md
+++ b/src/Examples/Classical/CommutativeSemigroup.lagda.md
@@ -6,9 +6,13 @@ date: "2026-05-24"
 author: "the agda-algebras development team"
 ---
 
-### Worked Example: `(ℕ, +, 0)` as a commutative semigroup
+### Worked example: `(ℕ, +)` as a commutative semigroup
 
 This is the [Examples.Classical.CommutativeSemigroup][] module of the [Agda Universal Algebra Library][].
+
+The natural numbers under addition, one theory up from
+[`Examples.Classical.Semigroup`][Examples.Classical.Semigroup]: the same carrier and
+operation, now additionally witnessing commutativity via stdlib's `+-comm`.
 
 <!--
 ```agda
@@ -25,6 +29,11 @@ open import Classical.Small.Structures.CommutativeSemigroup
 import Classical.Structures.CommutativeSemigroup as Polymorphic
 ```
 -->
+
+`ℕ-commutativeSemigroup` hands `eqsToCommutativeSemigroup` the carrier, the
+operation, and the two laws `+-assoc` and `+-comm`.  The acceptance check
+`∙-is-+-cs` records that the accessor's curried `_∙_` interprets to `_+_` on the
+nose, discharged by `refl`.
 
 ```agda
 ℕ-commutativeSemigroup : CommutativeSemigroup

--- a/src/Examples/Classical/Groups/AbelianGroup.lagda.md
+++ b/src/Examples/Classical/Groups/AbelianGroup.lagda.md
@@ -46,6 +46,9 @@ open Polymorphic.AbelianGroup-Op ℤ-abelianGroup using ( _∙_ ; ε ; _⁻¹ )
 
 #### Acceptance checks
 
+`∙-is-+-ag`, `ε-is-0-ag`, and `⁻¹-is-neg-ag` record that the accessors interpret to
+`_+_`, `0ℤ`, and negation on the nose, each discharged by `refl`.
+
 ```agda
 ∙-is-+-ag : ∀ (a b : ℤ) → a ∙ b ≡ a + b
 ∙-is-+-ag a b = refl

--- a/src/Examples/Classical/Groups/CyclicGroup.lagda.md
+++ b/src/Examples/Classical/Groups/CyclicGroup.lagda.md
@@ -45,6 +45,9 @@ open Polymorphic.Group-Op ℤ-group using ( _∙_ ; ε ; _⁻¹ )
 
 #### Acceptance checks
 
+`∙-is-+-group`, `ε-is-0-group`, and `⁻¹-is-neg-group` record that the accessors
+interpret to `_+_`, `0ℤ`, and negation on the nose, each discharged by `refl`.
+
 ```agda
 ∙-is-+-group : ∀ (a b : ℤ) → a ∙ b ≡ a + b
 ∙-is-+-group a b = refl

--- a/src/Examples/Classical/Groups/CyclicGroup3.lagda.md
+++ b/src/Examples/Classical/Groups/CyclicGroup3.lagda.md
@@ -94,6 +94,10 @@ open Polymorphic.Group-Op z3-group using ( _∙_ ; ε ; _⁻¹ )
 
 #### `ℤ/3ℤ` is abelian
 
+Commutativity is not among the five group axioms, so it is a separate result:
+`·-comm` is decided over the finite carrier exactly as the axioms were, by
+`from-yes` applied to `Commutative?`.
+
 ```agda
 ·-comm : ∀ a b → a · b ≡ b · a
 ·-comm = from-yes (Commutative? _·_)

--- a/src/Examples/Classical/Groups/KleinFourGroup.lagda.md
+++ b/src/Examples/Classical/Groups/KleinFourGroup.lagda.md
@@ -74,6 +74,12 @@ v4-inv x = x
 
 #### The group `V₄`
 
+As for `ℤ/3ℤ`, the five group axioms are decided over the finite carrier:
+`v4-group` hands `eqsToGroup` the operation, the identity `0F`, the inverse map,
+and `from-yes` of each of the five checkers.  If the table failed an axiom the
+corresponding decision would reduce to `no` and the definition would not
+type-check.
+
 ```agda
 v4-group : Group
 v4-group = eqsToGroup (Fin 4) _·_ 0F v4-inv
@@ -85,6 +91,10 @@ open Polymorphic.Group-Op v4-group using ( _∙_ ; ε ; _⁻¹ )
 ```
 
 #### `V₄` is abelian and has exponent 2
+
+`·-comm` is decided like the axioms.  Exponent 2 needs no separate lemma: the
+acceptance check `⁻¹-is-self` below records that the inverse accessor is the
+identity map on the nose.
 
 ```agda
 ·-comm : ∀ a b → a · b ≡ b · a

--- a/src/Examples/Classical/Groups/SymmetricGroup3.lagda.md
+++ b/src/Examples/Classical/Groups/SymmetricGroup3.lagda.md
@@ -98,8 +98,8 @@ s3-inv 5F = 5F
 
 The five group axioms are decided over the finite carrier: `s3-group` hands
 `eqsToGroup` the tabulated operation, the identity `0F`, the inverse map, and
-`from-yes` of each of the five checkers.  At `Fin 6` this is the largest decision
-the examples ask of the checkers (216 triples for associativity).
+`from-yes` of each of the five checkers.  At `Fin 6` the associativity decision
+alone ranges over 216 triples.
 
 ```agda
 s3-group : Group

--- a/src/Examples/Classical/Groups/SymmetricGroup3.lagda.md
+++ b/src/Examples/Classical/Groups/SymmetricGroup3.lagda.md
@@ -96,6 +96,11 @@ s3-inv 5F = 5F
 
 #### The group `S₃`
 
+The five group axioms are decided over the finite carrier: `s3-group` hands
+`eqsToGroup` the tabulated operation, the identity `0F`, the inverse map, and
+`from-yes` of each of the five checkers.  At `Fin 6` this is the largest decision
+the examples ask of the checkers (216 triples for associativity).
+
 ```agda
 s3-group : Group
 s3-group = eqsToGroup (Fin 6) _·_ 0F s3-inv

--- a/src/Examples/Classical/Lattices/L2.lagda.md
+++ b/src/Examples/Classical/Lattices/L2.lagda.md
@@ -45,6 +45,10 @@ Bool-absorbʳ a b = trans (∨-comm (a ∧ b) a) (∨-absorbs-∧ a b)
 
 #### The lattice `𝑳𝟚 = (Bool, _∧_, _∨_)` {#bool-lattice}
 
+`𝑳𝟚` hands `eqsToLattice` the carrier, both operations, and the eight lattice
+equations: six stdlib lemmas verbatim, stdlib's `∧-absorbs-∨`, and the derived
+`Bool-absorbʳ`.
+
 ```agda
 𝑳𝟚 : Lattice
 𝑳𝟚 = eqsToLattice Bool _∧_ _∨_

--- a/src/Examples/Classical/Lattices/L2Distributive.lagda.md
+++ b/src/Examples/Classical/Lattices/L2Distributive.lagda.md
@@ -55,6 +55,10 @@ Bool-absorbʳ-dl a b = trans (∨-comm (a ∧ b) a) (∨-absorbs-∧ a b)
 
 #### The distributive lattice `𝟚 = (Bool, _∧_, _∨_)` {#bool-distributive-lattice}
 
+`Bool-distributiveLattice` hands `eqsToDistributiveLattice` the same eight lattice
+equations as the `Lattice` example plus the two left-distributivity laws, ten in
+all.
+
 ```agda
 Bool-distributiveLattice : DistributiveLattice
 Bool-distributiveLattice = eqsToDistributiveLattice Bool _∧_ _∨_

--- a/src/Examples/Classical/Monoid.lagda.md
+++ b/src/Examples/Classical/Monoid.lagda.md
@@ -47,6 +47,9 @@ open Polymorphic.Monoid-Op list-monoid using ( _∙_ ; ε )
 
 #### Acceptance checks
 
+`∙-is-++-mn` and `ε-is-[]-mn` record that the accessor's curried operation and
+identity interpret to `_++_` and `[]` on the nose, both discharged by `refl`.
+
 ```agda
 ∙-is-++-mn : ∀ (xs ys : List ℕ) → xs ∙ ys ≡ xs ++ ys
 ∙-is-++-mn xs ys = refl

--- a/src/Examples/Demos.lagda.md
+++ b/src/Examples/Demos.lagda.md
@@ -7,6 +7,14 @@ author: "the agda-algebras development team"
 
 ## Demos of the Agda Algebras Library
 
+This is the [Examples.Demos][] module of the [Agda Universal Algebra Library][].
+
+Three self-contained demonstrations:
+[Examples.Demos.GeneralOperationsAndRelations][] is a linked index of the general
+operations-and-relations vocabulary; [Examples.Demos.HSP][] is the frozen literate
+artifact of the TYPES 2021 paper, a machine-checked proof of Birkhoff's variety
+theorem; and [Examples.Demos.ContraX][] is a cautionary counterexample from an
+early formalization attempt.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Examples/Demos/ContraX.lagda.md
+++ b/src/Examples/Demos/ContraX.lagda.md
@@ -7,6 +7,13 @@ author: "the agda-algebras development team"
 
 ### Inconsistency in first formalization attempt
 
+This is the [Examples.Demos.ContraX][] module of the [Agda Universal Algebra Library][].
+
+A cautionary counterexample kept from an early formalization attempt.  It is
+tempting to posit a surjection from an arbitrary context type onto every algebra's
+domain; this module shows the global form of that assumption is inconsistent, so
+any such surjection must be a hypothesis about a suitably chosen context, never a
+theorem about all of them.
 
 <!--
 ```agda
@@ -31,6 +38,13 @@ open import Setoid.Functions         using (IsSurjective ; Image_∋_)
 open Algebra
 ```
 -->
+
+`_↠_` packages a setoid function from `setoid X` into the algebra's domain together
+with a proof that it is surjective.  `myA` is the one-point setoid with the trivial
+equality, and `myAlg` an algebra on it whose interpretation Agda infers, the
+codomain being a one-point setoid.  `contradiction` refutes `∀ X 𝑨 → X ↠ 𝑨`:
+instantiating at the empty type and `myAlg`, the assumed surjection must witness
+the point in its image, and that witness is an element of `⊥`.
 
 ```agda
 _↠_ : Set → Algebra {𝑆 = 𝑆} 0ℓ 0ℓ → _

--- a/src/Examples/Structures.lagda.md
+++ b/src/Examples/Structures.lagda.md
@@ -9,6 +9,13 @@ author: "the agda-algebras development team"
 
 This is the [Examples.Structures][] module of the [Agda Universal Algebra Library][].
 
+The structure examples exercise the general `structure` type of the frozen
+`Legacy.Base` tree, which packages operation symbols and relation symbols in one
+signature pair.  [Examples.Structures.Signatures][] supplies eight tiny signatures
+named by an arity-counting convention, and [Examples.Structures.Basic][]
+instantiates them with two structures: a three-element meet semilattice and the
+NAE-3-SAT relational structure.  The signatures are also consumed by the
+finite-CSP exercises of [Exercises.Complexity.FiniteCSP][].
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Examples/Structures/Basic.lagda.md
+++ b/src/Examples/Structures/Basic.lagda.md
@@ -7,6 +7,12 @@ author: "agda-algebras development team"
 
 ### Examples of Structures
 
+This is the [Examples.Structures.Basic][] module of the [Agda Universal Algebra Library][].
+
+Two tiny worked examples of the general `structure` type of the frozen
+`Legacy.Base` tree, which packages operation symbols and relation symbols in one
+signature pair: a purely algebraic structure and a purely relational one.  The
+signatures come from [Examples.Structures.Signatures][].
 
 <!--
 ```agda
@@ -23,6 +29,11 @@ open import Legacy.Base.Structures          using ( structure )
 open import Examples.Structures.Signatures  using ( S001 ; S∅ ; S0001 )
 ```
 -->
+
+`SL` is a three-element meet semilattice presented as a `structure` with one binary
+operation symbol (`S001`) and no relation symbols (`S∅`).  The meet of two distinct
+elements is `𝟎`, so the induced order has bottom `𝟎` below the incomparable pair
+`𝟏`, `𝟐`.
 
 ```agda
 -- An example of a (purely) algebraic structure is a 3-element meet semilattice.

--- a/src/Examples/Structures/Signatures.lagda.md
+++ b/src/Examples/Structures/Signatures.lagda.md
@@ -5,6 +5,16 @@ date : "2021-07-16"
 author: "agda-algebras development team"
 ---
 
+### Example signatures for general structures
+
+This is the [Examples.Structures.Signatures][] module of the [Agda Universal Algebra Library][].
+
+Eight tiny signatures for the general `structure` type of the frozen `Legacy.Base`
+tree, named by an arity-counting convention: position `k` of the digit string
+counts the symbols of arity `k`, so `S001` has one binary symbol and `S111` has one
+nullary, one unary, and one binary.  They give the structure examples of
+[Examples.Structures.Basic][] and the finite-CSP exercises of
+[Exercises.Complexity.FiniteCSP][] something concrete to instantiate.
 
 <!--
 ```agda
@@ -25,6 +35,12 @@ open import Legacy.Base.Structures.Basic  using ( signature )
 
 #### Examples of finite signatures
 
+Each is a `signature` record whose `symbol` type is `𝟘`, `𝟙`, `𝟚`, or `𝟛` and
+whose arity map sends a symbol to the finite type of its argument positions: `S∅`
+(no symbols, so bare sets), `S1` (one constant, pointed sets), `S01` (one unary),
+`S001` (one binary, magmas and their kin), `S0001` (one ternary, the NAE-3-SAT
+relation), `S021` (two unary and one binary), `S101` (one constant and one binary,
+monoids), and `S111` (one constant, one unary, and one binary, groups).
 
 ```agda
 -- The signature with...


### PR DESCRIPTION
Closes #546.  Sub-issue of #268.

## What this clears

All of #546's scope: **30 definitions** whose fence carried no real prose, and all **eight** weak headers.  The scope now reports **0 gaps and 0 weak headers**.  The frozen TYPES 2021 artifact (`Examples/Demos/HSP.lagda.md`) is untouched, as the issue requires.

## Where the prose went

Seventeen files.  The bulk is the Classical examples, where the missing blocks were mostly acceptance-check fences (the accessors interpret to the stdlib operations on the nose, discharged by `refl`) and Cayley-table group constructions (the axioms decided over the finite carrier by `from-yes`); each block names every member of its family.  The rest is headers:

+  `Examples.Demos.ContraX` now says what the counterexample refutes and how: a globally assumed surjection from an arbitrary context type onto every algebra's domain is inconsistent (instantiate at the empty type and a one-point algebra).
+  `Examples.Structures.Signatures` had no heading and no prose at all; it now has both, including the arity-counting naming convention (position `k` of the digit string counts symbols of arity `k`), and its fence block names all eight signatures.
+  `Examples.Structures.Basic` explains the two structures (the three-element meet semilattice with bottom below an incomparable pair, and the NAE-3-SAT relational structure).
+  The three barrels (`Examples`, `Examples.Structures`, `Examples.Demos`) each map their submodules.

One heading defect fixed in a header rewritten anyway, declared per the workflow: the commutative-semigroup example's heading claimed `(ℕ, +, 0)`; the construction has no identity element, so it now reads `(ℕ, +)` (and "Worked Example" lowercased to match its siblings).

## Least confident

+  The ContraX header says the demo is "kept from an early formalization attempt"; that phrasing extends the module's own heading ("Inconsistency in first formalization attempt"), but I could not find where the flawed assumption originally appeared, so the header stops short of naming a source.  A first draft claimed the HSP development takes the corrected, per-algebra form of the hypothesis; `↠` does not occur in `HSP.lagda.md`, so that clause was cut.
+  The `SymmetricGroup3` block notes 216 associativity triples at `Fin 6`; arithmetic, not a measured cost.

No `TODO(#268)` markers remain in the scope.

## The ratchet

Measured on this tree after the change: `DOCSTRING_MAX_GAPS` 102 to **72**, `DOCSTRING_MAX_WEAK_HEADERS` 20 to **12**.  Three PRs are now open in parallel off the same master (#556 sets 71/19, #557 sets 67/19, this one 72/12); each later merge conflicts on the two ceiling lines, and the right resolution is always to re-measure, never to take a side.  After all three land the expected counts are 36 gaps and 10 weak headers, with one more PR (for #547) to follow.

## Copilot round 1

Two findings, both accepted, fixed in c0e75c3c with a reply on each thread:

+  The `Examples` barrel claimed importing it type-checks every worked example, but `Examples.Classical` omitted `CommutativeRing`.  Fixed at the root: the barrel now imports it (the branch's only Agda change; the example's exports are all `-cr`-suffixed, so no clashes, and the barrel type-checks).  The finding was narrower than reality: `Examples.Setoid` likewise imports five of its nine modules, but its own header enumerates exactly those five, so that restriction reads as deliberate and is left for a separate decision.
+  `SymmetricGroup3`'s "largest decision the examples ask" was false (`L7` decides `Associative?` twice over `Fin 7`, 343 triples each); the comparison is removed and the 216-triple arithmetic kept.

## Verification

+  **Prose-only, with one declared exception.**  Fence contents extracted from `HEAD` and `master` with the repository's own `extract_agda_lines`: byte-identical for the seventeen prose files; the review-round fix adds one `open import ... public` line to `Examples/Classical.lagda.md`, the branch's only Agda change.
+  All changed modules type-check (Agda 2.8.0 via the flake), including the barrel with its new import.
+  `make check-links` green (322 pages); `make docstrings` exit 0 at the new ceilings; `make docstrings-test` 72/72.
+  No em-dashes and no issue or PR numbers in the added prose.

🤖 AI-assisted development: Claude Fable 5 (Anthropic)
