### PR TITLE
[M4-2i] Docstrings: Overture, FLRP, Exercises, and the top-level barrels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ REPO      ?= ualib/agda-algebras
 DOCSTRING_MAX_GAPS ?= 67
 # The other half of the bar ADR-010 states: modules whose header is only the
 # boilerplate sentence.  Ratcheted the same way; never raise it.
-DOCSTRING_MAX_WEAK_HEADERS ?= 12
+DOCSTRING_MAX_WEAK_HEADERS ?= 10
 
 # The certificate census: generated representation certificates for the FLRP
 # research track (issue #515).  Excluded from Everything.agda and checked by

--- a/src/Exercises.lagda.md
+++ b/src/Exercises.lagda.md
@@ -9,6 +9,8 @@ author: "the agda-algebras development team"
 
 This is the [Exercises][] module of the [Agda Universal Algebra Library][].
 
+The exercise tree has one set at present, [Exercises.Complexity][]: exercises at
+the border of universal algebra and computational complexity.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Exercises/Complexity.lagda.md
+++ b/src/Exercises/Complexity.lagda.md
@@ -9,6 +9,9 @@ author: "the agda-algebras development team"
 
 This is the [Exercises.Complexity][] module of the [Agda Universal Algebra Library][].
 
+One module so far: [Exercises.Complexity.FiniteCSP][], constraint-satisfaction
+exercises over small finite relational structures, created by Libor Barto for
+students at Charles University and formalized here.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/FLRP/Closure.lagda.md
+++ b/src/FLRP/Closure.lagda.md
@@ -6,7 +6,16 @@ date: "2026-07-24"
 author: "the agda-algebras development team"
 ---
 
+### Closure properties of representability
+
 This is the [FLRP.Closure][] module of the [Agda Universal Algebra Library][].
+
+This is a barrel module for the closure toolkit: the operations under which the
+class of representable lattices is closed, formalized at Layer D (decidable
+representability).  [FLRP.Closure.Basic][] is the umbrella, deriving the corollary
+closures (adjoined bottom, adjoined top, the unglued sum) from the two proved
+theorems: [FLRP.Closure.Product][] for finite direct products and
+[FLRP.Closure.OrdinalSum][] for glued ordinal sums.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/FLRP/Closure.lagda.md
+++ b/src/FLRP/Closure.lagda.md
@@ -12,10 +12,13 @@ This is the [FLRP.Closure][] module of the [Agda Universal Algebra Library][].
 
 This is a barrel module for the closure toolkit: the operations under which the
 class of representable lattices is closed, formalized at Layer D (decidable
-representability).  [FLRP.Closure.Basic][] is the umbrella, deriving the corollary
-closures (adjoined bottom, adjoined top, the unglued sum) from the two proved
-theorems: [FLRP.Closure.Product][] for finite direct products and
-[FLRP.Closure.OrdinalSum][] for glued ordinal sums.
+representability).  [FLRP.Closure.Basic][] is the umbrella over the two proved
+theorems, [FLRP.Closure.Product][] for finite direct products and
+[FLRP.Closure.OrdinalSum][] for glued ordinal sums, and derives its corollaries
+from them: `adjoinBottom-Representableᵈ`, `adjoinTop-Representableᵈ`, and
+`dual-Representableᵈ`, the last conditional on a Kurzweil–Netter duality
+hypothesis.  The unglued ordinal sum appears there as a recipe (glue `chain₂`
+between the summands), not as an exported theorem.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/FLRP/Closure/Basic.lagda.md
+++ b/src/FLRP/Closure/Basic.lagda.md
@@ -8,7 +8,7 @@ author: "the agda-algebras development team"
 
 ### The closure toolkit for decidable representability
 
-This is the [FLRP.Closure][] module of the [Agda Universal Algebra Library][].
+This is the [FLRP.Closure.Basic][] module of the [Agda Universal Algebra Library][].
 
 The class of representable lattices is closed under a catalogue of operations
 (the roadmap's § 3; `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure

--- a/src/FLRP/Enforceable.lagda.md
+++ b/src/FLRP/Enforceable.lagda.md
@@ -343,6 +343,10 @@ cfIE : {ℓP : Level} → GroupProperty ℓP → Lattice → Type (lsuc 0ℓ ⊔
 cfIE P 𝑳 = ∀ 𝒢 H H-sg → CoreFree 𝒢 H H-sg → IntervalIso 𝒢 H H-sg 𝑳 → P 𝒢
 ```
 
+The weakening is one-directional and costs nothing to witness: `IE→cfIE` turns an
+interval-enforceable property into a core-free interval-enforceable one by
+discarding the core-freeness hypothesis.
+
 ```agda
 -- Interval enforceable implies core-free interval enforceable.
 IE→cfIE : {ℓP : Level} {P : GroupProperty ℓP} {𝑳 : Lattice} → IE P 𝑳 → cfIE P 𝑳

--- a/src/Overture.lagda.md
+++ b/src/Overture.lagda.md
@@ -9,6 +9,26 @@ author: "the agda-algebras development team"
 
 This is the [Overture][] module of the [Agda Universal Algebra Library][].
 
+The Overture is the foundation layer: the vocabulary every later tree (`Setoid/`,
+`Classical/`, `FLRP/`) imports.  In re-export order:
+
++  [Overture.Preface][] is the front door: why the library exists, why Agda, and
+   how to read what follows.
++  [Overture.Basic][] sets the logical foundations and shared preliminaries.
++  [Overture.Signatures][] defines the `Signature` type: operation symbols paired
+   with an arity function.
++  [Overture.Operations][] represents an operation of arity `I` as a function
+   from tuples `I → A` to `A`.
++  [Overture.Relations][] supplies the relation vocabulary, including the
+   `Equivalence` bundle over a fixed carrier.
++  [Overture.Functions][] collects the raw-function infrastructure (images,
+   computed inverses, surjectivity) that the `Setoid/` tree builds on.
++  [Overture.Terms][] gives terms over a signature, their interpretation, and
+   translation along signature morphisms.
++  [Overture.Adjunction][] is the order-theoretic adjunction toolkit: closure,
+   Galois connections, residuation.
++  [Overture.Cayley][] represents finite binary operations by Cayley tables, with
+   decision procedures that discharge their laws.
 
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Overture/Adjunction/Closure.lagda.md
+++ b/src/Overture/Adjunction/Closure.lagda.md
@@ -9,6 +9,11 @@ author: "the agda-algebras development team"
 
 This is the [Overture.Adjunction.Closure][] module of the [Agda Universal Algebra Library][].
 
+The order-theoretic vocabulary of closure: closure systems, families of subsets
+closed under arbitrary intersection, and closure operators, extensive, monotone,
+idempotent endofunctions of a poset.  Among the library's instances of this
+vocabulary are the subuniverses and the congruences of an algebra.
+
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Overture/Adjunction/Galois.lagda.md
+++ b/src/Overture/Adjunction/Galois.lagda.md
@@ -9,6 +9,11 @@ author: "the agda-algebras development team"
 
 This is the [Overture.Adjunction.Galois][] module of the [Agda Universal Algebra Library][].
 
+The definition of a Galois connection between two posets, followed by
+`PosetOfSubsets`, the poset of all subsets of a set under inclusion (with
+mutual-inclusion `_≐_` as its equivalence), which supplies the classical setting
+for such connections.
+
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Overture/Adjunction/Residuation.lagda.md
+++ b/src/Overture/Adjunction/Residuation.lagda.md
@@ -9,6 +9,13 @@ author: "the agda-algebras development team"
 
 This is the [Overture.Adjunction.Residuation][] module of the [Agda Universal Algebra Library][].
 
+A **residuation** between two posets is a pair of monotone maps `f : A → B` and
+`g : B → A` satisfying `a ≤ᴬ g (f a)` and `f (g b) ≤ᴮ b`: the same data as a
+Galois connection ([Overture.Adjunction.Galois][]) packaged as two inequalities
+rather than two implications.  The `Residuation` record bundles the maps, their
+monotonicity, and the two inequalities; the rest of the module proves each map is
+a weak inverse of the other.
+
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
@@ -47,6 +54,11 @@ module _ (𝑨 : Poset a ιᵃ α)(𝑩 : Poset b ιᵇ β) where
 ```
 
 #### Basic properties of residual pairs
+
+With a residuation fixed, `_≈A_` and `_≈B_` are pointwise equality of functions
+into `A` and into `B`, each with respect to the corresponding poset's underlying
+equivalence.  They are the equalities in which the weak-inverse laws below are
+stated.
 
 ```agda
 -- open Residuation

--- a/src/Overture/Adjunction/Residuation.lagda.md
+++ b/src/Overture/Adjunction/Residuation.lagda.md
@@ -10,11 +10,14 @@ author: "the agda-algebras development team"
 This is the [Overture.Adjunction.Residuation][] module of the [Agda Universal Algebra Library][].
 
 A **residuation** between two posets is a pair of monotone maps `f : A → B` and
-`g : B → A` satisfying `a ≤ᴬ g (f a)` and `f (g b) ≤ᴮ b`: the same data as a
-Galois connection ([Overture.Adjunction.Galois][]) packaged as two inequalities
-rather than two implications.  The `Residuation` record bundles the maps, their
+`g : B → A` satisfying `a ≤ᴬ g (f a)` and `f (g b) ≤ᴮ b`; in the order-theoretic
+literature this is the inequality form of a monotone Galois connection, that is,
+an adjunction between posets.  The `Residuation` record bundles the maps, their
 monotonicity, and the two inequalities; the rest of the module proves each map is
-a weak inverse of the other.
+a weak inverse of the other.  It is a different bundle from the `Galois` record of
+[Overture.Adjunction.Galois][], whose two inequalities are both in the extensive
+direction and which carries no monotonicity fields; the two records are not
+interchangeable.
 
 <!--
 ```agda

--- a/src/Overture/Preface.lagda.md
+++ b/src/Overture/Preface.lagda.md
@@ -10,6 +10,9 @@ author: "the agda-algebras development team"
 
 This is the [Overture.Preface][] module of the [Agda Universal Algebra Library][].
 
+The front door of the library, and the one module whose only code is its own
+declaration: why a mathematician might formalize universal algebra, why in Agda,
+what the 3.0 reconstruction changed, and where to go next.
 
 <!--
 ```agda

--- a/src/Overture/Signatures.lagda.md
+++ b/src/Overture/Signatures.lagda.md
@@ -10,6 +10,11 @@ author: "agda-algebras development team"
 
 This is the [Overture.Signatures][] module of the [Agda Universal Algebra Library][].
 
+The signature vocabulary of the library: the reserved universe levels `𝓞` (for
+operation-symbol types) and `𝓥` (for arity types), the theoretical background,
+and the `Signature` type itself, a type of operation symbols paired with its
+arity function.
+
 <!--
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}

--- a/src/Overture/Terms.lagda.md
+++ b/src/Overture/Terms.lagda.md
@@ -8,6 +8,14 @@ author: "the agda-algebras development team"
 
 ## Terms
 
+This is the [Overture.Terms][] module of the [Agda Universal Algebra Library][].
+
+A barrel over the term machinery, parameterized by a signature `𝑆` that it passes
+to [Overture.Terms.Basic][] for the `Term` type and its level shorthand `ov`.
+[Overture.Terms.Interpretation][] gives theory interpretations, sending operation
+symbols to derived terms, and [Overture.Terms.Translation][] translates terms
+along a signature morphism.
+
 ```agda
 {-# OPTIONS --cubical-compatible --exact-split --safe #-}
 


### PR DESCRIPTION
Closes #547.  Sub-issue of #268, and the last of the nine: with this and the three PRs already open (#556, #557, #558), the entire prose backlog measured by the audit is written.

## What this clears

All of #547's scope: **4 definitions** whose fence carried no real prose and all **ten** weak headers.  The scope now reports **0 gaps and 0 weak headers**.

## Where the prose went

Almost entirely module headers, as the issue predicted.  A recurring shape in `Overture/`: five modules (Preface, Signatures, and the three Adjunction modules) had real prose that all sat *below* the hidden preamble, where the audit rightly attributes it to the first fence; each now gets a genuine header paragraph above the preamble.  The `Overture` and `Overture.Terms` barrels get maps of their re-exports, the two `Exercises` barrels get real headers, and `Residuation` gets a block for its pointwise-equality pair.

On the FLRP items, a deviation from the issue's guidance, stated openly: the issue says `FLRP/` needs research context and prefers deferral, but its two items turned out not to need any.  The `FLRP.Closure` barrel is grounded entirely in its three submodule headers (which postdate the issue and carry the intent), and the one fence gap, `IE→cfIE`, is a one-liner whose proof simply discards the core-freeness hypothesis; the surrounding module already documents `cfIE` itself.  Nothing was guessed; no `TODO(#268)` markers remain.

Two defects fixed in passing, both declared per the workflow: `FLRP.Closure.Basic`'s boilerplate line called itself `FLRP.Closure` (the barrel), and `FLRP.Closure` itself lacked a heading line entirely.

## Least confident

+  The Galois header calls `PosetOfSubsets` "the classical setting for such connections"; the module itself only says the stdlib lacks this poset, so the "classical setting" framing is mine.
+  The `Overture` barrel's one-line characterizations compress each submodule's header into a clause; the Preface and Basic lines are the loosest.

## The ratchet

Measured on this tree after the change: `DOCSTRING_MAX_GAPS` 102 to **98**, `DOCSTRING_MAX_WEAK_HEADERS` 20 to **10**.  Four PRs are now open in parallel off the same master (#556 sets 71/19, #557 sets 67/19, #558 sets 72/12, this one 98/10); every merge after the first conflicts on those two lines, and the right resolution is always to re-measure, never to take a side.  **After all four land the tree measures 0 gaps and 0 weak headers**, closing #268's prose backlog; the ceilings should then be lowered to 0 and 0 to lock it in.  The duplicated `DOCSTRING_MAX_WEAK_HEADERS` block on master is collapsed here as in the other three.

## Copilot round 1

Two findings, both accepted, fixed in 0b5eaa25 with a reply on each thread:

+  The Residuation header equated the record with the `Galois` record; that record's two inequalities are both extensive and it has no monotonicity fields, so the two are not interchangeable.  The header now describes the standard notion (the inequality form of a monotone Galois connection) and states the contrast; changing the `Galois` API itself would be an Agda semantics change out of scope here.
+  The `FLRP.Closure` barrel advertised an unglued-sum closure that `Closure.Basic` does not export.  It now names the actual corollaries (`adjoinBottom-Representableᵈ`, `adjoinTop-Representableᵈ`, and `dual-Representableᵈ`, the last conditional on a Kurzweil–Netter duality hypothesis) and describes the unglued sum as the recipe it is there.

## Verification

+  **Prose-only.**  Fence contents extracted from `HEAD` and `master` with the repository's own `extract_agda_lines`: byte-identical, **12 of 12**.
+  All twelve changed modules type-check (Agda 2.8.0 via the flake), including `FLRP.Enforceable` and the full `FLRP.Closure` cone.
+  `make check-links` green (322 pages); `make docstrings` exit 0 at the new ceilings; `make docstrings-test` 72/72.
+  No em-dashes and no issue or PR numbers in the added prose.

🤖 AI-assisted development: Claude Fable 5 (Anthropic)
