### PR TITLE
Count the landing page's corpus stats, and gate them (#575)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,12 @@
 #  ci.yml — CI Pipeline for agda-algebras
 #  ----------------------------------------------------------------------------
 #
-#  Two Agda lanes plus a docs lane: the library (and the frozen Legacy tree),
-#  the FLRP certificate census, and the reference-link check.  The census is a
-#  separate lane because it is 44% of a clean full type-check and no library
-#  module imports it (issue #515); running it in parallel keeps the library
-#  result fast without leaving anything unchecked.
+#  Two Agda lanes plus three pure-Python docs lanes: the library (and the frozen
+#  Legacy tree), the FLRP certificate census, the reference-link check, the
+#  docstring-coverage ratchet, and the landing page's corpus stats.  The census
+#  is a separate lane because it is 44% of a clean full type-check and no
+#  library module imports it (issue #515); running it in parallel keeps the
+#  library result fast without leaving anything unchecked.
 #
 #  The workflow reuses the project's Nix flake, so CI runs exactly the same
 #  command a developer runs locally: `nix develop --command make check`.
@@ -215,6 +216,38 @@ jobs:
           make docstrings
 
   # ---------------------------------------------------------------------------
+  # Landing-page stats.  Pure-Python, like the two checks above.  docs/index.md
+  # advertises a module count, a line count, a machine-checked share and the
+  # pinned toolchain; all of them are facts about this repository, and all of
+  # them are counted by scripts/python/corpus_stats.py.  The MkDocs hook already
+  # substituted the counted values into the *rendered* page, but never wrote
+  # them back, so the values committed in the source (the ones GitHub renders)
+  # went stale for six weeks and were quoted elsewhere as current (issue #575).
+  # This job fails when a committed value has drifted from the tree, so the PR
+  # that moves a number is the PR that refreshes the page.  See
+  # `make corpus-stats`.
+  # ---------------------------------------------------------------------------
+  landing-stats:
+    name: Landing-page stats
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: docs/index.md's committed figures match the tree
+        run: |
+          set -euxo pipefail
+          make corpus-stats-test
+          make corpus-stats-check
+
+  # ---------------------------------------------------------------------------
   # Aggregate status: a single stable required-check name for branch
   # protection.  Uses `if: always()` so that skipped/conditional jobs added
   # in the future don't block the gate.
@@ -224,12 +257,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: always()
-    needs: [check, certificates, link-check, docstrings]
+    needs: [check, certificates, link-check, docstrings, landing-stats]
     steps:
       - name: Verify all required jobs passed
         run: |
           set -euxo pipefail
-          results=( "${{ needs.check.result }}" "${{ needs.certificates.result }}" "${{ needs.link-check.result }}" "${{ needs.docstrings.result }}" )
+          results=( "${{ needs.check.result }}" "${{ needs.certificates.result }}" "${{ needs.link-check.result }}" "${{ needs.docstrings.result }}" "${{ needs.landing-stats.result }}" )
           for r in "${results[@]}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "A required job ended with result: $r"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,23 @@ Migration recipe for the M2-7 destinations: replace `open import Legacy.Base.Rel
 
 ### Fixed
 
-Nothing to report.  3.0 is a forward-looking reconstruction rather than a bug-fix release.
++  **The landing page's corpus stats no longer rot** (#575).  `docs/index.md`
+   advertises how many literate modules the library holds and how many lines of
+   Agda they contain.  Those two figures were recomputed by the MkDocs hook on
+   every build, but the hook rewrote only the *rendered* page and never wrote
+   back, so the values committed in the source, which are the ones GitHub
+   renders, stayed at their 2026-07-28 reading (302 modules, 60k lines) while
+   the library grew to 339 modules and 67k lines.  The stale pair was quoted
+   outside this repository as current.  [`scripts/python/corpus_stats.py`](scripts/python/corpus_stats.py)
+   now counts the figures and writes them into the page (`make corpus-stats`),
+   and CI fails when a committed value has drifted (`make corpus-stats-check`,
+   the *Landing-page stats* job), so the pull request that moves a number is the
+   one that refreshes the page.  The two hand-written literals beside them are
+   counted as well: the machine-checked share is the proportion of canonical
+   modules whose `OPTIONS` pragma carries `--safe`, and the Agda and
+   standard-library versions are read from `mkdocs.yml`'s site variables and
+   reconciled against `agda-algebras.agda-lib`'s `depend:` line and the
+   version-floor guards in `flake.nix`.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@
 #      where a path segment happens to contain the substring `agda`.
 # =============================================================================
 
-.PHONY: default all check check-certificates check-all test clean site serve serve-full html agda-md site-full profile project-plan unused-imports unused-imports-test check-links check-links-test gen-links gap-hunt docstrings docstrings-test docstrings-list docstrings-unused docstrings-json flrp-test flrp-slr gap-smoke Everything.agda EverythingLegacy.agda EverythingCertificates.agda
+.PHONY: default all check check-certificates check-all test clean site serve serve-full html agda-md site-full profile project-plan unused-imports unused-imports-test check-links check-links-test gen-links corpus-stats corpus-stats-check corpus-stats-test gap-hunt docstrings docstrings-test docstrings-list docstrings-unused docstrings-json flrp-test flrp-slr gap-smoke Everything.agda EverythingLegacy.agda EverythingCertificates.agda
 
 # -- Configuration -----------------------------------------------------------
 SRCDIR    := src
@@ -305,6 +305,31 @@ check-links-test:
 gen-links:
 	@echo "target: $@"
 	python3 scripts/python/gen_links.py
+
+# The landing page's headline figures (issue #575).  docs/index.md advertises a
+# module count, a line count, a machine-checked share, and the pinned toolchain;
+# every one is a fact about this repository, so scripts/python/corpus_stats.py
+# counts them (from src/ minus Legacy/, and from the toolchain pins) and writes
+# them into the page's `ualib:stat` markers.  The MkDocs hook substitutes the
+# same values at build time, but it rewrites only the *rendered* page: before
+# this gate, nothing refreshed the committed values, which are the ones GitHub
+# renders, and they sat at July's numbers for six weeks while the library grew
+# 12.7%.  The check is therefore the point: a PR that moves a number cannot
+# merge without refreshing the page.
+#   corpus-stats        refresh docs/index.md from the tree
+#   corpus-stats-check  fail (with a diff) if a committed value has drifted
+#   corpus-stats-test   the tool's own test suite
+corpus-stats:
+	@echo "target: $@"
+	python3 scripts/python/corpus_stats.py
+
+corpus-stats-check:
+	@echo "target: $@"
+	python3 scripts/python/corpus_stats.py --check
+
+corpus-stats-test:
+	@echo "target: $@"
+	python3 scripts/python/test_corpus_stats.py
 
 # Audit the prose block attached to every public definition (STYLE_GUIDE
 # § "Every public definition has a prose comment block", issue #268, ADR-010).

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,14 +27,14 @@ every commit.
 </div>
 
 <div class="ualib-stats">
-  <!-- The two figures below are recomputed from the src/ tree on every build by
-       scripts/python/mkdocs_hooks.py (via the ualib:stat markers).  The values
-       here are only a fallback for non-MkDocs (e.g. GitHub) views — do not
-       hand-tune them; run `make site` and they refresh. -->
-  <div class="ualib-stat"><span class="ualib-stat__num"><!-- ualib:stat:modules -->302<!-- /ualib:stat:modules --></span><span class="ualib-stat__label">literate modules</span></div>
-  <div class="ualib-stat"><span class="ualib-stat__num"><!-- ualib:stat:loc -->60k<!-- /ualib:stat:loc --></span><span class="ualib-stat__label">lines of Agda</span></div>
-  <div class="ualib-stat"><span class="ualib-stat__num">100%</span><span class="ualib-stat__label">machine-checked</span></div>
-  <div class="ualib-stat"><span class="ualib-stat__num">2.8.0</span><span class="ualib-stat__label">Agda · stdlib 2.3</span></div>
+  <!-- Counted, not typed: scripts/python/corpus_stats.py writes these figures
+       into the markers below (`make corpus-stats`), and CI fails when a
+       committed value has drifted from the tree (`make corpus-stats-check`).
+       Do not hand-tune them.  See docs/site-guide.md, "Corpus stats". -->
+  <div class="ualib-stat"><span class="ualib-stat__num"><!-- ualib:stat:modules -->339<!-- /ualib:stat:modules --></span><span class="ualib-stat__label">literate modules</span></div>
+  <div class="ualib-stat"><span class="ualib-stat__num"><!-- ualib:stat:loc -->67k<!-- /ualib:stat:loc --></span><span class="ualib-stat__label">lines of Agda</span></div>
+  <div class="ualib-stat"><span class="ualib-stat__num"><!-- ualib:stat:checked -->100%<!-- /ualib:stat:checked --></span><span class="ualib-stat__label">machine-checked</span></div>
+  <div class="ualib-stat"><span class="ualib-stat__num"><!-- ualib:stat:agda -->2.8.0<!-- /ualib:stat:agda --></span><span class="ualib-stat__label">Agda · stdlib <!-- ualib:stat:stdlib -->2.3<!-- /ualib:stat:stdlib --></span></div>
 </div>
 
 ## Featured results

--- a/docs/site-guide.md
+++ b/docs/site-guide.md
@@ -276,15 +276,19 @@ into the `<!-- ualib:stat:NAME -->…<!-- /ualib:stat:NAME -->` marker pairs in
 +  `agda` and `stdlib`, read from `mkdocs.yml`'s `extra:` site variables and
    reconciled against the two pins that bind them: the `depend:` line of
    `agda-algebras.agda-lib`, whose stdlib version Agda enforces exactly, and the
-   version-floor guards in `flake.nix`.
+   version-floor guards in `flake.nix`.  The stdlib half is therefore exact; the
+   Agda half is by *series*, because `flake.nix` deliberately guards `2.8.*` and
+   nothing in the repository states a patch level.  A move from Agda 2.8.0 to
+   2.8.1 is thus visible in the dev shell's banner on entry, but no check in this
+   repository fails on it.
 
-Two commands, one gate:
+Three commands, one gate:
 
 +  `make corpus-stats` rewrites the figures in `docs/index.md`;
 +  `make corpus-stats-check` fails, with a diff, when a committed figure has
    drifted from the tree.  CI runs it as the *Landing-page stats* job, so the
-   pull request that moves a number is the one that refreshes the page.
-   `make corpus-stats-test` exercises the tool's own unit tests.
+   pull request that moves a number is the one that refreshes the page;
++  `make corpus-stats-test` exercises the tool's own unit tests.
 
 The MkDocs hook substitutes the same values into the rendered page at build
 time, but that is a convenience, not the mechanism: it rewrites only the built

--- a/docs/site-guide.md
+++ b/docs/site-guide.md
@@ -224,7 +224,8 @@ section) are defined in `scripts/python/mkdocs_gen_library.py` in the
 `custom.css` (`§8`–`§11`):
 
 +  the **hero** (`.ualib-hero`) — title, tagline, the formula, the buttons;
-+  the **stat strip** (`.ualib-stats`) — edit the four numbers inline;
++  the **stat strip** (`.ualib-stats`), whose four figures are counted from the
+   tree and must never be edited by hand (see [Corpus stats](#corpus-stats));
 +  the **Featured results gallery** (`.ualib-figures`) — each card is one
    `<a class="ualib-figure">`; swap a monogram for a photo by replacing the
    `<span class="ualib-portrait">GB</span>` with
@@ -261,6 +262,37 @@ does not error, it renders as literal text and sails past `mkdocs build
 Run `make check-links` before pushing docs changes; `make check-links-test`
 exercises the scanner's own unit tests.
 
+### Corpus stats
+
+The landing page's four figures are facts about this repository, so none of them
+is typed by hand.  `scripts/python/corpus_stats.py` counts them and writes them
+into the `<!-- ualib:stat:NAME -->…<!-- /ualib:stat:NAME -->` marker pairs in
+`docs/index.md`:
+
++  `modules` and `loc`, the literate modules under `src/` outside the frozen
+   `Legacy/` tree and the lines of Agda inside their code fences;
++  `checked`, the share of those modules whose `OPTIONS` pragma carries
+   `--safe`, which is what "100% machine-checked" asserts;
++  `agda` and `stdlib`, read from `mkdocs.yml`'s `extra:` site variables and
+   reconciled against the two pins that bind them: the `depend:` line of
+   `agda-algebras.agda-lib`, whose stdlib version Agda enforces exactly, and the
+   version-floor guards in `flake.nix`.
+
+Two commands, one gate:
+
++  `make corpus-stats` rewrites the figures in `docs/index.md`;
++  `make corpus-stats-check` fails, with a diff, when a committed figure has
+   drifted from the tree.  CI runs it as the *Landing-page stats* job, so the
+   pull request that moves a number is the one that refreshes the page.
+   `make corpus-stats-test` exercises the tool's own unit tests.
+
+The MkDocs hook substitutes the same values into the rendered page at build
+time, but that is a convenience, not the mechanism: it rewrites only the built
+HTML, so before the gate existed the committed values, which are the ones GitHub
+renders, sat six weeks behind the tree and were quoted elsewhere as current.
+`corpus_stats.py --json` prints the figures as one record for anything outside
+this repository that wants to cite them.
+
 ## Where things live
 
 ```
@@ -277,5 +309,6 @@ scripts/python/
   mkdocs_hooks.py                       link rewriting + per-page build log
   gen_links.py                          regenerates the module + ADR sections of _links.md
   check_links.py                        fails CI on any undefined reference-style link
+  corpus_stats.py                       counts the landing page's figures; refreshes and gates them
 .github/workflows/docs.yml              build (make site-full) + deploy to gh-pages
 ```

--- a/scripts/python/_utils/literate.py
+++ b/scripts/python/_utils/literate.py
@@ -5,10 +5,11 @@ Description: Literate-Agda (``.lagda.md``) front end shared by the corpus tools.
 
   Every module under ``src/`` is literate Markdown (ADR-004): Agda code lives
   inside ```` ```agda ```` fenced blocks and everything outside a fence is
-  prose.  Two tools now need to read that structure — ``unused_imports.py``
-  (which needs the Agda code with comments blanked) and ``docstring_audit.py``
-  (which needs the *prose* attached to each fence as well) — so the front end
-  lives here rather than in either of them.
+  prose.  Three tools now read that structure: ``unused_imports.py`` (which
+  needs the Agda code with comments blanked), ``docstring_audit.py`` (which
+  needs the *prose* attached to each fence as well), and ``corpus_stats.py``
+  (which counts the code and reads each module's pragma), so the front end
+  lives here rather than in any one of them.
 
   Three layers, each a pure function of the file text:
 
@@ -19,6 +20,10 @@ Description: Literate-Agda (``.lagda.md``) front end shared by the corpus tools.
                                 ``''``, so diagnostics keep real line numbers;
     3. ``clean_code_lines``   -> the same, with comments and string literals
                                 blanked (length-preserving, so columns survive).
+
+  Then ``options_pragma``, which reads the ``OPTIONS`` a module is checked
+  under.  It stands apart from the three because it must see what they erase:
+  layer 3 blanks pragmas along with comments, by design.
 
 Design Principles:
   Line numbering is preserved at every layer: a tool reports ``path:line`` into
@@ -256,6 +261,59 @@ def clean_code_lines(agda_lines: list[str]) -> list[str]:
 def file_code_lines(text: str) -> list[str]:
     """Full front end: ``.lagda.md`` text -> comment-free Agda, line-numbered."""
     return clean_code_lines(extract_agda_lines(text))
+
+
+# =============================================================================
+# The OPTIONS pragma a module is actually checked under
+# =============================================================================
+
+_OPTIONS_PRAGMA = re.compile(r"\{-#\s*OPTIONS\b([^#]*)#-\}")
+
+
+def options_pragma(code: str) -> str | None:
+    """The options Agda applies to a module, or ``None`` if it declares none.
+
+    Agda requires ``{-# OPTIONS … #-}`` to precede the module header, so only
+    whitespace and comments may come before it.  This walks the code that way:
+    a line comment (Agda's ``--`` rule, as :func:`_line_comment_at` states it)
+    and a block comment (``{- … -}``, which nests, and which ``{-#`` does *not*
+    open) are skipped, another pragma is skipped, the first ``OPTIONS`` pragma
+    reached is the answer, and anything else is real code, which means the
+    module carries no pragma.
+
+    Neither simpler reading works.  :func:`clean_code_lines` blanks pragmas
+    along with comments, by design, so a search over cleaned code finds no
+    pragma at all; a search over raw code accepts a pragma that is *commented
+    out*, and would call a module ``--safe`` on the strength of a line its
+    author had disabled.
+    """
+    i, n, depth = 0, len(code), 0
+    while i < n:
+        if code[i].isspace():
+            i += 1
+        elif depth:                              # inside {- … -}: everything is text
+            if code.startswith("{-", i):
+                depth, i = depth + 1, i + 2
+            elif code.startswith("-}", i):
+                depth, i = depth - 1, i + 2
+            else:
+                i += 1
+        elif code.startswith("{-#", i):          # a pragma, not a comment
+            end = code.find("#-}", i)
+            if end < 0:
+                return None                      # unterminated; Agda applies nothing
+            match = _OPTIONS_PRAGMA.fullmatch(code[i:end + 3])
+            if match:
+                return match.group(1)
+            i = end + 3                          # some other pragma; keep looking
+        elif code.startswith("{-", i):
+            depth, i = 1, i + 2
+        elif _line_comment_at(code, i):
+            newline = code.find("\n", i)
+            i = n if newline < 0 else newline
+        else:
+            return None                          # real code before any OPTIONS
+    return None
 
 
 # =============================================================================

--- a/scripts/python/corpus_stats.py
+++ b/scripts/python/corpus_stats.py
@@ -46,7 +46,13 @@ Design Principles:
        actually bind: ``agda-algebras.agda-lib``'s ``depend:`` line, whose
        stdlib version Agda enforces exactly, and ``flake.nix``'s version-floor
        guards, which state the series the dev shell expects.  Bumping the
-       toolchain without updating the docs therefore fails the check.
+       toolchain without updating the docs therefore fails the check, with one
+       limit worth stating plainly: the stdlib comparison is exact, the Agda one
+       is by series, because ``flake.nix`` deliberately guards ``2.8.*`` and no
+       file in this repository states a patch level.  A move from Agda 2.8.0 to
+       2.8.1 shows in the dev shell's banner and is checked nowhere; pinning it
+       would mean tightening the flake's own guard, which is a decision about
+       the toolchain, not about the docs.
 
   A source of truth that cannot be read is an error, never a skipped check.  If
   one of those files is reshaped so a pattern stops matching, the tool says
@@ -73,7 +79,7 @@ if str(_SCRIPT_DIR) not in sys.path:
 
 from _utils import ErrorType, PipelineError, Result, sequence_results  # noqa: E402
 from _utils.file_ops import read_text, write_text  # noqa: E402
-from _utils.literate import fences  # noqa: E402
+from _utils.literate import fences, options_pragma  # noqa: E402
 
 # -- Sources of truth ---------------------------------------------------------
 
@@ -153,25 +159,21 @@ class Stats:
         }
 
 
-# The module's OPTIONS pragma.  `[^#]*` stops at the closing `#-}` and cannot
-# run past it into the body.
-_OPTIONS = re.compile(r"\{-#\s*OPTIONS\b([^#]*)#-\}")
-
-
 def module_stats(text: str) -> tuple[int, bool]:
     """``(lines of Agda, checked under --safe)`` for one literate module.
 
-    One pass over the fences serves both: the lines are everything between the
+    One pass over the fences serves both.  The lines are everything between the
     fence delimiters of the module's ```` ```agda ```` blocks (the hidden
     preamble fence counts, because Agda checks it; prose and the delimiters
-    themselves do not), and the pragma is read from that same code, so an
-    OPTIONS line quoted in prose cannot be mistaken for the module's own.
+    themselves do not).  The pragma is read from that same code, so an OPTIONS
+    line quoted in *prose* cannot be mistaken for the module's own, and read by
+    :func:`options_pragma`, so neither can one that is commented *out*.
     """
     blocks = fences(text)
     code = "\n".join(line for block in blocks for line in block.body)
-    pragma = _OPTIONS.search(code)
+    options = options_pragma(code)
     return (sum(len(block.body) for block in blocks),
-            pragma is not None and "--safe" in pragma.group(1).split())
+            options is not None and "--safe" in options.split())
 
 
 def corpus(texts: Sequence[str]) -> Corpus:
@@ -193,8 +195,24 @@ def canonical_modules(src: Path = SRC) -> list[Path]:
 
 
 def measure(src: Path = SRC) -> Result[Corpus, PipelineError]:
-    """Read and count the canonical tree."""
-    return sequence_results([read_text(p) for p in canonical_modules(src)]).map(corpus)
+    """Read and count the canonical tree.
+
+    An absent or empty ``src/`` is an error, not a corpus of size zero.  Both
+    mean the tool is looking at the wrong place (it is run from the repo root,
+    like its siblings), and a tree of 0 modules and 0 lines is a figure it would
+    otherwise publish or, worse, write into the page.
+    """
+    if not src.is_dir():
+        return Result.err(PipelineError(
+            ErrorType.FILE_NOT_FOUND,
+            f"{src} is not a directory; run this from the repository root"))
+    modules = canonical_modules(src)
+    if not modules:
+        return Result.err(PipelineError(
+            ErrorType.VALIDATION_ERROR,
+            f"{src} holds no literate modules outside {LEGACY}/; "
+            "that is not a corpus, so nothing is counted"))
+    return sequence_results([read_text(p) for p in modules]).map(corpus)
 
 
 # =============================================================================

--- a/scripts/python/corpus_stats.py
+++ b/scripts/python/corpus_stats.py
@@ -202,6 +202,9 @@ def measure(src: Path = SRC) -> Result[Corpus, PipelineError]:
 # =============================================================================
 
 # mkdocs.yml's `extra:` site variables (two-space indented under `extra:`).
+# Read by pattern rather than parsed: the CI job is stdlib-only (no PyYAML), and
+# mkdocs.yml carries `!!python/name:` tags for the Material emoji extension, so
+# `yaml.safe_load` refuses it outright.
 _EXTRA_AGDA = re.compile(r"^\s+agda_version:\s*\"?([0-9][0-9.]*)\"?\s*$", re.MULTILINE)
 _EXTRA_STDLIB = re.compile(r"^\s+stdlib_version:\s*\"?([0-9][0-9.]*)\"?\s*$", re.MULTILINE)
 

--- a/scripts/python/corpus_stats.py
+++ b/scripts/python/corpus_stats.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""
+File: scripts/python/corpus_stats.py
+
+Description: The landing page's headline figures, counted from the tree,
+  written back into the source, and gated in CI (issue #575).
+
+  ``docs/index.md`` opens with a strip of four numbers: how many literate
+  modules the library holds, how many lines of Agda they contain, what share of
+  them is machine-checked, and which toolchain checks them.  Every one of those
+  is a fact about this repository, so none of them should be typed by hand.
+
+  They were, and it showed.  ``mkdocs_hooks.py`` substituted the two counted
+  figures into the *rendered* page at build time and never wrote them back, so
+  the values committed in ``docs/index.md`` stayed at their 2026-07-28 reading
+  (302 modules, 60k lines) while the library grew to 339 modules and 67k lines.
+  Anyone reading this repository on GitHub rather than at the deployed site read
+  July's figures for six weeks, and the stale pair was quoted elsewhere as
+  current.
+
+  This module is the fix, and it is used three ways:
+
+    +  ``corpus_stats.py``          refresh the markers in ``docs/index.md``
+       (``make corpus-stats``);
+    +  ``corpus_stats.py --check``  fail, with a diff, when a committed value
+       has drifted (``make corpus-stats-check``, which the *Landing-page stats*
+       CI job runs, so a pull request that moves a number cannot merge without
+       refreshing the page);
+    +  ``corpus_stats.py --json``   emit the figures as one JSON record, for
+       anything outside this repository that wants to quote them rather than
+       hand-copy them.
+
+  ``mkdocs_hooks.py`` imports :func:`landing_values` and :func:`fill` for its
+  build-time substitution, so the deployed site and the committed source are
+  computed by one function and cannot disagree.
+
+Design Principles:
+  Every figure names a source of truth and is read from it, never restated:
+
+    +  ``modules``, ``loc`` and ``checked`` come from the canonical tree,
+       ``src/`` minus the frozen ``Legacy/``.  That is exactly the set of
+       modules CI type-checks, between the *Type-check library* and *Type-check
+       certificates* jobs.
+    +  ``agda`` and ``stdlib`` come from ``mkdocs.yml``'s ``extra:`` site
+       variables, which the tool reconciles in turn against the two pins that
+       actually bind: ``agda-algebras.agda-lib``'s ``depend:`` line, whose
+       stdlib version Agda enforces exactly, and ``flake.nix``'s version-floor
+       guards, which state the series the dev shell expects.  Bumping the
+       toolchain without updating the docs therefore fails the check.
+
+  A source of truth that cannot be read is an error, never a skipped check.  If
+  one of those files is reshaped so a pattern stops matching, the tool says
+  which pattern and exits non-zero rather than quietly passing; a check that
+  silently measures nothing is how the stale number survived six weeks.
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+# Import the shared utilities the way the sibling scripts do: make this file's
+# directory importable, then pull in the Result monad, the pure file-reading
+# wrappers, and the literate front end.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from _utils import ErrorType, PipelineError, Result, sequence_results  # noqa: E402
+from _utils.file_ops import read_text, write_text  # noqa: E402
+from _utils.literate import fences  # noqa: E402
+
+# -- Sources of truth ---------------------------------------------------------
+
+SRC = Path("src")
+LEGACY = "Legacy"                       # the frozen tree, excluded (ADR-001)
+LIB = Path("agda-algebras.agda-lib")
+FLAKE = Path("flake.nix")
+MKDOCS = Path("mkdocs.yml")
+
+# The pages carrying stat markers.  Only the landing page does today; the tool
+# loops, so a second page costs one line.  Every page listed here must carry
+# every marker the tool computes (see `unfilled`).
+PAGES: tuple[Path, ...] = (Path("docs/index.md"),)
+
+# <!-- ualib:stat:NAME -->value<!-- /ualib:stat:NAME -->.  DOTALL so the markers
+# keep matching if a page is reformatted with the comments on separate lines;
+# the \1 backreference pins each pair to its own name.
+STAT = re.compile(r"<!-- ualib:stat:(\w+) -->.*?<!-- /ualib:stat:\1 -->", re.DOTALL)
+
+
+# =============================================================================
+# What the tree holds
+# =============================================================================
+
+@dataclass(frozen=True)
+class Corpus:
+    """The canonical tree in three numbers: how many literate modules it holds,
+    how many lines of Agda they contain, and how many of them are checked under
+    ``--safe`` (so nothing in them is postulated, assumed terminating, or built
+    on an unsafe primitive)."""
+
+    modules: int
+    loc: int
+    safe: int
+
+
+@dataclass(frozen=True)
+class Toolchain:
+    """The Agda and standard-library versions the library is checked against."""
+
+    agda: str
+    stdlib: str
+
+
+@dataclass(frozen=True)
+class Stats:
+    """Everything the landing page advertises."""
+
+    corpus: Corpus
+    toolchain: Toolchain
+
+    @property
+    def markers(self) -> dict[str, str]:
+        """The string each ``ualib:stat`` marker should hold."""
+        c, t = self.corpus, self.toolchain
+        return {
+            "modules": str(c.modules),
+            # Half-up rounding to thousands.  round() rounds ties to even, so
+            # 60_500 would render as "60k"; a reader of a "…k" stat expects 61k.
+            "loc": f"{(c.loc + 500) // 1000}k",
+            # Floor, never round: 338 of 339 must not print as "100%".
+            "checked": f"{100 * c.safe // c.modules if c.modules else 0}%",
+            "agda": t.agda,
+            "stdlib": t.stdlib,
+        }
+
+    @property
+    def record(self) -> dict[str, object]:
+        """The JSON record: the raw counts alongside the rendered markers."""
+        return {
+            "modules": self.corpus.modules,
+            "loc": self.corpus.loc,
+            "safe": self.corpus.safe,
+            "agda": self.toolchain.agda,
+            "stdlib": self.toolchain.stdlib,
+            "markers": self.markers,
+        }
+
+
+# The module's OPTIONS pragma.  `[^#]*` stops at the closing `#-}` and cannot
+# run past it into the body.
+_OPTIONS = re.compile(r"\{-#\s*OPTIONS\b([^#]*)#-\}")
+
+
+def module_stats(text: str) -> tuple[int, bool]:
+    """``(lines of Agda, checked under --safe)`` for one literate module.
+
+    One pass over the fences serves both: the lines are everything between the
+    fence delimiters of the module's ```` ```agda ```` blocks (the hidden
+    preamble fence counts, because Agda checks it; prose and the delimiters
+    themselves do not), and the pragma is read from that same code, so an
+    OPTIONS line quoted in prose cannot be mistaken for the module's own.
+    """
+    blocks = fences(text)
+    code = "\n".join(line for block in blocks for line in block.body)
+    pragma = _OPTIONS.search(code)
+    return (sum(len(block.body) for block in blocks),
+            pragma is not None and "--safe" in pragma.group(1).split())
+
+
+def corpus(texts: Sequence[str]) -> Corpus:
+    """Aggregate the per-module numbers."""
+    per_module = [module_stats(text) for text in texts]
+    return Corpus(modules=len(per_module),
+                  loc=sum(loc for loc, _ in per_module),
+                  safe=sum(1 for _, safe in per_module if safe))
+
+
+def canonical_modules(src: Path = SRC) -> list[Path]:
+    """The modules the landing page counts: every literate module under ``src/``
+    except the frozen ``Legacy/`` tree (ADR-001).  That is the union of the two
+    walks the Makefile's ``find`` makes for ``Everything.agda`` and
+    ``EverythingCertificates.agda``, so every module counted here is one CI
+    type-checks."""
+    return sorted(p for p in src.rglob("*.lagda.md")
+                  if p.relative_to(src).parts[0] != LEGACY)
+
+
+def measure(src: Path = SRC) -> Result[Corpus, PipelineError]:
+    """Read and count the canonical tree."""
+    return sequence_results([read_text(p) for p in canonical_modules(src)]).map(corpus)
+
+
+# =============================================================================
+# What the toolchain pins say
+# =============================================================================
+
+# mkdocs.yml's `extra:` site variables (two-space indented under `extra:`).
+_EXTRA_AGDA = re.compile(r"^\s+agda_version:\s*\"?([0-9][0-9.]*)\"?\s*$", re.MULTILINE)
+_EXTRA_STDLIB = re.compile(r"^\s+stdlib_version:\s*\"?([0-9][0-9.]*)\"?\s*$", re.MULTILINE)
+
+# agda-algebras.agda-lib's `depend: standard-library-2.3`.  Agda resolves an
+# exact-version dependency exactly, so this is the pin that binds.
+_DEPEND_STDLIB = re.compile(r"^depend:.*\bstandard-library-([0-9][0-9.]*)", re.MULTILINE)
+
+
+def _guard(var: str) -> re.Pattern[str]:
+    """flake.nix's version-floor guard for a shell variable.  The dev shell
+    warns when the realized toolchain leaves the expected series::
+
+        case "${agdaVer}" in
+          2.8.*) : ;;
+
+    and this captures that series (``2.8``), which the version the docs declare
+    must belong to."""
+    return re.compile(r'case\s+"\$\{' + var + r'\}"\s+in\s+([0-9][0-9.]*?)\.?\*\)')
+
+
+def _field(text: str, pattern: re.Pattern[str], what: str,
+           where: Path) -> Result[str, PipelineError]:
+    """The first capture of ``pattern`` in ``text``, or an error naming what was
+    being read and from where.  A source of truth that has moved must fail the
+    check loudly rather than drop out of it."""
+    match = pattern.search(text)
+    if match is None:
+        return Result.err(PipelineError(
+            ErrorType.PARSING_ERROR,
+            f"could not read {what} from {where}; the file's shape changed, so "
+            f"scripts/python/corpus_stats.py needs updating",
+            context={"pattern": pattern.pattern}))
+    return Result.ok(match.group(1))
+
+
+def _in_series(version: str, series: str) -> bool:
+    """Whether ``version`` (2.8.0) belongs to ``series`` (2.8)."""
+    return version == series or version.startswith(series + ".")
+
+
+def _reconcile(fields: Sequence[str]) -> Result[Toolchain, PipelineError]:
+    """Cross-check the toolchain the docs declare against the pins that bind it."""
+    agda, stdlib, pinned, agda_series, stdlib_series = fields
+    checks = (
+        (stdlib == pinned,
+         f"{MKDOCS} says stdlib {stdlib}, but {LIB} depends on "
+         f"standard-library-{pinned}"),
+        (_in_series(agda, agda_series),
+         f"{MKDOCS} says Agda {agda}, but {FLAKE} guards the {agda_series} series"),
+        (_in_series(pinned, stdlib_series),
+         f"{LIB} depends on standard-library-{pinned}, but {FLAKE} guards the "
+         f"{stdlib_series} series"),
+    )
+    disagreements = [why for holds, why in checks if not holds]
+    if disagreements:
+        return Result.err(PipelineError(
+            ErrorType.VALIDATION_ERROR,
+            "the declared toolchain disagrees with the pins:\n  "
+            + "\n  ".join(disagreements)))
+    return Result.ok(Toolchain(agda=agda, stdlib=stdlib))
+
+
+def toolchain(mkdocs_text: str, lib_text: str,
+              flake_text: str) -> Result[Toolchain, PipelineError]:
+    """The toolchain the landing page should advertise, read from the three
+    files that declare it and reconciled across them."""
+    return sequence_results([
+        _field(mkdocs_text, _EXTRA_AGDA, "extra.agda_version", MKDOCS),
+        _field(mkdocs_text, _EXTRA_STDLIB, "extra.stdlib_version", MKDOCS),
+        _field(lib_text, _DEPEND_STDLIB, "the standard-library version in depend:", LIB),
+        _field(flake_text, _guard("agdaVer"), "the Agda version-floor guard", FLAKE),
+        _field(flake_text, _guard("stdlibVer"), "the stdlib version-floor guard", FLAKE),
+    ]).and_then(_reconcile)
+
+
+def read_toolchain(mkdocs: Path = MKDOCS, lib: Path = LIB,
+                   flake: Path = FLAKE) -> Result[Toolchain, PipelineError]:
+    """Read the three declaring files and reconcile them."""
+    return sequence_results([read_text(mkdocs), read_text(lib), read_text(flake)]) \
+        .and_then(lambda texts: toolchain(*texts))
+
+
+def measure_all(src: Path = SRC) -> Result[Stats, PipelineError]:
+    """Everything the landing page advertises, counted and read."""
+    return measure(src).and_then(
+        lambda c: read_toolchain().map(lambda t: Stats(corpus=c, toolchain=t)))
+
+
+def landing_values(src: Path = SRC) -> Result[dict[str, str], PipelineError]:
+    """The stat-marker values for the landing page.  This is what the MkDocs
+    hook substitutes at build time and what ``--check`` holds the committed file
+    to, so the site and the source are one computation."""
+    return measure_all(src).map(lambda s: s.markers)
+
+
+# =============================================================================
+# The pages that carry the markers
+# =============================================================================
+
+def fill(markdown: str, values: Mapping[str, str]) -> str:
+    """Rewrite every known stat marker to hold its counted value.
+
+    The markers are preserved rather than consumed, because the same
+    substitution serves the committed source (where they must survive to be
+    refreshed again) and the rendered page (where an HTML comment is invisible).
+    A marker the tool does not compute is left exactly as it stands.
+    """
+    def value(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in values:
+            return match.group(0)
+        return f"<!-- ualib:stat:{name} -->{values[name]}<!-- /ualib:stat:{name} -->"
+
+    return STAT.sub(value, markdown)
+
+
+def marker_names(text: str) -> set[str]:
+    """The stat markers a page carries."""
+    return {match.group(1) for match in STAT.finditer(text)}
+
+
+def unfilled(text: str, values: Mapping[str, str]) -> tuple[str, ...]:
+    """Markers the tool computes that the page does not carry.  A renamed or
+    misspelled marker would otherwise leave a hand-typed number standing while
+    the check reported success, which is exactly the failure this tool exists to
+    end."""
+    return tuple(sorted(set(values) - marker_names(text)))
+
+
+@dataclass(frozen=True)
+class PageDrift:
+    """One page, as committed and as it would be with the counted values in it."""
+
+    path: Path
+    committed: str
+    refreshed: str
+
+    @property
+    def stale(self) -> bool:
+        return self.committed != self.refreshed
+
+    @property
+    def diff(self) -> str:
+        return "".join(difflib.unified_diff(
+            self.committed.splitlines(keepends=True),
+            self.refreshed.splitlines(keepends=True),
+            fromfile=f"{self.path} (committed)",
+            tofile=f"{self.path} (counted)"))
+
+
+def analyze(values: Mapping[str, str],
+            pages: Sequence[Path] = PAGES) -> Result[tuple[PageDrift, ...], PipelineError]:
+    """The pages whose committed markers do not hold the counted values."""
+    def compare(texts: Sequence[str]) -> Result[tuple[PageDrift, ...], PipelineError]:
+        absent = [(page, unfilled(text, values)) for page, text in zip(pages, texts)]
+        missing = [(page, names) for page, names in absent if names]
+        if missing:
+            return Result.err(PipelineError(
+                ErrorType.VALIDATION_ERROR,
+                "\n".join(f"{page} carries no marker for {', '.join(names)}"
+                          for page, names in missing)
+                + "\nAdd the <!-- ualib:stat:NAME -->…<!-- /ualib:stat:NAME --> "
+                  "pair to the page, or drop the stat from corpus_stats.py."))
+        drifts = (PageDrift(page, text, fill(text, values))
+                  for page, text in zip(pages, texts))
+        return Result.ok(tuple(drift for drift in drifts if drift.stale))
+
+    return sequence_results([read_text(page) for page in pages]).and_then(compare)
+
+
+# =============================================================================
+# The three ways to run it
+# =============================================================================
+
+def summary(stats: Stats) -> str:
+    """The figures on one line, in the landing page's own words."""
+    v = stats.markers
+    return (f"{v['modules']} literate modules, {v['loc']} lines of Agda, "
+            f"{v['checked']} machine-checked, Agda {v['agda']} · stdlib {v['stdlib']}")
+
+
+def stale_report(stale: Sequence[PageDrift]) -> PipelineError:
+    """The gate's failure message: a unified diff per page, then the one command
+    that fixes it."""
+    return PipelineError(
+        ErrorType.VALIDATION_ERROR,
+        "".join(drift.diff for drift in stale)
+        + f"\n✗ {len(stale)} page(s) carry stale corpus stats.\n"
+          "Run:  make corpus-stats")
+
+
+def check(src: Path = SRC) -> Result[str, PipelineError]:
+    """Verify the committed markers against the tree.  The CI gate."""
+    def verdict(stats: Stats) -> Result[str, PipelineError]:
+        return analyze(stats.markers).and_then(
+            lambda stale: Result.err(stale_report(stale)) if stale
+            else Result.ok(f"✓ corpus stats are up to date: {summary(stats)}"))
+
+    return measure_all(src).and_then(verdict)
+
+
+def refresh(src: Path = SRC) -> Result[str, PipelineError]:
+    """Write the counted values into the pages that carry markers."""
+    def apply(stats: Stats) -> Result[str, PipelineError]:
+        def write(stale: Sequence[PageDrift]) -> Result[str, PipelineError]:
+            failed = [w.unwrap_err() for w in
+                      [write_text(drift.path, drift.refreshed) for drift in stale]
+                      if w.is_err]
+            if failed:
+                return Result.err(failed[0])
+            wrote = ", ".join(str(drift.path) for drift in stale)
+            return Result.ok(f"{summary(stats)}\n"
+                             + (f"  wrote {wrote}" if stale
+                                else "  every page already up to date"))
+
+        return analyze(stats.markers).and_then(write)
+
+    return measure_all(src).and_then(apply)
+
+
+def emit_json(src: Path = SRC) -> Result[str, PipelineError]:
+    """The figures as one JSON record."""
+    return measure_all(src).map(lambda stats: json.dumps(stats.record, indent=2))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Count the landing page's corpus stats; refresh or check them.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true",
+                      help="fail (with a diff) if a committed value has drifted")
+    mode.add_argument("--json", action="store_true",
+                      help="print the figures as one JSON record and exit")
+    args = parser.parse_args()
+
+    outcome = emit_json() if args.json else check() if args.check else refresh()
+
+    if outcome.is_err:
+        error = outcome.unwrap_err()
+        sys.stderr.write(error.message.rstrip("\n") + "\n")
+        if error.context:
+            sys.stderr.write("  " + ", ".join(f"{k}={v}"
+                                              for k, v in error.context.items()) + "\n")
+        return 1
+    print(outcome.unwrap().rstrip("\n"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/mkdocs_hooks.py
+++ b/scripts/python/mkdocs_hooks.py
@@ -18,7 +18,17 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
+import sys
 from pathlib import Path
+
+# MkDocs loads this file by path, so its directory is not importable by default;
+# make it so, the way the sibling scripts do, and share the corpus counting with
+# the tool that writes those same figures back into docs/index.md.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from corpus_stats import fill, landing_values  # noqa: E402
 
 log = logging.getLogger("mkdocs.plugins.ualib.render")
 
@@ -131,51 +141,36 @@ def on_files(files, config):
 
 
 # --- Landing-page corpus stats, kept current at build time -------------------
-# docs/index.md advertises "<N> literate modules, <M>k lines of Agda".  Rather
-# than let those drift, the hook recomputes them from the tree and substitutes
-# them into the `<!-- ualib:stat:… -->` markers on that one page.  It is a single
-# pass over the canonical (non-Legacy) modules — a few hundred files, ~50 ms —
-# run only when rendering index.md, so it adds nothing meaningful to the build.
-SRC = Path("src")
-# DOTALL so the markers keep matching even if index.md is reformatted with the
-# open/close comments on separate lines; the \1 backreference pins each pair.
-STAT = re.compile(r"<!-- ualib:stat:(\w+) -->.*?<!-- /ualib:stat:\1 -->", re.DOTALL)
-
-
-def _agda_loc(text: str) -> int:
-    """Lines inside the module's ```agda fenced blocks — its actual Agda code
-    (the hidden import scaffolding counts; prose and the fence lines do not)."""
-    n, in_agda = 0, False
-    for line in text.splitlines():
-        stripped = line.lstrip()
-        if stripped.startswith("```"):
-            if in_agda:
-                in_agda = False
-            elif stripped[3:].strip().lower().startswith("agda"):
-                in_agda = True
-            continue
-        if in_agda:
-            n += 1
-    return n
-
-
-def _corpus_stats() -> tuple[int, int]:
-    """(literate-module count, Agda-code lines) over src/ minus the frozen
-    Legacy/ tree — the canonical library the landing page advertises."""
-    mods = [p for p in SRC.rglob("*.lagda.md")
-            if p.relative_to(SRC).parts[0] != "Legacy"]
-    loc = sum(_agda_loc(p.read_text(encoding="utf-8")) for p in mods)
-    return len(mods), loc
-
-
+# docs/index.md advertises a module count, a line count, a machine-checked
+# share, and the pinned toolchain, all of them inside `<!-- ualib:stat:… -->`
+# markers.  The counting lives in scripts/python/corpus_stats.py, which is also
+# what `make corpus-stats` writes into the source and what CI holds the
+# committed values to (issue #575); the hook calls that one function so the
+# deployed site and the committed file cannot disagree.  It is a single pass
+# over the canonical (non-Legacy) modules, a few hundred files and ~50 ms, run
+# only when rendering index.md, so it adds nothing meaningful to the build.
+#
+# Before #575 the substitution here was the *only* thing that refreshed the
+# figures, and it rewrote the rendered page without ever writing back, so the
+# committed values, the ones GitHub renders, sat at July's numbers.  The gate
+# is what fixed that; this remains so the published site is current even between
+# refreshes.
 def _fill_corpus_stats(markdown: str) -> str:
-    """Replace the landing page's stat markers with freshly counted values."""
-    mods, loc = _corpus_stats()
-    # Half-up rounding to thousands (round() would round ties to even, e.g.
-    # 60_500 → "60k"; readers of a "…k" stat expect 60_500 → "61k").
-    values = {"modules": str(mods), "loc": f"{(loc + 500) // 1000}k"}
-    log.info(f"📊  corpus stats: {values['modules']} modules, {values['loc']} lines of Agda")
-    return STAT.sub(lambda m: values.get(m.group(1), m.group(0)), markdown)
+    """Replace the landing page's stat markers with freshly counted values.
+
+    A failure to count (a toolchain pin whose file was reshaped, say) leaves the
+    committed values in place and warns: they are gated by CI, so they are the
+    right fallback, but falling back silently is the very failure #575 records.
+    """
+    values = landing_values()
+    if values.is_err:
+        log.warning(f"⚠  corpus stats not recomputed: {values.unwrap_err().message}")
+        return markdown
+    filled = values.unwrap()
+    log.info(f"📊  corpus stats: {filled['modules']} modules, "
+             f"{filled['loc']} lines of Agda, {filled['checked']} machine-checked, "
+             f"Agda {filled['agda']} · stdlib {filled['stdlib']}")
+    return fill(markdown, filled)
 
 
 def on_page_markdown(markdown: str, *, page=None, config=None, files=None) -> str:

--- a/scripts/python/mkdocs_hooks.py
+++ b/scripts/python/mkdocs_hooks.py
@@ -147,8 +147,9 @@ def on_files(files, config):
 # what `make corpus-stats` writes into the source and what CI holds the
 # committed values to (issue #575); the hook calls that one function so the
 # deployed site and the committed file cannot disagree.  It is a single pass
-# over the canonical (non-Legacy) modules, a few hundred files and ~50 ms, run
-# only when rendering index.md, so it adds nothing meaningful to the build.
+# over the canonical (non-Legacy) modules plus the three toolchain files, 88 ms
+# measured over 339 modules, run only when rendering index.md, so it adds
+# nothing meaningful to a build that takes four minutes.
 #
 # Before #575 the substitution here was the *only* thing that refreshed the
 # figures, and it rewrote the rendered page without ever writing back, so the
@@ -161,6 +162,9 @@ def _fill_corpus_stats(markdown: str) -> str:
     A failure to count (a toolchain pin whose file was reshaped, say) leaves the
     committed values in place and warns: they are gated by CI, so they are the
     right fallback, but falling back silently is the very failure #575 records.
+    The warning is deliberately loud enough to stop `mkdocs build --strict`,
+    which is `make site`: the same failure fails the gate on the same commit,
+    so a red docs build here is consistent rather than extra damage.
     """
     values = landing_values()
     if values.is_err:

--- a/scripts/python/test_corpus_stats.py
+++ b/scripts/python/test_corpus_stats.py
@@ -20,6 +20,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import corpus_stats as cs  # noqa: E402
 
+# One scratch directory for the whole suite; cleaned up at interpreter exit.
+_TMP = tempfile.TemporaryDirectory(prefix="corpus-stats-test-")
+
 
 def module(*blocks: str, pragma: str = "--cubical-compatible --exact-split --safe") -> str:
     """A minimal literate module: a hidden preamble fence carrying the OPTIONS
@@ -74,12 +77,61 @@ def test_options_pragma_quoted_in_prose_is_ignored() -> None:
     assert cs.module_stats(text)[1] is False
 
 
+def test_a_commented_out_safe_pragma_does_not_count() -> None:
+    # Agda applies the pragma on the next line, not the disabled one; a raw
+    # search over the fence body would take the first and call this safe.
+    text = ("<!--\n```agda\n-- {-# OPTIONS --safe #-}\n"
+            "{-# OPTIONS --cubical-compatible #-}\nmodule M where\n```\n-->\n")
+    assert cs.module_stats(text)[1] is False
+
+
+def test_a_safe_pragma_inside_a_block_comment_does_not_count() -> None:
+    text = ("<!--\n```agda\n{- a note:\n{-# OPTIONS --safe #-}\n-}\n"
+            "module M where\n```\n-->\n")
+    assert cs.module_stats(text)[1] is False
+
+
+def test_a_pragma_after_the_module_header_does_not_count() -> None:
+    # Agda requires OPTIONS before the header and rejects it after, so a tool
+    # that honored one there would disagree with the type-checker.
+    text = "<!--\n```agda\nmodule M where\n{-# OPTIONS --safe #-}\n```\n-->\n"
+    assert cs.module_stats(text)[1] is False
+
+
+def test_a_pragma_behind_another_pragma_still_counts() -> None:
+    text = ("<!--\n```agda\n{-# BUILTIN NATURAL N #-}\n"
+            "{-# OPTIONS --safe #-}\nmodule M where\n```\n-->\n")
+    assert cs.module_stats(text)[1] is True
+
+
+def test_a_pragma_split_across_lines_still_counts() -> None:
+    text = ("<!--\n```agda\n{-# OPTIONS --cubical-compatible\n"
+            "            --safe #-}\nmodule M where\n```\n-->\n")
+    assert cs.module_stats(text)[1] is True
+
+
 # --------------------------------------------------------------------------- #
 # corpus: the aggregate over the tree.
 # --------------------------------------------------------------------------- #
 def test_corpus_aggregates_modules_loc_and_safe() -> None:
     texts = [module("f = ?"), module("g = ?", pragma="--cubical-compatible")]
     assert cs.corpus(texts) == cs.Corpus(modules=2, loc=6, safe=1)
+
+
+def test_measure_rejects_a_missing_src_rather_than_counting_zero() -> None:
+    # Publishing "0 literate modules", or writing it into the page, is worse
+    # than failing: it means the tool is looking at the wrong place.
+    got = cs.measure(Path(_TMP.name) / "no-such-tree")
+    assert got.is_err
+    assert "not a directory" in got.unwrap_err().message
+
+
+def test_measure_rejects_an_empty_src() -> None:
+    empty = Path(_TMP.name) / "empty-src"
+    empty.mkdir(exist_ok=True)
+    got = cs.measure(empty)
+    assert got.is_err
+    assert "no literate modules" in got.unwrap_err().message
 
 
 # --------------------------------------------------------------------------- #
@@ -218,9 +270,6 @@ def test_in_series_does_not_accept_a_bare_string_prefix() -> None:
 # --------------------------------------------------------------------------- #
 # analyze: what the gate reports about a page on disk.
 # --------------------------------------------------------------------------- #
-_TMP = tempfile.TemporaryDirectory(prefix="corpus-stats-test-")
-
-
 def page(text: str, name: str) -> Path:
     """Write ``text`` to a page in the suite's temporary directory."""
     path = Path(_TMP.name) / name

--- a/scripts/python/test_corpus_stats.py
+++ b/scripts/python/test_corpus_stats.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+File: scripts/python/test_corpus_stats.py
+
+Description: Tests for ``corpus_stats.py``.
+
+  Dependency-free: run directly with ``python3 scripts/python/test_corpus_stats.py``
+  (prints ``N/N passed`` and exits non-zero on failure) or under ``pytest`` if it
+  is installed.  Nothing here needs Agda, MkDocs, or the real tree: each test is
+  a small literate fragment, a snippet of one of the three toolchain files, or a
+  page written into a temporary directory.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import corpus_stats as cs  # noqa: E402
+
+
+def module(*blocks: str, pragma: str = "--cubical-compatible --exact-split --safe") -> str:
+    """A minimal literate module: a hidden preamble fence carrying the OPTIONS
+    pragma, then one visible fence per extra block."""
+    head = ("<!--\n"
+            "```agda\n"
+            f"{{-# OPTIONS {pragma} #-}}\n"
+            "module M where\n"
+            "```\n"
+            "-->\n")
+    body = "".join(f"\nsome prose\n\n```agda\n{b}\n```\n" for b in blocks)
+    return head + body
+
+
+# --------------------------------------------------------------------------- #
+# module_stats: lines of Agda, and whether the module is checked under --safe.
+# --------------------------------------------------------------------------- #
+def test_counts_the_hidden_preamble_fence() -> None:
+    # Agda checks the hidden preamble, so its two lines count.
+    assert cs.module_stats(module())[0] == 2
+
+
+def test_counts_visible_fences_and_not_prose_or_delimiters() -> None:
+    loc, _ = cs.module_stats(module("f : Set\nf = ?", "g : Set"))
+    assert loc == 2 + 2 + 1
+
+
+def test_blank_lines_inside_a_fence_count() -> None:
+    # "Lines of Agda" is the size of the code block, not its non-empty lines;
+    # the committed figure has always been counted this way.
+    assert cs.module_stats(module("f : Set\n\nf = ?"))[0] == 2 + 3
+
+
+def test_safe_pragma_is_detected() -> None:
+    assert cs.module_stats(module())[1] is True
+
+
+def test_module_without_safe_is_not_counted_as_checked() -> None:
+    assert cs.module_stats(module(pragma="--cubical-compatible"))[1] is False
+
+
+def test_safe_is_matched_as_a_whole_option() -> None:
+    # A longer option that merely starts with "--safe" must not satisfy it.
+    assert cs.module_stats(module(pragma="--safety-net"))[1] is False
+
+
+def test_options_pragma_quoted_in_prose_is_ignored() -> None:
+    # The pragma is read from the fenced code, so prose showing an example
+    # cannot make an unsafe module look safe.
+    text = ("Modules in this library open with `{-# OPTIONS --safe #-}`.\n"
+            + module(pragma="--cubical-compatible"))
+    assert cs.module_stats(text)[1] is False
+
+
+# --------------------------------------------------------------------------- #
+# corpus: the aggregate over the tree.
+# --------------------------------------------------------------------------- #
+def test_corpus_aggregates_modules_loc_and_safe() -> None:
+    texts = [module("f = ?"), module("g = ?", pragma="--cubical-compatible")]
+    assert cs.corpus(texts) == cs.Corpus(modules=2, loc=6, safe=1)
+
+
+# --------------------------------------------------------------------------- #
+# Stats.markers: how the numbers are rendered on the page.
+# --------------------------------------------------------------------------- #
+def markers(modules: int, loc: int, safe: int) -> dict[str, str]:
+    return cs.Stats(corpus=cs.Corpus(modules=modules, loc=loc, safe=safe),
+                    toolchain=cs.Toolchain(agda="2.8.0", stdlib="2.3")).markers
+
+
+def test_loc_rounds_half_up_not_to_even() -> None:
+    # round() would give "60k" for 60_500 (ties to even); a reader of a "…k"
+    # stat expects 61k.
+    assert markers(1, 60_500, 1)["loc"] == "61k"
+    assert markers(1, 60_499, 1)["loc"] == "60k"
+    assert markers(1, 67_175, 1)["loc"] == "67k"
+
+
+def test_checked_share_floors_and_never_rounds_up_to_a_false_hundred() -> None:
+    assert markers(339, 1, 339)["checked"] == "100%"
+    assert markers(339, 1, 338)["checked"] == "99%"
+    assert markers(3, 1, 2)["checked"] == "66%"
+
+
+def test_checked_share_on_an_empty_tree_does_not_divide_by_zero() -> None:
+    assert markers(0, 0, 0)["checked"] == "0%"
+
+
+def test_toolchain_values_pass_through() -> None:
+    assert markers(1, 1, 1)["agda"] == "2.8.0"
+    assert markers(1, 1, 1)["stdlib"] == "2.3"
+
+
+# --------------------------------------------------------------------------- #
+# fill / marker_names / unfilled: the marker substitution itself.
+# --------------------------------------------------------------------------- #
+STRIP = ('<span><!-- ualib:stat:modules -->302<!-- /ualib:stat:modules --></span>\n'
+         '<span>Agda <!-- ualib:stat:agda -->2.8.0<!-- /ualib:stat:agda --> · '
+         'stdlib <!-- ualib:stat:stdlib -->2.3<!-- /ualib:stat:stdlib --></span>\n')
+
+
+def test_fill_replaces_the_value_and_keeps_the_markers() -> None:
+    out = cs.fill(STRIP, {"modules": "339"})
+    assert "<!-- ualib:stat:modules -->339<!-- /ualib:stat:modules -->" in out
+    assert "302" not in out
+
+
+def test_fill_handles_two_markers_on_one_line() -> None:
+    out = cs.fill(STRIP, {"agda": "2.9.0", "stdlib": "2.4"})
+    assert "Agda <!-- ualib:stat:agda -->2.9.0<!-- /ualib:stat:agda --> · " in out
+    assert "stdlib <!-- ualib:stat:stdlib -->2.4<!-- /ualib:stat:stdlib -->" in out
+
+
+def test_fill_leaves_a_marker_it_does_not_compute_alone() -> None:
+    assert cs.fill(STRIP, {}) == STRIP
+
+
+def test_fill_spans_a_marker_split_across_lines() -> None:
+    split = "<!-- ualib:stat:loc -->\n60k\n<!-- /ualib:stat:loc -->"
+    assert cs.fill(split, {"loc": "67k"}) == \
+        "<!-- ualib:stat:loc -->67k<!-- /ualib:stat:loc -->"
+
+
+def test_fill_is_idempotent() -> None:
+    values = {"modules": "339", "agda": "2.8.0", "stdlib": "2.3"}
+    once = cs.fill(STRIP, values)
+    assert cs.fill(once, values) == once
+
+
+def test_marker_names_reads_the_page() -> None:
+    assert cs.marker_names(STRIP) == {"modules", "agda", "stdlib"}
+
+
+def test_unfilled_names_the_stats_the_page_is_missing() -> None:
+    assert cs.unfilled(STRIP, {"modules": "339", "loc": "67k", "checked": "100%"}) \
+        == ("checked", "loc")
+
+
+# --------------------------------------------------------------------------- #
+# toolchain: the declared versions, reconciled against the pins that bind.
+# --------------------------------------------------------------------------- #
+MKDOCS = 'extra:\n  agda_version: "2.8.0"\n  stdlib_version: "2.3"\n'
+LIB = "name: agda-algebras\ndepend: standard-library-2.3\ninclude: src\n"
+FLAKE = ('case "${agdaVer}" in\n  2.8.*) : ;;\n  *) echo warn ;;\nesac\n'
+         'case "${stdlibVer}" in\n  2.3*) : ;;\n  *) echo warn ;;\nesac\n')
+
+
+def test_toolchain_reads_all_three_files() -> None:
+    got = cs.toolchain(MKDOCS, LIB, FLAKE)
+    assert got.is_ok
+    assert got.unwrap() == cs.Toolchain(agda="2.8.0", stdlib="2.3")
+
+
+def test_toolchain_rejects_a_site_variable_that_disagrees_with_the_agda_lib() -> None:
+    # The dependency Agda enforces is the pin that binds; the site variable
+    # quoting a different stdlib is the drift this check exists to catch.
+    got = cs.toolchain(MKDOCS.replace('"2.3"', '"2.4"'), LIB, FLAKE)
+    assert got.is_err
+    assert "standard-library-2.3" in got.unwrap_err().message
+
+
+def test_toolchain_rejects_an_agda_version_outside_the_flake_guard() -> None:
+    got = cs.toolchain(MKDOCS.replace('"2.8.0"', '"2.9.0"'), LIB, FLAKE)
+    assert got.is_err
+    assert "2.8 series" in got.unwrap_err().message
+
+
+def test_toolchain_rejects_an_agda_lib_outside_the_flake_guard() -> None:
+    got = cs.toolchain(MKDOCS.replace('"2.3"', '"2.4"'),
+                       LIB.replace("2.3", "2.4"), FLAKE)
+    assert got.is_err
+    assert "2.3 series" in got.unwrap_err().message
+
+
+def test_toolchain_reports_the_file_whose_shape_changed() -> None:
+    # A source of truth that cannot be read must fail loudly, not drop out of
+    # the check.
+    got = cs.toolchain(MKDOCS, "name: agda-algebras\ninclude: src\n", FLAKE)
+    assert got.is_err
+    assert "agda-algebras.agda-lib" in got.unwrap_err().message
+
+
+def test_flake_guard_series_are_parsed_from_both_shapes() -> None:
+    # The Agda guard is written `2.8.*)` and the stdlib guard `2.3*)`.
+    assert cs._guard("agdaVer").search(FLAKE).group(1) == "2.8"
+    assert cs._guard("stdlibVer").search(FLAKE).group(1) == "2.3"
+
+
+def test_in_series_does_not_accept_a_bare_string_prefix() -> None:
+    assert cs._in_series("2.8.0", "2.8")
+    assert cs._in_series("2.8", "2.8")
+    # 2.80 starts with "2.8" as text but is a different series.
+    assert not cs._in_series("2.80", "2.8")
+
+
+# --------------------------------------------------------------------------- #
+# analyze: what the gate reports about a page on disk.
+# --------------------------------------------------------------------------- #
+_TMP = tempfile.TemporaryDirectory(prefix="corpus-stats-test-")
+
+
+def page(text: str, name: str) -> Path:
+    """Write ``text`` to a page in the suite's temporary directory."""
+    path = Path(_TMP.name) / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+VALUES = {"modules": "339", "agda": "2.8.0", "stdlib": "2.3"}
+
+
+def test_analyze_reports_no_drift_when_the_page_is_current() -> None:
+    got = cs.analyze(VALUES, [page(cs.fill(STRIP, VALUES), "current.md")])
+    assert got.is_ok
+    assert got.unwrap() == ()
+
+
+def test_analyze_reports_the_page_and_a_diff_when_a_value_drifted() -> None:
+    got = cs.analyze(VALUES, [page(STRIP, "drifted.md")])
+    assert got.is_ok
+    drift, = got.unwrap()
+    assert drift.stale
+    assert drift.path.name == "drifted.md"
+    assert "302" in drift.diff and "339" in drift.diff
+
+
+def test_analyze_fails_when_the_page_lost_a_marker() -> None:
+    # A renamed or misspelled marker would otherwise leave a hand-typed number
+    # standing while the gate reported success.
+    got = cs.analyze({**VALUES, "loc": "67k"}, [page(STRIP, "no-loc.md")])
+    assert got.is_err
+    assert "no marker for loc" in got.unwrap_err().message
+
+
+def test_analyze_fails_when_a_page_is_missing() -> None:
+    got = cs.analyze(VALUES, [Path("does/not/exist.md")])
+    assert got.is_err
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+
+def _run() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failures = []
+    for t in tests:
+        try:
+            t()
+        except AssertionError as e:  # noqa: PERF203
+            failures.append((t.__name__, e))
+    for name, err in failures:
+        print(f"FAIL {name}: {err}")
+    print(f"{len(tests) - len(failures)}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run())


### PR DESCRIPTION
`docs/index.md`'s two counted figures were substituted into the *rendered* page by the MkDocs hook and never written back, so the values committed in the source, which are the ones GitHub renders, sat at their 2026-07-28 reading while the library grew 12.7%.  This is fix 1 from [#575], the gate, extended to cover the two hand-written literals standing beside them.

## What changed

+  **`scripts/python/corpus_stats.py`** counts the landing page's four figures and owns them.  `make corpus-stats` writes the counted values into the page's `ualib:stat` markers; `make corpus-stats-check` fails, with a diff, when a committed value has drifted; `make corpus-stats-test` is the tool's own suite; and `--json` prints the figures as one record, for anything outside this repository that would otherwise hand-copy them.
+  **A CI job**, *Landing-page stats*, runs the check and the tests on every pull request, wired into both `needs:` and the `results=(…)` array of the `all-green` gate.  The consequence is deliberate: the pull request that moves a number is the one that refreshes the page.
+  **`docs/index.md`** now reads 339 modules and 67k lines, and the comment above the strip no longer promises a refresh that never happened.
+  **`scripts/python/mkdocs_hooks.py`** still substitutes at build time, so the deployed site is current even between refreshes, but it now calls the same function the gate does; the site and the committed source cannot disagree.  Its private fence scanner is gone in favor of the shared literate front end (`_utils/literate.fences`), which the two were measured to agree with exactly (339 modules, 67,175 lines) before the swap.

## The other two figures

The issue's "while you are in there" note: `100%` machine-checked and `2.8.0` Agda · stdlib 2.3 sat as literals beside the generated pair.  Both are derived now.

+  `checked` is the share of canonical modules whose `OPTIONS` pragma carries `--safe`, which is what "machine-checked" asserts for a library like this one; it measures 339 of 339 today.  It floors rather than rounds, so 338 of 339 would print `99%`, never a false `100%`.  The pragma is read by `_utils/literate.options_pragma`, a new pure addition to the shared front end that reads what Agda applies rather than what the text contains, so a pragma that is commented out, nested in a block comment, or written after the module header does not count.
+  `agda` and `stdlib` are read from `mkdocs.yml`'s `extra:` site variables and reconciled against the two pins that actually bind: the `depend:` line of `agda-algebras.agda-lib`, whose stdlib version Agda enforces exactly, and the version-floor guards in `flake.nix`.  The stdlib comparison is exact, so a stdlib bump that misses the docs fails the check.  The Agda one is by *series*, because `flake.nix` deliberately guards `2.8.*` and no file here states a patch level: a move from 2.8.0 to 2.8.1 would pass, and the tool now says so where it makes the claim (raised by Copilot, discussed below).

A source of truth the tool cannot read is an error, never a skipped check.  If one of those files is reshaped so a pattern stops matching, the tool names the pattern and exits non-zero rather than quietly passing; a check that silently measures nothing is how the stale number survived six weeks.  For the same reason the gate also fails when a page has lost a marker, so a renamed or misspelled marker cannot leave a hand-typed number standing behind a green check.

## Verification

+  The gate reproduces the reported drift exactly.  Before the refresh, `--check` printed `-302 → +339` and `-60k → +67k` on `docs/index.md` and exited 1; after `make corpus-stats` it exits 0, and a second run reports "every page already up to date".
+  The forward scenario works as well, which is the one contributors will meet: with a throwaway module added under `src/Setoid/`, `make corpus-stats-check` fails with `-339` / `+340` on the module count and points at `make corpus-stats`; removing the module restores a green check.
+  `make corpus-stats-test`: 30/30 passed.  The suite covers the line counting (hidden preamble fences included, prose and delimiters excluded), the `--safe` detection (whole-option matching, and an `OPTIONS` pragma quoted in prose correctly ignored), the half-up rounding to thousands, the floor on the checked share, the marker substitution (two markers on one line, a marker split across lines, idempotence), the toolchain reconciliation in all three of its failure modes, and what the gate reports about a page on disk.
+  `make site` builds under `--strict` in 234 s, and the rendered `site/index.html` carries all four values (339, 67k, 100%, 2.8.0 / 2.3) with the markers surviving as invisible comments.  Driving `on_page_markdown` directly confirms the hook refills a deliberately wrong value on `index.md` and leaves other pages alone.
+  `make check-links` and `make docstrings` still pass.  No `.lagda.md` under `src/` is touched, so I did not run `make check` locally; both Agda lanes pass in CI on this branch, along with the new *Landing-page stats* job and the `all-green` gate.

## Not done

The issue's fixes 2 and 3 are deliberately not taken.  Writing back from the MkDocs build would make the build mutate the source tree, and dropping the fallback would cost the GitHub reader a number worth having.  The gate keeps the number in the file, where GitHub renders it, and makes it impossible for it to rot.

Closes #575

[#575]: https://github.com/ualib/agda-algebras/issues/575



