### PR TITLE
[FLRP] Entry 4 => LEM at Layer S: no-go theorem, ᵈ-restatement, consumer rewire (#566)

### DIFF
--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -76,7 +76,9 @@ partition subgroup `K_π`; this is the surjectivity half of Kurzweil's lemma,
 `[D , Sⁿ] ≅ Eq(n)′`, whose dual-embedding half is proved outright in
 [Classical.Structures.Group.PartitionSubgroup][].  It is registered as
 `KurzweilSurjectivityAt`{.AgdaFunction}, in the witness-producing form defined by
-[FLRP.KurzweilInterval][].
+[FLRP.KurzweilInterval][], with the decidable working form
+`KurzweilSurjectivityᵈAt`{.AgdaFunction} beside it; the Layer-S form is excluded
+middle (that module's no-go theorem), so consumers take the working form.
 
 **Entry 5**: Kurzweil's wreath interval.  For a core-free representation
 `[H , G] ≅ 𝑳` of a lattice with two distinct elements (`G` finite) and a finite
@@ -252,8 +254,10 @@ algebra with lifted operations.
    simple group.  What is retired is Entry 2's role as an *independent*
    hypothesis: nothing consumes it any more, and the definitions below remain
    as the canonical *statement* of the theorem (they are its conclusion's
-   type).  The residue is tracked by issue #522 (Entry 4) and issue #527
-   (the `A₅` instantiation, needing the simplicity predicates of issue #512).
+   type).  The residue is tracked by issue #522 (Entry 4, scoped to the decidable
+   form by issue #566) and issue #527 (the `A₅` instantiation; the simplicity
+   predicates it once awaited landed with
+   [Classical.Structures.Group.Simple][]).
 
 +  **Layer**.  The statement is at Layer D (`Representableᵈ`{.AgdaRecord}),
    the program's working notion per [ADR-008][]; the classical statement is the
@@ -340,6 +344,19 @@ remaining classical delta.
    defined in [FLRP.KurzweilInterval][], which is precisely what the inverse map
    of `kurzweilIntervalIso`{.AgdaFunction} consumes.
 
++  **Strength**.  The Layer-S form is not a constructively open statement
+   awaiting proof: `kurzweilSurjectivity→EM`{.AgdaFunction} of
+   [FLRP.KurzweilInterval][] shows that at exponent `2`, over any base group
+   with an apartness witness, it implies full excluded middle for level-zero
+   types, by feeding the produced partition an oracle subgroup.  It therefore
+   caps the `WLEM₀`{.AgdaFunction} no-go family of [FLRP.Problem][] from
+   above, and no proof of it can land in the safe fragment.  The *working*
+   form is `KurzweilSurjectivityᵈAt`{.AgdaFunction}, the same Σ-form over the
+   decidable interval elements `Intervalᵈ`{.AgdaFunction} of
+   [FLRP.Enforceable][]; every consumer takes it, and the Layer-S statement
+   remains registered as the classical statement of record, exactly as
+   Entry 2's types remain as its statement.
+
 +  **Side condition**.  The statement type is defined for an arbitrary
    `𝒮 : Group 0ℓ 0ℓ`, and for arbitrary `𝒮` it is *false* (for `S = ℤ₃` and
    `n = 3` the tuples with `x₀ x₂ = x₁²` form a non-partition subgroup above the
@@ -356,26 +373,40 @@ remaining classical delta.
    retirement.
 
 +  **Status and retirement path**.  A classically proven theorem imported
-   pending formalization.  The missing mathematics is the normal-subgroup
-   structure theory of powers of a nonabelian simple group (normal subgroups of
-   `Sⁿ` are partial products; subdirect subgroups containing the diagonal
-   collapse blockwise), a follow-up flagged in issue #521.  On completion this
-   entry retires, `kurzweilIntervalIso`{.AgdaFunction} holds outright at simple
-   instantiations, and the Kurzweil–Netter route of issue #502 loses one of its
-   two imported steps toward retiring Entry 2.
+   pending formalization, with the provable target now precisely scoped: the
+   decidable form.  The missing mathematics is the normal-subgroup structure
+   theory of powers of a nonabelian simple group (normal subgroups of `Sⁿ` are
+   partial products; subdirect subgroups containing the diagonal collapse
+   blockwise), applied over interval elements whose membership is decided,
+   where the partition is computable as the kernel meet of the member tuples;
+   the selecting predicates and the certified instance the proof needs are in
+   place ([Classical.Structures.Group.Simple][],
+   [Examples.Classical.Groups.AlternatingGroup5][]).  On completion
+   `KurzweilSurjectivityᵈAt`{.AgdaFunction} holds outright at simple
+   instantiations, this entry retires, and the Kurzweil–Netter route of issue
+   #502 becomes a closed theorem there; the Layer-S form stays behind as the
+   classical statement, priced exactly by the no-go.
 
-+  **Layer**.  Layer S, on the respecting interval `Interval≈`{.AgdaFunction}.
-   Over a decidable interval element (`Intervalᵈ`{.AgdaFunction}) with a finite
-   base group the partition is computable as the kernel meet of the member
-   tuples, so a formal proof is expected to produce the Layer-D reading
-   directly, mirroring Entry 2's layer note.
++  **Layer**.  Layer S for the statement of record; Layer D
+   (`Intervalᵈ`{.AgdaFunction}) for the working form, per the sibling
+   discipline of [ADR-008][].  The Kurzweil–Netter route consumes only the
+   working form: every interval element it manipulates is the base-coset class
+   of a decidable congruence, delivered with its decider by the Layer-D bridge
+   of [FLRP.Bridge][].
 
 ```agda
--- Entry 4, per-instance form: every subgroup in [D , Sⁿ] is a partition
--- subgroup, with the partition produced as data.  Classically true for 𝒮 a
--- finite nonabelian simple group; consumers instantiate it there.
+-- Entry 4, statement of record (Layer S): every subgroup in [D , Sⁿ] is a
+-- partition subgroup, with the partition produced as data.  Classically true
+-- for 𝒮 a finite nonabelian simple group; unprovable outright (the no-go of
+-- FLRP.KurzweilInterval), and consumed by nothing.
 KurzweilSurjectivityAt : Group 0ℓ 0ℓ → ℕ → Type (lsuc 0ℓ)
 KurzweilSurjectivityAt 𝒮 n = KurzweilInterval.KurzweilSurjectivity 𝒮 n
+
+-- Entry 4, working form (Layer D): the same Σ-form, over interval elements
+-- carrying a membership decider.  This is the form consumers take, and the
+-- form whose proof at a finite nonabelian simple 𝒮 retires the entry.
+KurzweilSurjectivityᵈAt : Group 0ℓ 0ℓ → ℕ → Type (lsuc 0ℓ)
+KurzweilSurjectivityᵈAt 𝒮 n = KurzweilInterval.KurzweilSurjectivityᵈ 𝒮 n
 ```
 
 #### Entry 5: Kurzweil's wreath interval

--- a/src/FLRP/Assumptions.lagda.md
+++ b/src/FLRP/Assumptions.lagda.md
@@ -77,8 +77,9 @@ partition subgroup `K_π`; this is the surjectivity half of Kurzweil's lemma,
 [Classical.Structures.Group.PartitionSubgroup][].  It is registered as
 `KurzweilSurjectivityAt`{.AgdaFunction}, in the witness-producing form defined by
 [FLRP.KurzweilInterval][], with the decidable working form
-`KurzweilSurjectivityᵈAt`{.AgdaFunction} beside it; the Layer-S form is excluded
-middle (that module's no-go theorem), so consumers take the working form.
+`KurzweilSurjectivityᵈAt`{.AgdaFunction} beside it; the Layer-S form implies
+excluded middle, at exponent `2` over a base group with an apartness witness
+(that module's no-go theorem), so consumers take the working form.
 
 **Entry 5**: Kurzweil's wreath interval.  For a core-free representation
 `[H , G] ≅ 𝑳` of a lattice with two distinct elements (`G` finite) and a finite
@@ -385,7 +386,10 @@ remaining classical delta.
    `KurzweilSurjectivityᵈAt`{.AgdaFunction} holds outright at simple
    instantiations, this entry retires, and the Kurzweil–Netter route of issue
    #502 becomes a closed theorem there; the Layer-S form stays behind as the
-   classical statement, priced exactly by the no-go.
+   classical statement, bounded below by the no-go, which shows it implies
+   excluded middle.  The converse, deciding the finitely many membership
+   questions with excluded middle and applying the decidable theorem, is not
+   formalized.
 
 +  **Layer**.  Layer S for the statement of record; Layer D
    (`Intervalᵈ`{.AgdaFunction}) for the working form, per the sibling

--- a/src/FLRP/Closure/Basic.lagda.md
+++ b/src/FLRP/Closure/Basic.lagda.md
@@ -58,7 +58,7 @@ open import Classical.Small.Structures.Lattice        using  ( Lattice )
 open import Classical.Structures.Group.Basic          using  ( Group ; module Group-Op )
 open import Classical.Structures.Lattice.Dual         using  ( dualLattice )
 open import Classical.Structures.Lattice.OrdinalSum   using  ( ordinalSum )
-open import FLRP.Assumptions                          using  ( KurzweilSurjectivityAt )
+open import FLRP.Assumptions                          using  ( KurzweilSurjectivityᵈAt )
 open import FLRP.KurzweilNetter.Duality               using  ( module KurzweilNetterProof )
 open import FLRP.Problem                              using  ( chain₂-lattice )
 open import FLRP.Representable                        using  ( Representableᵈ
@@ -111,8 +111,8 @@ adjoinTop-Representableᵈ t r =
 Here we prove closure under dualization (the Kurzweil–Netter theorem) using
 [FLRP.KurzweilNetter.Duality][].  The parameters are the simple-group package of
 the proof module: a finite group with a nontriviality witness and the
-Kurzweil-surjectivity family (Entry 4 of [FLRP.Assumptions][], classically true
-for `𝒮` finite nonabelian simple).
+Kurzweil-surjectivity family in its decidable working form (Entry 4 of
+[FLRP.Assumptions][], classically true for `𝒮` finite nonabelian simple).
 
 Every consumer displays its remaining classical debt (Entry 4 at the chosen group)
 in its own type, exactly as the registry discipline demands.
@@ -123,7 +123,7 @@ module _ ((𝑺 , eqns) : Group 0ℓ 0ℓ) where
   open Group-Op (𝑺 , eqns) using (ε)
   -- The Kurzweil–Netter closure, from the simple-group package of the proof.
   dual-Representableᵈ : (𝑭ₛ : FiniteAlgebra 𝑺) (s₀ : 𝕌[ 𝑺 ])
-    → ¬ s₀ ≈ ε → (∀ n → KurzweilSurjectivityAt (𝑺 , eqns) n)
+    → ¬ s₀ ≈ ε → (∀ n → KurzweilSurjectivityᵈAt (𝑺 , eqns) n)
     → (𝑳 : Lattice) → Representableᵈ 𝑳 → Representableᵈ (dualLattice 𝑳)
   dual-Representableᵈ 𝑭ₛ s₀ s₀≉ε surj =
     KurzweilNetterProof.kurzweilNetterDuality (𝑺 , eqns) 𝑭ₛ s₀ s₀≉ε surj

--- a/src/FLRP/Closure/Basic.lagda.md
+++ b/src/FLRP/Closure/Basic.lagda.md
@@ -11,32 +11,21 @@ author: "the agda-algebras development team"
 This is the [FLRP.Closure.Basic][] module of the [Agda Universal Algebra Library][].
 
 The class of representable lattices is closed under a catalogue of operations.[^1]
-This module is work package WP-5's umbrella over that catalogue at Layer D,
-re-exporting the two proved closure theorems and deriving the rest:
 
-+  **finite direct products**: `product-Representableᵈ`{.AgdaFunction}
-   ([FLRP.Closure.Product][], after Tůma);
-+  **ordinal sums**: `ordinalSum-Representableᵈ`{.AgdaFunction}
-   ([FLRP.Closure.OrdinalSum][], after McKenzie and Snow); the *unglued* sum is
-   the derived composite with `chain₂` glued in the middle;
-+  **adjoining a new bottom or top**: `adjoinBottom-Representableᵈ`{.AgdaFunction}
-   / `adjoinTop-Representableᵈ`{.AgdaFunction}, *corollaries* of ordinal-sum
-   closure, obtained by instantiating one summand at the two-element chain (whose
-   Layer-D representation `chain₂-Representableᵈ`{.AgdaFunction} is the
-   constructive centerpiece of [FLRP.Representable][]);
-+  **lattice duals**: `dual-Representableᵈ`{.AgdaFunction}, the Kurzweil–Netter
++  **Finite direct products** (`product-Representableᵈ`{.AgdaFunction}
+   in [FLRP.Closure.Product][]) after Tůma.
++  **Ordinal sums** (`ordinalSum-Representableᵈ`{.AgdaFunction}
+   in [FLRP.Closure.OrdinalSum][]) after McKenzie and Snow; the *unglued* sum is
+   the derived composite with `chain₂` glued in the middle.
++  **Adjoining a new bottom or top** (`adjoinBottom-Representableᵈ`{.AgdaFunction}
+   / `adjoinTop-Representableᵈ`{.AgdaFunction}) including *corollaries* of
+   ordinal-sum closure, obtained by instantiating one summand at the two-element
+   chain (whose Layer-D representation `chain₂-Representableᵈ`{.AgdaFunction} is the
+   constructive centerpiece of [FLRP.Representable][]).
++  **Lattice duals** (`dual-Representableᵈ`{.AgdaFunction}): the Kurzweil–Netter
    duality theorem, proved in [FLRP.KurzweilNetter.Duality][] and consumed here
    through the simple-group package that parameterizes the proof with a finite
-   nontrivial group together with the Kurzweil-surjectivity family, Entry 4 of
-   [FLRP.Assumptions][]; Entry 2 of the registry (the duality theorem as an
-   *imported* hypothesis) is retired; what remains classical is exactly Entry 4
-   and the choice of a concrete nonabelian simple instantiation.
-
-The payoff downstream: the two dual entries of the small-lattice census
-(`L18` and `L22`, duals of the certified `SLR19` and `SLR23`) now rest on Entry 4
-and an instantiation rather than on the full duality theorem; materializing those
-conditional certificates remains computationally out of reach, since the
-construction represents an `n`-element algebra's dual on `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹` elements.
+   nontrivial group together with the Kurzweil-surjectivity family.[^2]
 
 <!--
 ```agda
@@ -88,9 +77,9 @@ Adjoining a fresh extremum to a lattice is the special case of the glued ordinal
 sum in which one summand is the two-element chain: gluing `chain₂`'s top onto
 `𝑳`'s bottom leaves exactly one new element below everything (`adjoinBottom`), and
 mirrored for `adjoinTop`.  Each is a one-application corollary of
-`ordinalSum-Representableᵈ`{.AgdaFunction} at `chain₂-Representableᵈ`{.AgdaFunction},
-confirming that the ordinal-sum statement carries no hidden nontriviality
-assumptions on its summands.
+`ordinalSum-Representableᵈ`{.AgdaFunction} at
+`chain₂-Representableᵈ`{.AgdaFunction}, confirming that the ordinal-sum statement
+carries no hidden nontriviality assumptions on its summands.
 
 ```agda
 -- Adjoin a new bottom: chain₂ glued below 𝑳, at 𝑳's chosen bottom.
@@ -132,4 +121,22 @@ module _ ((𝑺 , eqns) : Group 0ℓ 0ℓ) where
 --------------------------------------
 
 
-[^1]: See the roadmap's § 3; `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, § Closure properties.
+[^1]: See the roadmap's § 3; `docs/papers/fin-lat-rep/SmallLatticeReps.tex`, §
+      Closure properties.  This module is work package WP-5's umbrella over that
+      catalogue at Layer D, re-exporting the two proved closure theorems and
+      deriving the rest.
+
+[^2]: Entry 2 of the assumptions registry ([FLRP.Assumptions][]) provided the
+      duality theorem as an imported hypothesis, but is now retired; what remains
+      classical is exactly Entry 4 and the choice of a concrete nonabelian simple
+      instantiation; this will soon be replaced by a fully constructive proof of
+      the Kurzweil–Netter theorem in [FLRP.KurzweilNetter.Duality][].
+
+      **The payoff downstream**.  The two dual entries of the small-lattice census
+      (`L18` and `L22`, duals of the certified `SLR19` and `SLR23`) rests only on
+      Entry 4 and an instantiation rather than on the full duality theorem;
+      materializing those conditional certificates seemed computationally out of
+      reach, since the construction would require an `n`-element algebra's dual
+      on `|S|ⁿ⁻¹ ≥ 60ⁿ⁻¹` elements.  However, there is work in progress that
+      should offer a way around this; see PR
+      [#569](https://github.com/ualib/agda-algebras/pull/569).

--- a/src/FLRP/Closure/Basic.lagda.md
+++ b/src/FLRP/Closure/Basic.lagda.md
@@ -133,7 +133,7 @@ module _ ((𝑺 , eqns) : Group 0ℓ 0ℓ) where
       the Kurzweil–Netter theorem in [FLRP.KurzweilNetter.Duality][].
 
       **The payoff downstream**.  The two dual entries of the small-lattice census
-      (`L18` and `L22`, duals of the certified `SLR19` and `SLR23`) rests only on
+      (`L18` and `L22`, duals of the certified `SLR19` and `SLR23`) rest only on
       Entry 4 and an instantiation rather than on the full duality theorem;
       materializing those conditional certificates seemed computationally out of
       reach, since the construction would require an `n`-element algebra's dual

--- a/src/FLRP/KurzweilInterval.lagda.md
+++ b/src/FLRP/KurzweilInterval.lagda.md
@@ -41,9 +41,14 @@ characters, and the formal treatment mirrors the split honestly:[^1]
    explicit hypothesis `KurzweilSurjectivity`{.AgdaFunction}, registered as
    **Entry 4** of [FLRP.Assumptions][]; it is stated in the Σ-form that
    *hands the consumer the partition witness*, which is exactly what the
-   isomorphism's inverse map needs.  Retiring the entry, proving surjectivity for
-   a nonabelian simple base, is follow-up work, and will upgrade
-   `kurzweilIntervalIso`{.AgdaFunction} with no change to consumers.
+   isomorphism's inverse map needs.  The Σ-form now comes in two layers: over
+   semantic interval elements (`KurzweilSurjectivity`{.AgdaFunction}, the
+   classical statement of record) and over decidable ones
+   (`KurzweilSurjectivityᵈ`{.AgdaFunction}, the working form the
+   Kurzweil–Netter route consumes).  The split is forced, not stylistic: the
+   closing theorem of this module shows the Layer-S form implies full excluded
+   middle at level zero, so the retirement of Entry 4, proving surjectivity
+   for a nonabelian simple base, can only ever land on the decidable form.
 
 Given the hypothesis, `kurzweilIntervalIso`{.AgdaFunction} is a theorem:
 `[D , Sⁿ] ≅ (Eq n)′` in the `IntervalIso` presentation, with the dual order
@@ -64,28 +69,38 @@ module FLRP.KurzweilInterval where
 open import Agda.Primitive using () renaming ( Set to Type )
 
 -- Imports from the Agda Standard Library ---------------------------------------
+open import Data.Empty        using ( ⊥-elim )
+open import Data.Fin.Patterns using ( 0F ; 1F )
+open import Data.Fin.Properties using ( _≟_ )
 open import Data.Nat.Base     using ( ℕ )
 open import Data.Product      using ( Σ-syntax ; _×_ ; _,_ ; proj₁ ; proj₂ )
+open import Data.Sum.Base     using ( _⊎_ ; inj₁ ; inj₂ )
 open import Level             using ( 0ℓ ) renaming ( suc to lsuc )
 open import Relation.Binary   using ( Setoid )
-open import Relation.Nullary  using ( ¬_ )
-open import Relation.Unary    using ( _⊆_ )
+open import Relation.Binary.Definitions using ( _Respects_ )
+open import Relation.Binary.PropositionalEquality as ≡ using ()
+open import Relation.Nullary  using ( ¬_ ; Dec ; yes ; no )
+open import Relation.Unary    using ( Pred ; _∈_ ; _⊆_ )
 
 -- Imports from the Agda Universal Algebra Library ------------------------------
 open import Classical.Structures.Group.Basic             using  ( Group
                                                                 ; module Group-Op )
 open import Classical.Structures.Group.GSet              using  ( module CosetAction )
+open import Classical.Signatures.Group                   using  ( ∙-Op ; ⁻¹-Op )
 open import Classical.Structures.Group.PartitionSubgroup using  ( module PartitionSubgroups )
+open import Classical.Structures.Group.Subgroups         using  ( mkIsSubgroup )
+open import Classical.Structures.Interpret               using  ( interp-cong )
 open import Classical.Structures.Lattice.Dual            using  ( module LatticeDual
                                                                 ; dualLattice )
-open import Classical.Structures.Lattice.Partitions      using  ( EqLattice ; _⊑_
-                                                                ; ⊑→≤ ; ≤→⊑ )
+open import Classical.Structures.Lattice.Partitions      using  ( EqLattice ; SameBlock
+                                                                ; _⊑_ ; ⊑→≤ ; ≤→⊑ )
 open import FLRP.Enforceable                             using  ( module UpperInterval
                                                                 ; IntervalIso
                                                                 ; GroupRepresentable )
-open import FLRP.Problem                                 using  ( ConIso )
+open import FLRP.Problem                                 using  ( ConIso ; EM₀ ; WLEM₀
+                                                                ; EM₀→WLEM₀ )
 open import Setoid.Algebras                              using  ( 𝕌[_] ; 𝔻[_] ; Algebra)
-open import Setoid.Congruences.Certificates.Schema       using  ( ParentVec )
+open import Setoid.Congruences.Certificates.Schema       using  ( ParentVec ; parent )
 ```
 -->
 
@@ -125,6 +140,33 @@ simple group; the registry documents source, status, and retirement path.
   KurzweilSurjectivity : Type (lsuc 0ℓ)
   KurzweilSurjectivity =
     (𝑴 : Interval≈) → Σ[ pv ∈ ParentVec n ] ((set 𝑴 ⊆ K pv) × (K pv ⊆ set 𝑴))
+```
+
+The definition above quantifies over *semantic* interval elements.  Its Layer-D
+sibling quantifies instead over the decidable interval elements
+`Intervalᵈ`{.AgdaFunction} of [FLRP.Enforceable][]: the same Σ-form, taken over
+elements that carry a membership decider.  This is the form the Kurzweil–Netter
+route consumes, because every interval element it manipulates is the base-coset
+class of a *decidable* congruence, and it is the form whose proof for a finite
+nonabelian simple base group retires Entry 4; the closing theorem of this
+module shows the Layer-S form above is not provable at all.
+
+```agda
+  -- Kurzweil surjectivity, Layer-D form: the partition witness over interval
+  -- elements carrying a membership decider.
+  KurzweilSurjectivityᵈ : Type (lsuc 0ℓ)
+  KurzweilSurjectivityᵈ =
+    (𝑴 : Intervalᵈ) → Σ[ pv ∈ ParentVec n ] ((set (𝑴 .proj₁) ⊆ K pv) × (K pv ⊆ set (𝑴 .proj₁)))
+```
+
+Forgetting the decider restricts the Layer-S form to the decidable instances,
+so the classical statement of record implies the working form; nothing runs the
+other way constructively, and the closing theorem prices the gap exactly.
+
+```agda
+  -- The Layer-S form restricts to the decidable instances.
+  surjectivity→surjectivityᵈ : KurzweilSurjectivity → KurzweilSurjectivityᵈ
+  surjectivity→surjectivityᵈ surj 𝑴 = surj (𝑴 .proj₁)
 ```
 
 #### The interval isomorphism `[D , Sⁿ] ≅ Eq(n)′`
@@ -185,6 +227,117 @@ group representable, witnessed on `[D , Sⁿ]`.
       ; isSubgroup    = Diag-isSubgroup
       ; interval-iso  = kurzweilIntervalIso
       }
+```
+
+#### The Layer-S form is excluded middle
+
+The Σ-form of `KurzweilSurjectivity`{.AgdaFunction} produces the partition as
+concrete data from an *arbitrary* respecting interval element, and interval
+elements can encode arbitrary propositions in their membership predicates (the
+observation footnoted at `Intervalᵈ`{.AgdaFunction} in [FLRP.Enforceable][]).
+The two collide: producing discrete data from an oracle element decides the
+proposition it encodes.  This is the oracle-congruence obstruction of
+[FLRP.Problem][] in interval clothing, with one sharpening: it prices the full
+Layer-S statement rather than any particular representation, and it lands on
+the strong formula `EM₀`{.AgdaFunction} rather than `WLEM₀`{.AgdaFunction}.
+
+The construction needs only the exponent `2` and an apartness witness in the
+base group.  For a proposition `P`, the **oracle subgroup** relates the two
+coordinates *or* asserts `P`.  It respects the pointwise equality and is closed
+under the power operations because the right branch of the disjunction is
+absorbing, and it contains the diagonal through the left branch.  Where the
+produced partition puts the two indices is decidable, and either answer
+decides `P`: if they share a block, the containment `U ⊆ K pv` evaluated at
+the probe tuple `(ε , s₀)` under hypothesis `P` forces `ε ≈ s₀`, refuting
+`P`; if they do not, the probe lies in `K pv` outright, and the other
+containment hands over `(ε ≈ s₀) ⊎ P` with the left branch absurd.
+
+```agda
+module _ (𝒮@(𝑺 , _)  : Group 0ℓ 0ℓ)  (open Setoid 𝔻[ 𝑺 ] using ( _≈_ ))
+                                      (open Group-Op 𝒮 using ( ε ))
+         (s₀          : 𝕌[ 𝑺 ])
+         (s₀≉ε        : ¬ s₀ ≈ ε)
+  where
+
+  open KurzweilInterval 𝒮 2
+  open Setoid 𝔻[ 𝑺 ]  using () renaming ( refl to ≈refl ; sym to ≈sym ; trans to ≈trans )
+  open Setoid 𝔻[ Sⁿ ] using () renaming ( _≈_ to _≈ₚ_ )
+  open Group-Op 𝑺ⁿ    using () renaming ( _∙_ to _∙ₚ_ ; ε to εₚ ; _⁻¹ to _⁻¹ₚ )
+
+  -- Kurzweil surjectivity at Layer S decides every level-zero proposition.
+  kurzweilSurjectivity→EM : KurzweilSurjectivity → EM₀
+  kurzweilSurjectivity→EM surj P = decide (parent pv 0F ≟ parent pv 1F)
+    where
+    -- The oracle subgroup: the two coordinates agree, or P holds.
+    U : Pred 𝕌[ Sⁿ ] 0ℓ
+    U u = (u 0F ≈ u 1F) ⊎ P
+
+    U-respects : U Respects _≈ₚ_
+    U-respects e (inj₁ q)  = inj₁ (≈trans (≈sym (e 0F)) (≈trans q (e 1F)))
+    U-respects e (inj₂ p)  = inj₂ p
+
+    U-∙ : ∀ {x y} → x ∈ U → y ∈ U → (x ∙ₚ y) ∈ U
+    U-∙ {x} {y} (inj₁ qx) (inj₁ qy) =
+      inj₁ (≈trans  (⊗-pointwise x y 0F)
+                    (≈trans  (interp-cong 𝑺 ∙-Op λ { 0F → qx ; 1F → qy })
+                             (≈sym (⊗-pointwise x y 1F))))
+    U-∙ (inj₁ _)   (inj₂ p) = inj₂ p
+    U-∙ (inj₂ p)   _        = inj₂ p
+
+    U-ε : εₚ ∈ U
+    U-ε = inj₁ (≈trans (e-pointwise 0F) (≈sym (e-pointwise 1F)))
+
+    U-⁻¹ : ∀ {x} → x ∈ U → (x ⁻¹ₚ) ∈ U
+    U-⁻¹ {x} (inj₁ q) =
+      inj₁ (≈trans  (inv-pointwise x 0F)
+                    (≈trans  (interp-cong 𝑺 ⁻¹-Op λ { 0F → q })
+                             (≈sym (inv-pointwise x 1F))))
+    U-⁻¹ (inj₂ p) = inj₂ p
+
+    -- The oracle subgroup as an interval element.
+    𝑴P : Interval≈
+    𝑴P = mk U  (mkIsSubgroup 𝑺ⁿ U-respects
+                  (λ {x} {y} → U-∙ {x} {y}) U-ε (λ {x} → U-⁻¹ {x}))
+               (λ d → inj₁ (d 0F 1F))
+
+    -- The partition the hypothesis attaches to it, with its two containments.
+    pv : ParentVec 2
+    pv = surj 𝑴P .proj₁
+
+    U⊆Kpv : U ⊆ K pv
+    U⊆Kpv = surj 𝑴P .proj₂ .proj₁
+
+    Kpv⊆U : K pv ⊆ U
+    Kpv⊆U = surj 𝑴P .proj₂ .proj₂
+
+    -- The probe tuple (ε , s₀).
+    w : 𝕌[ Sⁿ ]
+    w 0F = ε
+    w 1F = s₀
+
+    decide : Dec (SameBlock pv 0F 1F) → P ⊎ ¬ P
+    decide (yes sb) = inj₂ (λ p → s₀≉ε (≈sym (U⊆Kpv {w} (inj₂ p) {0F} {1F} sb)))
+    decide (no ¬e)  = fromU (Kpv⊆U {w} w∈K)
+      where
+      w∈K : w ∈ K pv
+      w∈K {0F} {0F} _   = ≈refl
+      w∈K {0F} {1F} sb  = ⊥-elim (¬e sb)
+      w∈K {1F} {0F} sb  = ⊥-elim (¬e (≡.sym sb))
+      w∈K {1F} {1F} _   = ≈refl
+
+      fromU : w ∈ U → P ⊎ ¬ P
+      fromU (inj₁ e)  = ⊥-elim (s₀≉ε (≈sym e))
+      fromU (inj₂ p)  = inj₁ p
+```
+
+Through the generic weakening of [FLRP.Problem][], the theorem places the
+Layer-S form at or above every obstruction of `WLEM₀`{.AgdaFunction} strength
+in that module's no-go family.
+
+```agda
+  -- The weak form, for comparison with the chain₂ no-go family.
+  kurzweilSurjectivity→WLEM : KurzweilSurjectivity → WLEM₀
+  kurzweilSurjectivity→WLEM surj = EM₀→WLEM₀ (kurzweilSurjectivity→EM surj)
 ```
 
 #### Consumer interface checks

--- a/src/FLRP/KurzweilInterval.lagda.md
+++ b/src/FLRP/KurzweilInterval.lagda.md
@@ -149,7 +149,9 @@ elements that carry a membership decider.  This is the form the Kurzweil–Nette
 route consumes, because every interval element it manipulates is the base-coset
 class of a *decidable* congruence, and it is the form whose proof for a finite
 nonabelian simple base group retires Entry 4; the closing theorem of this
-module shows the Layer-S form above is not provable at all.
+module shows that the Layer-S form above, at exponent `2` over a base group
+with an apartness witness, implies excluded middle, so no proof of it for such
+a group can land in the safe fragment.
 
 ```agda
   -- Kurzweil surjectivity, Layer-D form: the partition witness over interval
@@ -229,7 +231,7 @@ group representable, witnessed on `[D , Sⁿ]`.
       }
 ```
 
-#### The Layer-S form is excluded middle
+#### The Layer-S form implies excluded middle
 
 The Σ-form of `KurzweilSurjectivity`{.AgdaFunction} produces the partition as
 concrete data from an *arbitrary* respecting interval element, and interval

--- a/src/FLRP/KurzweilNetter/Duality.lagda.md
+++ b/src/FLRP/KurzweilNetter/Duality.lagda.md
@@ -27,8 +27,9 @@ lectures).  Given a representation `𝑳 ≅ DecCon 𝑨`, proceed as follows:
 2. expand the coset algebra of the diagonal `D ≤ Sᵐ` by the lifted translations;
    its decidable congruence poset is the *reversed* poset of invariant partitions
    ([FLRP.KurzweilNetter.Expansion][], composing the WP-3 bridge
-   `DecCon (Sᵐ ↷ Sᵐ/D) ≅ [D , Sᵐ]` of [FLRP.Bridge][] with Kurzweil's interval
-   isomorphism `[D , Sᵐ] ≅ Eq(m)′` of [FLRP.KurzweilInterval][]);
+   `DecCon (Sᵐ ↷ Sᵐ/D) ≅ [D , Sᵐ]` of [FLRP.Bridge][] with the
+   decidable-instance passage of Kurzweil's interval isomorphism
+   `[D , Sᵐ] ≅ Eq(m)′` of [FLRP.KurzweilInterval][]);
 
 3. compose the two, and the original representation, into
    `DecCon 𝑬 ≅ dualLattice 𝑳`, the record `dual-representation`{.AgdaFunction} below.
@@ -48,10 +49,13 @@ argument actually uses:
    order reflection and injectivity of `π ↦ K_π`, and for extracting
    invariance from closure in the expansion step (the indicator tuples);
 
-+  **Kurzweil surjectivity at every exponent**
-   (`KurzweilSurjectivityAt`{.AgdaFunction}` 𝒮 n`, Entry 4 of
-   [FLRP.Assumptions][]): every subgroup in `[D , Sⁿ]` is a partition
-   subgroup.
++  **Kurzweil surjectivity at every exponent, in the decidable form**
+   (`KurzweilSurjectivityᵈAt`{.AgdaFunction}` 𝒮 n`, the working form of
+   Entry 4 of [FLRP.Assumptions][]): every *decidable* subgroup in
+   `[D , Sⁿ]` is a partition subgroup.  The semantic form is deliberately
+   not consumed: it is unprovable outright (the no-go of
+   [FLRP.KurzweilInterval][]), while the decidable form is exactly what the
+   construction's base-coset classes deliver.
 
 *Nonabelianness and simplicity of `S` enter only through the third item*;
 they are what makes Entry 4 true classically.  Thus no simplicity predicate is
@@ -101,7 +105,7 @@ open import Classical.Structures.Lattice.Dual   using  ( dualLattice
                                                        ; module LatticeDual )
 open import FLRP.Assumptions                    using  ( KurzweilNetterDualityAt
                                                        ; KurzweilNetterDuality
-                                                       ; KurzweilSurjectivityAt )
+                                                       ; KurzweilSurjectivityᵈAt )
 open import FLRP.KurzweilNetter.Blocks          using  ( module KNBlocks )
 open import FLRP.KurzweilNetter.Expansion       using  ( module KNExpansion )
 open import FLRP.KurzweilNetter.Translations    using  ( module KNTranslations )
@@ -144,7 +148,7 @@ module KNGlue
   (𝑭ₛ         : FiniteAlgebra 𝑺)
   (s₀         : 𝕌[ 𝑺 ])
   (s₀≉ε       : ¬ s₀ ≈ ε)
-  (surjm      : KurzweilSurjectivityAt 𝒮 (IrredundantEnumeration.icard 𝑬ᵢ))
+  (surjm      : KurzweilSurjectivityᵈAt 𝒮 (IrredundantEnumeration.icard 𝑬ᵢ))
   (𝓛@(𝑳 , _)  : Lattice)
   (iso        : ConIsoᵈ 𝑨 𝓛)
   where
@@ -302,7 +306,7 @@ canonical irredundant enumeration of each representation.
 One reading note, so the module cannot overstate itself: the definitions below
 inhabit `KurzweilNetterDuality`{.AgdaFunction} *inside* this parameterized
 module; the library holds no closed inhabitant of the statement, and Entry 4's
-family is a genuine hypothesis of the result.  Entry 2 of [FLRP.Assumptions][] is
+decidable family is a genuine hypothesis of the result.  Entry 2 of [FLRP.Assumptions][] is
 thereby *reduced to Entry 4*, not discharged; the registry entry records the same
 reading.
 
@@ -312,7 +316,7 @@ module KurzweilNetterProof
   (𝑭ₛ         : FiniteAlgebra 𝑺)
   (s₀         : 𝕌[ 𝑺 ])
   (s₀≉ε       : ¬ (Setoid._≈_ 𝔻[ 𝑺 ] s₀ (Group-Op.ε 𝒮)))
-  (surj       : (n : ℕ) → KurzweilSurjectivityAt 𝒮 n)
+  (surj       : (n : ℕ) → KurzweilSurjectivityᵈAt 𝒮 n)
   where
 
   -- Kurzweil–Netter duality at a lattice.

--- a/src/FLRP/KurzweilNetter/Duality.lagda.md
+++ b/src/FLRP/KurzweilNetter/Duality.lagda.md
@@ -160,17 +160,18 @@ the expansion module builds the representing algebra `𝑬` on `Sᵐ/D`.
 
 ```agda
   private
-    module KB = KNBlocks 𝑨 𝑬ᵢ
-    module KT = KNTranslations 𝑨 𝑆fin 𝑬ᵢ
-    module KE = KNExpansion 𝒮 𝑭ₛ s₀ s₀≉ε  (IrredundantEnumeration.icard 𝑬ᵢ)
-                                          KT.trCount KT.trFamily surjm
-
-    module I₀ = OrderIso iso
-    module KEIso = OrderIso KE.expansionIso
-
-    open ConIsoᵈ-Consequences {𝑆 = 𝑆} {𝑨 = 𝑨} {𝑳 = 𝓛} iso using ( to-cong≑ )
+    open KNBlocks 𝑨 𝑬ᵢ using  ( pvOf ; blockRel-mono ; pvOf-mono ; blockRel-pvOf-out
+                              ; blockRel-pvOf-in ; pvOf-blockRel )
+    open KNTranslations 𝑨 𝑆fin 𝑬ᵢ using  ( trCount ; trFamily ; blockConᶠ
+                                         ; pvOf-invariant-family)
+    open ConIsoᵈ-Consequences {𝑆 = 𝑆} {𝑨} {𝓛} iso using ( to-cong≑ )
 
     open Setoid 𝔻[ 𝑳 ] using () renaming ( trans to ≈ᴸ-trans )
+    open KNExpansion 𝒮 𝑭ₛ s₀ s₀≉ε  (IrredundantEnumeration.icard 𝑬ᵢ)
+      trCount trFamily surjm using ( InvPart ; _≈ᵛ_ ; _≥ᵛ_ ; expandedAlgebra
+                                         ; expansionIso ; Sig-Exp
+                                         ; expandedAlgebra-FiniteAlgebra
+                                         ; Sig-Exp-FiniteSignature )
 ```
 
 **The middle stage of the composite**.  The family-invariant partitions are the
@@ -180,12 +181,12 @@ congruence the other.
 
 ```agda
     -- an invariant partition presents a congruence of the represented algebra ...
-    midTo : KE.InvPart → DecCon 𝑨 0ℓ
-    midTo (pv , h) = KT.blockConᶠ pv h
+    midTo : InvPart → DecCon 𝑨 0ℓ
+    midTo (pv , h) = blockConᶠ pv h
 
     -- ... and a congruence has an invariant partition.
-    midFrom : DecCon 𝑨 0ℓ → KE.InvPart
-    midFrom d = KB.pvOf d , KT.pvOf-invariant-family d
+    midFrom : DecCon 𝑨 0ℓ → InvPart
+    midFrom d = pvOf d , pvOf-invariant-family d
 ```
 
 **The middle stage as an order isomorphism in its own right**.  The round trips
@@ -201,14 +202,14 @@ verbatim.
     _⊇ᵈ_ : DecCon 𝑨 0ℓ → DecCon 𝑨 0ℓ → Type _
     d ⊇ᵈ e = e ⊆ᵈ d
 
-    midIso : OrderIso KE._≈ᵛ_ KE._≥ᵛ_ (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) _⊇ᵈ_
+    midIso : OrderIso _≈ᵛ_ _≥ᵛ_ (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) _⊇ᵈ_
     midIso = record
       { to         = midTo
       ; from       = midFrom
-      ; to-mono    = λ {(P , _)} {(Q , _)} ge → KB.blockRel-mono {pu = Q} {pw = P} ge
-      ; from-mono  = λ {d} {e} sup → KB.pvOf-mono e d sup
-      ; to∘from    = λ d → KB.blockRel-pvOf-out d , KB.blockRel-pvOf-in d
-      ; from∘to    = λ P → KB.pvOf-blockRel (midTo P) (proj₁ P) id id
+      ; to-mono    = λ {(P , _)} {(Q , _)} ge → blockRel-mono {pu = Q} {pw = P} ge
+      ; from-mono  = λ {d} {e} sup → pvOf-mono e d sup
+      ; to∘from    = λ d → blockRel-pvOf-out d , blockRel-pvOf-in d
+      ; from∘to    = λ P → pvOf-blockRel (midTo P) (proj₁ P) id id
       }
 ```
 
@@ -217,17 +218,19 @@ representation, with the monotonicity directions flipped through the two flip
 lemmas of [Classical.Structures.Lattice.Dual][].
 
 ```agda
-    I₀-dual : OrderIso  (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) _⊇ᵈ_
-                        (Setoid._≈_ 𝔻[ proj₁ (dualLattice 𝓛) ])
-                        (Lattice-Order._≤_ (dualLattice 𝓛))
+    I₀-dual : OrderIso _≑ᵈ_ _⊇ᵈ_  (Setoid._≈_ 𝔻[ dualLattice 𝓛 .proj₁ ])
+                                  (Lattice-Order._≤_ (dualLattice 𝓛))
     I₀-dual = record
-      { to = I₀.to
-      ; from = I₀.from
-      ; to-mono = λ sup → LatticeDual.≤ᵈ-unflip 𝓛 (I₀.to-mono sup)
-      ; from-mono = λ le → I₀.from-mono (LatticeDual.≤ᵈ-flip 𝓛 le)
-      ; to∘from = I₀.to∘from
-      ; from∘to = I₀.from∘to
+      { to         = to
+      ; from       = from
+      ; to-mono    = ≤ᵈ-unflip ∘ to-mono
+      ; from-mono  = from-mono ∘ ≤ᵈ-flip
+      ; to∘from    = to∘from
+      ; from∘to    = from∘to
       }
+      where
+      open OrderIso iso
+      open LatticeDual 𝓛 using (≤ᵈ-unflip ; ≤ᵈ-flip)
 ```
 
 **The junction data for composing the three stages**: transitivity of the mutual
@@ -235,28 +238,27 @@ containments, and the congruence of each map with respect to the middle
 equivalence it crosses; every one of them is monotonicity applied twice.
 
 ```agda
-    ≑ᴱ-trans : {a b c : DecCon KE.expandedAlgebra 0ℓ} → a ≑ᵈ b → b ≑ᵈ c → a ≑ᵈ c
+    ≑ᴱ-trans : {a b c : DecCon expandedAlgebra 0ℓ} → a ≑ᵈ b → b ≑ᵈ c → a ≑ᵈ c
     ≑ᴱ-trans (p₁ , p₂) (q₁ , q₂) = q₁ ∘ p₁ , p₂ ∘ q₂
 
     ≑ᴬ-trans : {a b c : DecCon 𝑨 0ℓ} → a ≑ᵈ b → b ≑ᵈ c → a ≑ᵈ c
     ≑ᴬ-trans (p₁ , p₂) (q₁ , q₂) = q₁ ∘ p₁ , p₂ ∘ q₂
 
-    midTo-cong : {P Q : KE.InvPart} → P KE.≈ᵛ Q → midTo P ≑ᵈ midTo Q
+    midTo-cong : {P Q : InvPart} → P ≈ᵛ Q → midTo P ≑ᵈ midTo Q
     midTo-cong {(P , _)} {(Q , _)} (uw , wu) =
-        KB.blockRel-mono {pu = P} {pw = Q} uw
-      , KB.blockRel-mono {pu = Q} {pw = P} wu
+      blockRel-mono {pu = P} {pw = Q} uw , blockRel-mono {pu = Q} {pw = P} wu
 
-    midFrom-cong : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → midFrom d KE.≈ᵛ midFrom e
-    midFrom-cong {d} {e} (p , q) = KB.pvOf-mono d e p , KB.pvOf-mono e d q
+    midFrom-cong : {d e : DecCon 𝑨 0ℓ} → d ≑ᵈ e → midFrom d ≈ᵛ midFrom e
+    midFrom-cong {d} {e} (p , q) = pvOf-mono d e p , pvOf-mono e d q
 
-    KEfrom-cong : {P Q : KE.InvPart} → P KE.≈ᵛ Q → KEIso.from P ≑ᵈ KEIso.from Q
-    KEfrom-cong {P} {Q} (uw , wu) =
-      KEIso.from-mono {P} {Q} wu , KEIso.from-mono {Q} {P} uw
+    open OrderIso expansionIso using ( from ; from-mono)
+
+    KEfrom-cong : {P Q : InvPart} → P ≈ᵛ Q → from P ≑ᵈ from Q
+    KEfrom-cong {P} {Q} (uw , wu) = from-mono {P} {Q} wu , from-mono {Q} {P} uw
 
     stage₁-from-cong : {d e : DecCon 𝑨 0ℓ}
-      → d ≑ᵈ e → KEIso.from (midFrom d) ≑ᵈ KEIso.from (midFrom e)
-    stage₁-from-cong {d} {e} de =
-      KEfrom-cong {midFrom d} {midFrom e} (midFrom-cong {d} {e} de)
+      → d ≑ᵈ e → from (midFrom d) ≑ᵈ from (midFrom e)
+    stage₁-from-cong {d} {e} de = KEfrom-cong {midFrom d} {midFrom e} (midFrom-cong de)
 ```
 
 **The composite isomorphism `DecCon 𝑬 ≅ dualLattice 𝑳`**: by two applications of
@@ -265,21 +267,16 @@ inside the expansion isomorphism; the middle stages run against the reversed
 orders, and the boundary lands in the dual lattice's meet order.
 
 ```agda
-    stage₁ : OrderIso  (_≑ᵈ_ {𝑨 = KE.expandedAlgebra} {ℓ = 0ℓ})
-                       (_⊆ᵈ_ {𝑨 = KE.expandedAlgebra} {ℓ = 0ℓ})
-                       (_≑ᵈ_ {𝑨 = 𝑨} {ℓ = 0ℓ}) _⊇ᵈ_
-    stage₁ = OrderIso-trans KE.expansionIso midIso
+    stage₁ : OrderIso _≑ᵈ_ _⊆ᵈ_ _≑ᵈ_ _⊇ᵈ_
+    stage₁ = OrderIso-trans expansionIso midIso
       (λ {P} {Q} → midTo-cong {P} {Q})
       (λ {P} {Q} → KEfrom-cong {P} {Q})
       (λ {a} {b} {c} → ≑ᴱ-trans {a} {b} {c})
       (λ {a} {b} {c} → ≑ᴬ-trans {a} {b} {c})
 
-    dualConIso : ConIsoᵈ {𝑆 = KE.Sig-Exp} KE.expandedAlgebra (dualLattice 𝓛)
-    dualConIso = OrderIso-trans stage₁ I₀-dual
-      (λ {d} {e} → to-cong≑ {d} {e})
-      (λ {d} {e} → stage₁-from-cong {d} {e})
-      (λ {a} {b} {c} → ≑ᴱ-trans {a} {b} {c})
-      (λ {x} {y} {z} → ≈ᴸ-trans {x} {y} {z})
+    dualConIso : ConIsoᵈ expandedAlgebra (dualLattice 𝓛)
+    dualConIso = OrderIso-trans stage₁ I₀-dual to-cong≑ stage₁-from-cong
+      (λ {a} {b} {c} → ≑ᴱ-trans {a} {b} {c}) ≈ᴸ-trans
 ```
 
 **The representation of the dual**: the expanded coset algebra, its finiteness
@@ -289,10 +286,10 @@ and finite signature from the expansion module, and the composite isomorphism.
   -- The dual of a decidably representable lattice is decidably representable.
   dual-representation : Representableᵈ (dualLattice 𝓛)
   dual-representation = record
-    { sigᵈ      = KE.Sig-Exp
-    ; algᵈ      = KE.expandedAlgebra
-    ; finiteᵈ   = KE.expandedAlgebra-FiniteAlgebra
-    ; finsigᵈ   = KE.Sig-Exp-FiniteSignature
+    { sigᵈ      = Sig-Exp
+    ; algᵈ      = expandedAlgebra
+    ; finiteᵈ   = expandedAlgebra-FiniteAlgebra
+    ; finsigᵈ   = Sig-Exp-FiniteSignature
     ; con-isoᵈ  = dualConIso
     }
 ```
@@ -321,14 +318,14 @@ module KurzweilNetterProof
 
   -- Kurzweil–Netter duality at a lattice.
   kurzweilNetterDualityAt : (𝑳 : Lattice) → KurzweilNetterDualityAt 𝑳
-  kurzweilNetterDualityAt 𝑳 r =
-    KNGlue.dual-representation {𝑆 = sigᵈ} {𝑨 = algᵈ} finsigᵈ 𝑬ᵢ
-      𝒮 𝑭ₛ s₀ s₀≉ε (surj (IrredundantEnumeration.icard 𝑬ᵢ)) 𝑳 con-isoᵈ
+  kurzweilNetterDualityAt 𝑳 r = dual-representation
     where
     open Representableᵈ r  -- sigᵈ, algᵈ, finiteᵈ, finsigᵈ, con-isoᵈ
 
     𝑬ᵢ : IrredundantEnumeration algᵈ
     𝑬ᵢ = irredundantEnumeration finiteᵈ
+    open IrredundantEnumeration 𝑬ᵢ
+    open KNGlue finsigᵈ 𝑬ᵢ 𝒮 𝑭ₛ s₀ s₀≉ε (surj icard) 𝑳 con-isoᵈ
 
   -- The Kurzweil–Netter duality theorem, conditional on the module's package.
   kurzweilNetterDuality : KurzweilNetterDuality

--- a/src/FLRP/KurzweilNetter/Expansion.lagda.md
+++ b/src/FLRP/KurzweilNetter/Expansion.lagda.md
@@ -54,13 +54,17 @@ Three design points, each forced by a constraint worth recording.
    (`K-closed→Inv`{.AgdaFunction}).  This is one of the few places the base
    group's properties enter the proof at all.
 
-+  **Kurzweil surjectivity enters as the registered hypothesis**.
++  **Kurzweil surjectivity enters in its decidable form**.
 
    The passage from an arbitrary congruence to a partition routes through Entry 4
-   of [FLRP.Assumptions][] (`KurzweilSurjectivity`{.AgdaFunction}, the classical
-   half of Kurzweil's lemma, true for `𝒮` finite nonabelian simple); this module
-   takes it as a module parameter, exactly as `kurzweilIntervalIso`{.AgdaFunction}
-   does.
+   of [FLRP.Assumptions][] in the working form
+   `KurzweilSurjectivityᵈ`{.AgdaFunction} (the classical half of Kurzweil's
+   lemma, true for `𝒮` finite nonabelian simple), taken as a module parameter.
+   Every interval element this construction manipulates is the base-coset class
+   of a *decidable* congruence, delivered with its decider by the Layer-D bridge
+   map `toᵈ`{.AgdaFunction}, so the semantic form is never needed; that matters,
+   because the semantic form is unprovable outright (the no-go of
+   [FLRP.KurzweilInterval][]).
 
 <!--
 ```agda
@@ -97,9 +101,7 @@ open import Classical.Structures.Group.Basic         using  ( Group ; module Gro
 open import Classical.Structures.Group.Cosets        using  ( module Coset )
 open import Classical.Structures.Group.GSet          using  ( module CosetAction )
 open import Classical.Structures.Interpret           using  ( interp-cong )
-open import Classical.Structures.Lattice.Dual        using  ( module LatticeDual )
-open import Classical.Structures.Lattice.Partitions  using  ( SameBlock ; _⊑_ ; _≈ᵖ_
-                                                            ; EqLattice ; ≤→⊑ )
+open import Classical.Structures.Lattice.Partitions  using  ( SameBlock ; _⊑_ ; _≈ᵖ_ )
 open import FLRP.Bridge                              using  ( module Bridge )
 open import FLRP.KurzweilInterval                    using  ( module KurzweilInterval )
 open import FLRP.KurzweilNetter.Invariance           using  ( Inv )
@@ -123,7 +125,7 @@ open import Setoid.Signatures.Finite                 using  ( FiniteSignature )
 
 `KNExpansion`{.AgdaModule} fixes the base group with its finiteness and
 nontriviality witnesses, the exponent `m`, the abstract family `tr` of index maps,
-and the Kurzweil surjectivity hypothesis at `m`.
+and the decidable Kurzweil surjectivity hypothesis at `m`.
 
 ```agda
 module KNExpansion
@@ -134,7 +136,7 @@ module KNExpansion
   (s₀≉ε       : ¬ s₀ ≈ ε)
   (m T        : ℕ)
   (tr         : Fin T → Fin m → Fin m)
-  (surj       : KurzweilInterval.KurzweilSurjectivity 𝒮 m)
+  (surj       : KurzweilInterval.KurzweilSurjectivityᵈ 𝒮 m)
   where
 
   -- Sⁿ = Sᵐ, Diag, K, the interval, kurzweilIntervalIso; the power kit's
@@ -362,28 +364,35 @@ the relation level.
 #### From congruences to invariant partitions and back
 
 The forward passage composes the WP-3 bridge with the surjectivity hypothesis.
-The congruence's base-coset class is an interval element, the hypothesis hands
-over a partition, and closure of the class under the lifts (one compatibility
-instance at `ε`) makes that partition invariant through the indicator argument.
+The congruence's base-coset class, carried with the congruence's own decision
+procedure through the bridge's Layer-D map, is a decidable interval element;
+the hypothesis hands over a partition, and closure of the class under the lifts
+(one compatibility instance at `ε`) makes that partition invariant through the
+indicator argument.
 
 ```agda
   private
     module B = Bridge 𝑺ⁿ Diag Diag-isSubgroup
 
-  -- The interval element of an expanded congruence: its base-coset class.
+  -- The decidable interval element of an expanded congruence: its base-coset
+  -- class, with the congruence's own decision procedure.
+  intervalOfᵈ : DecCon expandedAlgebra 0ℓ → Intervalᵈ
+  intervalOfᵈ θE = B.toᵈ (forget θE)
+
+  -- The underlying interval element (the base-coset class alone).
   intervalOf : DecCon expandedAlgebra 0ℓ → Interval≈
-  intervalOf θE = B.to (forget θE .proj₁)
+  intervalOf θE = intervalOfᵈ θE .proj₁
 
   -- The partition the surjectivity hypothesis attaches to it.
   partOf : DecCon expandedAlgebra 0ℓ → ParentVec m
-  partOf θE = surj (intervalOf θE) .proj₁
+  partOf θE = surj (intervalOfᵈ θE) .proj₁
 
   private
     partOf-in : (θE : DecCon expandedAlgebra 0ℓ) → set (intervalOf θE) ⊆ K (partOf θE)
-    partOf-in θE = surj (intervalOf θE) .proj₂ .proj₁
+    partOf-in θE = surj (intervalOfᵈ θE) .proj₂ .proj₁
 
     partOf-out : (θE : DecCon expandedAlgebra 0ℓ) → K (partOf θE) ⊆ set (intervalOf θE)
-    partOf-out θE = surj (intervalOf θE)  .proj₂ .proj₂
+    partOf-out θE = surj (intervalOfᵈ θE)  .proj₂ .proj₂
 
     -- the base-coset class is closed under the lifts
     classClosed : (θE : DecCon expandedAlgebra 0ℓ) (τ : Fin T)
@@ -461,22 +470,28 @@ The two maps of the isomorphism.
 ```
 
 **Monotonicity**.  Forward: a containment of congruences passes through the bridge
-to an inclusion of interval elements, through the interval isomorphism of
-[FLRP.KurzweilInterval][] to the dual lattice order, and unflips to reversed
-refinement.  Backward: reversed refinement is an inclusion of partition
-subgroups (`K-antitone`{.AgdaFunction}), which the bridge's inverse forwards.
+to an inclusion of base-coset classes, which the order-reflection argument of
+[Classical.Structures.Group.PartitionSubgroup][] flips to reversed refinement of
+the attached partitions (this is the mono-flip step of
+`kurzweilIntervalIso`{.AgdaFunction}, taken directly at the decidable elements
+this module manipulates).  Backward: reversed refinement is an inclusion of
+partition subgroups (`K-antitone`{.AgdaFunction}), which the bridge's inverse
+forwards.
 
 ```agda
   private
-    KI = kurzweilIntervalIso s₀ s₀≉ε surj
+    -- Inclusion of base-coset classes reflects to reversed refinement of the
+    -- attached partitions.
+    partOf-flip : {θE φE : DecCon expandedAlgebra 0ℓ}
+      → intervalOf θE ≤ᵢ intervalOf φE → partOf φE ⊑ partOf θE
+    partOf-flip {θE} {φE} le =
+      K-reflects s₀ s₀≉ε {pu = partOf φE} {pw = partOf θE}
+        λ k → partOf-in φE (le (partOf-out θE k))
 
   toInvPart-mono : (θE φE : DecCon expandedAlgebra 0ℓ)
     → (∀ {x y} → ConRel θE x y → ConRel φE x y) → toInvPart θE ≥ᵛ toInvPart φE
   toInvPart-mono θE φE sub =
-    ≤→⊑ {pu = partOf φE} {pw = partOf θE}
-      (LatticeDual.≤ᵈ-flip (EqLattice m) {x = partOf θE} {y = partOf φE}
-        (OrderIso.to-mono KI {intervalOf θE} {intervalOf φE}
-          (B.to-mono {forget θE .proj₁} {forget φE .proj₁} sub)))
+    partOf-flip {θE} {φE} (B.to-mono {forget θE .proj₁} {forget φE .proj₁} sub)
 
   fromInvPart-mono : (P Q : InvPart) → P ≥ᵛ Q
     → ∀ {x y} → ConRel (fromInvPart P) x y → ConRel (fromInvPart Q) x y

--- a/src/FLRP/Problem.lagda.md
+++ b/src/FLRP/Problem.lagda.md
@@ -400,6 +400,25 @@ WLEM₀ : Type (lsuc 0ℓ)
 WLEM₀ = ∀ P → ¬ P ⊎ ¬ ¬ P
 ```
 
+The *strong* formula, full excluded middle for level-zero types, is recorded
+beside it.  No result of this module reaches it; it is the conclusion of the
+surjectivity no-go of [FLRP.KurzweilInterval][], and the generic weakening
+`EM₀→WLEM₀`{.AgdaFunction} places that conclusion above every
+`WLEM₀`{.AgdaFunction}-strength obstruction in this family.
+
+```agda
+EM₀ : Type (lsuc 0ℓ)
+EM₀ = ∀ P → P ⊎ ¬ P
+
+-- Full excluded middle weakens to weak excluded middle.
+EM₀→WLEM₀ : EM₀ → WLEM₀
+EM₀→WLEM₀ em P = weaken (em P)
+  where
+  weaken : P ⊎ ¬ P → ¬ P ⊎ ¬ ¬ P
+  weaken (inj₁ p)   = inj₂ (λ ¬p → ¬p p)
+  weaken (inj₂ ¬p)  = inj₁ ¬p
+```
+
 The proof needs three small facts, each with a one-line justification.
 
 +  `to-cong`{.AgdaFunction}: `≑`-equal congruences have equal images, because both


### PR DESCRIPTION
Closes #566.

**What this proves.**  `kurzweilSurjectivity→EM` in `FLRP.KurzweilInterval`: the registered Layer-S form of Kurzweil surjectivity, at exponent `2` over any base group with an apartness witness, implies full excluded middle for level-zero types.  The oracle subgroup `U u = (u 0F ≈ u 1F) ⊎ P` is a respecting subgroup above the diagonal (the right branch of the disjunction is absorbing), and where the produced partition puts the two indices is decidable, with either answer deciding `P` through the two containments at the probe tuple `(ε , s₀)`.  `EM₀` and the generic weakening `EM₀→WLEM₀` land in `FLRP.Problem` beside the `chain₂` no-go family, and `kurzweilSurjectivity→WLEM` places the hypothesis at or above that family's strength.  So Entry 4 as previously registered could never have been proved in the safe fragment, and the "assemble at Layer S, then derive the Layer-D reading" half of #522's task list was unachievable, exactly as flagged there.

**The restatement.**  `KurzweilSurjectivityᵈ` (registry alias `KurzweilSurjectivityᵈAt`) is the same Σ-form over the decidable interval elements `Intervalᵈ` of `FLRP.Enforceable`, with `surjectivity→surjectivityᵈ` the forgetful restriction.  The Layer-S type stays registered as the classical statement of record, Entry-2 style; the entry's new Strength note and its rewritten Status and Layer notes document the two forms and the corrected retirement path, and Entry 2's residue note drops its stale simplicity-predicate dependency.

**The rewire.**  `KNExpansion`, `KNGlue`, `KurzweilNetterProof`, and `dual-Representableᵈ` now take the `ᵈ`-family.  Nothing is lost: the construction applies the hypothesis only at base-coset classes of decidable congruences, and `intervalOfᵈ = Bridge.toᵈ ∘ forget` carries each congruence's own decision procedure through the bridge's existing Layer-D map (the ticket's bridge task turned out to be already on master as `toᵈ`/`bridgeᵈ`).  One simplification fell out: `toInvPart-mono` previously built the full Layer-S `kurzweilIntervalIso` only to use its `to-mono`, wrapped in a dual-lattice flip and unflip that cancelled each other; it now takes the underlying `K-reflects` step directly, as `partOf-flip`.

**Deferred, deliberately.**  The `ᵈ`-carrier variant of `kurzweilIntervalIso` is not built here: with `partOf-flip` in place no consumer needs it, and it is precisely the statement #522's assembly will inhabit, so it belongs in that PR.  The Layer-S `kurzweilIntervalIso` and `eqDual-groupRepresentable` are untouched; they remain hypothesis-driven and are still what RP-4 consumes.

**Gates.**  `make check` green at each commit (367 modules); `make unused-imports` 0 flagged; `make gen-links` produced no diff and `make check-links` resolves all 339 pages; `make docstrings` at 7 gaps under the ceiling with the FLRP subtree at 0; `make flrp-test` OK.  After this PR the only remaining hypothesis of `kurzweilNetterDuality` is `(n : ℕ) → KurzweilSurjectivityᵈAt 𝒮 n` beside the finiteness and nontriviality witnesses, all of which already exist for `A₅` (#527).

🤖 AI-assisted development: Claude Fable 5 (Anthropic)
